### PR TITLE
fix for umask tests issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -177,6 +177,8 @@ build_test() {
 		for _n in ${SOURCE_PKGS}; do
 			go test -race -cover -covermode=atomic -coverprofile=test_results/$(echo $_n | sed 's/\//_/g').out ${_n}
 		done
+		# several tests set the umask to 000, which gets applied to the results files
+		chmod u+r test_results/*
 		gocoverutil -coverprofile=test_results/cover.report merge test_results/*.out
 		goveralls -coverprofile=test_results/cover.report -service=ci
 	else


### PR DESCRIPTION
umask tests were also setting the creation mode for the test
output files, making them unreadable

