### PR TITLE
Fix error string formatting type mismatch in AWS node attestor plugin

### DIFF
--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -163,7 +163,7 @@ func (p *IIDAttestorPlugin) Attest(req *nodeattestor.AttestRequest) (*nodeattest
 	}
 
 	if rootDeviceIndex == -1 {
-		innerErr := fmt.Errorf("could not locate a device mapping with name '%s'", instance.RootDeviceName)
+		innerErr := fmt.Errorf("could not locate a device mapping with name '%v'", instance.RootDeviceName)
 		err = caws.AttestationStepError("locating the root device block mapping", innerErr)
 		return &nodeattestor.AttestResponse{Valid: false}, err
 	}


### PR DESCRIPTION
I discovered that master is failing after trying to merge in the workload api handler code. An error formatting string using `%s` was causing an exception as it was being used with a pointer to a string, rather than a string. This commit updates the string to use `%v`.

This should not have happened. The PR which introduced this code was the last change on master, and both the PR build and master build passed on Travis. The dependent library has also been locked by glide in the commit which introduced it. I am not sure how this could be... we should definitely investigate. For now, this commit clears the error so we can fix master and unblock other pending PRs.