### PR TITLE
Move git hook section in README to developing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,6 @@ into the directory `.build/`.
 `eval $(build.sh env)` will configure GOPATH, GOROOT and PATH for development outside
 of `build.sh`
 
-### Git hooks
-
-We have checked in a pre-commit hook which enforces `go fmt` styling. Please install it
-before sending a pull request. From the project root:
-
-```
-ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
-```
-
 ## Developing the SRI
 
 The above-referenced build scripts may be used natively under Linux. For your convenience,
@@ -54,7 +45,7 @@ root@65a22fa2d89f:~/go/src/github.com/spiffe/sri# ./build.sh setup
 ...
 ```
 
-## Prerequisites
+### Prerequisites
 
 * Linux or Docker
 
@@ -63,3 +54,13 @@ If not using Docker, the following "non-standard" utilities are also required:
 * `curl`
 * `git`
 * `unzip`
+
+### Git hooks
+
+We have checked in a pre-commit hook which enforces `go fmt` styling. Please install it
+before sending a pull request. From the project root:
+
+```
+ln -s ../../.githooks/pre-commit .git/hooks/pre-commit
+```
+


### PR DESCRIPTION
This was previously in the Build section, but it really belongs in the Developing section