### PR TITLE
Fixed sqlite in memory issue.

### DIFF
--- a/plugin/server/datastore-sqlite/sqlite.go
+++ b/plugin/server/datastore-sqlite/sqlite.go
@@ -648,7 +648,24 @@ func (ds *sqlitePlugin) convertEntries(fetchedRegisteredEntries []registeredEntr
 }
 
 func New() (datastore.DataStore, error) {
-	db, err := gorm.Open("sqlite3", ":memory:")
+	db, err := gorm.Open("sqlite3", "file::memory:?cache=shared")
+	if err != nil {
+		return nil, err
+	}
+
+	db.LogMode(true)
+
+	if err := migrateDB(db); err != nil {
+		return nil, err
+	}
+
+	return &sqlitePlugin{
+		db: db,
+	}, nil
+}
+
+func NewTemp() (datastore.DataStore, error) {
+	db, err := gorm.Open("sqlite3", "")
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/server/datastore-sqlite/sqlite.go
+++ b/plugin/server/datastore-sqlite/sqlite.go
@@ -647,8 +647,8 @@ func (ds *sqlitePlugin) convertEntries(fetchedRegisteredEntries []registeredEntr
 	return responseEntries, nil
 }
 
-func New() (datastore.DataStore, error) {
-	db, err := gorm.Open("sqlite3", "file::memory:?cache=shared")
+func newPlugin(dbType string) (datastore.DataStore, error) {
+	db, err := gorm.Open("sqlite3", dbType)
 	if err != nil {
 		return nil, err
 	}
@@ -662,27 +662,22 @@ func New() (datastore.DataStore, error) {
 	return &sqlitePlugin{
 		db: db,
 	}, nil
+
 }
 
+//New creates a new sqlite plugin with
+//an in-memory database and shared cache
+func New() (datastore.DataStore, error) {
+	return newPlugin("file::memory:?cache=shared")
+}
+
+//NewTemp create a new plugin with a temporal database,
+//different connections won't access the same database
 func NewTemp() (datastore.DataStore, error) {
-	db, err := gorm.Open("sqlite3", "")
-	if err != nil {
-		return nil, err
-	}
-
-	db.LogMode(true)
-
-	if err := migrateDB(db); err != nil {
-		return nil, err
-	}
-
-	return &sqlitePlugin{
-		db: db,
-	}, nil
+	return newPlugin("")
 }
 
 func main() {
-
 	impl, err := New()
 	if err != nil {
 		panic(err.Error())

--- a/plugin/server/datastore-sqlite/sqlite_test.go
+++ b/plugin/server/datastore-sqlite/sqlite_test.go
@@ -704,7 +704,7 @@ func Test_race(t *testing.T) {
 }
 
 func createDefault(t *testing.T) datastore.DataStore {
-	ds, err := New()
+	ds, err := NewTemp()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Changed sqlite to use shared cache.
- Added NewTemp() function that creates a temporal DB, necessary for testing in isolation.

More details: https://www.sqlite.org/inmemorydb.html