### PR TITLE
Refactor agent, get ready for bundle rotation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3,25 +3,23 @@ package agent
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
 	"path"
+	"sync"
 	"syscall"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spiffe/go-spiffe/uri"
 	"github.com/spiffe/spire/pkg/agent/auth"
 	"github.com/spiffe/spire/pkg/agent/cache"
 	"github.com/spiffe/spire/pkg/agent/catalog"
-	common_catalog "github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/agent/keymanager"
 	"github.com/spiffe/spire/proto/agent/nodeattestor"
 	"github.com/spiffe/spire/proto/api/node"
@@ -30,467 +28,350 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/peer"
 
 	spiffe_tls "github.com/spiffe/go-spiffe/tls"
+	tomb "gopkg.in/tomb.v2"
 )
 
-type Config struct {
-	// Address to bind the workload api to
-	BindAddress *net.UnixAddr
-
-	// Distinguished Name to use for all CSRs
-	CertDN *pkix.Name
-
-	// Directory to store runtime data
-	DataDir string
-
-	// Configurations for agent plugins
-	PluginConfigs common_catalog.PluginConfigMap
-
-	Log logrus.FieldLogger
-
-	// Address of SPIRE server
-	ServerAddress *net.TCPAddr
-
-	// A channel for receiving errors from agent goroutines
-	ErrorCh chan error
-
-	// Trust domain and associated CA bundle
-	TrustDomain url.URL
-	TrustBundle *x509.CertPool
-
-	// Join token to use for attestation, if needed
-	JoinToken string
-
-	// Umask value to use
-	Umask int
-}
-
 type Agent struct {
-	BaseSVID     *x509.Certificate
-	baseSVIDKey  *ecdsa.PrivateKey
-	BaseSVIDTTL  int32
-	config       *Config
-	grpcServer   *grpc.Server
-	CacheMgr     cache.Manager
-	Catalog      catalog.Catalog
-	serverCerts  []*x509.Certificate
-	ctx          context.Context
-	cancel       context.CancelFunc
-	baseSVIDPath string
-}
+	c   *Config
+	t   *tomb.Tomb
+	mtx *sync.RWMutex
 
