### PR TITLE
Check in a simple e2e test script

### DIFF
--- a/script/e2e_test.sh
+++ b/script/e2e_test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# This script performs a lightweight end-to-end test of the SPIRE server and
+# agent. It creates a registration entry, and uses the SPIRE agent cli tool
+# to fetch the minted SVID from the Workload API. This script will exit with
+# code 0 if all steps are completed successfully.
+#
+# PLEASE NOTE: This script must be run from the project root, and will remove the
+# default datastore file before beginning in order to ensure accurate resutls.
+#
+
+set -e
+
+rm .data/datastore.sqlite3
+./cmd/spire-server/spire-server run &
+sleep 2
+
+./cmd/spire-server/spire-server entry create \
+-spiffeID spiffe://example.org/test \
+-parentID spiffe://example.org/agent \
+-selector unix:uid:$(id -u)
+
+TOKEN=$(./cmd/spire-server/spire-server token generate -spiffeID spiffe://example.org/agent | awk '{print $2}')
+./cmd/spire-agent/spire-agent run -joinToken $TOKEN &
+sleep 8
+
+set +e
+RESULT=$(./cmd/spire-agent/spire-agent api fetch)
+echo $RESULT | grep "Fetched 1 bundle"
+if [ $? != 0 ]; then
+    CODE=1
+    echo
+    echo
+    echo $RESULT
+    echo
+    echo "Test failed."
+    echo
+else
+    CODE=0
+    echo
+    echo
+    echo "Test passed."
+    echo
+fi
+
+kill %2
+kill %1
+wait
+
+exit $CODE


### PR DESCRIPTION
I found myself performing the same rough end-to-end test following changes that are hard to capture in unit tests. To save time, I have codified the procedure and figure it would be useful to check in. This VERY simple and rudimentary bash script starts the server and an agent, creating a registration entry for the current user. It then attempts to fetch the entry from the Workload API. Exits non-zero on error, zero if the test passes.