### PR TITLE
Dont try to close stream if we get an error when opening it

### DIFF
--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -454,7 +454,6 @@ func (m *manager) getGRPCConn(svid *x509.Certificate, key *ecdsa.PrivateKey) (*g
 }
 
 func (m *manager) rotateBaseSVID() error {
-	m.log.Debug("Checking for BaseSVID expiration")
 	entry := m.getBaseSVIDEntry()
 
 	ttl := entry.svid.NotAfter.Sub(time.Now())

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -327,7 +327,7 @@ func (m *manager) expiredCacheEntryHandler(cacheFrequency time.Duration, wg *syn
 					return
 				}
 			}
-			vanityRecord := m.managedCache.Entry([]*proto.Selector{&proto.Selector{
+			vanityRecord := m.managedCache.Entry([]*proto.Selector{{
 				Type: "spiffe_id", Value: m.baseSPIFFEID}})
 
 			if vanityRecord != nil {
@@ -480,7 +480,6 @@ func (m *manager) rotateBaseSVID() error {
 
 		stream, err := node.NewNodeClient(conn).FetchSVID(context.Background())
 		if err != nil {
-			stream.CloseSend()
 			return err
 		}
 


### PR DESCRIPTION
I ran into an error condition in my dev environment which caused the agent to panic. Upon further inspection, it looks like we can encounter an error during creation of FetchSVID stream, but the error handling code also attempts to close the stream, which may be nil. Don't attempt to close the stream if we hit an error trying to establish it.

Also picked up a minor update enforced by go fmt git hook.

Here's the exception:
```
WARN[3600] rpc error: code = Unavailable desc = all SubConns are in TransientFailure  subsystem_name=cacheManager
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x81373a]

goroutine 91 [running]:
github.com/spiffe/spire/pkg/agent/cache.(*manager).rotateBaseSVID(0xc4203b1cc0, 0x0, 0x0)
	/root/go/src/github.com/spiffe/spire/pkg/agent/cache/manager.go:483 +0x93a
github.com/spiffe/spire/pkg/agent/cache.(*manager).rotateBaseSVIDHandler(0xc4203b1cc0, 0x6fc23ac00, 0xc42007e000)
	/root/go/src/github.com/spiffe/spire/pkg/agent/cache/manager.go:421 +0x18a
created by github.com/spiffe/spire/pkg/agent/cache.(*manager).Init.func1
	/root/go/src/github.com/spiffe/spire/pkg/agent/cache/manager.go:145 +0x17d
```