### PR TITLE
Workload API min TTL is a time.Duration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -174,6 +174,7 @@ func (a *Agent) initEndpoints() error {
 	a.config.Log.Info("Starting the workload API")
 
 	maxWorkloadTTL := time.Duration(a.BaseSVIDTTL/2) * time.Second
+	minWorkloadTTL := time.Duration(5) * time.Second
 
 	log := a.config.Log.WithField("subsystem_name", "workload")
 	ws := &workloadServer{
@@ -182,7 +183,7 @@ func (a *Agent) initEndpoints() error {
 		catalog: a.Catalog,
 		l:       log,
 		maxTTL:  maxWorkloadTTL,
-		minTTL:  5,
+		minTTL:  minWorkloadTTL,
 	}
 
 	// Create a gRPC server with our custom "credential" resolver


### PR DESCRIPTION
I found one of the reasons for Workload API TTL funniness.

minTTL is a duration type, which I had hardcoded to `5` meaning 5 seconds, but that's not how time.Duration works! Update the agent code to specify the correct duration.