### PR TITLE
Fix to properly handle disabled plugins

### DIFF
--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -145,7 +145,7 @@ func (c *catalog) categorize() error {
 	errMsg := "Plugin %s does not adhere to %s interface"
 	for _, p := range c.com.Plugins() {
 		if !p.Config.Enabled {
-			c.log.Infof("%s plugin %s is disabled and will not be categorized", p.Config.PluginType, p.Config.PluginName)
+			c.log.Debugf("%s plugin %s is disabled and will not be categorized", p.Config.PluginType, p.Config.PluginName)
 			continue
 		}
 

--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -45,6 +45,7 @@ type Config struct {
 type catalog struct {
 	com common.Catalog
 	m   *sync.RWMutex
+	log logrus.FieldLogger
 
 	keyManagerPlugins       []keymanager.KeyManager
 	nodeAttestorPlugins     []nodeattestor.NodeAttestor
@@ -59,6 +60,7 @@ func New(c *Config) Catalog {
 	}
 
 	return &catalog{
+		log: c.Log,
 		com: common.New(commonConfig),
 		m:   new(sync.RWMutex),
 	}
@@ -142,6 +144,11 @@ func (c *catalog) categorize() error {
 
 	errMsg := "Plugin %s does not adhere to %s interface"
 	for _, p := range c.com.Plugins() {
+		if !p.Config.Enabled {
+			c.log.Infof("%s plugin %s is disabled and will not be categorized", p.Config.PluginType, p.Config.PluginName)
+			continue
+		}
+
 		switch p.Config.PluginType {
 		case KeyManagerType:
 			pl, ok := p.Plugin.(keymanager.KeyManager)

--- a/pkg/agent/catalog/catalog_test.go
+++ b/pkg/agent/catalog/catalog_test.go
@@ -36,6 +36,7 @@ var plugins = []*common_catalog.ManagedPlugin{
 		},
 	},
 	{
+		// Have another WorkloadAttestor plugin, but disabled
 		Plugin: &mock_workloadattestor.MockWorkloadAttestor{},
 		Config: common_catalog.PluginConfig{
 			PluginType: WorkloadAttestorType,

--- a/pkg/agent/catalog/catalog_test.go
+++ b/pkg/agent/catalog/catalog_test.go
@@ -13,6 +13,37 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+var plugins = []*common_catalog.ManagedPlugin{
+	{
+		Plugin: &mock_keymanager.MockKeyManager{},
+		Config: common_catalog.PluginConfig{
+			PluginType: KeyManagerType,
+			Enabled:    true,
+		},
+	},
+	{
+		Plugin: &mock_nodeattestor.MockNodeAttestor{},
+		Config: common_catalog.PluginConfig{
+			PluginType: NodeAttestorType,
+			Enabled:    true,
+		},
+	},
+	{
+		Plugin: &mock_workloadattestor.MockWorkloadAttestor{},
+		Config: common_catalog.PluginConfig{
+			PluginType: WorkloadAttestorType,
+			Enabled:    true,
+		},
+	},
+	{
+		Plugin: &mock_workloadattestor.MockWorkloadAttestor{},
+		Config: common_catalog.PluginConfig{
+			PluginType: WorkloadAttestorType,
+			Enabled:    false,
+		},
+	},
+}
+
 type AgentCatalogTestSuite struct {
 	suite.Suite
 
@@ -28,9 +59,11 @@ type AgentCatalogTestSuite struct {
 
 func (c *AgentCatalogTestSuite) SetupTest() {
 	mockCtrl := gomock.NewController(c.t)
-	_, logHook := test.NewNullLogger()
+	log, logHook := test.NewNullLogger()
 
-	cat := &catalog{}
+	cat := &catalog{
+		log: log,
+	}
 
 	c.catalog = cat
 	c.ctrl = mockCtrl
@@ -44,46 +77,35 @@ func (c *AgentCatalogTestSuite) TeardownTest() {
 func (c *AgentCatalogTestSuite) TestCategorizeNotEnoughTypes() {
 	comCatalog := mock_catalog.NewMockCatalog(c.ctrl)
 	c.catalog.com = comCatalog
+	var expectedErr = "At least one plugin of type"
 
-	plugins := []*common_catalog.ManagedPlugin{
+	// Have all plugins, but one disabled
+	plugins[0].Config.Enabled = false
+	comCatalog.EXPECT().Plugins().Return(plugins)
+	err := c.catalog.categorize()
+	c.Assert().Error(err)
+	c.Assert().Contains(err.Error(), expectedErr)
+
+	// Have only one plugin
+	var onePlugin = []*common_catalog.ManagedPlugin{
 		{
 			Plugin: &mock_workloadattestor.MockWorkloadAttestor{},
 			Config: common_catalog.PluginConfig{
 				PluginType: WorkloadAttestorType,
+				Enabled:    true,
 			},
 		},
 	}
-	comCatalog.EXPECT().Plugins().Return(plugins)
-
-	err := c.catalog.categorize()
+	comCatalog.EXPECT().Plugins().Return(onePlugin)
+	err = c.catalog.categorize()
 	c.Assert().Error(err)
-	c.Assert().Contains(err.Error(), "At least one plugin of type")
+	c.Assert().Contains(err.Error(), expectedErr)
 }
 
 func (c *AgentCatalogTestSuite) TestCategorize() {
 	comCatalog := mock_catalog.NewMockCatalog(c.ctrl)
 	c.catalog.com = comCatalog
 
-	plugins := []*common_catalog.ManagedPlugin{
-		{
-			Plugin: &mock_keymanager.MockKeyManager{},
-			Config: common_catalog.PluginConfig{
-				PluginType: KeyManagerType,
-			},
-		},
-		{
-			Plugin: &mock_nodeattestor.MockNodeAttestor{},
-			Config: common_catalog.PluginConfig{
-				PluginType: NodeAttestorType,
-			},
-		},
-		{
-			Plugin: &mock_workloadattestor.MockWorkloadAttestor{},
-			Config: common_catalog.PluginConfig{
-				PluginType: WorkloadAttestorType,
-			},
-		},
-	}
 	comCatalog.EXPECT().Plugins().Return(plugins)
 
 	err := c.catalog.categorize()

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -177,7 +177,7 @@ func (c *catalog) loadConfigFromHclConfig(hclPluginConfig HclPluginConfig) error
 func (c *catalog) startPlugins() error {
 	for _, p := range c.plugins {
 		if !p.Config.Enabled {
-			c.l.Infof("%s plugin %s is disabled and will not be started", p.Config.PluginType, p.Config.PluginName)
+			c.l.Debugf("%s plugin %s is disabled and will not be started", p.Config.PluginType, p.Config.PluginName)
 			continue
 		}
 
@@ -210,7 +210,7 @@ func (c *catalog) startPlugins() error {
 func (c *catalog) configurePlugins() error {
 	for _, p := range c.plugins {
 		if !p.Config.Enabled {
-			c.l.Infof("%s plugin %s is disabled and will not be configured", p.Config.PluginType, p.Config.PluginName)
+			c.l.Debugf("%s plugin %s is disabled and will not be configured", p.Config.PluginType, p.Config.PluginName)
 			continue
 		}
 

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -177,7 +177,7 @@ func (c *catalog) loadConfigFromHclConfig(hclPluginConfig HclPluginConfig) error
 func (c *catalog) startPlugins() error {
 	for _, p := range c.plugins {
 		if !p.Config.Enabled {
-			c.l.Infof("%s plugin %s is disabled", p.Config.PluginType, p.Config.PluginName)
+			c.l.Infof("%s plugin %s is disabled and will not be started", p.Config.PluginType, p.Config.PluginName)
 			continue
 		}
 
@@ -209,6 +209,11 @@ func (c *catalog) startPlugins() error {
 
 func (c *catalog) configurePlugins() error {
 	for _, p := range c.plugins {
+		if !p.Config.Enabled {
+			c.l.Infof("%s plugin %s is disabled and will not be configured", p.Config.PluginType, p.Config.PluginName)
+			continue
+		}
+
 		req := &pb.ConfigureRequest{
 			Configuration: p.Config.PluginData,
 		}

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -168,7 +168,7 @@ func (c *catalog) categorize() error {
 
 	for _, p := range c.com.Plugins() {
 		if !p.Config.Enabled {
-			c.log.Infof("%s plugin %s is disabled and will not be categorized", p.Config.PluginType, p.Config.PluginName)
+			c.log.Debugf("%s plugin %s is disabled and will not be categorized", p.Config.PluginType, p.Config.PluginName)
 			continue
 		}
 

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -44,6 +44,7 @@ var plugins = []*common_catalog.ManagedPlugin{
 		},
 	},
 	{
+		// Have another DataStore plugin, but disabled
 		Plugin: &mock_datastore.MockDataStore{},
 		Config: common_catalog.PluginConfig{
 			Enabled:    false,


### PR DESCRIPTION
- Fix plugin catalog functions to properly handle disabled plugins.
- Have catalog tests with plugins not enabled.

This fixes #335.