### PR TITLE
[#185] Introduce ca manager

### DIFF
--- a/pkg/server/ca/config.go
+++ b/pkg/server/ca/config.go
@@ -1,0 +1,26 @@
+package ca
+
+import (
+	"net/url"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/server/catalog"
+
+	tomb "gopkg.in/tomb.v2"
+)
+
+type Config struct {
+	Catalog     catalog.Catalog
+	TrustDomain url.URL
+
+	Log logrus.FieldLogger
+}
+
+func New(c *Config) *manager {
+	return &manager{
+		c:   c,
+		t:   new(tomb.Tomb),
+		mtx: new(sync.RWMutex),
+	}
+}

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -1,0 +1,102 @@
+package ca
+
+import (
+	"crypto/x509"
+	"fmt"
+	"sync"
+
+	"github.com/spiffe/spire/proto/server/ca"
+	"github.com/spiffe/spire/proto/server/datastore"
+	"github.com/spiffe/spire/proto/server/upstreamca"
+
+	tomb "gopkg.in/tomb.v2"
+)
+
+type Manager interface {
+	// Start the CA Manager. Blocks until the CA is fully intialized.
+	Start() error
+
+	// Wait on the CA manager to either encounter an error or shutdown.
+	Wait() error
+
+	// Shutdown the CA manager.
+	Shutdown()
+}
+
+type manager struct {
+	c   *Config
+	t   *tomb.Tomb
+	mtx *sync.RWMutex
+
+	caCert *x509.Certificate
+}
+
+func (m *manager) Start() error {
+	err := m.rotateCA()
+	if err != nil {
+		return fmt.Errorf("rotate ca cert: %v", err)
+	}
+
+	return nil
+}
+
+func (m *manager) Wait() error {
+	// Until we actually need tomb, just wait for dying state
+	<-m.t.Dying()
+	return nil
+}
+
+func (m *manager) Shutdown() {
+	m.t.Kill(nil)
+}
+
+func (m *manager) rotateCA() error {
+	m.c.Log.Debug("Initiating rotation of signing certificate")
+
+	// Get a CSR from the CA plugin
+	serverCA := m.c.Catalog.CAs()[0]
+	csrRes, err := serverCA.GenerateCsr(&ca.GenerateCsrRequest{})
+	if err != nil {
+		return fmt.Errorf("generate csr: %v", err)
+	}
+
+	// Get it signed by Upstream
+	upstreamCA := m.c.Catalog.UpstreamCAs()[0]
+	signRes, err := upstreamCA.SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: csrRes.Csr})
+	if err != nil {
+		return fmt.Errorf("submit csr to upstream ca: %v", err)
+	}
+
+	// Store the new cert
+	cert, err := x509.ParseCertificate(signRes.Cert)
+	if err != nil {
+		return fmt.Errorf("invalid cert from upstream: %v", err)
+	}
+
+	m.mtx.RLock()
+	storeReq := &datastore.Bundle{
+		TrustDomain: m.c.TrustDomain.String(),
+		CaCerts:     cert.Raw,
+	}
+	m.mtx.RUnlock()
+
+	ds := m.c.Catalog.DataStores()[0]
+	_, err = ds.AppendBundle(storeReq)
+	if err != nil {
+		return fmt.Errorf("store new ca cert: %v", err)
+	}
+
+	// Load the new cert into the CA plugin
+	loadReq := &ca.LoadCertificateRequest{
+		SignedIntermediateCert: cert.Raw,
+	}
+	_, err = serverCA.LoadCertificate(loadReq)
+	if err != nil {
+		return fmt.Errorf("load new ca cert: %v", err)
+	}
+
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.caCert = cert
+	return nil
+}

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -1,0 +1,84 @@
+package ca
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spiffe/spire/pkg/common/log"
+	"github.com/spiffe/spire/proto/server/ca"
+	"github.com/spiffe/spire/proto/server/datastore"
+	"github.com/spiffe/spire/proto/server/upstreamca"
+	"github.com/spiffe/spire/test/mock/proto/server/ca"
+	"github.com/spiffe/spire/test/mock/proto/server/datastore"
+	"github.com/spiffe/spire/test/mock/proto/server/upstreamca"
+	"github.com/spiffe/spire/test/mock/server/catalog"
+	"github.com/spiffe/spire/test/util"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ServerTestSuite struct {
+	suite.Suite
+
+	t       *testing.T
+	m       *manager
+	catalog *mock_catalog.MockCatalog
+	ca      *mock_ca.MockControlPlaneCa
+	ds      *mock_datastore.MockDataStore
+	upsCa   *mock_upstreamca.MockUpstreamCa
+}
+
+func (s *ServerTestSuite) SetupTest() {
+	mockCtrl := gomock.NewController(s.t)
+	defer mockCtrl.Finish()
+
+	s.catalog = mock_catalog.NewMockCatalog(mockCtrl)
+	s.ca = mock_ca.NewMockControlPlaneCa(mockCtrl)
+	s.ds = mock_datastore.NewMockDataStore(mockCtrl)
+	s.upsCa = mock_upstreamca.NewMockUpstreamCa(mockCtrl)
+
+	logger, err := log.NewLogger("DEBUG", "")
+	s.Nil(err)
+
+	config := &Config{
+		Catalog: s.catalog,
+		Log:     logger,
+		TrustDomain: url.URL{
+			Scheme: "spiffe",
+			Host:   "example.org",
+		},
+	}
+
+	s.m = New(config)
+}
+
+func (s *ServerTestSuite) TestRotateSigningCert() {
+	cert, _, err := util.LoadSVIDFixture()
+	require.NoError(s.T(), err)
+
+	// Set expectations
+	s.catalog.EXPECT().CAs().Return([]ca.ControlPlaneCa{s.ca})
+	s.catalog.EXPECT().DataStores().Return([]datastore.DataStore{s.ds})
+	s.catalog.EXPECT().UpstreamCAs().Return([]upstreamca.UpstreamCa{s.upsCa})
+
+	generateCsrResponse := &ca.GenerateCsrResponse{}
+	s.ca.EXPECT().GenerateCsr(&ca.GenerateCsrRequest{}).Return(generateCsrResponse, nil)
+	submitCSRResponse := &upstreamca.SubmitCSRResponse{
+		Cert: cert.Raw,
+	}
+	s.upsCa.EXPECT().SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: generateCsrResponse.Csr}).Return(submitCSRResponse, nil)
+
+	dsBundle := &datastore.Bundle{
+		TrustDomain: "spiffe://example.org",
+		CaCerts:     cert.Raw,
+	}
+	s.ds.EXPECT().AppendBundle(dsBundle).Return(dsBundle)
+
+	loadCertificateResponse := &ca.LoadCertificateResponse{}
+	s.ca.EXPECT().LoadCertificate(&ca.LoadCertificateRequest{SignedIntermediateCert: submitCSRResponse.Cert}).Return(loadCertificateResponse, nil)
+
+	err = s.m.rotateCA()
+	s.NoError(err)
+	s.Equal(cert, s.m.caCert)
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,13 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/spiffe/spire/test/mock/proto/server/upstreamca"
-
 	"github.com/golang/mock/gomock"
 	"github.com/spiffe/spire/pkg/common/log"
