### PR TITLE
docker/build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ cache:
 
 script:
     - ./build.sh setup
-    - ./build.sh deps
+    - ./build.sh utils
+    - ./build.sh vendor
     - ./build.sh protobuf_verify
     - ./build.sh binaries
     - ./build.sh test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,16 @@
 FROM ubuntu:xenial
 
 RUN apt-get update
-
-RUN apt-get -y install \
-    software-properties-common python-software-properties
-
-RUN add-apt-repository ppa:longsleep/golang-backports
-RUN add-apt-repository ppa:masterminds/glide
-
-RUN apt-get update
-
 RUN apt-get -y install \
     curl unzip git build-essential
 
-RUN apt-get -y install golang-go glide
+COPY build.sh /root/
+ENV BUILD_DIR=/root/build
+RUN /root/build.sh setup
 
-RUN mkdir -p /root/go/src/github.com/spiffe/spire
-
-RUN ln -s ~/go/src/github.com/spiffe/spire/.build_cache ~/go/pkg
-
-ENV GOPATH /root/go
-ENV GOROOT /usr/lib/go/
-ENV PWD /root/go/src/github.com/spiffe/spire
-WORKDIR ${PWD}
+ENV GOPATH=/root/go
+ENV GOROOT=/root/build
+ENV GOBIN=$GOPATH/bin/linux_amd64
+ENV PATH=$GOROOT/bin:$GOBIN:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN mkdir /root/go
+WORKDIR /root/go/src/github.com/spiffe/spire

--- a/README.md
+++ b/README.md
@@ -14,150 +14,81 @@ dependencies and install them in $GOPATH/bin
 
 ## Configuring SPIRE
 
