### PR TITLE
Rotate SPIRE CA when expiry is approaching

### DIFF
--- a/pkg/server/ca/config.go
+++ b/pkg/server/ca/config.go
@@ -24,6 +24,7 @@ func New(c *Config) *manager {
 		t:   new(tomb.Tomb),
 		mtx: new(sync.RWMutex),
 
-		pruneTicker: time.NewTicker(6 * time.Hour),
+		rotateTicker: time.NewTicker(30 * time.Minute),
+		pruneTicker:  time.NewTicker(6 * time.Hour),
 	}
 }

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -30,16 +30,25 @@ type manager struct {
 	t   *tomb.Tomb
 	mtx *sync.RWMutex
 
-	caCert      *x509.Certificate
-	pruneTicker *time.Ticker
+	caCert     *x509.Certificate
+	nextCACert *x509.Certificate
+
+	rotateTicker *time.Ticker
+	pruneTicker  *time.Ticker
 }
 
 func (m *manager) Start() error {
-	err := m.rotateCA()
+	err := m.prepareNextCA()
 	if err != nil {
-		return fmt.Errorf("rotate ca cert: %v", err)
+		return fmt.Errorf("create ca certificate: %v", err)
 	}
 
+	err = m.activateNextCA()
+	if err != nil {
+		return fmt.Errorf("activate ca certificate: %v", err)
+	}
+
+	m.t.Go(m.startCARotator)
 	m.t.Go(m.startPruner)
 	return nil
 }
@@ -52,8 +61,48 @@ func (m *manager) Shutdown() {
 	m.t.Kill(nil)
 }
 
-func (m *manager) rotateCA() error {
-	m.c.Log.Debug("Initiating rotation of signing certificate")
+func (m *manager) startCARotator() error {
+	for {
+		select {
+		case <-m.rotateTicker.C:
+			err := m.caRotate()
+			if err != nil {
+				m.c.Log.Errorf("Problem encountered while tending to CA rotation: %v", err)
+			}
+		case <-m.t.Dying():
+			return tomb.ErrDying
+		}
+	}
+}
+
+// caRotate inspects certificate expiration times and determines if rotation
+// actions need to be performed, calling either prepareNextCA() or activateNextCA()
+// as needed.
+//
+// TODO: This could probably be simplified with something like a FSM
+func (m *manager) caRotate() error {
+	if m.caCert == nil {
+		return errors.New("ca manager not initialized; no ca cert present")
+	}
+
+	// Prepare a new CA once the current one is 1/2 of the way to expiration
+	ttl := time.Until(m.caCert.NotAfter)
+	lifetime := m.caCert.NotAfter.Sub(m.caCert.NotBefore)
+	if (ttl < lifetime/2) && m.nextCACert == nil {
+		return m.prepareNextCA()
+	}
+
+	// Activate the new CA once the current one is 5/6ths of the way to expiration
+	if ttl < lifetime/6 {
+		return m.activateNextCA()
+	}
+
+	// Nothing to see here, move along now...
+	return nil
+}
+
+func (m *manager) prepareNextCA() error {
+	m.c.Log.Debug("Creating a new CA certificate")
 
 	// Get a CSR from the CA plugin
 	serverCA := m.c.Catalog.CAs()[0]
@@ -88,18 +137,32 @@ func (m *manager) rotateCA() error {
 		return fmt.Errorf("store new ca cert: %v", err)
 	}
 
-	// Load the new cert into the CA plugin
-	loadReq := &ca.LoadCertificateRequest{
-		SignedIntermediateCert: cert.Raw,
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.nextCACert = cert
+	return nil
+}
+
+func (m *manager) activateNextCA() error {
+	if m.nextCACert == nil {
+		return errors.New("next ca cert not prepared")
 	}
-	_, err = serverCA.LoadCertificate(loadReq)
+
+	m.c.Log.Debug("Activating new CA certificate")
+	serverCA := m.c.Catalog.CAs()[0]
+
+	loadReq := &ca.LoadCertificateRequest{
+		SignedIntermediateCert: m.nextCACert.Raw,
+	}
+	_, err := serverCA.LoadCertificate(loadReq)
 	if err != nil {
 		return fmt.Errorf("load new ca cert: %v", err)
 	}
 
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
-	m.caCert = cert
+	m.caCert = m.nextCACert
+	m.nextCACert = nil
 	return nil
 }
 

--- a/pkg/server/plugin/ca/memory/memory.go
+++ b/pkg/server/plugin/ca/memory/memory.go
@@ -231,8 +231,6 @@ func (m *MemoryPlugin) LoadCertificate(request *ca.LoadCertificateRequest) (resp
 		return &ca.LoadCertificateResponse{}, errors.New("Invalid state: no private key. GenerateCsr() should be called first")
 	}
 
-	m.key = m.newKey
-
 	cert, err := x509.ParseCertificate(request.SignedIntermediateCert)
 	if err != nil {
 		return &ca.LoadCertificateResponse{}, err
@@ -292,6 +290,7 @@ func (m *MemoryPlugin) LoadCertificate(request *ca.LoadCertificateRequest) (resp
 	}
 
 	m.cert = cert
+	m.key = m.newKey
 
 	log.Printf("Signing certificate with SPIFFE ID: '%v' successfully loaded", spiffeidUrl.String())
 


### PR DESCRIPTION
This change add support for CA rotation when an expiration date is approaching. When the server's signing certificate is >50% old, a new certificate is prepared and injected into the bundle. When the signing certificate is approx. >80% old, the new certificate is activated and installed for signing.

Note that we currently do not have a system by which we can ensure it is safe to rotate. That is, we don't have a good way to know if the new certificate has been fully propagated. This is a problem we may or may not have to solve somewhere down the line... for now, we will count on workload API push and push/short-poll from agent. Small steps :)