### PR TITLE
Avoid the use of PEM encoding if not needed

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -7,7 +7,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -292,7 +291,7 @@ func (a *Agent) Attest() error {
 
 // Generate a CSR for the given SPIFFE ID
 func (a *Agent) GenerateCSR(spiffeID *url.URL) ([]byte, error) {
-	a.Config.Logger.Log("msg", "Generating a CSR for %s", spiffeID.String())
+	a.Config.Logger.Log("msg", "Generating CSR", "SPIFFE_ID", spiffeID.String())
 
 	uriSANs, err := uri.MarshalUriSANs([]string{spiffeID.String()})
 	if err != nil {
@@ -315,7 +314,7 @@ func (a *Agent) GenerateCSR(spiffeID *url.URL) ([]byte, error) {
 		return nil, err
 	}
 
-	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr}), nil
+	return csr, nil
 }
 
 // Read base SVID from data dir and load it
@@ -353,10 +352,8 @@ func (a *Agent) StoreBaseSVID() {
 		return
 	}
 
-	err = pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: a.BaseSVID})
-	if err != nil {
-		a.Config.Logger.Log("msg", "Unable to store Base SVID at path %s!", certPath)
-	}
+	f.Write(a.BaseSVID)
+	f.Sync()
 
 	return
 }

--- a/plugin/server/ca-memory/memory.go
+++ b/plugin/server/ca-memory/memory.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"log"
@@ -62,7 +61,7 @@ type memoryPlugin struct {
 }
 
 func (m *memoryPlugin) Configure(req *sriplugin.ConfigureRequest) (*sriplugin.ConfigureResponse, error) {
-	log.Print("Stating Configure")
+	log.Print("Starting Configure")
 
 	resp := &sriplugin.ConfigureResponse{}
 
@@ -133,17 +132,12 @@ func (m *memoryPlugin) SignCsr(request *ca.SignCsrRequest) (*ca.SignCsrResponse,
 		BasicConstraintsValid: true,
 	}
 
-	cert, err := x509.CreateCertificate(rand.Reader,
+	signedCertificate, err := x509.CreateCertificate(rand.Reader,
 		&template, m.cert, csr.PublicKey, m.key)
 
 	if err != nil {
 		return nil, err
 	}
-
-	signedCertificate := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert,
-	})
 
 	log.Print("Certificate successfully created")
 	return &ca.SignCsrResponse{SignedCertificate: signedCertificate}, nil
@@ -193,13 +187,8 @@ func (m *memoryPlugin) GenerateCsr(*ca.GenerateCsrRequest) (*ca.GenerateCsrRespo
 		return nil, err
 	}
 
-	csrPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE REQUEST",
-		Bytes: csr,
-	})
-
 	log.Printf("CSR with SPIFFE ID: '%v' successfully generated", spiffeID.String())
-	return &ca.GenerateCsrResponse{Csr: csrPEM}, nil
+	return &ca.GenerateCsrResponse{Csr: csr}, nil
 }
 
 func (m *memoryPlugin) FetchCertificate(request *ca.FetchCertificateRequest) (*ca.FetchCertificateResponse, error) {
@@ -214,19 +203,14 @@ func (m *memoryPlugin) FetchCertificate(request *ca.FetchCertificateRequest) (*c
 		return &ca.FetchCertificateResponse{}, nil
 	}
 
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: m.cert.Raw,
-	})
-
 	certUris, err := uri.GetURINamesFromCertificate(m.cert)
 	if err != nil && len(certUris) > 0 {
 		log.Printf("Certificate with SPIFFE ID: '%v' found", certUris[0])
 	} else {
-		log.Print ("The signing certificate loaded does not have a SPIFFE ID!")
+		log.Print("The signing certificate loaded does not have a SPIFFE ID!")
 	}
 
-	return &ca.FetchCertificateResponse{StoredIntermediateCert: certPEM}, nil
+	return &ca.FetchCertificateResponse{StoredIntermediateCert: m.cert.Raw}, nil
 }
 
 func (m *memoryPlugin) LoadCertificate(request *ca.LoadCertificateRequest) (response *ca.LoadCertificateResponse, err error) {
@@ -240,17 +224,7 @@ func (m *memoryPlugin) LoadCertificate(request *ca.LoadCertificateRequest) (resp
 
 	m.key = m.newKey
 
-	block, rest := pem.Decode(request.SignedIntermediateCert)
-
-	if block == nil {
-		return &ca.LoadCertificateResponse{}, errors.New("Invalid cert format")
-	}
-
-	if len(rest) > 0 {
-		return &ca.LoadCertificateResponse{}, errors.New("Invalid cert format: too many certs")
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
+	cert, err := x509.ParseCertificate(request.SignedIntermediateCert)
 	if err != nil {
 		return &ca.LoadCertificateResponse{}, err
 	}

--- a/plugin/server/upstreamca-memory/pkg/ca.go
+++ b/plugin/server/upstreamca-memory/pkg/ca.go
@@ -177,31 +177,16 @@ func (m *memoryPlugin) SubmitCSR(request *upstreamca.SubmitCSRRequest) (*upstrea
 		return nil, err
 	}
 
-	certPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: cert,
-	})
-
-	upstreamTrustBundlePEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: m.cert.Raw,
-	})
-
 	log.Print("Successfully created certificate")
 
 	return &upstreamca.SubmitCSRResponse{
-		Cert: certPEM,
-		UpstreamTrustBundle: upstreamTrustBundlePEM,
+		Cert: cert,
+		UpstreamTrustBundle: m.cert.Raw,
 	}, nil
 }
 
