### PR TITLE
Introduce a disk-based keymanager plugin

### DIFF
--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/disk"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/jointoken"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/k8s"
@@ -40,6 +41,7 @@ var (
 
 	builtinPlugins = common.BuiltinPluginMap{
 		KeyManagerType: {
+			"disk":   disk.New(),
 			"memory": memory.New(),
 		},
 		NodeAttestorType: {

--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -23,12 +23,12 @@ type pluginConfig struct {
 	Directory string `hcl:"directory" json:"directory"`
 }
 
-type DiskPlugin struct {
+type diskPlugin struct {
 	mtx *sync.RWMutex
 	dir string
 }
 
-func (d *DiskPlugin) GenerateKeyPair(*keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
+func (d *diskPlugin) GenerateKeyPair(*keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
 	d.mtx.RLock()
 	if d.dir == "" {
 		d.mtx.RUnlock()
@@ -62,7 +62,7 @@ func (d *DiskPlugin) GenerateKeyPair(*keymanager.GenerateKeyPairRequest) (*keyma
 	return resp, nil
 }
 
-func (d *DiskPlugin) FetchPrivateKey(*keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {
+func (d *diskPlugin) FetchPrivateKey(*keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {
 	// Start with empty response
 	resp := &keymanager.FetchPrivateKeyResponse{[]byte{}}
 
@@ -88,7 +88,7 @@ func (d *DiskPlugin) FetchPrivateKey(*keymanager.FetchPrivateKeyRequest) (*keyma
 	return resp, nil
 }
 
-func (d *DiskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (d *diskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	config := &pluginConfig{}
 	hclTree, err := hcl.Parse(req.Configuration)
 	if err != nil {
@@ -105,12 +105,12 @@ func (d *DiskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureRespons
 	return &spi.ConfigureResponse{}, nil
 }
 
-func (d *DiskPlugin) GetPluginInfo(*spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+func (d *diskPlugin) GetPluginInfo(*spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func New() *DiskPlugin {
-	return &DiskPlugin{
+func New() *diskPlugin {
+	return &diskPlugin{
 		mtx: new(sync.RWMutex),
 	}
 }

--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -1,0 +1,116 @@
+package disk
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire/proto/agent/keymanager"
+
+	spi "github.com/spiffe/spire/proto/common/plugin"
+)
+
+const keyFileName = "svid.key"
+
+type pluginConfig struct {
+	Directory string `hcl:"directory" json:"directory"`
+}
+
+type DiskPlugin struct {
+	mtx *sync.RWMutex
+	dir string
+}
+
+func (d *DiskPlugin) GenerateKeyPair(*keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
+	d.mtx.RLock()
+	if d.dir == "" {
+		d.mtx.RUnlock()
+		return nil, errors.New("path not configured")
+	}
+
+	keyPath := path.Join(d.dir, keyFileName)
+	d.mtx.RUnlock()
+
+	key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	privData, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ioutil.WriteFile(keyPath, privData, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	pubData, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := &keymanager.GenerateKeyPairResponse{pubData, privData}
+	return resp, nil
+}
+
+func (d *DiskPlugin) FetchPrivateKey(*keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {
+	// Start with empty response
+	resp := &keymanager.FetchPrivateKeyResponse{[]byte{}}
+
+	d.mtx.RLock()
+	p := path.Join(d.dir, keyFileName)
+	d.mtx.RUnlock()
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return resp, nil
+	}
+
+	data, err := ioutil.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check key integrity first
+	key, err := x509.ParseECPrivateKey(data)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.PrivateKey, _ = x509.MarshalECPrivateKey(key)
+	return resp, nil
+}
+
+func (d *DiskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := &pluginConfig{}
+	hclTree, err := hcl.Parse(req.Configuration)
+	if err != nil {
+		return nil, err
+	}
+	err = hcl.DecodeObject(&config, hclTree)
+	if err != nil {
+		return nil, err
+	}
+
+	d.mtx.Lock()
+	defer d.mtx.Unlock()
+	d.dir = config.Directory
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (d *DiskPlugin) GetPluginInfo(*spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func New() *DiskPlugin {
+	return &DiskPlugin{
+		mtx: new(sync.RWMutex),
+	}
+}

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -1,0 +1,67 @@
+package disk
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spiffe/spire/proto/agent/keymanager"
+	spi "github.com/spiffe/spire/proto/common/plugin"
+)
+
+func TestMemory_GenerateKeyPair(t *testing.T) {
+	plugin := New()
+	tempDir, err := ioutil.TempDir("", "km-disk-test")
+	require.NoError(t, err)
+	plugin.dir = tempDir
+	defer os.RemoveAll(tempDir)
+
+	genResp, err := plugin.GenerateKeyPair(&keymanager.GenerateKeyPairRequest{})
+	require.NoError(t, err)
+	_, err = os.Stat(path.Join(tempDir, keyFileName))
+	assert.False(t, os.IsNotExist(err))
+	assert.NoError(t, err)
+
+	fileData, err := ioutil.ReadFile(path.Join(tempDir, keyFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, genResp.PrivateKey, fileData)
+
+	_, err = x509.ParseECPrivateKey(genResp.PrivateKey)
+	require.NoError(t, err)
+}
+
+func TestMemory_FetchPrivateKey(t *testing.T) {
+	plugin := New()
+	tempDir, err := ioutil.TempDir("", "km-disk-test")
+	require.NoError(t, err)
+	plugin.dir = tempDir
+	defer os.RemoveAll(tempDir)
+
+	genResp, err := plugin.GenerateKeyPair(&keymanager.GenerateKeyPairRequest{})
+	require.NoError(t, err)
+
+	fetchResp, err := plugin.FetchPrivateKey(&keymanager.FetchPrivateKeyRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, genResp.PrivateKey, fetchResp.PrivateKey)
+}
+
+func TestMemory_Configure(t *testing.T) {
+	plugin := New()
+	cReq := &spi.ConfigureRequest{
+		Configuration: "directory = \"foo/bar\"",
+	}
+	_, e := plugin.Configure(cReq)
+	assert.NoError(t, e)
+	assert.Equal(t, "foo/bar", plugin.dir)
+}
+
+func TestMemory_GetPluginInfo(t *testing.T) {
+	plugin := New()
+	_, e := plugin.GetPluginInfo(&spi.GetPluginInfoRequest{})
+	require.NoError(t, e)
+}


### PR DESCRIPTION
This commit introduces a basic keymanager plugin which writes the agent's SVID private key to disk, allowing the agent to easily recover from restarts and reboots. This plugin is not enabled unless configured, allowing users to make a choice: keys on disk + survivability, or security - survivability.

I will be submitting documentation updates in subsequent PR.

Fixes #242 (for now).