### PR TITLE
Fixed workload attestation when using AWS Node Resolver

### DIFF
--- a/functional/Makefile
+++ b/functional/Makefile
@@ -13,7 +13,7 @@ all: clean build server agent test
 build:
 	docker-compose build runner
 	docker-compose up -d runner
-	docker-compose exec runner bash -c 'mkdir -p $(DOCKER_SPIRE) $(DOCKER_SPIRE)/.data && cp -R /spire-orig/* $(DOCKER_SPIRE)'
+	docker-compose exec runner bash -c 'mkdir -p $(DOCKER_SPIRE)/.data && cp -R /spire-orig/* $(DOCKER_SPIRE)'
 	docker-compose exec runner bash -c 'cd $(DOCKER_SPIRE) && ./build.sh setup && ./build.sh binaries'
 
 server:

--- a/functional/Makefile
+++ b/functional/Makefile
@@ -13,7 +13,7 @@ all: clean build server agent test
 build:
 	docker-compose build runner
 	docker-compose up -d runner
-	docker-compose exec runner bash -c 'mkdir -p $(DOCKER_SPIRE) && cp -R /spire-orig/* $(DOCKER_SPIRE)'
+	docker-compose exec runner bash -c 'mkdir -p $(DOCKER_SPIRE) $(DOCKER_SPIRE)/.data && cp -R /spire-orig/* $(DOCKER_SPIRE)'
 	docker-compose exec runner bash -c 'cd $(DOCKER_SPIRE) && ./build.sh setup && ./build.sh binaries'
 
 server:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -267,6 +267,7 @@ func (a *Agent) bootstrap() error {
 			ServerCerts:    a.serverCerts,
 			ServerSPIFFEID: serverId.String(),
 			ServerAddr:     a.config.ServerAddress.String(),
+			TrustDomain:    a.config.TrustDomain,
 
 			BaseSVID:       a.BaseSVID,
 			BaseSVIDKey:    a.baseSVIDKey,

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -163,7 +163,7 @@ func (m *manager) Init() {
 						svid = entry.svid
 						key = entry.key
 					} else {
-						m.log.Debug("Unknown parent ", parentId, "... ignoring")
+						m.log.Warnf("Unknown parent %s... ignoring", parentId)
 						continue
 					}
 					conn, err := m.getGRPCConn(svid, key)


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Workloads fail to receive identity when using AWS Node Resolver plugin.

**Description of change**
- Changed fetchRegistrationEntries so that it looks for all possible combinations of selectors.
- Changed Cache Manager to identity the registration entry with the magic parentSpiffeID (feel free to suggest a better name) that identities the node entry and keep track of its spiffeID.

**Which issue this PR fixes**
Fixes #326

