### PR TITLE
Improved logs in node and workload attestors

### DIFF
--- a/cmd/spire-agent/cli/cli.go
+++ b/cmd/spire-agent/cli/cli.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"log"
-	"os"
 
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/command"
@@ -11,7 +10,7 @@ import (
 func Run(args []string) int {
 
 	c := cli.NewCLI("spire-agent", "0.0.1") //TODO expose version configuration
-	c.Args = os.Args[1:]
+	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
 		"run": func() (cli.Command, error) {
 			return &command.RunCommand{}, nil

--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -108,6 +108,13 @@ func (c *catalog) Plugins() []*common.ManagedPlugin {
 	return c.com.Plugins()
 }
 
+func (c *catalog) Find(plugin common.Plugin) *common.ManagedPlugin {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	return c.com.Find(plugin)
+}
+
 func (c *catalog) KeyManagers() []keymanager.KeyManager {
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/agent/workload_test.go
+++ b/pkg/agent/workload_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"sort"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/spiffe/spire/pkg/agent/cache"
+	common_catalog "github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/selector"
 	"github.com/spiffe/spire/proto/agent/workloadattestor"
 	"github.com/spiffe/spire/proto/api/node"
@@ -93,6 +95,36 @@ func (s *WorkloadServerTestSuite) TestAttestCaller() {
 		sort.Sort(got)
 		s.Assert().Equal(expected, got)
 	}
+}
+
+func (s *WorkloadServerTestSuite) TestAttestCallerError() {
+	var testPID int32 = 1000
+	pluginName := "WorkloadAttestor"
+	plugins := []workloadattestor.WorkloadAttestor{s.attestor1, s.attestor2}
+	pRequest := &workloadattestor.AttestRequest{Pid: testPID}
+	pRes1 := &workloadattestor.AttestResponse{Selectors: selector.Set{selector1}.Raw()}
+	pRes2 := &workloadattestor.AttestResponse{}
+	pError2 := errors.New("failed")
+	pInfo2 := &common_catalog.ManagedPlugin{
+		Config: common_catalog.PluginConfig{
+			PluginName: pluginName,
+		},
+	}
+
+	s.catalog.EXPECT().WorkloadAttestors().Return(plugins)
+	s.attestor1.EXPECT().Attest(pRequest).Return(pRes1, nil)
+	s.attestor2.EXPECT().Attest(pRequest).Return(pRes2, pError2)
+	s.catalog.EXPECT().Find(plugins[1].(common_catalog.Plugin)).Return(pInfo2)
+
+	selectors, errs := s.w.attestCaller(testPID)
+	s.Assert().NotNil(errs)
+	s.Assert().Equal(pError2, errs[pluginName])
+
+	expected := selector.Set{selector1}
+	got := selector.NewSet(selectors)
+	sort.Sort(expected)
+	sort.Sort(got)
+	s.Assert().Equal(expected, got)
 }
 
 func (s *WorkloadServerTestSuite) TestFindEntries() {

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -33,6 +33,9 @@ type Catalog interface {
 	// Plugins returns all plugins managed by this catalog as
 	// the generic Plugin type
 	Plugins() []*ManagedPlugin
+
+	// Finds plugin metadata
+	Find(Plugin) *ManagedPlugin
 }
 
 type Config struct {
@@ -135,6 +138,15 @@ func (c *catalog) Plugins() []*ManagedPlugin {
 		newSlice = append(newSlice, mp)
 	}
 	return newSlice
+}
+
+func (c *catalog) Find(plugin Plugin) *ManagedPlugin {
+	for _, p := range c.plugins {
+		if p.Plugin == plugin {
+			return p
+		}
+	}
+	return nil
 }
 
 func (c *catalog) loadConfigs() error {

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -118,6 +118,13 @@ func (c *catalog) Plugins() []*common.ManagedPlugin {
 	return c.com.Plugins()
 }
 
+func (c *catalog) Find(plugin common.Plugin) *common.ManagedPlugin {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	return c.com.Find(plugin)
+}
+
 func (c *catalog) CAs() []ca.ControlPlaneCa {
 	c.m.RLock()
 	defer c.m.RUnlock()

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -103,6 +103,10 @@ func (s *nodeServer) FetchBaseSVID(
 		return response, errors.New("Error trying to compose response")
 	}
 
+	s.l.Info("Received node attestation request from ", baseSpiffeIDFromCSR,
+		" using strategy '", request.AttestedData.Type,
+		"' completed successfully. SVID issued with TTL=", s.baseSpiffeIDTTL)
+
 	return response, nil
 }
 

--- a/test/mock/agent/catalog/catalog.go
+++ b/test/mock/agent/catalog/catalog.go
@@ -5,12 +5,13 @@
 package mock_catalog
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	catalog "github.com/spiffe/spire/pkg/common/catalog"
 	keymanager "github.com/spiffe/spire/proto/agent/keymanager"
 	nodeattestor "github.com/spiffe/spire/proto/agent/nodeattestor"
 	workloadattestor "github.com/spiffe/spire/proto/agent/workloadattestor"
-	reflect "reflect"
 )
 
 // MockCatalog is a mock of Catalog interface
@@ -34,6 +35,18 @@ func NewMockCatalog(ctrl *gomock.Controller) *MockCatalog {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockCatalog) EXPECT() *MockCatalogMockRecorder {
 	return m.recorder
+}
+
+// Find mocks base method
+func (m *MockCatalog) Find(arg0 catalog.Plugin) *catalog.ManagedPlugin {
+	ret := m.ctrl.Call(m, "Find", arg0)
+	ret0, _ := ret[0].(*catalog.ManagedPlugin)
+	return ret0
+}
+
+// Find indicates an expected call of Find
+func (mr *MockCatalogMockRecorder) Find(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockCatalog)(nil).Find), arg0)
 }
 
 // KeyManagers mocks base method

--- a/test/mock/server/catalog/catalog.go
+++ b/test/mock/server/catalog/catalog.go
@@ -5,6 +5,8 @@
 package mock_catalog
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	catalog "github.com/spiffe/spire/pkg/common/catalog"
 	ca "github.com/spiffe/spire/proto/server/ca"
@@ -12,7 +14,6 @@ import (
 	nodeattestor "github.com/spiffe/spire/proto/server/nodeattestor"
 	noderesolver "github.com/spiffe/spire/proto/server/noderesolver"
 	upstreamca "github.com/spiffe/spire/proto/server/upstreamca"
-	reflect "reflect"
 )
 
 // MockCatalog is a mock of Catalog interface
@@ -60,6 +61,18 @@ func (m *MockCatalog) DataStores() []datastore.DataStore {
 // DataStores indicates an expected call of DataStores
 func (mr *MockCatalogMockRecorder) DataStores() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataStores", reflect.TypeOf((*MockCatalog)(nil).DataStores))
+}
+
+// Find mocks base method
+func (m *MockCatalog) Find(arg0 catalog.Plugin) *catalog.ManagedPlugin {
+	ret := m.ctrl.Call(m, "Find", arg0)
+	ret0, _ := ret[0].(*catalog.ManagedPlugin)
+	return ret0
+}
+
+// Find indicates an expected call of Find
+func (mr *MockCatalogMockRecorder) Find(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockCatalog)(nil).Find), arg0)
 }
 
 // NodeAttestors mocks base method


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Improved logs in node and workload attestation.

**Description of change**
Improved logs during node attestation, particularly strategy used (plugin name) was added (#213).
Also fixed workload attestor plugin error logging (#190).
To make these changes a new function `Find` was added in plugin catalog to get plugin metadata from a given plugin interface. Suggestions for a better name for `Find` are welcome.

**Which issue this PR fixes**
Fixes #213. Fixes #190.

