### PR TITLE
Fix for upstreamca-memory plugin to address #144

### DIFF
--- a/plugin/server/upstreamca-memory/main.go
+++ b/plugin/server/upstreamca-memory/main.go
@@ -10,10 +10,7 @@ import (
 func main() {
 	log.Print("Starting plugin")
 
-	ca, err := pkg.NewWithDefault("../../plugin/server/upstreamca-memory/pkg/_test_data/keys/private_key.pem", "../../plugin/server/upstreamca-memory/pkg/_test_data/keys/cert.pem")
-	if err != nil {
-		panic(err.Error())
-	}
+	ca := pkg.NewEmpty()
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: upstreamca.Handshake,
 		Plugins: map[string]plugin.Plugin{

--- a/plugin/server/upstreamca-memory/pkg/ca.go
+++ b/plugin/server/upstreamca-memory/pkg/ca.go
@@ -244,3 +244,9 @@ func NewWithDefault(keyFilePath string, certFilePath string) (m upstreamca.Upstr
 
 	return m, err
 }
+
+func NewEmpty () (m upstreamca.UpstreamCa) {
+	return &memoryPlugin{
+		mtx:&sync.RWMutex{},
+	}
+}


### PR DESCRIPTION
- Do not use hardcoded paths when starting the upstreamca-memory plugin. This fixes #144 