-All SPIRE component configuration files are in the Hashicorp [HCL](https://github.com/hashicorp/hcl)
-format. HCL is less verbose than JSON and permits comments. And unlike YAML, it does not suffer
-from the ambiguity of when to use a : versus a -.
+See the [server README](/cmd/spire-server/README.md) and the [agent
+README](/cmd/spire-agent/README.md)
 
-The SPIRE server and agent require a configuration file that includes:
-
-* `trustDomain` - the SPIFFE trust domain
-* `logFile` - the pathname to the logfile. This logfile is overwritten on every server start
-* `logLevel` - the verbosity level of the logs, which will default to NONE if not set to
-  DEBUG, INFO, WARN, or ERROR
-* The local TCP port that each plugin is listening on
-
-An example server configuration:
-```
-logFile = "spire-server.log"
-logLevel = "DEBUG"
-nodeAPIGRPCPort = "8086"
-registrationAPIGRPCPort ="8086"
-nodeAPIHTTPPort = "8086"
-registrationAPIHTTPPort ="8086"
-trustDomain = "spiffe://"
-```
-
-Each plugin also requires a configuration file that is read by the server
-or agent process in addition to the plugin itself. The configuration includes:
-
-* `pluginName` - the plugin name, which must match the string defined in plugin serverConfig
-* `pluginType` - plugin type, which must match the plugin name presented during the handshake
-* `pluginCmd` - path to the plugin binary
-* `pluginChecksum` - plugin checksum, if using
-* `enabled` - whether to load the plugin or not
-* `pluginData` - an arbitrary dictionary of additional configuration for the plugin
-
-Example configuration for the token-based Node Attester:
-
-```
-pluginName = "join_token"
-pluginType = "NodeAttestor"
-pluginCmd = "../../plugin/agent/nodeattestor-jointoken/nodeattestor-jointoken"
-pluginChecksum = ""
-enabled = true
-pluginData {
-  join_token = "NOT-A-SECRET"
-}
-```
-
-## Starting the server and agent
-
-The server and agent support two environment variables to set the location of their configuration:
-
-* `SPIRE_SERVER_CONFIG` - path to the .hcl file containing server configuration.
-  Defaults to `$PWD/.conf/default_server_config.hcl`
-* `SPIRE_AGENT_CONFIG_PATH` - path to the .hcl file containing agent configuration.
-  Defaults to `$PWD/.conf/default_agent_config.hcl`
-
-Both server and agent support:
-
-* `SPIRE_PLUGIN_CONFIG_DIR` - path to the directory containing per-plugin configuration files.
-  This directory must _only_ contain plugin configurations. Defaults to
-  `$PWD/../../plugin/server/.conf/` and `$PWD/../../plugin/agent/.conf`
-
-To start the agent:
-
-```
-SPIRE_PLUGIN_CONFIG_DIR=/etc/spire/pluginconf SPIRE_AGENT_CONFIG_PATH=/etc/spire/default_agent_config.hcl spire-agent start
-```
-
-The agent will run silently in the foreground, logging status to its logfile.
-
-
-## Building SPIRE for development
-
-### Docker vs Host development
-
-YOu can either develop Spire inside a docker container or on bare metal. In both cases you will use the same Makefile commands.
-
-To run in a docker container set the environment variable `SPIRE_DEV_HOST` to `docker` like so:
-
-`$: export SPIRE_DEV_HOST=docker`
-
-To run on bare metal leave this variable unset.
-
-When using the docker container build artifacts to speed up development are cached in the shared volume under the directory .build_cache.
-
-### Setup
-
-Spire is developed inside a docker container. To get up and running you will need the following installed
-
-1. [docker](https://docs.docker.com/engine/installation/)
-2. [git](https://git-scm.com/downloads) 
-
-All frequently used commands can be run through the Makefile.
-Once you have both of these, clone this repository and run from a terminal
-
-`$: make install`
-
-This will download and build a docker image from the `Dockerfile` in this directory. It will then install all
-go dependencies into the `vendor` sub-directory. Because the docker container shares the current directory you 
-will not have to re-install the go dependencies everytime you run the container.
-
-To run all the tests run:
-
-`$: make test`
-
-Other useful commands
-
-| command       | what does it do?  |
-| ------------- |:-------------:| 
-| image_build     | build the docker image | 
-| cmd      | Run /bin/bash in the container      | 
-| build | run `go build -i`      |
-| test | run `go test`      |
-| race-test | run `go test -race`      |
-| clean | cleans `vendor` directory, glide cache     |
-| install | installs the go dependencies using glide |
-
-### CI / Build.sh
-
-The script `build.sh` manages the build process and can be used for development. It expects
-this repo to be present at and to be run from `$GOPATH/src/github.com/spiffe/spire`. It has
-been tested on Linux only.
-
-* `build.sh setup` will download and install necessary dependencies (including golang)
-into the directory `.build/`.
-* `deps` processes the `glide.lock` file
-* `protobuf` will regenerate the gRPC pb.go and README.md files
-* `binaries` will build the main binary and the plugins
-* `test` will run the tests
-* `clean` remove built binaries and
-* `distclean` remove built binaries as well as the `.build` directory
-* `build.sh` with no options will list available functions
-* `eval $(build.sh env)` will configure GOPATH, GOROOT and PATH for development outside
-of `build.sh`
-
+## Building SPIRE
 
 ### Prerequisites
 
-* Linux or Docker
+For basic development you will need:
 
-If not using Docker, the following "non-standard" utilities are also required:
+* **Go** (https://golang.org/dl/)
+* **Glide**, for managing third-party dependancies (https://github.com/Masterminds/glide)
 
-* `curl`
-* `git`
-* `unzip`
+For development that requires changes to the gRPC interfaces you will need:
+
+* The protobuf compiler (https://github.com/google/protobuf)
+* The protobuf documentation generator (https://github.com/pseudomuto/protoc-gen-doc)
+* protoc-gen-go, protoc-gen-grpc-gateway and protoc-gen-swagger (`make utils`)
+
+
+###  Building
+
+It is assumed that this repository lives in $GOPATH/src/github.com/spiffe/spire on your local disk,
+and that your GOPATH only contains one element.
+
+Because of the use of Glide and the unusual layout of this repository a Makefile is provide for
+common actions.
+
+* `make all` - installs 3rd-party dependancies, build all binaries, and run all tests
+* `make build` - only builds binaries
+* `make cmd/spire-agent` - builds one binary
+* `make test` - runs all tests
+
+**Other Makefile targets**
+
+* `vendor` - installs 3rd-party dependencies using glide
+* `race-test` - run `go test -race`
+* `clean` - cleans `vendor` directory, glide cache
+* `distclean` - removes caches in addition to `make clean`
+* `utils` - installs gRPC related development utilities
+* `container` - builds the docker image
+* `cmd` - runs /bin/bash in the container
+
+### Development in Docker
+
+You can either build Spire on your host or in a Ubuntu docker container. In both cases you will use
+the same Makefile commands.
+
+To run in a docker container set the environment variable `SPIRE_DEV_HOST` to `docker` like so:
+
+```
+$: export SPIRE_DEV_HOST=docker
+```
+
+To set up the build container:
+
+```
+$: make container
+```
+
+This will download and build a docker image from the `Dockerfile` in this directory. Because the
+docker container shares $GOPATH you will not have to re-install the go dependencies every time you
+run the container. NOTE: any binaries installed from within the container will be located in
+$GOPATH/bin/linux_amd64 to avoid conflicts with the host OS. Packages are automatically versioned by
+golang into $GOPATH/pkg/\<os\>_\<arch\>
+
+### CI
+
+The script `build.sh` manages the CI build process, implementing several unique steps and sanity
+checks. It is also used to bootstrap the Docker container.
+
+* `setup` - download and install necessary build tools into the directory *.build-\<os\>-\<arch\>*
+* `protobuf` - regenerate the gRPC pb.go and README.md files
+* `protobuf_verify` - check that the checked-in generated code is up-to-date
+* `distclean` - calls `make distclean` and removes CI-related caches
+* `eval $(build.sh env)` - configure GOPATH, GOROOT and PATH to use the private build tool directory
 
 
 ### Git hooks

--- a/build.sh
+++ b/build.sh
@@ -3,28 +3,28 @@
 set -o errexit
 [[ -n $DEBUG ]] && set -o xtrace
 
-declare -r BINARY_DIRS="$(find cmd/* plugin/*/* -maxdepth 0 -type d)"
-declare -r PROTO_FILES="$(find pkg -name '*.proto')"
+declare -r BINARY_DIRS="$(find cmd/* plugin/*/* -maxdepth 0 -type d 2>/dev/null)"
+declare -r PROTO_FILES="$(find pkg -name '*.proto' 2>/dev/null)"
 
 case $(uname) in
     Darwin) declare -r OS1="darwin"
-			declare -r OS2="osx"
-			;;
-	Linux)  declare -r OS1="linux"
-			declare -r OS2="linux"
-			;;
+            declare -r OS2="osx"
+            ;;
+    Linux)  declare -r OS1="linux"
+            declare -r OS2="linux"
+            ;;
 esac
 
 case $(uname -m) in
-	x86_64) declare -r ARCH1="x86_64"
-			declare -r ARCH2="amd64"
-			;;
+    x86_64) declare -r ARCH1="x86_64"
+            declare -r ARCH2="amd64"
+            ;;
 esac
 
 declare -r BUILD_DIR=${BUILD_DIR:-$PWD/.build-${OS1}-${ARCH1}}
 declare -r BUILD_CACHE=${BUILD_CACHE:-$PWD/.cache}
 
-# versioned packages that we need
+# versioned binaries that we need for builds
 declare -r GO_VERSION=${GO_VERSION:-1.8.3}
 declare -r GO_URL="https://storage.googleapis.com/golang"
 declare -r GO_TGZ="go${GO_VERSION}.${OS1}-${ARCH2}.tar.gz"
@@ -38,12 +38,13 @@ declare -r PROTOC_GEN_DOCS_VERSION=${PROTOC_GEN_DOCS_VERSION:-1.0.0-beta}
 declare -r PROTOC_GEN_DOCS_URL="https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${PROTOC_GEN_DOCS_VERSION}"
 declare -r PROTOC_GEN_DOCS_TGZ="protoc-gen-doc-${PROTOC_GEN_DOCS_VERSION}.${OS1}-${ARCH2}.go1.8.1.tar.gz"
 
-[[ -n $CIRCLECI ]] && unset GOPATH
+[[ -n $TRAVIS ]] && unset GOPATH GOROOT
 
 _exit_error() { echo "ERROR: $*" 1>&2; exit 1; }
 _log_info() { echo "INFO: $*"; }
 
 _fetch_url() {
+    mkdir -p ${BUILD_CACHE}
     if [[ ! -r ${BUILD_CACHE}/${2} ]]; then
         _log_info "downloading \"${1}/${2}\""
         curl --output ${BUILD_CACHE}/${2} --location --silent ${1}/${2}
@@ -52,60 +53,59 @@ _fetch_url() {
     fi
 }
 
+## print export commands to set up the environment
+## to use our private set of tools
 build_env() {
     local _gp _gr
 
-    _gp="${GOPATH:-$HOME/go}"
-    _gr="${BUILD_DIR}/golang-${GO_VERSION}"
+    _gp="${GOPATH:-$HOME/gopath}"
+    _gr="${GOROOT:-$BUILD_DIR}"
     echo "export GOPATH=${_gp}"
-    echo "export GOROOT=${BUILD_DIR}/golang-${GO_VERSION}"
-    echo "export PATH=${_gr}/bin:${_gp}/bin:$(ls -d ${BUILD_DIR}/*/bin 2>/dev/null | tr '\n' ':')${PATH}"
+    echo "export GOROOT=${_gr}"
+    echo "export PATH=$(ls -d ${BUILD_DIR}/*/bin 2>/dev/null | tr '\n' ':'):${_gr}/bin:${_gp}/bin:${PATH}"
 }
 
+## fetch first-party versions of binaries we can not 'go get'
 build_setup() {
     eval $(build_env)
 
-    mkdir -p ${BUILD_CACHE} ${BUILD_DIR}
+    rm -rf ${BUILD_DIR}
+    mkdir -p ${BUILD_DIR}
 
-    rm -rf ${GOROOT}
-    mkdir -p ${GOROOT}
     _fetch_url ${GO_URL} ${GO_TGZ}
-    tar --directory ${GOROOT} --strip 1 -xf ${BUILD_CACHE}/${GO_TGZ}
+    tar --directory ${BUILD_DIR} --strip 1 -xf ${BUILD_CACHE}/${GO_TGZ}
 
-    rm -rf ${BUILD_DIR}/protobuf
-    mkdir -p ${BUILD_DIR}/protobuf
-    _fetch_url ${PROTOBUF_URL} ${PROTOBUF_TGZ}
-    unzip -qod ${BUILD_DIR}/protobuf ${BUILD_CACHE}/${PROTOBUF_TGZ}
-
-    rm -rf ${BUILD_DIR}/protoc-gen-doc
-    mkdir -p ${BUILD_DIR}/protoc-gen-doc/bin
-    _fetch_url ${PROTOC_GEN_DOCS_URL} ${PROTOC_GEN_DOCS_TGZ}
-    tar --directory ${BUILD_DIR}/protoc-gen-doc/bin --strip 1 -xf ${BUILD_CACHE}/${PROTOC_GEN_DOCS_TGZ}
-
-    rm -rf ${BUILD_DIR}/glide
-    mkdir -p ${BUILD_DIR}/glide/bin
     _fetch_url ${GLIDE_URL} ${GLIDE_TGZ}
-    tar --directory ${BUILD_DIR}/glide/bin --strip 1 -xf ${BUILD_CACHE}/${GLIDE_TGZ}
+    tar --directory ${BUILD_DIR}/bin --strip 1 -xf ${BUILD_CACHE}/${GLIDE_TGZ}
 
-	# tools the build needs, version is not important
-    go get github.com/golang/protobuf/protoc-gen-go
-    go get github.com/jstemmer/go-junit-report
-    go get github.com/AlekSi/gocoverutil
-    go get github.com/mattn/goveralls
-    go get github.com/jteeuwen/go-bindata/...
-    go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-    go get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+    _fetch_url ${PROTOC_GEN_DOCS_URL} ${PROTOC_GEN_DOCS_TGZ}
+    tar --directory ${BUILD_DIR}/bin --strip 1 -xf ${BUILD_CACHE}/${PROTOC_GEN_DOCS_TGZ}
+
+    _fetch_url ${PROTOBUF_URL} ${PROTOBUF_TGZ}
+    unzip -qod ${BUILD_DIR} ${BUILD_CACHE}/${PROTOBUF_TGZ}
 }
 
-build_deps() {
+## go-get extra utils needed for CI builds
+build_utils() {
     eval $(build_env)
 
-    glide --home ${BUILD_CACHE} install 2>&1 | tee /tmp/glide.out
+    make utils
+    go get github.com/AlekSi/gocoverutil
+    go get github.com/mattn/goveralls
+}
+
+## Fetch all vendored dependancies and check if the lock file
+## is up-to-date
+build_vendor() {
+    eval $(build_env)
+
+    make vendor 2>&1 | tee /tmp/glide.out
     if grep -q "Lock file may be out of date" /tmp/glide.out; then
         _exit_error "glide.lock file may be out of date"
     fi
 }
 
+## Rebuild all .proto files, generated README, and generated gRPC/REST interfaces
 build_protobuf() {
     local _n _d _dir _prefix="$1"
     eval $(build_env)
@@ -126,6 +126,7 @@ build_protobuf() {
         protoc --proto_path=${_dir} --proto_path=${GOPATH}/src \
             --proto_path=${GOPATH}/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
             --doc_out=markdown,README_pb.md:${_d} ${_n}
+        # only build gateway code if necessary
         if grep -q 'option (google.api.http)' ${_n}; then
             _log_info "creating http gateway \"${_n%.proto}.pb.gw.go\""
             protoc --proto_path=${_dir} --proto_path=${GOPATH}/src \
@@ -135,6 +136,8 @@ build_protobuf() {
     done
 }
 
+## Create a private copy of generated code and compare it to
+## what's checked in. Fail if there's a difference
 build_protobuf_verify() {
     local _n _result _tmp="$(mktemp -d)"
     eval $(build_env)
@@ -156,82 +159,73 @@ build_protobuf_verify() {
 }
 
 build_binaries() {
-    local _n _dirs="${1:-$BINARY_DIRS}"
     eval $(build_env)
-
-    for _n in ${_dirs}; do
-        _log_info "building in directory \"${_n}\""
-        ( cd $_n; go build ${DEBUG+-v} -i )
-    done
+    make build
 }
 
+## Run coverate tests and send to coveralls if this CI build
+## has been called by cron.
 build_test() {
-    local _test_path _result
     eval $(build_env)
 
-    _test_path=$(go list ./... | grep -v -e'/vendor')
-    if [[ -n ${CI} ]]; then
-        mkdir -p test_results
-        go test ${DEBUG+-v} -race ${_test_path} | tee test_results/report.raw
-        cat test_results/report.raw | go-junit-report > test_results/report.xml
-        if [[ -n ${COVERALLS_TOKEN} && ${TRAVIS_EVENT_TYPE} = cron ]]; then
-            gocoverutil -coverprofile=test_results/cover.out test -covermode=count ${_test_path}
-            goveralls -coverprofile=test_results/cover.out -service=circle-ci -repotoken=${COVERALLS_TOKEN}
-        fi
-    else
-        go test ${DEBUG+-v} -race ${_test_path}
+    make test
+    if [[ -n ${COVERALLS_TOKEN} && ${TRAVIS_EVENT_TYPE} = cron ]]; then
+        gocoverutil -coverprofile=test_results/cover.out test -covermode=count ${_test_path}
+        goveralls -coverprofile=test_results/cover.out -service=circle-ci -repotoken=${COVERALLS_TOKEN}
     fi
 }
 
+## Create a distributable tgz of all the binaries
 build_artifact() {
-	local _hash _libc _artifact _binaries _n _tmp
+    local _hash _libc _artifact _binaries _n _tmp
 
-	_binaries="$(find $BINARY_DIRS -executable -a -type f)"
+    _binaries="$(find $BINARY_DIRS -perm -u=x -a -type f)"
 
-	mkdir -p artifacts
+    mkdir -p artifacts
 
-	# handle the case that we're building for alpine
-	if [[ $OS1 == linux ]]; then
-		case $(ldd --version 2>&1) in
-			*GLIB*) _libc="-glibc" ;;
-			*muslr*) _libc="-musl" ;;
-			*) _libc="-unknown" ;;
-		esac
-	fi
-	_hash="$(git log -n1 --pretty=format:%h)"
-    _artifact="spire-${_hash}-${_os}-${ARCH1}${_libc}.tgz"
+    # handle the case that we're building for alpine
+    if [[ $OS1 == linux ]]; then
+        case $(ldd --version 2>&1) in
+            *GLIB*) _libc="-glibc" ;;
+            *muslr*) _libc="-musl" ;;
+            *) _libc="-unknown" ;;
+        esac
+    fi
+    _hash="$(git log -n1 --pretty=format:%h)"
+    _artifact="spire-${_hash}-${OS1}-${ARCH1}${_libc}.tgz"
 
     _log_info "creating artifact \"${_artifact}\""
 
-	_tmp=".tmp/spire"
-	rm -rf $_tmp
-	mkdir -p $_tmp
+    _tmp=".tmp/spire"
+    rm -rf $_tmp
+    mkdir -p $_tmp
 
-	# we munge the file structure a bit here
-	for _n in $_binaries; do
-		if [[ $_n == *cmd/* ]]; then
-			cp $_n $_tmp
-		elif [[ $_n == *plugin/* ]]; then
-			mkdir -p ${_tmp}/$(dirname $(dirname $_n))
-			cp -r $_n ${_tmp}/$(dirname $_n)
-		fi
-	done
+    # we munge the file structure a bit here
+    for _n in $_binaries; do
+        if [[ $_n == *cmd/* ]]; then
+            cp $_n $_tmp
+        elif [[ $_n == *plugin/* ]]; then
+            mkdir -p ${_tmp}/$(dirname $(dirname $_n))
+            cp -r $_n ${_tmp}/$(dirname $_n)
+        fi
+    done
 
     tar --directory .tmp -cvzf artifacts/${_artifact} .
 }
 
 build_clean() {
-    rm -f $(find ${BINARY_DIRS} -type f -perm '-u+x')
+    make clean
 }
 
 build_distclean() {
-    build_clean
-    rm -rf ${BUILD_CACHE} ${BUILD_DIR}
+    make distclean
+    # remove some additional directories
+    rm -rf ${BUILD_DIR}
 }
 
 build_all() {
     build_setup
-    build_deps
+    build_vendor
     build_binaries
     build_test
 }
@@ -240,7 +234,8 @@ build_all() {
 case "$1" in
     env) build_env ;;
     setup) build_setup ;;
-    deps) build_deps ;;
+    utils) build_utils ;;
+    vendor) build_vendor ;;
     protobuf) build_protobuf ;;
     protobuf_verify) build_protobuf_verify ;;
     binaries|bin) build_binaries $2 ;;


### PR DESCRIPTION
this PR does several things...

- build.sh calls out to Makefile where functionality overlaps
- Dockerfile uses build.sh to bootstrap itself the same as CI (./build.sh setup)
- the volume shared with the container starts at $GOPATH
- improves documentation / comments