### PR TITLE
Changed permission on unix socket for WL api.

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -174,6 +174,11 @@ func (a *Agent) initEndpoints() error {
 		return fmt.Errorf("Error creating GRPC listener: %s", err)
 	}
 
+	if addr.Network() == "unix" {
+		// Any process should be able to use this unix socket
+		os.Chmod(addr.String(), os.ModePerm)
+	}
+
 	go func() {
 		a.config.ErrorCh <- a.grpcServer.Serve(listener)
 	}()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -82,6 +82,20 @@ func (suite *AgentTestSuite) Testbootstrap() {
 	suite.Assert().Equal(expectedkey, suite.agent.baseSVIDKey)
 }
 
+func (suite *AgentTestSuite) TestSocketPermission() {
+	suite.agent = &Agent{
+		Catalog: suite.mockPluginCatalog,
+		config:  suite.config}
+
+	suite.agent.serverCerts = []*x509.Certificate{&x509.Certificate{}, &x509.Certificate{}}
+	err := suite.agent.initEndpoints()
+	suite.Require().NoError(err)
+
+	info, err := os.Stat("./spire_api")
+	suite.Require().NoError(err)
+	suite.Assert().Equal(os.ModePerm|os.ModeSocket, info.Mode())
+}
+
 // WIP(walmav)
 func TestAgent_FetchSVID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Sidecar sometimes is unable to consume WL API, depending on the UID of the process.

**Description of change**
Updated permission on Unix socket created for Agent's WL API so that any process can access it.

**Which issue this PR fixes**
Fixes #219.