### PR TITLE
Simple change to add go:generate comments to run mockgen

### DIFF
--- a/services/attestation.go
+++ b/services/attestation.go
@@ -1,5 +1,7 @@
 package services
 
+//go:generate mockgen -source=$GOFILE -destination=attestation_mock.go -package=$GOPACKAGE
+
 import (
 	"crypto/x509"
 	"time"

--- a/services/ca.go
+++ b/services/ca.go
@@ -1,5 +1,7 @@
 package services
 
+//go:generate mockgen -source=$GOFILE -destination=ca_mock.go -package=$GOPACKAGE
+
 import (
 	"crypto/x509"
 	"errors"

--- a/services/identity.go
+++ b/services/identity.go
@@ -1,5 +1,7 @@
 package services
 
+//go:generate mockgen -source=$GOFILE -destination=identity_mock.go -package=$GOPACKAGE
+
 import (
 	"github.com/spiffe/spire/pkg/common"
 	"github.com/spiffe/spire/pkg/server/datastore"


### PR DESCRIPTION
Add //go:generate comments to the source files of the  *_mock.go files. This way, they can be easily generated just running `go generate`, or with a click from the IDE. Also, is easier to figure out that the files generate code that needs to be updated if the source file changes.
- https://blog.golang.org/generate