-func New(ctx context.Context, c *Config) *Agent {
-	config := &catalog.Config{
-		PluginConfigs: c.PluginConfigs,
-		Log:           c.Log.WithField("subsystem_name", "catalog"),
-	}
-	ctx, cancel := context.WithCancel(ctx)
-	return &Agent{
-		config:       c,
-		Catalog:      catalog.New(config),
-		ctx:          ctx,
-		cancel:       cancel,
-		baseSVIDPath: path.Join(c.DataDir, "base_svid.crt"),
-	}
+	Manager cache.Manager
+	Catalog catalog.Catalog
+
+	grpcServer *grpc.Server
 }
 
 // Run the agent
 // This method initializes the agent, including its plugins,
 // and then blocks on the main event loop.
 func (a *Agent) Run() error {
-	a.prepareUmask()
+	syscall.Umask(a.c.Umask)
 
-	err := a.initPlugins()
+	a.t.Go(a.run)
+	return a.t.Wait()
+}
+
+func (a *Agent) Shutdown() {
+	a.t.Kill(nil)
+}
+
+func (a *Agent) run() error {
+	err := a.startPlugins()
 	if err != nil {
 		return err
 	}
 
-	err = a.bootstrap()
+	bundle, err := a.loadBundle()
 	if err != nil {
 		return err
 	}
 
-	err = a.initEndpoints()
+	svid, key, err := a.loadSVID()
 	if err != nil {
 		return err
 	}
 
-	// Main event loop
-	a.config.Log.Info("SPIRE Agent is now running")
-	for {
-		select {
-		case err = <-a.config.ErrorCh:
-			e := a.Shutdown()
-			if e != nil {
-				a.config.Log.Debug(e)
-			}
+	if svid == nil {
+		svid, bundle, err = a.newSVID(key, bundle)
+		if err != nil {
 			return err
-		case <-a.ctx.Done():
-			return a.Shutdown()
 		}
 	}
+
+	ctx, err := a.startManager(svid, key, bundle)
+	if err != nil {
+		return err
+	}
+
+	a.t.Go(func() error { return a.managerWait(ctx) })
+	a.t.Go(func() error { return a.startWorkloadAPI(bundle) })
+
+	<-a.t.Dying()
+	a.shutdown()
+	return nil
 }
 
-func (a *Agent) prepareUmask() {
-	a.config.Log.Debug("Setting umask to ", a.config.Umask)
-	syscall.Umask(a.config.Umask)
-}
+func (a *Agent) shutdown() {
+	if a.grpcServer != nil {
+		a.grpcServer.Stop()
+	}
 
-func (a *Agent) Shutdown() error {
-	defer a.cancel()
+	if a.Manager != nil {
+		a.Manager.Shutdown(nil)
+	}
+
 	if a.Catalog != nil {
 		a.Catalog.Stop()
 	}
-
-	a.grpcServer.GracefulStop()
-
-	// Drain error channel, last one wins
-	var err error
-Drain:
-	for {
-		select {
-		case e := <-a.config.ErrorCh:
-			err = e
-		default:
-			break Drain
-		}
-	}
-
-	return err
 }
 
-func (a *Agent) initPlugins() error {
-	err := a.Catalog.Run()
+func (a *Agent) startPlugins() error {
+	return a.Catalog.Run()
+}
+
+// loadBundle tries to recover a cached bundle from previous executions, and falls back
+// to the configured trust bundle if an updated bundle isn't found.
+// TODO: Actually check for cached bundle
+func (a *Agent) loadBundle() ([]*x509.Certificate, error) {
+	if a.c.TrustBundle == nil {
+		return nil, errors.New("load bundle: no bundle provided")
+	}
+
+	if len(a.c.TrustBundle) < 1 {
+		return nil, errors.New("load bundle: no certs in bundle")
+	}
+
+	return a.c.TrustBundle, nil
+}
+
+// loadSVID loads the private key from key manager and the cached SVID from disk. If the key
+// manager doesn't have a key loaded, a new one will be created, and the returned SVID will be nil.
+func (a *Agent) loadSVID() (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	mgrs := a.Catalog.KeyManagers()
+	if len(mgrs) > 1 {
+		return nil, nil, errors.New("more than one key manager configured")
+	}
+
+	mgr := mgrs[0]
+	fResp, err := mgr.FetchPrivateKey(&keymanager.FetchPrivateKeyRequest{})
 	if err != nil {
-		return err
+		return nil, nil, fmt.Errorf("load private key: %v", err)
 	}
 
-	return nil
+	svid := a.readSVIDFromDisk()
+	if len(fResp.PrivateKey) > 0 && svid == nil {
+		a.c.Log.Warn("Private key recovered, but no SVID found")
+	}
+
+	var keyData []byte
+	if len(fResp.PrivateKey) > 0 && svid != nil {
+		keyData = fResp.PrivateKey
+	} else {
+		gResp, err := mgr.GenerateKeyPair(&keymanager.GenerateKeyPairRequest{})
+		if err != nil {
+			return nil, nil, fmt.Errorf("generate key pair: %s", err)
+		}
+
+		svid = nil
+		keyData = gResp.PrivateKey
+	}
+
+	key, err := x509.ParseECPrivateKey(keyData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse key from keymanager: %v", key)
+	}
+
+	return svid, key, nil
 }
 
-func (a *Agent) initEndpoints() error {
-	a.config.Log.Info("Starting the workload API")
+// newSVID obtains an agent svid for the given private key by performing node attesatation. The bundle is
+// necessary in order to validate the SPIRE server we are attesting to. Returns the SVID and an updated bundle.
+func (a *Agent) newSVID(key *ecdsa.PrivateKey, bundle []*x509.Certificate) (*x509.Certificate, []*x509.Certificate, error) {
+	data, err := a.attestableData()
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetch attestable data: %v", err)
+	}
 
-	maxWorkloadTTL := time.Duration(a.BaseSVIDTTL/2) * time.Second
-	minWorkloadTTL := time.Duration(5) * time.Second
+	csr, err := util.MakeCSR(key, data.SpiffeId)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate CSR for agent SVID: %v", err)
+	}
 
-	log := a.config.Log.WithField("subsystem_name", "workload")
-	ws := &workloadServer{
-		bundle:   a.serverCerts[1].Raw, // TODO: Fix handling of serverCerts
-		cacheMrg: a.CacheMgr,
-		catalog:  a.Catalog,
-		l:        log,
-		maxTTL:   maxWorkloadTTL,
-		minTTL:   minWorkloadTTL,
+	conn, err := a.serverConn(bundle)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create attestation client: %v", err)
+	}
+	defer conn.Close()
+
+	c := node.NewNodeClient(conn)
+	req := &node.FetchBaseSVIDRequest{
+		AttestedData: data.AttestedData,
+		Csr:          csr,
+	}
+	resp, err := c.FetchBaseSVID(context.TODO(), req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("attesting to SPIRE server: %v", err)
+	}
+
+	svid, bundle, err := a.parseAttestationResponse(data.SpiffeId, resp)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse attestation response: %v", err)
+	}
+
+	return svid, bundle, nil
+}
+
+func (a *Agent) startManager(svid *x509.Certificate, key *ecdsa.PrivateKey, bundle []*x509.Certificate) (context.Context, error) {
+	mgrConfig := &cache.MgrConfig{
+		ServerCerts:    bundle,
+		ServerSPIFFEID: a.serverID().String(),
+		ServerAddr:     a.c.ServerAddress.String(),
+		TrustDomain:    a.c.TrustDomain,
+
+		BaseSVID:     svid,
+		BaseSVIDKey:  key,
+		BaseSVIDPath: a.agentSVIDPath(),
+		Logger:       a.c.Log.WithField("subsystem_name", "manager"),
+	}
+
+	ctx := context.Background()
+	mgr, err := cache.NewManager(ctx, mgrConfig)
+	if err != nil {
+		return ctx, err
+	}
+
+	mgr.Init()
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+	a.Manager = mgr
+	return ctx, nil
+}
+
+func (a *Agent) managerWait(ctx context.Context) error {
+	<-a.Manager.Done()
+	return a.Manager.Err()
+}
+
+// attestableData examines the agent configuation, and returns attestableData
+// for use when joining a trust domain for the first time.
+func (a *Agent) attestableData() (*nodeattestor.FetchAttestationDataResponse, error) {
+	resp := &nodeattestor.FetchAttestationDataResponse{}
+
+	if a.c.JoinToken != "" {
+		data := &common.AttestedData{
+			Type: "join_token",
+			Data: []byte(a.c.JoinToken),
+		}
+
+		id := &url.URL{
+			Scheme: "spiffe",
+			Host:   a.c.TrustDomain.Host,
+			Path:   path.Join("spire", "agent", "join_token", a.c.JoinToken),
+		}
+
+		resp.AttestedData = data
+		resp.SpiffeId = id.String()
+		return resp, nil
+	}
+
+	plugins := a.Catalog.NodeAttestors()
+	if len(plugins) > 1 {
+		return nil, errors.New("more then one node attestor configured")
+	}
+	attestor := plugins[0]
+
+	return attestor.FetchAttestationData(&nodeattestor.FetchAttestationDataRequest{})
+}
+
+// TODO: Refactor into endpoints package
+// TODO: Shouldn't need to pass bundle here
+func (a *Agent) startWorkloadAPI(bundle []*x509.Certificate) error {
+	addr := a.c.BindAddress
+	if addr.Network() != "unix" {
+		return fmt.Errorf("only unix socket supported, got type %v", addr.Network())
 	}
 
 	// Create a gRPC server with our custom "credential" resolver
+	a.mtx.Lock()
 	a.grpcServer = grpc.NewServer(grpc.Creds(auth.NewCredentials()))
+	a.mtx.Unlock()
+
+	ws := &workloadServer{
+		bundle:   bundle, // TODO: update bundle type in workload
+		cacheMrg: a.Manager,
+		catalog:  a.Catalog,
+		l:        a.c.Log.WithField("subsystem_name", "workload"),
+		maxTTL:   1 * time.Minute,
+		minTTL:   5 * time.Second,
+	}
 	workload.RegisterWorkloadServer(a.grpcServer, ws)
 
-	addr := a.config.BindAddress
-	if addr.Network() == "unix" {
-		_ = os.Remove(addr.String())
-	}
-
+	// Create world-writable socket
+	os.Remove(addr.String())
 	listener, err := net.Listen(addr.Network(), addr.String())
 	if err != nil {
-		return fmt.Errorf("Error creating GRPC listener: %s", err)
+		return fmt.Errorf("create gRPC listener: %s", err)
 	}
+	os.Chmod(addr.String(), os.ModePerm)
 
-	if addr.Network() == "unix" {
-		// Any process should be able to use this unix socket
-		os.Chmod(addr.String(), os.ModePerm)
-	}
-
-	go func() {
-		a.config.ErrorCh <- a.grpcServer.Serve(listener)
-	}()
-
-	return nil
+	return a.grpcServer.Serve(listener)
 }
 
-func (a *Agent) bootstrap() error {
-	a.config.Log.Info("Bootstrapping SPIRE agent")
-
-	plugins := a.Catalog.KeyManagers()
-	if len(plugins) != 1 {
-		return fmt.Errorf("Expected only one key manager plugin, found %i", len(plugins))
-	}
-	keyManager := plugins[0]
-
-	// Fetch or generate private key
-	res, err := keyManager.FetchPrivateKey(&keymanager.FetchPrivateKeyRequest{})
-	if err != nil {
-		return err
-	}
-	if len(res.PrivateKey) > 0 {
-		key, err := x509.ParseECPrivateKey(res.PrivateKey)
-		if err != nil {
-			return err
-		}
-
-		err = a.loadBaseSVID()
-		if err != nil {
-			return err
-		}
-		a.baseSVIDKey = key
-	} else {
-		if a.BaseSVID != nil {
-			a.config.Log.Info("Certificate configured but no private key found!")
-		}
-
-		a.config.Log.Info("Generating private key for new base SVID")
-		res, err := keyManager.GenerateKeyPair(&keymanager.GenerateKeyPairRequest{})
-		if err != nil {
-			return fmt.Errorf("Failed to generate private key: %s", err)
-		}
-		key, err := x509.ParseECPrivateKey(res.PrivateKey)
-		if err != nil {
-			return err
-		}
-		a.baseSVIDKey = key
-
-		// If we're here, we need to attest/Re-attest
-		regEntries, err := a.attest()
-		if err != nil {
-			return err
-		}
-		serverId := url.URL{
-			Scheme: "spiffe",
-			Host:   a.config.TrustDomain.Host,
-			Path:   path.Join("spiffe", "cp"),
-		}
-		cmgrConfig := &cache.MgrConfig{
-			ServerCerts:    a.serverCerts,
-			ServerSPIFFEID: serverId.String(),
-			ServerAddr:     a.config.ServerAddress.String(),
-			TrustDomain:    a.config.TrustDomain,
-
-			BaseSVID:       a.BaseSVID,
-			BaseSVIDKey:    a.baseSVIDKey,
-			BaseRegEntries: regEntries,
-			BaseSVIDPath:   a.baseSVIDPath,
-			Logger:         a.config.Log,
-		}
-
-		a.CacheMgr, err = cache.NewManager(a.ctx, cmgrConfig)
-
-		a.CacheMgr.Init()
-		go func() {
-			<-a.CacheMgr.Done()
-			a.config.Log.Info("Cache Update Stopped")
-			if a.CacheMgr.Err() != nil {
-				a.config.Log.Warning(a.CacheMgr.Err())
-			}
-		}()
+func (a *Agent) parseAttestationResponse(id string, r *node.FetchBaseSVIDResponse) (*x509.Certificate, []*x509.Certificate, error) {
+	if len(r.SvidUpdate.Svids) < 1 {
+		return nil, nil, errors.New("no svid received")
 	}
 
-	a.config.Log.Info("Bootstrapping done")
-	return nil
-}
-
-// Attest the agent, obtain a new Base SVID. Returns a spiffeid->registration entries map
-// which is used to generate CSRs for non-base SVIDs and update the agent cache entries
-//
-// TODO: Refactor me for length, testability
-
-func (a *Agent) attest() ([]*common.RegistrationEntry, error) {
-	var err error
-	a.config.Log.Info("Preparing to attest against ", a.config.ServerAddress.String())
-
-	// Handle the join token seperately, if defined
-	pluginResponse := &nodeattestor.FetchAttestationDataResponse{}
-	if a.config.JoinToken != "" {
-		a.config.Log.Info("Preparing to attest this node against ",
-			a.config.ServerAddress.String(), " using strategy 'join-token'")
-		data := &common.AttestedData{
-			Type: "join_token",
-			Data: []byte(a.config.JoinToken),
-		}
-		id := &url.URL{
-			Scheme: "spiffe",
-			Host:   a.config.TrustDomain.Host,
-			Path:   path.Join("spire", "agent", "join_token", a.config.JoinToken),
-		}
-		pluginResponse.AttestedData = data
-		pluginResponse.SpiffeId = id.String()
-	} else {
-		plugins := a.Catalog.NodeAttestors()
-		if len(plugins) != 1 {
-			return nil, fmt.Errorf("Expected only one node attestor plugin, found %i", len(plugins))
-		}
-		attestor := plugins[0]
-
-		attestorInfo := a.Catalog.Find(attestor.(common_catalog.Plugin))
-		a.config.Log.Info("Preparing to attest this node against ", a.config.ServerAddress.String(),
-			" using strategy '", attestorInfo.Config.PluginName, "'")
-
-		pluginResponse, err = attestor.FetchAttestationData(&nodeattestor.FetchAttestationDataRequest{})
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get attestation data from plugin: %s", err)
-		}
-	}
-
-	// Parse the SPIFFE ID, form a CSR with it
-	id, err := url.Parse(pluginResponse.SpiffeId)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to form SPIFFE ID: %s", err)
-	}
-	csr, err := a.generateCSR(id, a.baseSVIDKey)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to generate CSR for attestation: %s", err)
-	}
-
-	// Since we are bootstrapping, this is explicitly _not_ mTLS
-	conn, err := a.getNodeAPIClientConn(false, a.BaseSVID, a.baseSVIDKey)
-	if err != nil {
-		return nil, err
-	}
-	defer conn.Close()
-	nodeClient := node.NewNodeClient(conn)
-
-	// Perform attestation
-	req := &node.FetchBaseSVIDRequest{
-		AttestedData: pluginResponse.AttestedData,
-		Csr:          csr,
-	}
-
-	calloptPeer := new(peer.Peer)
-
-	serverResponse, err := nodeClient.FetchBaseSVID(context.Background(), req, grpc.Peer(calloptPeer))
-	if err != nil {
-		return nil, fmt.Errorf("Failed attestation against spire server: %s", err)
-	}
-
-	if tlsInfo, ok := calloptPeer.AuthInfo.(credentials.TLSInfo); ok {
-		a.serverCerts = tlsInfo.State.PeerCertificates
-	}
-
-	// Pull base SVID out of the response
-	svids := serverResponse.SvidUpdate.Svids
-	if len(svids) > 1 {
-		a.config.Log.Info("More than one SVID received during attestation!")
-	}
-	svid, ok := svids[id.String()]
+	svidMsg, ok := r.SvidUpdate.Svids[id]
 	if !ok {
-		return nil, fmt.Errorf("Base SVID not found in attestation response")
+		return nil, nil, errors.New("incorrect svid")
 	}
 
-	cert, err := x509.ParseCertificate(svid.SvidCert)
+	svid, err := x509.ParseCertificate(svidMsg.SvidCert)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse base svid: %s", err)
+		return nil, nil, fmt.Errorf("invalid svid: %v", err)
 	}
 
-	a.BaseSVID = cert
-	a.BaseSVIDTTL = svid.Ttl
-	a.storeBaseSVID()
-	a.config.Log.Info("Attestation complete")
-	return serverResponse.SvidUpdate.RegistrationEntries, nil
+	bundle, err := x509.ParseCertificates(r.SvidUpdate.Bundle)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid bundle: %v", bundle)
+	}
+
+	return svid, bundle, nil
 }
 
