### PR TITLE
naming: consistency, visibility changes

### DIFF
--- a/pkg/agent/keymanager/grpc.go
+++ b/pkg/agent/keymanager/grpc.go
@@ -5,50 +5,50 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	KeyManagerImpl KeyManager
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) GenerateKeyPair(ctx context.Context, req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
-	response, err := m.KeyManagerImpl.GenerateKeyPair(req)
+func (m *grpcServer) GenerateKeyPair(ctx context.Context, req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
+	response, err := m.delegate.GenerateKeyPair(req)
 	return response, err
 }
 
-func (m *GRPCServer) FetchPrivateKey(ctx context.Context, req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
-	response, err := m.KeyManagerImpl.FetchPrivateKey(req)
+func (m *grpcServer) FetchPrivateKey(ctx context.Context, req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
+	response, err := m.delegate.FetchPrivateKey(req)
 	return response, err
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.KeyManagerImpl.Configure(req)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req)
 	return response, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.KeyManagerImpl.GetPluginInfo(req)
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo(req)
 	return response, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client KeyManagerClient
 }
 
-func (m *GRPCClient) GenerateKeyPair(req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
+func (m *grpcClient) GenerateKeyPair(req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
 	res, err := m.client.GenerateKeyPair(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) FetchPrivateKey(req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
+func (m *grpcClient) FetchPrivateKey(req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
 	res, err := m.client.FetchPrivateKey(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+func (m *grpcClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
 	res, err := m.client.Configure(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
 	res, err := m.client.GetPluginInfo(context.Background(), req)
 	return res, err
 }

--- a/pkg/agent/keymanager/interface.go
+++ b/pkg/agent/keymanager/interface.go
@@ -17,30 +17,30 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "KeyManager",
 }
 
-type KeyManager interface {
+type Interface interface {
 	GenerateKeyPair(*GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
 	FetchPrivateKey(*FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
 	Configure(*sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error)
 	GetPluginInfo(*sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error)
 }
 
-type KeyManagerPlugin struct {
-	KeyManagerImpl KeyManager
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p KeyManagerPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p KeyManagerPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p KeyManagerPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterKeyManagerServer(s, &GRPCServer{KeyManagerImpl: p.KeyManagerImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterKeyManagerServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p KeyManagerPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewKeyManagerClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewKeyManagerClient(c)}, nil
 }

--- a/pkg/agent/nodeattestor/grpc.go
+++ b/pkg/agent/nodeattestor/grpc.go
@@ -5,40 +5,40 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	NodeAttestorImpl NodeAttestor
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) FetchAttestationData(ctx context.Context, req *FetchAttestationDataRequest) (*FetchAttestationDataResponse, error) {
-	response, err := m.NodeAttestorImpl.FetchAttestationData(req)
+func (m *grpcServer) FetchAttestationData(ctx context.Context, req *FetchAttestationDataRequest) (*FetchAttestationDataResponse, error) {
+	response, err := m.delegate.FetchAttestationData(req)
 	return response, err
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.NodeAttestorImpl.Configure(req)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req)
 	return response, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.NodeAttestorImpl.GetPluginInfo(req)
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo(req)
 	return response, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client NodeAttestorClient
 }
 
-func (m *GRPCClient) FetchAttestationData(req *FetchAttestationDataRequest) (*FetchAttestationDataResponse, error) {
+func (m *grpcClient) FetchAttestationData(req *FetchAttestationDataRequest) (*FetchAttestationDataResponse, error) {
 	res, err := m.client.FetchAttestationData(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+func (m *grpcClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
 	res, err := m.client.Configure(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
 	res, err := m.client.GetPluginInfo(context.Background(), req)
 	return res, err
 }

--- a/pkg/agent/nodeattestor/interface.go
+++ b/pkg/agent/nodeattestor/interface.go
@@ -17,29 +17,29 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "NodeAttestor",
 }
 
-type NodeAttestor interface {
+type Interface interface {
 	FetchAttestationData(*FetchAttestationDataRequest) (*FetchAttestationDataResponse, error)
 	Configure(*sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error)
 	GetPluginInfo(*sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error)
 }
 
-type NodeAttestorPlugin struct {
-	NodeAttestorImpl NodeAttestor
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p NodeAttestorPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeAttestorPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeAttestorPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterNodeAttestorServer(s, &GRPCServer{NodeAttestorImpl: p.NodeAttestorImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterNodeAttestorServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p NodeAttestorPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewNodeAttestorClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewNodeAttestorClient(c)}, nil
 }

--- a/pkg/agent/workloadattestor/grpc.go
+++ b/pkg/agent/workloadattestor/grpc.go
@@ -5,40 +5,40 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	WorkloadAttestorImpl WorkloadAttestor
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) Attest(ctx context.Context, req *AttestRequest) (*AttestResponse, error) {
-	response, err := m.WorkloadAttestorImpl.Attest(req)
+func (m *grpcServer) Attest(ctx context.Context, req *AttestRequest) (*AttestResponse, error) {
+	response, err := m.delegate.Attest(req)
 	return response, err
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.WorkloadAttestorImpl.Configure(req)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req)
 	return response, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.WorkloadAttestorImpl.GetPluginInfo(req)
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo(req)
 	return response, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client WorkloadAttestorClient
 }
 
-func (m *GRPCClient) Attest(req *AttestRequest) (*AttestResponse, error) {
+func (m *grpcClient) Attest(req *AttestRequest) (*AttestResponse, error) {
 	res, err := m.client.Attest(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+func (m *grpcClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
 	res, err := m.client.Configure(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
 	res, err := m.client.GetPluginInfo(context.Background(), req)
 	return res, err
 }

--- a/pkg/agent/workloadattestor/interface.go
+++ b/pkg/agent/workloadattestor/interface.go
@@ -17,29 +17,29 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "WorkloadAttestor",
 }
 
-type WorkloadAttestor interface {
+type Interface interface {
 	Attest(*AttestRequest) (*AttestResponse, error)
 	Configure(*sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error)
 	GetPluginInfo(*sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error)
 }
 
-type WorkloadAttestorPlugin struct {
-	WorkloadAttestorImpl WorkloadAttestor
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p WorkloadAttestorPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p WorkloadAttestorPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p WorkloadAttestorPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterWorkloadAttestorServer(s, &GRPCServer{WorkloadAttestorImpl: p.WorkloadAttestorImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterWorkloadAttestorServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p WorkloadAttestorPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewWorkloadAttestorClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewWorkloadAttestorClient(c)}, nil
 }

--- a/pkg/server/ca/grpc.go
+++ b/pkg/server/ca/grpc.go
@@ -5,45 +5,45 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	ControlPlaneCaImpl ControlPlaneCa
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.ControlPlaneCaImpl.Configure(req.Configuration)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req.Configuration)
 	return &sriplugin.ConfigureResponse{ErrorList: response}, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.ControlPlaneCaImpl.GetPluginInfo()
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo()
 	return response, err
 }
 
-func (m *GRPCServer) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResponse, error) {
-	response, err := m.ControlPlaneCaImpl.SignCsr(req.Csr)
+func (m *grpcServer) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResponse, error) {
+	response, err := m.delegate.SignCsr(req.Csr)
 	return &SignCsrResponse{SignedCertificate: response}, err
 }
 
-func (m *GRPCServer) GenerateCsr(ctx context.Context, req *GenerateCsrRequest) (*GenerateCsrResponse, error) {
-	response, err := m.ControlPlaneCaImpl.GenerateCsr()
+func (m *grpcServer) GenerateCsr(ctx context.Context, req *GenerateCsrRequest) (*GenerateCsrResponse, error) {
+	response, err := m.delegate.GenerateCsr()
 	return &GenerateCsrResponse{Csr: response}, err
 }
 
-func (m *GRPCServer) FetchCertificate(ctx context.Context, req *FetchCertificateRequest) (*FetchCertificateResponse, error) {
-	response, err := m.ControlPlaneCaImpl.FetchCertificate()
+func (m *grpcServer) FetchCertificate(ctx context.Context, req *FetchCertificateRequest) (*FetchCertificateResponse, error) {
+	response, err := m.delegate.FetchCertificate()
 	return &FetchCertificateResponse{StoredIntermediateCert: response}, err
 }
 
-func (m *GRPCServer) LoadCertificate(ctx context.Context, req *LoadCertificateRequest) (*LoadCertificateResponse, error) {
-	err := m.ControlPlaneCaImpl.LoadCertificate(req.SignedIntermediateCert)
+func (m *grpcServer) LoadCertificate(ctx context.Context, req *LoadCertificateRequest) (*LoadCertificateResponse, error) {
+	err := m.delegate.LoadCertificate(req.SignedIntermediateCert)
 	return &LoadCertificateResponse{}, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client ControlPlaneCAClient
 }
 
-func (m *GRPCClient) Configure(configuration string) ([]string, error) {
+func (m *grpcClient) Configure(configuration string) ([]string, error) {
 	response, err := m.client.Configure(context.Background(), &sriplugin.ConfigureRequest{configuration})
 	if err != nil {
 		return []string{}, err
@@ -51,27 +51,27 @@ func (m *GRPCClient) Configure(configuration string) ([]string, error) {
 	return response.ErrorList, err
 }
 
-func (m *GRPCClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
 	response, err := m.client.GetPluginInfo(context.Background(), &sriplugin.GetPluginInfoRequest{})
 	return response, err
 }
 
-func (m *GRPCClient) SignCsr(csr []byte) (signedCertificate []byte, err error) {
+func (m *grpcClient) SignCsr(csr []byte) (signedCertificate []byte, err error) {
 	response, err := m.client.SignCsr(context.Background(), &SignCsrRequest{Csr: csr})
 	return response.SignedCertificate, err
 }
 
-func (m *GRPCClient) GenerateCsr() (csr []byte, err error) {
+func (m *grpcClient) GenerateCsr() (csr []byte, err error) {
 	response, err := m.client.GenerateCsr(context.Background(), &GenerateCsrRequest{})
 	return response.Csr, err
 }
 
-func (m *GRPCClient) FetchCertificate() (storedIntermediateCert []byte, err error) {
+func (m *grpcClient) FetchCertificate() (storedIntermediateCert []byte, err error) {
 	response, err := m.client.FetchCertificate(context.Background(), &FetchCertificateRequest{})
 	return response.StoredIntermediateCert, err
 }
 
-func (m *GRPCClient) LoadCertificate(signedIntermediateCert []byte) error {
+func (m *grpcClient) LoadCertificate(signedIntermediateCert []byte) error {
 	_, err := m.client.LoadCertificate(context.Background(), &LoadCertificateRequest{SignedIntermediateCert: signedIntermediateCert})
 	return err
 }

--- a/pkg/server/ca/interface.go
+++ b/pkg/server/ca/interface.go
@@ -17,7 +17,7 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "ControlPlaneCA",
 }
 
-type ControlPlaneCa interface {
+type Interface interface {
 	Configure(config string) ([]string, error)
 	GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error)
 	SignCsr([]byte) ([]byte, error)
@@ -26,23 +26,23 @@ type ControlPlaneCa interface {
 	LoadCertificate([]byte) error
 }
 
-type ControlPlaneCaPlugin struct {
-	ControlPlaneCaImpl ControlPlaneCa
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p ControlPlaneCaPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p ControlPlaneCaPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p ControlPlaneCaPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterControlPlaneCAServer(s, &GRPCServer{ControlPlaneCaImpl: p.ControlPlaneCaImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterControlPlaneCAServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p ControlPlaneCaPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewControlPlaneCAClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewControlPlaneCAClient(c)}, nil
 }

--- a/pkg/server/datastore/grpc.go
+++ b/pkg/server/datastore/grpc.go
@@ -5,250 +5,250 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	DataStoreImpl DataStore
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) CreateFederatedEntry(ctx context.Context, req *CreateFederatedEntryRequest) (*CreateFederatedEntryResponse, error) {
-	res, err := m.DataStoreImpl.CreateFederatedEntry(req)
+func (m *grpcServer) CreateFederatedEntry(ctx context.Context, req *CreateFederatedEntryRequest) (*CreateFederatedEntryResponse, error) {
+	res, err := m.delegate.CreateFederatedEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) ListFederatedEntry(ctx context.Context, req *ListFederatedEntryRequest) (*ListFederatedEntryResponse, error) {
-	res, err := m.DataStoreImpl.ListFederatedEntry(req)
+func (m *grpcServer) ListFederatedEntry(ctx context.Context, req *ListFederatedEntryRequest) (*ListFederatedEntryResponse, error) {
+	res, err := m.delegate.ListFederatedEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) UpdateFederatedEntry(ctx context.Context, req *UpdateFederatedEntryRequest) (*UpdateFederatedEntryResponse, error) {
-	res, err := m.DataStoreImpl.UpdateFederatedEntry(req)
+func (m *grpcServer) UpdateFederatedEntry(ctx context.Context, req *UpdateFederatedEntryRequest) (*UpdateFederatedEntryResponse, error) {
+	res, err := m.delegate.UpdateFederatedEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) DeleteFederatedEntry(ctx context.Context, req *DeleteFederatedEntryRequest) (*DeleteFederatedEntryResponse, error) {
-	res, err := m.DataStoreImpl.DeleteFederatedEntry(req)
+func (m *grpcServer) DeleteFederatedEntry(ctx context.Context, req *DeleteFederatedEntryRequest) (*DeleteFederatedEntryResponse, error) {
+	res, err := m.delegate.DeleteFederatedEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
-	res, err := m.DataStoreImpl.CreateAttestedNodeEntry(req)
-	return res, err
-}
-
-//
-
-func (m *GRPCServer) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
-	res, err := m.DataStoreImpl.FetchAttestedNodeEntry(req)
-	return res, err
-}
-
-func (m *GRPCServer) FetchStaleNodeEntries(ctx context.Context, req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
-	res, err := m.DataStoreImpl.FetchStaleNodeEntries(req)
-	return res, err
-}
-
-func (m *GRPCServer) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
-	res, err := m.DataStoreImpl.UpdateAttestedNodeEntry(req)
-	return res, err
-}
-
-func (m *GRPCServer) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
-	res, err := m.DataStoreImpl.DeleteAttestedNodeEntry(req)
+func (m *grpcServer) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
+	res, err := m.delegate.CreateAttestedNodeEntry(req)
 	return res, err
 }
 
 //
 
-func (m *GRPCServer) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
-	res, err := m.DataStoreImpl.CreateNodeResolverMapEntry(req)
+func (m *grpcServer) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
+	res, err := m.delegate.FetchAttestedNodeEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) FetchNodeResolverMapEntry(ctx context.Context, req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
-	res, err := m.DataStoreImpl.FetchNodeResolverMapEntry(req)
+func (m *grpcServer) FetchStaleNodeEntries(ctx context.Context, req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
+	res, err := m.delegate.FetchStaleNodeEntries(req)
 	return res, err
 }
 
-func (m *GRPCServer) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
-	res, err := m.DataStoreImpl.DeleteNodeResolverMapEntry(req)
+func (m *grpcServer) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
+	res, err := m.delegate.UpdateAttestedNodeEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) RectifyNodeResolverMapEntries(ctx context.Context, req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
-	res, err := m.DataStoreImpl.RectifyNodeResolverMapEntries(req)
-	return res, err
-}
-
-//
-
-func (m *GRPCServer) CreateRegistrationEntry(ctx context.Context, req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
-	res, err := m.DataStoreImpl.CreateRegistrationEntry(req)
-	return res, err
-}
-
-func (m *GRPCServer) FetchRegistrationEntry(ctx context.Context, req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
-	res, err := m.DataStoreImpl.FetchRegistrationEntry(req)
-	return res, err
-}
-
-func (m *GRPCServer) UpdateRegistrationEntry(ctx context.Context, req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
-	res, err := m.DataStoreImpl.UpdateRegistrationEntry(req)
-	return res, err
-}
-
-func (m *GRPCServer) DeleteRegistrationEntry(ctx context.Context, req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
-	res, err := m.DataStoreImpl.DeleteRegistrationEntry(req)
+func (m *grpcServer) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
+	res, err := m.delegate.DeleteAttestedNodeEntry(req)
 	return res, err
 }
 
 //
 
-func (m *GRPCServer) ListParentIDEntries(ctx context.Context, req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
-	res, err := m.DataStoreImpl.ListParentIDEntries(req)
+func (m *grpcServer) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
+	res, err := m.delegate.CreateNodeResolverMapEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) ListSelectorEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	res, err := m.DataStoreImpl.ListSelectorEntries(req)
+func (m *grpcServer) FetchNodeResolverMapEntry(ctx context.Context, req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
+	res, err := m.delegate.FetchNodeResolverMapEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) ListSpiffeEntries(ctx context.Context, req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
-	res, err := m.DataStoreImpl.ListSpiffeEntries(req)
+func (m *grpcServer) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
+	res, err := m.delegate.DeleteNodeResolverMapEntry(req)
+	return res, err
+}
+
+func (m *grpcServer) RectifyNodeResolverMapEntries(ctx context.Context, req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
+	res, err := m.delegate.RectifyNodeResolverMapEntries(req)
 	return res, err
 }
 
 //
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	res, err := m.DataStoreImpl.Configure(req)
+func (m *grpcServer) CreateRegistrationEntry(ctx context.Context, req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
+	res, err := m.delegate.CreateRegistrationEntry(req)
 	return res, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	res, err := m.DataStoreImpl.GetPluginInfo(req)
+func (m *grpcServer) FetchRegistrationEntry(ctx context.Context, req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
+	res, err := m.delegate.FetchRegistrationEntry(req)
 	return res, err
 }
 
-type GRPCClient struct {
+func (m *grpcServer) UpdateRegistrationEntry(ctx context.Context, req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
+	res, err := m.delegate.UpdateRegistrationEntry(req)
+	return res, err
+}
+
+func (m *grpcServer) DeleteRegistrationEntry(ctx context.Context, req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
+	res, err := m.delegate.DeleteRegistrationEntry(req)
+	return res, err
+}
+
+//
+
+func (m *grpcServer) ListParentIDEntries(ctx context.Context, req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
+	res, err := m.delegate.ListParentIDEntries(req)
+	return res, err
+}
+
+func (m *grpcServer) ListSelectorEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
+	res, err := m.delegate.ListSelectorEntries(req)
+	return res, err
+}
+
+func (m *grpcServer) ListSpiffeEntries(ctx context.Context, req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
+	res, err := m.delegate.ListSpiffeEntries(req)
+	return res, err
+}
+
+//
+
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	res, err := m.delegate.Configure(req)
+	return res, err
+}
+
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	res, err := m.delegate.GetPluginInfo(req)
+	return res, err
+}
+
+type grpcClient struct {
 	client DataStoreClient
 }
 
-func (m *GRPCClient) CreateFederatedEntry(req *CreateFederatedEntryRequest) (*CreateFederatedEntryResponse, error) {
+func (m *grpcClient) CreateFederatedEntry(req *CreateFederatedEntryRequest) (*CreateFederatedEntryResponse, error) {
 	res, err := m.client.CreateFederatedEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) ListFederatedEntry(req *ListFederatedEntryRequest) (*ListFederatedEntryResponse, error) {
+func (m *grpcClient) ListFederatedEntry(req *ListFederatedEntryRequest) (*ListFederatedEntryResponse, error) {
 	res, err := m.client.ListFederatedEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) UpdateFederatedEntry(req *UpdateFederatedEntryRequest) (*UpdateFederatedEntryResponse, error) {
+func (m *grpcClient) UpdateFederatedEntry(req *UpdateFederatedEntryRequest) (*UpdateFederatedEntryResponse, error) {
 	res, err := m.client.UpdateFederatedEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) DeleteFederatedEntry(req *DeleteFederatedEntryRequest) (*DeleteFederatedEntryResponse, error) {
+func (m *grpcClient) DeleteFederatedEntry(req *DeleteFederatedEntryRequest) (*DeleteFederatedEntryResponse, error) {
 	res, err := m.client.DeleteFederatedEntry(context.Background(), req)
 	return res, err
 }
 
 //
 
-func (m *GRPCClient) CreateAttestedNodeEntry(req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
+func (m *grpcClient) CreateAttestedNodeEntry(req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
 	res, err := m.client.CreateAttestedNodeEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) FetchAttestedNodeEntry(req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
+func (m *grpcClient) FetchAttestedNodeEntry(req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
 	res, err := m.client.FetchAttestedNodeEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) FetchStaleNodeEntries(req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
+func (m *grpcClient) FetchStaleNodeEntries(req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
 	res, err := m.client.FetchStaleNodeEntries(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) UpdateAttestedNodeEntry(req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
+func (m *grpcClient) UpdateAttestedNodeEntry(req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
 	res, err := m.client.UpdateAttestedNodeEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) DeleteAttestedNodeEntry(req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
+func (m *grpcClient) DeleteAttestedNodeEntry(req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
 	res, err := m.client.DeleteAttestedNodeEntry(context.Background(), req)
 	return res, err
 }
 
 //
 
-func (m *GRPCClient) CreateNodeResolverMapEntry(req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
+func (m *grpcClient) CreateNodeResolverMapEntry(req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
 	res, err := m.client.CreateNodeResolverMapEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) FetchNodeResolverMapEntry(req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
+func (m *grpcClient) FetchNodeResolverMapEntry(req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
 	res, err := m.client.FetchNodeResolverMapEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) DeleteNodeResolverMapEntry(req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
+func (m *grpcClient) DeleteNodeResolverMapEntry(req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
 	res, err := m.client.DeleteNodeResolverMapEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) RectifyNodeResolverMapEntries(req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
+func (m *grpcClient) RectifyNodeResolverMapEntries(req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
 	res, err := m.client.RectifyNodeResolverMapEntries(context.Background(), req)
 	return res, err
 }
 
 //
 
-func (m *GRPCClient) CreateRegistrationEntry(req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
+func (m *grpcClient) CreateRegistrationEntry(req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
 	res, err := m.client.CreateRegistrationEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) FetchRegistrationEntry(req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
+func (m *grpcClient) FetchRegistrationEntry(req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
 	res, err := m.client.FetchRegistrationEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) UpdateRegistrationEntry(req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
+func (m *grpcClient) UpdateRegistrationEntry(req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
 	res, err := m.client.UpdateRegistrationEntry(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) DeleteRegistrationEntry(req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
+func (m *grpcClient) DeleteRegistrationEntry(req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
 	res, err := m.client.DeleteRegistrationEntry(context.Background(), req)
 	return res, err
 }
 
 //
 
-func (m *GRPCClient) ListParentIDEntries(req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
+func (m *grpcClient) ListParentIDEntries(req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
 	res, err := m.client.ListParentIDEntries(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) ListSelectorEntries(req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
+func (m *grpcClient) ListSelectorEntries(req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
 	res, err := m.client.ListSelectorEntries(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) ListSpiffeEntries(req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
+func (m *grpcClient) ListSpiffeEntries(req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
 	res, err := m.client.ListSpiffeEntries(context.Background(), req)
 	return res, err
 }
 
 //
 
-func (m *GRPCClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+func (m *grpcClient) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
 	res, err := m.client.Configure(context.Background(), req)
 	return res, err
 }
 
-func (m *GRPCClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo(req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
 	res, err := m.client.GetPluginInfo(context.Background(), req)
 	return res, err
 }

--- a/pkg/server/datastore/interface.go
+++ b/pkg/server/datastore/interface.go
@@ -20,7 +20,7 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "DataStore",
 }
 
-type DataStore interface {
+type Interface interface {
 	CreateFederatedEntry(request *CreateFederatedEntryRequest) (*CreateFederatedEntryResponse, error)
 	ListFederatedEntry(request *ListFederatedEntryRequest) (*ListFederatedEntryResponse, error)
 	UpdateFederatedEntry(request *UpdateFederatedEntryRequest) (*UpdateFederatedEntryResponse, error)
@@ -50,23 +50,23 @@ type DataStore interface {
 	GetPluginInfo(request *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error)
 }
 
-type DataStorePlugin struct {
-	DataStoreImpl DataStore
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p DataStorePlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p DataStorePlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p DataStorePlugin) GRPCServer(s *grpc.Server) error {
-	RegisterDataStoreServer(s, &GRPCServer{DataStoreImpl: p.DataStoreImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterDataStoreServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p DataStorePlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewDataStoreClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewDataStoreClient(c)}, nil
 }

--- a/pkg/server/nodeattestor/grpc.go
+++ b/pkg/server/nodeattestor/grpc.go
@@ -5,27 +5,27 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	NodeAttestorImpl NodeAttestor
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	return m.NodeAttestorImpl.Configure(req)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	return m.delegate.Configure(req)
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	return m.NodeAttestorImpl.GetPluginInfo(req)
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	return m.delegate.GetPluginInfo(req)
 }
 
-func (m *GRPCServer) Attest(ctx context.Context, req *AttestRequest) (*AttestResponse, error) {
-	return m.NodeAttestorImpl.Attest(req)
+func (m *grpcServer) Attest(ctx context.Context, req *AttestRequest) (*AttestResponse, error) {
+	return m.delegate.Attest(req)
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client NodeAttestorClient
 }
 
-func (m *GRPCClient) Configure(configuration string) ([]string, error) {
+func (m *grpcClient) Configure(configuration string) ([]string, error) {
 	response, err := m.client.Configure(context.Background(), &sriplugin.ConfigureRequest{configuration})
 	if err != nil {
 		return []string{}, err
@@ -33,12 +33,12 @@ func (m *GRPCClient) Configure(configuration string) ([]string, error) {
 	return response.ErrorList, err
 }
 
-func (m *GRPCClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
 	response, err := m.client.GetPluginInfo(context.Background(), &sriplugin.GetPluginInfoRequest{})
 	return response, err
 }
 
-func (m *GRPCClient) Attest(attestRequest *AttestRequest) (*AttestResponse, error) {
+func (m *grpcClient) Attest(attestRequest *AttestRequest) (*AttestResponse, error) {
 	response, err := m.client.Attest(context.Background(), attestRequest)
 	return response, err
 }

--- a/pkg/server/nodeattestor/interface.go
+++ b/pkg/server/nodeattestor/interface.go
@@ -17,29 +17,29 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "CPNodeAttestor",
 }
 
-type NodeAttestor interface {
+type Interface interface {
 	Configure(*sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error)
 	GetPluginInfo(*sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error)
 	Attest(*AttestRequest) (*AttestResponse, error)
 }
 
-type NodeAttestorPlugin struct {
-	NodeAttestorImpl NodeAttestor
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p NodeAttestorPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeAttestorPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeAttestorPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterNodeAttestorServer(s, &GRPCServer{NodeAttestorImpl: p.NodeAttestorImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterNodeAttestorServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p NodeAttestorPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewNodeAttestorClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewNodeAttestorClient(c)}, nil
 }

--- a/pkg/server/noderesolver/grpc.go
+++ b/pkg/server/noderesolver/grpc.go
@@ -6,30 +6,30 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	NodeResolverImpl NodeResolver
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.NodeResolverImpl.Configure(req.Configuration)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req.Configuration)
 	return &sriplugin.ConfigureResponse{ErrorList: response}, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.NodeResolverImpl.GetPluginInfo()
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo()
 	return response, err
 }
 
-func (m *GRPCServer) Resolve(ctx context.Context, req *ResolveRequest) (*ResolveResponse, error) {
-	resolutionMap, err := m.NodeResolverImpl.Resolve(req.BaseSpiffeIdList)
+func (m *grpcServer) Resolve(ctx context.Context, req *ResolveRequest) (*ResolveResponse, error) {
+	resolutionMap, err := m.delegate.Resolve(req.BaseSpiffeIdList)
 	return &ResolveResponse{Map: resolutionMap}, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client NodeResolverClient
 }
 
-func (m *GRPCClient) Configure(configuration string) ([]string, error) {
+func (m *grpcClient) Configure(configuration string) ([]string, error) {
 	response, err := m.client.Configure(context.Background(), &sriplugin.ConfigureRequest{configuration})
 	if err != nil {
 		return []string{}, err
@@ -37,12 +37,12 @@ func (m *GRPCClient) Configure(configuration string) ([]string, error) {
 	return response.ErrorList, err
 }
 
-func (m *GRPCClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
 	response, err := m.client.GetPluginInfo(context.Background(), &sriplugin.GetPluginInfoRequest{})
 	return response, err
 }
 
-func (m *GRPCClient) Resolve(physicalSpiffeIdList []string) (map[string]*common.Selectors, error) {
+func (m *grpcClient) Resolve(physicalSpiffeIdList []string) (map[string]*common.Selectors, error) {
 	node_res, err := m.client.Resolve(context.Background(), &ResolveRequest{
 		physicalSpiffeIdList})
 	return node_res.Map, err

--- a/pkg/server/noderesolver/interface.go
+++ b/pkg/server/noderesolver/interface.go
@@ -17,29 +17,29 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "NodeResolver",
 }
 
-type NodeResolver interface {
+type Interface interface {
 	Configure(config string) ([]string, error)
 	GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error)
 	Resolve([]string) (map[string]*common.Selectors, error)
 }
 
-type NodeResolverPlugin struct {
-	NodeResolverImpl NodeResolver
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p NodeResolverPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeResolverPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p NodeResolverPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterNodeResolverServer(s, &GRPCServer{NodeResolverImpl: p.NodeResolverImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterNodeResolverServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p NodeResolverPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewNodeResolverClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewNodeResolverClient(c)}, nil
 }

--- a/pkg/server/upstreamca/grpc.go
+++ b/pkg/server/upstreamca/grpc.go
@@ -5,30 +5,30 @@ import (
 	"golang.org/x/net/context"
 )
 
-type GRPCServer struct {
-	UpstreamCaImpl UpstreamCa
+type grpcServer struct {
+	delegate Interface
 }
 
-func (m *GRPCServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	response, err := m.UpstreamCaImpl.Configure(req.Configuration)
+func (m *grpcServer) Configure(ctx context.Context, req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
+	response, err := m.delegate.Configure(req.Configuration)
 	return &sriplugin.ConfigureResponse{ErrorList: response}, err
 }
 
-func (m *GRPCServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
-	response, err := m.UpstreamCaImpl.GetPluginInfo()
+func (m *grpcServer) GetPluginInfo(ctx context.Context, req *sriplugin.GetPluginInfoRequest) (*sriplugin.GetPluginInfoResponse, error) {
+	response, err := m.delegate.GetPluginInfo()
 	return response, err
 }
 
-func (m *GRPCServer) SubmitCSR(ctx context.Context, req *SubmitCSRRequest) (*SubmitCSRResponse, error) {
-	response, err := m.UpstreamCaImpl.SubmitCSR(req.Csr)
+func (m *grpcServer) SubmitCSR(ctx context.Context, req *SubmitCSRRequest) (*SubmitCSRResponse, error) {
+	response, err := m.delegate.SubmitCSR(req.Csr)
 	return response, err
 }
 
-type GRPCClient struct {
+type grpcClient struct {
 	client UpstreamCAClient
 }
 
-func (m *GRPCClient) Configure(configuration string) ([]string, error) {
+func (m *grpcClient) Configure(configuration string) ([]string, error) {
 	response, err := m.client.Configure(context.Background(), &sriplugin.ConfigureRequest{configuration})
 	if err != nil {
 		return []string{}, err
@@ -36,12 +36,12 @@ func (m *GRPCClient) Configure(configuration string) ([]string, error) {
 	return response.ErrorList, err
 }
 
-func (m *GRPCClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
+func (m *grpcClient) GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error) {
 	response, err := m.client.GetPluginInfo(context.Background(), &sriplugin.GetPluginInfoRequest{})
 	return response, err
 }
 
-func (m *GRPCClient) SubmitCSR(csr []byte) (*SubmitCSRResponse, error) {
+func (m *grpcClient) SubmitCSR(csr []byte) (*SubmitCSRResponse, error) {
 	response, err := m.client.SubmitCSR(context.Background(), &SubmitCSRRequest{Csr: csr})
 	return response, err
 }

--- a/pkg/server/upstreamca/interface.go
+++ b/pkg/server/upstreamca/interface.go
@@ -16,29 +16,29 @@ var Handshake = plugin.HandshakeConfig{
 	MagicCookieValue: "UpstreamCA",
 }
 
-type UpstreamCa interface {
+type Interface interface {
 	Configure(config string) ([]string, error)
 	GetPluginInfo() (*sriplugin.GetPluginInfoResponse, error)
 	SubmitCSR([]byte) (*SubmitCSRResponse, error)
 }
 
-type UpstreamCaPlugin struct {
-	UpstreamCaImpl UpstreamCa
+type Plugin struct {
+	Delegate Interface
 }
 
-func (p UpstreamCaPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+func (p Plugin) Server(*plugin.MuxBroker) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p UpstreamCaPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+func (p Plugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
 	return empty.Empty{}, nil
 }
 
-func (p UpstreamCaPlugin) GRPCServer(s *grpc.Server) error {
-	RegisterUpstreamCAServer(s, &GRPCServer{UpstreamCaImpl: p.UpstreamCaImpl})
+func (p Plugin) GRPCServer(s *grpc.Server) error {
+	RegisterUpstreamCAServer(s, &grpcServer{delegate: p.Delegate})
 	return nil
 }
 
-func (p UpstreamCaPlugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
-	return &GRPCClient{client: NewUpstreamCAClient(c)}, nil
+func (p Plugin) GRPCClient(c *grpc.ClientConn) (interface{}, error) {
+	return &grpcClient{client: NewUpstreamCAClient(c)}, nil
 }

--- a/plugin/agent/keymanager-memory/memory.go
+++ b/plugin/agent/keymanager-memory/memory.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/hashicorp/go-plugin"
-	"github.com/spiffe/sri/pkg/common/plugin"
 	"github.com/spiffe/sri/pkg/agent/keymanager"
+	"github.com/spiffe/sri/pkg/common/plugin"
 )
 
 type MemoryPlugin struct{}
@@ -28,7 +28,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: keymanager.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"km_memory": keymanager.KeyManagerPlugin{KeyManagerImpl: &MemoryPlugin{}},
+			"km_memory": keymanager.Plugin{Delegate: &MemoryPlugin{}},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/agent/nodeattestor-jointoken/join_token.go
+++ b/plugin/agent/nodeattestor-jointoken/join_token.go
@@ -7,8 +7,8 @@ import (
 	"path"
 
 	"github.com/hashicorp/go-plugin"
-	"github.com/spiffe/sri/pkg/common/plugin"
 	"github.com/spiffe/sri/pkg/agent/nodeattestor"
+	"github.com/spiffe/sri/pkg/common/plugin"
 )
 
 type JoinTokenConfig struct {
@@ -78,7 +78,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: nodeattestor.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"join_token": nodeattestor.NodeAttestorPlugin{NodeAttestorImpl: &JoinTokenPlugin{}},
+			"join_token": nodeattestor.Plugin{Delegate: &JoinTokenPlugin{}},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/agent/workloadattestor-secretfile/secret_file.go
+++ b/plugin/agent/workloadattestor-secretfile/secret_file.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"github.com/hashicorp/go-plugin"
-	"github.com/spiffe/sri/pkg/common/plugin"
 	"github.com/spiffe/sri/pkg/agent/workloadattestor"
+	"github.com/spiffe/sri/pkg/common/plugin"
 )
 
 type SecretFilePlugin struct{}
@@ -24,7 +24,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: workloadattestor.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"wla_secret_file": workloadattestor.WorkloadAttestorPlugin{WorkloadAttestorImpl: &SecretFilePlugin{}},
+			"wla_secret_file": workloadattestor.Plugin{Delegate: &SecretFilePlugin{}},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/server/ca-memory/memory.go
+++ b/plugin/server/ca-memory/memory.go
@@ -184,7 +184,7 @@ func (m *memoryPlugin) LoadCertificate(certPEM []byte) error {
 	return nil
 }
 
-func NewWithDefault() (ca.ControlPlaneCa, error) {
+func NewWithDefault() (ca.Interface, error) {
 	config := defaultConfig()
 	key, err := rsa.GenerateKey(rand.Reader, config.KeySize)
 	if err != nil {
@@ -193,7 +193,7 @@ func NewWithDefault() (ca.ControlPlaneCa, error) {
 	return NewWithConfig(config, key)
 }
 
-func NewWithConfig(config *configuration, key *rsa.PrivateKey) (ca.ControlPlaneCa, error) {
+func NewWithConfig(config *configuration, key *rsa.PrivateKey) (ca.Interface, error) {
 	return &memoryPlugin{
 		key:    key,
 		mtx:    &sync.RWMutex{},
@@ -232,8 +232,8 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: ca.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"ca": ca.ControlPlaneCaPlugin{
-				ControlPlaneCaImpl: cax,
+			"ca": ca.Plugin{
+				Delegate: cax,
 			},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,

--- a/plugin/server/ca-memory/memory_test.go
+++ b/plugin/server/ca-memory/memory_test.go
@@ -68,7 +68,7 @@ func TestMemory_bootstrap(t *testing.T) {
 	assert.NotEmpty(t, wcert)
 }
 
-func createDefault(t *testing.T) ca.ControlPlaneCa {
+func createDefault(t *testing.T) ca.Interface {
 	m, err := NewWithDefault()
 	require.NoError(t, err)
 	return m

--- a/plugin/server/datastore-sqlite/sqlite.go
+++ b/plugin/server/datastore-sqlite/sqlite.go
@@ -486,7 +486,7 @@ func (sqlitePlugin) GetPluginInfo(*sriplugin.GetPluginInfoRequest) (*sriplugin.G
 	return &pluginInfo, nil
 }
 
-func New() (datastore.DataStore, error) {
+func New() (datastore.Interface, error) {
 	db, err := gorm.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, err
@@ -513,7 +513,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: datastore.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"datastore": datastore.DataStorePlugin{DataStoreImpl: impl},
+			"datastore": datastore.Plugin{Delegate: impl},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/server/datastore-sqlite/sqlite_test.go
+++ b/plugin/server/datastore-sqlite/sqlite_test.go
@@ -288,7 +288,7 @@ func Test_DeleteNodeResolverMapEntry_all(t *testing.T) {
 func Test_RectifyNodeResolverMapEntries(t *testing.T) {
 }
 
-func createNodeResolverMapEntries(t *testing.T, ds datastore.DataStore) []*datastore.NodeResolverMapEntry {
+func createNodeResolverMapEntries(t *testing.T, ds datastore.Interface) []*datastore.NodeResolverMapEntry {
 	entries := []*datastore.NodeResolverMapEntry{
 		{
 			BaseSpiffeId: "main",
@@ -419,7 +419,7 @@ func Test_GetPluginInfo(t *testing.T) {
 	require.NotNil(t, resp)
 }
 
-func createDefault(t *testing.T) datastore.DataStore {
+func createDefault(t *testing.T) datastore.Interface {
 	ds, err := New()
 	if err != nil {
 		t.Fatal(err)

--- a/plugin/server/nodeattestor-jointoken/join_token.go
+++ b/plugin/server/nodeattestor-jointoken/join_token.go
@@ -104,7 +104,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: nodeattestor.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"join_token": nodeattestor.NodeAttestorPlugin{NodeAttestorImpl: p},
+			"join_token": nodeattestor.Plugin{Delegate: p},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/server/noderesolver-noop/noop.go
+++ b/plugin/server/noderesolver-noop/noop.go
@@ -25,7 +25,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: noderesolver.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"nr_noop": noderesolver.NodeResolverPlugin{NodeResolverImpl: &NoOp{}},
+			"nr_noop": noderesolver.Plugin{Delegate: &NoOp{}},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/server/upstreamca-memory/main.go
+++ b/plugin/server/upstreamca-memory/main.go
@@ -14,7 +14,7 @@ func main() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: upstreamca.Handshake,
 		Plugins: map[string]plugin.Plugin{
-			"upstreamca": upstreamca.UpstreamCaPlugin{UpstreamCaImpl: ca},
+			"upstreamca": upstreamca.Plugin{Delegate: ca},
 		},
 		GRPCServer: plugin.DefaultGRPCServer,
 	})

--- a/plugin/server/upstreamca-memory/pkg/ca.go
+++ b/plugin/server/upstreamca-memory/pkg/ca.go
@@ -117,7 +117,7 @@ func (m *memoryPlugin) SubmitCSR(csrPEM []byte) (*upstreamca.SubmitCSRResponse, 
 	}, nil
 }
 
-func NewWithDefault() (upstreamca.UpstreamCa, error) {
+func NewWithDefault() (upstreamca.Interface, error) {
 	m := &memoryPlugin{
 		mtx: &sync.RWMutex{},
 	}

--- a/plugin/server/upstreamca-memory/pkg/ca_test.go
+++ b/plugin/server/upstreamca-memory/pkg/ca_test.go
@@ -24,7 +24,7 @@ func TestMemory_SubmitCSR(t *testing.T) {
 	t.SkipNow()
 }
 
-func createDefault(t *testing.T) upstreamca.UpstreamCa {
+func createDefault(t *testing.T) upstreamca.Interface {
 	m, err := pkg.NewWithDefault()
 	require.NoError(t, err)
 	return m

--- a/services/registration.go
+++ b/services/registration.go
@@ -11,18 +11,18 @@ type Registration interface {
 	FetchEntry(registeredID string) (entry *common.RegistrationEntry, err error)
 }
 
-//RegistrationImpl is an implementation of the Registration interface.
-type RegistrationImpl struct {
-	dataStore ds.DataStore
+//registrationImpl is an implementation of the Registration interface.
+type registrationImpl struct {
+	dataStore ds.Interface
 }
 
-//NewRegistrationImpl creastes a new RegistrationImpl.
-func NewRegistrationImpl(dataStore ds.DataStore) RegistrationImpl {
-	return RegistrationImpl{dataStore: dataStore}
+//NewRegistration creastes a new Registration.
+func NewRegistration(dataStore ds.Interface) Registration {
+	return registrationImpl{dataStore: dataStore}
 }
 
 //CreateEntry with the DataStore plugin.
-func (r RegistrationImpl) CreateEntry(entry *common.RegistrationEntry) (string, error) {
+func (r registrationImpl) CreateEntry(entry *common.RegistrationEntry) (string, error) {
 	dsEntry := &ds.RegisteredEntry{
 		ParentId: entry.ParentId,
 		SpiffeId: entry.SpiffeId,
@@ -50,7 +50,7 @@ func (r RegistrationImpl) CreateEntry(entry *common.RegistrationEntry) (string, 
 }
 
 //FetchEntry gets a RegisteredEntry based on a registeredID.
-func (r RegistrationImpl) FetchEntry(registeredID string) (*common.RegistrationEntry, error) {
+func (r registrationImpl) FetchEntry(registeredID string) (*common.RegistrationEntry, error) {
 	response, err := r.dataStore.FetchRegistrationEntry(&ds.FetchRegistrationEntryRequest{RegisteredEntryId: registeredID})
 
 	if err != nil {


### PR DESCRIPTION
quick refactor for naming change proposal.

 * take advantage of package qualifiers to remove verbosity (`upstreamca.UpstreamCaPlugin` -> `upstreamca.Plugin`)
 * consistent, less verbose field names when possible (`UpstreamCaPlugin.UpstreamCaPluginImpl` -> `Plugin.Delegate`).
 * limit visibility of structs that don't need to be exported (`GRPCServer` -> `grpcServer`).
 * small changes from my editor running go format on edited files.