-	"github.com/spiffe/spire/proto/server/ca"
-	"github.com/spiffe/spire/proto/server/upstreamca"
 	"github.com/spiffe/spire/test/mock/proto/server/ca"
+	"github.com/spiffe/spire/test/mock/proto/server/upstreamca"
 	"github.com/spiffe/spire/test/mock/server/catalog"
 	"github.com/stretchr/testify/suite"
 )
@@ -50,21 +47,6 @@ func (suite *ServerTestSuite) SetupTest() {
 
 func TestServerTestSuite(t *testing.T) {
 	suite.Run(t, new(ServerTestSuite))
-}
-
-func (suite *ServerTestSuite) TestRotateSigningCert() {
-	generateCsrResponse := &ca.GenerateCsrResponse{}
-	suite.ca.EXPECT().GenerateCsr(&ca.GenerateCsrRequest{}).Return(generateCsrResponse, nil)
-	submitCSRResponse := &upstreamca.SubmitCSRResponse{
-		Cert: []byte{0},
-	}
-	suite.upsCa.EXPECT().SubmitCSR(&upstreamca.SubmitCSRRequest{Csr: generateCsrResponse.Csr}).Return(submitCSRResponse, nil)
-	loadCertificateResponse := &ca.LoadCertificateResponse{}
-	suite.ca.EXPECT().LoadCertificate(&ca.LoadCertificateRequest{SignedIntermediateCert: submitCSRResponse.Cert}).Return(loadCertificateResponse, nil)
-	suite.catalog.EXPECT().CAs().Return([]ca.ControlPlaneCa{suite.ca})
-	suite.catalog.EXPECT().UpstreamCAs().Return([]upstreamca.UpstreamCa{suite.upsCa})
-	err := suite.server.rotateSigningCert()
-	suite.NoError(err)
 }
 
 func (suite *ServerTestSuite) TestUmask() {

--- a/proto/server/datastore/README_pb.md
+++ b/proto/server/datastore/README_pb.md
@@ -923,7 +923,7 @@ Represents the updated Registration entry
 | ----------- | ------------ | ------------- | ------------|
 | CreateBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Creates a Bundle |
 | UpdateBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Updates the specified Bundle, overwriting existing certs |
-| AppendBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Appends the provided certs onto an existing bundle |
+| AppendBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Appends the provided certs onto an existing bundle, creating a new bundle if one doesn&#39;t exist |
 | DeleteBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Deletes the specified Bundle |
 | FetchBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Returns the specified Bundle |
 | ListBundles | [spire.common.Empty](#spire.common.Empty) | [Bundles](#spire.common.Empty) | List all Bundles |

--- a/proto/server/datastore/datastore.pb.go
+++ b/proto/server/datastore/datastore.pb.go
@@ -1106,7 +1106,7 @@ type DataStoreClient interface {
 	CreateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
 	// Updates the specified Bundle, overwriting existing certs
 	UpdateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
-	// Appends the provided certs onto an existing bundle
+	// Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
 	AppendBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
 	// Deletes the specified Bundle
 	DeleteBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
@@ -1449,7 +1449,7 @@ type DataStoreServer interface {
 	CreateBundle(context.Context, *Bundle) (*Bundle, error)
 	// Updates the specified Bundle, overwriting existing certs
 	UpdateBundle(context.Context, *Bundle) (*Bundle, error)
-	// Appends the provided certs onto an existing bundle
+	// Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
 	AppendBundle(context.Context, *Bundle) (*Bundle, error)
 	// Deletes the specified Bundle
 	DeleteBundle(context.Context, *Bundle) (*Bundle, error)

--- a/proto/server/datastore/datastore.proto
+++ b/proto/server/datastore/datastore.proto
@@ -287,7 +287,7 @@ service DataStore {
     rpc CreateBundle(Bundle) returns (Bundle);
     // Updates the specified Bundle, overwriting existing certs
     rpc UpdateBundle(Bundle) returns (Bundle);
-    // Appends the provided certs onto an existing bundle
+    // Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
     rpc AppendBundle(Bundle) returns (Bundle);
     // Deletes the specified Bundle
     rpc DeleteBundle(Bundle) returns (Bundle);


### PR DESCRIPTION
This change, in addition to actually storing CA certificates in the datastore, is intended to set the stage for CA rotation. It sets up a CA manager which will (eventually) implement rotation methods, as well as pruning routines to remove expired CA certs from the table. For now, it implements the existing CA creation logic, with the minor addition of shoving the CA cert into the datastore. My next PR will make updates to the endpoints which will ensure that CA certs served to clients will refer to this store.

Things to note about this PR:
* Other spots in SPIRE codebase (like endpoints package) implement the well-established golang pattern of block forever. In this case however, we must know when the CA has been initialized, as we can't start endpoints before then. As a result, CA manager tries a different pattern in which Start() blocks until fully initialized, and a subsequent call to Wait() is instead relied upon. This is decidedly less fragile than passing in an errChan.
* Minor search/replace update to server code to improve readability (server -> s)
* Removes mutex locking for datastore bundle methods as it got in my way and was only introduced to work around a deficiency in the functional test suite (which doesn't use bundle methods anyways). More information here https://github.com/spiffe/spire/issues/331
* The AppendBundle method in the datastore would previously return an error if the requested bundle did not exist. To simplify the CA management code, AppendBundle now creates a new bundle if necessary. Updated comments to reflect the change.
* I found a bug I introduced when using the Find method of GORM. I falsely assumed that Find would match populated fields of the passed struct. Updated datastore plugin code to scope with where clause - the addition of a second bundle in the test function covers this failure mode. Also patched the same bug in DeleteRegistrationEntry, and put a test in place.

And here's an interesting [history lesson](https://en.wikipedia.org/wiki/Patch_(computing)#History) I found along the way:
`
Historically, software suppliers distributed patches on paper tape or on punched cards, expecting the recipient to cut out the indicated part of the original tape (or deck), and patch in (hence the name) the replacement segment.
`

![alt text](https://upload.wikimedia.org/wikipedia/commons/f/fa/Harvard_Mark_I_program_tape.agr.jpg "A software patch")