-// Generate a CSR for the given SPIFFE ID
-func (a *Agent) generateCSR(spiffeID *url.URL, key *ecdsa.PrivateKey) ([]byte, error) {
-	a.config.Log.Info("Generating a CSR for ", spiffeID.String())
-
-	uriSANs, err := uri.MarshalUriSANs([]string{spiffeID.String()})
-	if err != nil {
-		return []byte{}, err
-	}
-	uriSANExtension := []pkix.Extension{{
-		Id:       uri.OidExtensionSubjectAltName,
-		Value:    uriSANs,
-		Critical: true,
-	}}
-
-	csrData := &x509.CertificateRequest{
-		Subject:            *a.config.CertDN,
-		SignatureAlgorithm: x509.ECDSAWithSHA256,
-		ExtraExtensions:    uriSANExtension,
+func (a *Agent) serverConn(bundle []*x509.Certificate) (*grpc.ClientConn, error) {
+	pool := x509.NewCertPool()
+	for _, c := range bundle {
+		pool.AddCert(c)
 	}
 
-	csr, err := x509.CreateCertificateRequest(rand.Reader, csrData, key)
-	if err != nil {
-		return nil, err
+	spiffePeer := &spiffe_tls.TLSPeer{
+		SpiffeIDs:  []string{a.serverID().String()},
+		TrustRoots: pool,
 	}
 
-	return csr, nil
+	// Explicitly not mTLS since we don't have an SVID yet
+	tlsConfig := spiffePeer.NewTLSConfig([]tls.Certificate{})
+	dialCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
+
+	return grpc.DialContext(context.TODO(), a.c.ServerAddress.String(), dialCreds)
 }
 
-// Read base SVID from data dir and load it
-func (a *Agent) loadBaseSVID() error {
-	a.config.Log.Info("Loading base SVID from disk")
-
-	if _, err := os.Stat(a.baseSVIDPath); os.IsNotExist(err) {
-		a.config.Log.Info("A base SVID could not be found. A new one will be generated")
+// Read agent SVID from data dir. If an error is encountered, it will be logged and `nil`
+// will be returned.
+func (a *Agent) readSVIDFromDisk() *x509.Certificate {
+	if _, err := os.Stat(a.agentSVIDPath()); os.IsNotExist(err) {
+		a.c.Log.Debug("No pre-existing agent SVID found. Will perform node attestation")
 		return nil
 	}
 
-	data, err := ioutil.ReadFile(a.baseSVIDPath)
+	data, err := ioutil.ReadFile(a.agentSVIDPath())
 	if err != nil {
-		return fmt.Errorf("Could not read Base SVID at path %s: %s", a.baseSVIDPath, err)
+		a.c.Log.Warnf("Could not read agent SVID from %s: %s", a.agentSVIDPath(), err)
+		return nil
 	}
 
 	cert, err := x509.ParseCertificate(data)
 	if err != nil {
-		return fmt.Errorf("Certificate at %s could not be understood: %s", a.baseSVIDPath, err)
+		a.c.Log.Warnf("Could not parse agent SVID at %s: %s", a.agentSVIDPath(), err)
+		return nil
 	}
 
-	a.BaseSVID = cert
-	return nil
+	return cert
 }
 
-// Write base SVID to storage dir
-func (a *Agent) storeBaseSVID() {
-	f, err := os.Create(a.baseSVIDPath)
-	defer f.Close()
-	if err != nil {
-		a.config.Log.Info("Unable to store Base SVID at path ", a.baseSVIDPath)
-		return
+func (a *Agent) serverID() *url.URL {
+	return &url.URL{
+		Scheme: "spiffe",
+		Host:   a.c.TrustDomain.Host,
+		Path:   path.Join("spiffe", "cp"),
 	}
-
-	f.Write(a.BaseSVID.Raw)
-	f.Sync()
-
-	return
 }
 
-func (a *Agent) getNodeAPIClientConn(mtls bool, svid *x509.Certificate, key *ecdsa.PrivateKey) (conn *grpc.ClientConn, err error) {
-
-	serverID := a.config.TrustDomain
-	serverID.Path = "spiffe/cp"
-
-	var spiffePeer *spiffe_tls.TLSPeer
-	var tlsCert []tls.Certificate
-	var tlsConfig *tls.Config
-
-	if !mtls {
-		spiffePeer = &spiffe_tls.TLSPeer{
-			SpiffeIDs:  []string{serverID.String()},
-			TrustRoots: a.config.TrustBundle,
-		}
-		tlsConfig = spiffePeer.NewTLSConfig(tlsCert)
-	} else {
-		certPool := x509.NewCertPool()
-		for _, cert := range a.serverCerts {
-			certPool.AddCert(cert)
-		}
-		spiffePeer = &spiffe_tls.TLSPeer{
-			SpiffeIDs:  []string{serverID.String()},
-			TrustRoots: certPool,
-		}
-		tlsCert = append(tlsCert, tls.Certificate{Certificate: [][]byte{svid.Raw}, PrivateKey: key})
-		tlsConfig = spiffePeer.NewTLSConfig(tlsCert)
-	}
-
-	dialCreds := grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
-
-	conn, err = grpc.DialContext(a.ctx, a.config.ServerAddress.String(), dialCreds)
-	if err != nil {
-		return
-	}
-
-	return
+func (a *Agent) agentSVIDPath() string {
+	return path.Join(a.c.DataDir, "agent_svid.der")
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -5,19 +5,22 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"os"
-	"testing"
+	"path"
 
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/proto/agent/keymanager"
+	"github.com/spiffe/spire/proto/agent/nodeattestor"
 	"github.com/spiffe/spire/proto/common"
 	"github.com/spiffe/spire/test/mock/agent/cache"
 	"github.com/spiffe/spire/test/mock/agent/catalog"
 	"github.com/spiffe/spire/test/mock/proto/agent/keymanager"
+	"github.com/spiffe/spire/test/mock/proto/agent/nodeattestor"
+	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,122 +28,148 @@ type selectors []*common.Selector
 
 type AgentTestSuite struct {
 	suite.Suite
-	t                 *testing.T
-	agent             *Agent
-	mockPluginCatalog *mock_catalog.MockCatalog
-	mockKeyManager    *mock_keymanager.MockKeyManager
-	kmManager         []keymanager.KeyManager
-	mockCacheManager  *mock_cache.MockManager
-	expectedKey       *ecdsa.PrivateKey
-	config            *Config
+
+	ctrl *gomock.Controller
+
+	agent      *Agent
+	catalog    *mock_catalog.MockCatalog
+	attestor   *mock_nodeattestor.MockNodeAttestor
+	keyManager *mock_keymanager.MockKeyManager
+	manager    *mock_cache.MockManager
 }
 
-func (suite *AgentTestSuite) SetupTest() {
-	mockCtrl := gomock.NewController(suite.t)
-	defer mockCtrl.Finish()
-	suite.mockPluginCatalog = mock_catalog.NewMockCatalog(mockCtrl)
-	suite.mockKeyManager = mock_keymanager.NewMockKeyManager(mockCtrl)
-	suite.mockCacheManager = mock_cache.NewMockManager(mockCtrl)
+func (s *AgentTestSuite) SetupTest() {
+	s.ctrl = gomock.NewController(s.T())
+
+	s.catalog = mock_catalog.NewMockCatalog(s.ctrl)
+	s.attestor = mock_nodeattestor.NewMockNodeAttestor(s.ctrl)
+	s.keyManager = mock_keymanager.NewMockKeyManager(s.ctrl)
+	s.manager = mock_cache.NewMockManager(s.ctrl)
 
 	addr := &net.UnixAddr{Name: "./spire_api", Net: "unix"}
-	srvAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8081}
-	certDN := &pkix.Name{
-		Country:      []string{"testCountry"},
-		Organization: []string{"testOrg"}}
-	errCh := make(chan error)
+	log, _ := test.NewNullLogger()
+	tempDir, err := ioutil.TempDir(os.TempDir(), "spire-test")
+	s.Require().NoError(err)
 
-	l, _ := test.NewNullLogger()
-	suite.config = &Config{BindAddress: addr, CertDN: certDN,
-		DataDir: os.TempDir(),
-		Log:     l, ServerAddress: srvAddr,
-		ErrorCh: errCh,
+	config := &Config{
+		BindAddress: addr,
+		DataDir:     tempDir,
+		Log:         log,
+		TrustDomain: url.URL{
+			Scheme: "spiffe",
+			Host:   "example.com",
+		},
 	}
 
+	s.agent = New(config)
 }
 
-func TestNodeServiceTestSuite(t *testing.T) {
-	suite.Run(t, new(AgentTestSuite))
+func (s *AgentTestSuite) TeardownTest() {
+	os.RemoveAll(s.agent.c.DataDir)
+	s.ctrl.Finish()
 }
 
-func (suite *AgentTestSuite) Testbootstrap() {
-	expectedkey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	suite.expectedKey = expectedkey
-	expectedPublicKey, _ := x509.MarshalPKIXPublicKey(expectedkey)
-	expectedPrivateKey, _ := x509.MarshalECPrivateKey(expectedkey)
+func (s *AgentTestSuite) TestLoadBundle() {
+	// No configured bundle
+	_, err := s.agent.loadBundle()
+	s.Assert().NotNil(err)
 
-	kmresp := &keymanager.GenerateKeyPairResponse{
-		PublicKey: expectedPublicKey, PrivateKey: expectedPrivateKey}
-	kmreq := &keymanager.GenerateKeyPairRequest{}
-	suite.mockKeyManager.EXPECT().GenerateKeyPair(
-		kmreq).Return(kmresp, nil)
-	suite.mockKeyManager.EXPECT().FetchPrivateKey(&keymanager.FetchPrivateKeyRequest{}).Return(
-		&keymanager.FetchPrivateKeyResponse{expectedPrivateKey}, nil)
-	suite.kmManager = append(suite.kmManager, suite.mockKeyManager)
-	suite.mockPluginCatalog.EXPECT().KeyManagers().Return(suite.kmManager)
-	suite.mockPluginCatalog.EXPECT().Run().Return(nil)
-	suite.agent = &Agent{
-		Catalog: suite.mockPluginCatalog,
-		config:  suite.config}
-	err := suite.agent.bootstrap()
-	suite.Require().NoError(err)
-	suite.Assert().Equal(expectedkey, suite.agent.baseSVIDKey)
+	// Empty bundle
+	s.agent.c.TrustBundle = []*x509.Certificate{}
+	_, err = s.agent.loadBundle()
+	s.Assert().NotNil(err)
+
+	// The right stuff
+	cert, _, err := util.LoadCAFixture()
+	s.Require().NoError(err)
+	s.agent.c.TrustBundle = []*x509.Certificate{cert}
+	bundle, err := s.agent.loadBundle()
+	s.Require().NoError(err)
+	s.Assert().Equal(s.agent.c.TrustBundle, bundle)
 }
 
-func (suite *AgentTestSuite) TestSocketPermission() {
-	suite.agent = &Agent{
-		Catalog:  suite.mockPluginCatalog,
-		CacheMgr: suite.mockCacheManager,
-		config:   suite.config}
+func (s *AgentTestSuite) TestLoadSVIDWithKey() {
+	// Generate a key to be returned
+	kmKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	s.Require().NoError(err)
+	keyData, err := x509.MarshalECPrivateKey(kmKey)
+	s.Require().NoError(err)
 
-	suite.agent.serverCerts = []*x509.Certificate{{}, {}}
-	suite.mockCacheManager.EXPECT().Cache().Return(nil)
-	err := suite.agent.initEndpoints()
-	suite.Require().NoError(err)
+	// Expect a call to keymanager
+	kmResp := &keymanager.FetchPrivateKeyResponse{keyData}
+	s.catalog.EXPECT().KeyManagers().Return([]*mock_keymanager.MockKeyManager{s.keyManager})
+	s.keyManager.EXPECT().FetchPrivateKey(gomock.Any()).Return(kmResp)
 
-	info, err := os.Stat("./spire_api")
-	suite.Require().NoError(err)
-	suite.Assert().Equal(os.ModePerm|os.ModeSocket, info.Mode())
+	// Without a cached SVID
+	svid, key, err := s.agent.loadSVID()
+	s.Assert().Nil(svid)
+	s.Assert().NotNil(key)
+	s.Assert().NotEqual(kmKey, key)
+	s.Assert().NoError(err)
+
+	// With a cached SVID
+	fixture, _, err := util.LoadSVIDFixture()
+	s.Require().NoError(err)
+	svidPath := path.Join(s.agent.c.DataDir, "agent_svid.der")
+	err = ioutil.WriteFile(svidPath, fixture.Raw, 0640)
+	s.Require().NoError(err)
+	svid, key, err = s.agent.loadSVID()
+	s.Assert().Equal(fixture, svid)
+	s.Assert().Equal(kmKey, key)
+	s.Assert().NoError(err)
 }
 
-func (suite *AgentTestSuite) TestUmask() {
-	suite.agent = &Agent{
-		config: suite.config}
+func (s *AgentTestSuite) TestLoadSVIDWithoutKey() {
+	// Generate a key to be returned with GenerateKeyPair()
+	kmKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	s.Require().NoError(err)
+	pubKey, err := x509.MarshalPKIXPublicKey(kmKey.PublicKey)
+	s.Require().NoError(err)
+	privKey, err := x509.MarshalECPrivateKey(kmKey)
+	s.Require().NoError(err)
 
-	suite.agent.config.Umask = 0000
-	suite.agent.prepareUmask()
-	f, err := ioutil.TempFile("", "")
-	suite.Nil(err)
-	defer os.Remove(f.Name())
-	fi, err := os.Stat(f.Name())
-	suite.Nil(err)
-	suite.Equal(os.FileMode(0600), fi.Mode().Perm()) //0600 is permission set by TempFile()
+	// Expect a call to keymanager
+	fetchResp := &keymanager.FetchPrivateKeyResponse{}
+	genResp := &keymanager.GenerateKeyPairResponse{pubKey, privKey}
+	s.catalog.EXPECT().KeyManagers().Return([]*mock_keymanager.MockKeyManager{s.keyManager})
+	s.keyManager.EXPECT().FetchPrivateKey(gomock.Any()).Return(fetchResp)
+	s.keyManager.EXPECT().GenerateKeyPair(gomock.Any()).Return(genResp)
 
-	suite.agent.config.Umask = 0777
-	suite.agent.prepareUmask()
-	f, err = ioutil.TempFile("", "")
-	suite.Nil(err)
-	defer os.Remove(f.Name())
-	fi, err = os.Stat(f.Name())
-	suite.Nil(err)
-	suite.Equal(os.FileMode(0000), fi.Mode().Perm())
+	// Without a cached SVID
+	svid, key, err := s.agent.loadSVID()
+	s.Assert().Nil(svid)
+	s.Assert().NotNil(key)
+	s.Assert().Equal(kmKey, key)
+	s.Assert().NoError(err)
+
+	// With a cached SVID
+	fixture, _, err := util.LoadSVIDFixture()
+	s.Require().NoError(err)
+	svidPath := path.Join(s.agent.c.DataDir, "agent_svid.der")
+	err = ioutil.WriteFile(svidPath, fixture.Raw, 0640)
+	s.Require().NoError(err)
+	svid, key, err = s.agent.loadSVID()
+	s.Assert().Nil(svid)
+	s.Assert().Equal(kmKey, key)
+	s.Assert().NoError(err)
 }
 
-// WIP(walmav)
-func TestAgent_FetchSVID(t *testing.T) {
-	tests := []struct {
-		name        string
-		regEntryMap map[string]*common.RegistrationEntry
-	}{{
-		name: "test",
-		regEntryMap: map[string]*common.RegistrationEntry{"spiffe:test": {
-			Selectors: selectors{&common.Selector{Type: "testtype", Value: "testValue"}},
-			ParentId:  "spiffe:parent",
-			SpiffeId:  "spiffe:test"}},
-	},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+func (s *AgentTestSuite) TestAttestableData() {
+	// Expect a call to a node attestor
+	expectData := &common.AttestedData{"foo", []byte{}}
+	expectResp := &nodeattestor.FetchAttestationDataResponse{expectData, "spiffe://example.com/bar"}
+	s.catalog.EXPECT().NodeAttestors().Return([]*mock_nodeattestor.MockNodeAttestor{s.attestor})
+	s.attestor.EXPECT().FetchAttestationData(gomock.Any()).Return(expectResp)
 
-		})
-	}
+	// Without a join token
+	resp, err := s.agent.attestableData()
+	s.Assert().NoError(err)
+	s.Assert().Equal(expectResp, resp)
+
+	// With a join token
+	s.agent.c.JoinToken = "foo"
+	tokenData := &common.AttestedData{"join_token", []byte("foo")}
+	tokenResp := &nodeattestor.FetchAttestationDataResponse{tokenData, "spiffe://example.com/agent/join_token/foo"}
+	resp, err = s.agent.attestableData()
+	s.Assert().Equal(tokenResp, resp)
 }

--- a/pkg/agent/cache/manager.go
+++ b/pkg/agent/cache/manager.go
@@ -46,7 +46,6 @@ type MgrConfig struct {
 	BaseSVID       *x509.Certificate
 	BaseSVIDKey    *ecdsa.PrivateKey
 	BaseSVIDPath   string
-	BaseRegEntries []*proto.RegistrationEntry
 	Logger         logrus.FieldLogger
 	TrustDomain    url.URL
 }
@@ -71,7 +70,6 @@ type manager struct {
 	baseSVIDKey      *ecdsa.PrivateKey
 	baseSVIDPath     string
 	baseSPIFFEID     string
-	baseRegEntries   []*proto.RegistrationEntry
 	log              logrus.FieldLogger
 	ctx              context.Context
 	cancel           context.CancelFunc
@@ -98,7 +96,6 @@ func NewManager(ctx context.Context, c *MgrConfig) (Manager, error) {
 		baseSVIDKey:      c.BaseSVIDKey,
 		baseSVIDPath:     c.BaseSVIDPath,
 		baseSPIFFEID:     basespiffeID[0],
-		baseRegEntries:   c.BaseRegEntries,
 		log:              c.Logger.WithField("subsystem_name", "cacheManager"),
 		spiffeIdEntryMap: make(map[string]CacheEntry),
 		entryRequestCh:   make(chan map[string][]EntryRequest),
@@ -145,8 +142,7 @@ func (m *manager) Init() {
 		go m.rotateBaseSVIDHandler(30*time.Second, &wg)
 
 		m.log.Debug("Initializing Cache Manager")
-		m.regEntriesCh <- m.baseRegEntries
-		m.addToPipeline(len(m.baseRegEntries) - 1)
+		m.fetchWithEmptyCSR(m.baseSVID, m.baseSVIDKey)
 
 		for {
 

--- a/pkg/agent/cache/manager_test.go
+++ b/pkg/agent/cache/manager_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	testServerCerts = []*x509.Certificate{&x509.Certificate{}, &x509.Certificate{}}
+	testServerCerts = []*x509.Certificate{{}, {}}
 	serverId        = "spiffe://testDomain/spiffe/cp"
 	baseSVIDKey, _  = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	testLogger, _   = testlog.NewNullLogger()
@@ -32,7 +32,7 @@ var (
 			SpiffeId: "spiffe://example.org/Blog",
 			ParentId: "spiffe://example.org/spire/agent/join_token/TokenBlog",
 			Selectors: []*common.Selector{
-				&common.Selector{Type: "unix", Value: "uid:111"},
+				{Type: "unix", Value: "uid:111"},
 			},
 			Ttl: 200,
 		},
@@ -44,7 +44,7 @@ var (
 	}
 
 	svidMap = map[string]*node.Svid{
-		"spiffe://example.org/Blog": &node.Svid{SvidCert: certsFixture.GetTestBlogSVID()}}
+		"spiffe://example.org/Blog": {SvidCert: certsFixture.GetTestBlogSVID()}}
 
 	svidUpdate = &node.SvidUpdate{
 		Svids:               svidMap,
@@ -67,7 +67,6 @@ func TestManager_FetchSVID(t *testing.T) {
 		ServerAddr:     "fakeServerAddr",
 		BaseSVID:       baseSVID,
 		BaseSVIDKey:    baseSVIDKey,
-		BaseRegEntries: regEntries,
 		Logger:         testLogger,
 	}
 	m, _ := NewManager(context.Background(), c)
@@ -91,7 +90,7 @@ func TestManager_FetchSVID(t *testing.T) {
 
 	wg.Wait()
 	expiry := cm.managedCache.Entry([]*common.Selector{
-		&common.Selector{Type: "unix", Value: "uid:111"},
+		{Type: "unix", Value: "uid:111"},
 	})[0].SVID.NotAfter
 
 	//TODO: review this
@@ -104,10 +103,9 @@ func TestManager_RegEntriesHandler(t *testing.T) {
 	baseSVID, _ := x509.ParseCertificate(certsFixture.GetTestBaseSVID())
 	c := &MgrConfig{ServerCerts: testServerCerts,
 		ServerSPIFFEID: serverId, ServerAddr: "fakeServerAddr",
-		BaseSVID:       baseSVID,
-		BaseSVIDKey:    baseSVIDKey,
-		BaseRegEntries: regEntries,
-		Logger:         testLogger}
+		BaseSVID:    baseSVID,
+		BaseSVIDKey: baseSVIDKey,
+		Logger:      testLogger}
 	m, _ := NewManager(context.Background(), c)
 	cm := m.(*manager)
 	cm.regEntriesCh = make(chan []*common.RegistrationEntry)
@@ -145,10 +143,9 @@ func TestManager_UpdateCache(t *testing.T) {
 	baseSVID, _ := x509.ParseCertificate(certsFixture.GetTestBaseSVID())
 	c := &MgrConfig{ServerCerts: testServerCerts,
 		ServerSPIFFEID: serverId, ServerAddr: "fakeServerAddr",
-		BaseSVID:       baseSVID,
-		BaseSVIDKey:    baseSVIDKey,
-		BaseRegEntries: regEntries,
-		Logger:         testLogger}
+		BaseSVID:    baseSVID,
+		BaseSVIDKey: baseSVIDKey,
+		Logger:      testLogger}
 	m, _ := NewManager(context.Background(), c)
 	cm := m.(*manager)
 	cm.Init()

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"crypto/x509"
+	"net"
+	"net/url"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/agent/catalog"
+
+	common_catalog "github.com/spiffe/spire/pkg/common/catalog"
+	tomb "gopkg.in/tomb.v2"
+)
+
+type Config struct {
+	// Address to bind the workload api to
+	BindAddress *net.UnixAddr
+
+	// Directory to store runtime data
+	DataDir string
+
+	// Configurations for agent plugins
+	PluginConfigs common_catalog.PluginConfigMap
+
+	Log logrus.FieldLogger
+
+	// Address of SPIRE server
+	ServerAddress *net.TCPAddr
+
+	// Trust domain and associated CA bundle
+	TrustDomain url.URL
+	TrustBundle []*x509.Certificate
+
+	// Join token to use for attestation, if needed
+	JoinToken string
+
+	// Umask value to use
+	Umask int
+}
+
+func New(c *Config) *Agent {
+	catConfig := &catalog.Config{
+		PluginConfigs: c.PluginConfigs,
+		Log:           c.Log.WithField("subsystem_name", "catalog"),
+	}
+
+	return &Agent{
+		c:       c,
+		t:       new(tomb.Tomb),
+		mtx:     new(sync.RWMutex),
+		Catalog: catalog.New(catConfig),
+	}
+}

--- a/pkg/agent/workload.go
+++ b/pkg/agent/workload.go
@@ -38,12 +38,12 @@ type workloadServer struct {
 	// distrubution to workloads. It is updaetd periodically,
 	// protect it with a mutex.
 	m      sync.RWMutex
-	bundle []byte
+	bundle []*x509.Certificate
 }
 
 // SetBundle exposes a setter for configuring the CA bundle. This
 // bundle is passed to the workload.
-func (s *workloadServer) SetBundle(bundle []byte) {
+func (s *workloadServer) SetBundle(bundle []*x509.Certificate) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
@@ -175,12 +175,11 @@ func (s *workloadServer) composeResponse(entries []cache.CacheEntry) (response *
 	var certs []*x509.Certificate
 	var bundles []*workload.WorkloadEntry
 
-	// TODO: Better way to do this?
 	// Grab a copy of the SVID bundle
 	s.m.RLock()
 	var svidBundle []byte
 	for _, b := range s.bundle {
-		svidBundle = append(svidBundle, b)
+		svidBundle = append(svidBundle, b.Raw...)
 	}
 	s.m.RUnlock()
 

--- a/pkg/agent/workload_test.go
+++ b/pkg/agent/workload_test.go
@@ -66,7 +66,7 @@ func (s *WorkloadServerTestSuite) SetupTest() {
 		cacheMrg: s.manager,
 		catalog:  s.catalog,
 		l:        log,
-		bundle:   []byte{},
+		bundle:   []*x509.Certificate{},
 		maxTTL:   maxTTL,
 		minTTL:   minTTL,
 	}


### PR DESCRIPTION
This commit refactors SPIRE agent to be more maintainable and easier to read. It also sets us up for the upcoming cache manager refactor and bundle rotation work.

Included in this change:
* Changes in cli code and types to support multiple certificates in the bundle
* Adoption of tomb in agent, simplifying shutdown and error handling logic
* Removal of CN configuration since it wasn't being used. Can add it back later once it's actually exposed.
* Less state carried on the Agent struct allowing for more explicit operations, easier testing
* More tests
* Bugfixes around interaction with the keymanager plugin
* Minor updates in existing cache manager - no longer seeded with registration entries (for simplicity in agent), and type updates... this will be refactored soon.
* Move agent config to dedicated file

I will follow this up with another PR aimed at moving the Workload API logic to a dedicated endpoints package, which should set us up well for the upcoming refactor there.