### PR TITLE
Add optional logging to workload api client lib

### DIFF
--- a/api/workload/client.go
+++ b/api/workload/client.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/proto/api/workload"
 
 	"google.golang.org/grpc"
@@ -35,6 +36,9 @@ type ClientConfig struct {
 
 	// The maximum number of seconds we should backoff for on dial and rpc calls
 	Timeout time.Duration
+
+	// A logging interface which is satisfied by stdlib logger. Can be nil.
+	Logger logrus.StdLogger
 }
 
 type client struct {
@@ -103,8 +107,11 @@ func (c *client) Start() error {
 				case err := <-errChan:
 					cancel()
 					if err == io.EOF {
+						c.log("SPIFFE server hung up. Redialing.")
 						break FetchLoop
 					} else {
+						msg := fmt.Sprintf("Received error from SPIFFE Workload API: %v", err)
+						c.log(msg)
 						break RecvLoop
 					}
 				case resp = <-respChan:
@@ -177,6 +184,8 @@ func (c *client) fetchWithBackoff(ctx context.Context, apiClient workload.Spiffe
 	for {
 		stream, err := apiClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
 		if err != nil && b.goAgain(c.shutdown) {
+			msg := fmt.Sprintf("Received error from SPIFFE Workload API: %v", err)
+			c.log(msg)
 			continue
 		} else if err != nil {
 			return nil, err
@@ -192,6 +201,8 @@ func (c *client) dialWithBackoff() (workload.SpiffeWorkloadAPIClient, error) {
 	for {
 		apiClient, err := c.dial()
 		if err != nil && b.goAgain(c.shutdown) {
+			msg := fmt.Sprintf("Received error while dialing SPIFFE Workload API: %v", err)
+			c.log(msg)
 			continue
 		} else if err != nil {
 			return nil, err
@@ -223,6 +234,12 @@ func (c *client) addr() (net.Addr, error) {
 	}
 
 	return c.addrFromEnv()
+}
+
+func (c *client) log(msg string) {
+	if c.c.Logger != nil {
+		c.c.Logger.Println(msg)
+	}
 }
 
 func (c client) addrFromEnv() (net.Addr, error) {
@@ -292,7 +309,6 @@ func (client) parseUDSAddr(u *url.URL) (net.Addr, error) {
 }
 
 func (client) dialer(network string) func(addr string, timeout time.Duration) (net.Conn, error) {
-	// Assume we're only dialing sockets
 	return func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(network, addr, timeout)
 	}


### PR DESCRIPTION
A few times now it has been hard to debug the workload api due to lack of visibility into the client library, since it performs backoff/retry etc. This commit adds an optional logger to the client, only logging when set. It uses a logrus interface which conforms to stdlib so either golang `log` or logrus can be used, depending on the consuming project.