-func ParseSpiffeCsr(csrPEM []byte, trustDomain string) (csr *x509.CertificateRequest, err error) {
-	block, rest := pem.Decode(csrPEM)
-	if len(rest) > 0 {
-		return nil, fmt.Errorf("Invalid CSR format: %s", rest)
-	}
-
-	csr, err = x509.ParseCertificateRequest(block.Bytes)
+func ParseSpiffeCsr(csrDER []byte, trustDomain string) (csr *x509.CertificateRequest, err error) {
+	csr, err = x509.ParseCertificateRequest(csrDER)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/server/upstreamca-memory/pkg/ca_test.go
+++ b/plugin/server/upstreamca-memory/pkg/ca_test.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"encoding/pem"
 	"io/ioutil"
 	"path/filepath"
 	"sync"
@@ -44,9 +45,12 @@ func TestMemory_SubmitValidCSR(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, validCsrFile := range validCsrFiles {
-		csr, err := ioutil.ReadFile(filepath.Join(testDataDir, validCsrFile.Name()))
+		csrPEM, err := ioutil.ReadFile(filepath.Join(testDataDir, validCsrFile.Name()))
 		require.NoError(t, err)
-		resp, err := m.SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: csr})
+		block, rest := pem.Decode(csrPEM)
+		assert.Len(t, rest, 0)
+
+		resp, err := m.SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: block.Bytes})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 	}
@@ -60,9 +64,12 @@ func TestMemory_SubmitInvalidCSR(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, validCsrFile := range validCsrFiles {
-		csr, err := ioutil.ReadFile(filepath.Join(testDataDir, validCsrFile.Name()))
+		csrPEM, err := ioutil.ReadFile(filepath.Join(testDataDir, validCsrFile.Name()))
 		require.NoError(t, err)
-		resp, err := m.SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: csr})
+		block, rest := pem.Decode(csrPEM)
+		assert.Len(t, rest, 0)
+
+		resp, err := m.SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: block.Bytes})
 		require.Error(t, err)
 		require.Nil(t, resp)
 	}

--- a/services/attestation.go
+++ b/services/attestation.go
@@ -2,8 +2,6 @@ package services
 
 import (
 	"crypto/x509"
-	"encoding/pem"
-	"errors"
 	"time"
 
 	"github.com/spiffe/sri/pkg/common"
@@ -57,7 +55,7 @@ func (att *AttestationImpl) Attest(attestedData *common.AttestedData, attestedBe
 }
 
 func (att *AttestationImpl) CreateEntry(attestationType string, baseSpiffeID string, certBytes []byte) (err error) {
-	cert, err := parsePEMBytes(certBytes)
+	cert, err := x509.ParseCertificate(certBytes)
 	if err != nil {
 		return err
 	}
@@ -73,7 +71,7 @@ func (att *AttestationImpl) CreateEntry(attestationType string, baseSpiffeID str
 }
 
 func (att *AttestationImpl) UpdateEntry(baseSpiffeID string, certBytes []byte) (err error) {
-	cert, err := parsePEMBytes(certBytes)
+	cert, err := x509.ParseCertificate(certBytes)
 	if err != nil {
 		return err
 	}
@@ -84,17 +82,4 @@ func (att *AttestationImpl) UpdateEntry(baseSpiffeID string, certBytes []byte) (
 		CertSerialNumber:   cert.SerialNumber.String(),
 	})
 	return err
-}
-
-func parsePEMBytes(bytes []byte) (*x509.Certificate, error) {
-	pemBlock, rest := pem.Decode(bytes)
-	if pemBlock == nil || len(rest) > 0 {
-		return nil, errors.New("Error decoding CA response")
-	}
-	cert, err := x509.ParseCertificate(pemBlock.Bytes)
-	if err != nil {
-		return nil, err
-	}
-
-	return cert, nil
 }

--- a/services/ca.go
+++ b/services/ca.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"crypto/x509"
-	"encoding/pem"
 	"errors"
 
 	"github.com/spiffe/go-spiffe/uri"
@@ -32,9 +31,8 @@ func (ca *CAImpl) SignCsr(request *ca.SignCsrRequest) (response *ca.SignCsrRespo
 
 //GetSpiffeIDFromCSR extracts an SpiffeID from a CSR
 func (ca *CAImpl) GetSpiffeIDFromCSR(csr []byte) (spiffeID string, err error) {
-	block, _ := pem.Decode(csr)
 	var parsedCSR *x509.CertificateRequest
-	if parsedCSR, err = x509.ParseCertificateRequest(block.Bytes); err != nil {
+	if parsedCSR, err = x509.ParseCertificateRequest(csr); err != nil {
 		return spiffeID, err
 	}
 


### PR DESCRIPTION
- Avoid the use of PEM encoding when is not needed. This is to address #101
- Minor fixes for logging messages