### PR TITLE
Logging improvements

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -100,7 +100,7 @@ func (*RunCLI) Run(args []string) int {
 		return 1
 	}
 
-	c.Log.Infof("agent stopped gracefully")
+	c.Log.Infof("Agent stopped gracefully")
 	return 0
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -180,6 +180,8 @@ func (a *Agent) loadSVID() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 // newSVID obtains an agent svid for the given private key by performing node attesatation. The bundle is
 // necessary in order to validate the SPIRE server we are attesting to. Returns the SVID and an updated bundle.
 func (a *Agent) newSVID(key *ecdsa.PrivateKey, bundle []*x509.Certificate) (*x509.Certificate, []*x509.Certificate, error) {
+	a.c.Log.Info("Performing node attestation")
+
 	data, err := a.attestableData()
 	if err != nil {
 		return nil, nil, fmt.Errorf("fetch attestable data: %v", err)

--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -37,6 +37,7 @@ func (e *endpoints) Start() error {
 		return err
 	}
 
+	e.c.Log.Info("Starting workload API")
 	e.t.Go(func() error { return e.start(l) })
 	return nil
 }

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -91,7 +91,7 @@ func (m *manager) close(err error) {
 	if err != nil {
 		m.c.Log.Errorf("cache manager crashed: %v", err)
 	} else {
-		m.c.Log.Info("cache manager stopped gracefully")
+		m.c.Log.Info("Cache manager stopped")
 	}
 }
 

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -18,9 +18,6 @@ import (
 
 // synchronize hits the node api, checks for entries we haven't fetched yet, and fetches them.
 func (m *manager) synchronize(spiffeID string) (err error) {
-	m.c.Log.Debugf("synchronize started for %s", spiffeID)
-	defer m.c.Log.Debug("synchronize finished")
-
 	var regEntries map[string]*proto.RegistrationEntry
 	var cEntryRequests entryRequests
 
@@ -64,9 +61,6 @@ type entryRequest struct {
 type entryRequests map[string][]*entryRequest
 
 func (m *manager) fetchUpdates(spiffeID string, entryRequests []*entryRequest) (map[string]*common.RegistrationEntry, map[string]*node.Svid, error) {
-	m.c.Log.Debugf("fetchUpdates started using SVID and key for spiffeId: %s", spiffeID)
-	defer m.c.Log.Debug("fetchUpdates finished")
-
 	client := m.syncClients.get(spiffeID)
 	if client == nil {
 		return nil, nil, fmt.Errorf("no client found for %s", spiffeID)
@@ -75,6 +69,7 @@ func (m *manager) fetchUpdates(spiffeID string, entryRequests []*entryRequest) (
 	csrs := [][]byte{}
 	if entryRequests != nil {
 		for _, entryRequest := range entryRequests {
+			m.c.Log.Debugf("Requesting SVID for %v", entryRequest.entry.RegistrationEntry.SpiffeId)
 			csrs = append(csrs, entryRequest.CSR)
 		}
 	}
@@ -83,8 +78,6 @@ func (m *manager) fetchUpdates(spiffeID string, entryRequests []*entryRequest) (
 	if err != nil && err != ErrPartialResponse {
 		return nil, nil, err
 	}
-
-	m.c.Log.Debugf("update received: %s", update)
 
 	if update.lastBundle != nil {
 		bundle, err := x509.ParseCertificates(update.lastBundle)
@@ -98,9 +91,6 @@ func (m *manager) fetchUpdates(spiffeID string, entryRequests []*entryRequest) (
 }
 
 func (m *manager) processEntryRequests(entryRequests entryRequests) (map[string]*common.RegistrationEntry, error) {
-	m.c.Log.Debug("processEntryRequests started")
-	defer m.c.Log.Debug("processEntryRequests finished")
-
 	regEntries := map[string]*common.RegistrationEntry{}
 	if len(entryRequests) == 0 {
 		return regEntries, nil
@@ -135,7 +125,7 @@ func (m *manager) updateEntriesSVIDs(entryRequestsList []*entryRequest, svids ma
 			// Complete the pre-built cache entry with the SVID and put it on the cache.
 			ce.SVID = cert
 			if m.isAgentAlias(ce.RegistrationEntry) {
-				m.c.Log.Debugf("agent alias detected: %s", ce.RegistrationEntry.SpiffeId)
+				m.c.Log.Debugf("Agent alias detected: %s", ce.RegistrationEntry.SpiffeId)
 				// Create a new client to be used when checking for new entries on behalf of this
 				// agent's alias.
 				err := m.newSyncClient([]string{ce.RegistrationEntry.SpiffeId}, ce.SVID, ce.PrivateKey)
@@ -144,16 +134,12 @@ func (m *manager) updateEntriesSVIDs(entryRequestsList []*entryRequest, svids ma
 				}
 			}
 			m.cache.SetEntry(ce)
-			m.c.Log.Debugf("updated CacheEntry for spiffeId: %s", ce.RegistrationEntry.SpiffeId)
 		}
 	}
 	return nil
 }
 
 func (m *manager) checkExpiredCacheEntries() (entryRequests, error) {
-	m.c.Log.Debug("checkExpiredCacheEntries started")
-	defer m.c.Log.Debug("checkExpiredCacheEntries finished")
-
 	entryRequests := entryRequests{}
 	for entry := range m.cache.Entries() {
 		ttl := entry.SVID.NotAfter.Sub(time.Now())
@@ -184,13 +170,8 @@ func (m *manager) checkExpiredCacheEntries() (entryRequests, error) {
 }
 
 func (m *manager) checkForNewCacheEntries(regEntries map[string]*proto.RegistrationEntry, entryRequests entryRequests) (entryRequests, error) {
-	m.c.Log.Debug("checkForNewCacheEntries started")
-	defer m.c.Log.Debug("checkForNewCacheEntries finished")
-
 	for _, regEntry := range regEntries {
 		if !m.isAlreadyCached(regEntry) && !m.isEntryRequestAlreadyCreated(regEntry, entryRequests) {
-			m.c.Log.Debugf("generating CSR for spiffeId: %s  parentId: %s", regEntry.SpiffeId, regEntry.ParentId)
-
 			privateKey, csr, err := m.newCSR(regEntry.SpiffeId)
 			if err != nil {
 				return nil, err
@@ -206,7 +187,6 @@ func (m *manager) checkForNewCacheEntries(regEntries map[string]*proto.Registrat
 			parentID := regEntry.ParentId
 			entryRequests[parentID] = append(entryRequests[parentID], &entryRequest{csr, cacheEntry})
 		} else {
-			m.c.Log.Debugf("cache hit for spiffeId: %s, parentId: %s, selectors: %v", regEntry.SpiffeId, regEntry.ParentId, regEntry.Selectors)
 			// This entry is a cached agent alias, we must synchronize updates on behalf of it.
 			if m.isAgentAlias(regEntry) {
 				err := m.synchronize(regEntry.SpiffeId)
@@ -221,15 +201,12 @@ func (m *manager) checkForNewCacheEntries(regEntries map[string]*proto.Registrat
 }
 
 func (m *manager) rotateSVID() error {
-	m.c.Log.Debug("rotateSVID started")
-	defer m.c.Log.Debug("rotateSVID finished")
-
 	svid, _ := m.getBaseSVIDEntry()
 	ttl := svid.NotAfter.Sub(time.Now())
 	lifetime := svid.NotAfter.Sub(svid.NotBefore)
 
 	if ttl < lifetime/2 {
-		m.c.Log.Debug("generating new CSR for BaseSVID")
+		m.c.Log.Debug("Rotating agent SVID")
 
 		privateKey, csr, err := m.newCSR(m.spiffeID)
 		if err != nil {
@@ -255,7 +232,6 @@ func (m *manager) rotateSVID() error {
 			return err
 		}
 
-		m.c.Log.Debug("updating manager with new BaseSVID")
 		m.setBaseSVIDEntry(cert, privateKey)
 		err = m.storeSVID()
 		if err != nil {

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -70,6 +70,7 @@ func (h *Handler) FetchBaseSVID(
 		return response, errors.New("Error trying to validate attestation")
 	}
 
+	h.Log.Debugf("Signing CSR for Agent SVID %v", baseSpiffeIDFromCSR)
 	signResponse, err := serverCA.SignCsr(&ca.SignCsrRequest{Csr: request.Csr})
 	if err != nil {
 		h.Log.Error(err)
@@ -105,9 +106,10 @@ func (h *Handler) FetchBaseSVID(
 		return response, errors.New("Error trying to compose response")
 	}
 
-	h.Log.Info("Received node attestation request from ", baseSpiffeIDFromCSR,
-		" using strategy '", request.AttestedData.Type,
-		"' completed successfully.")
+	p, ok := peer.FromContext(ctx)
+	if ok {
+		h.Log.Infof("Node attestation request from %v completed using strategy %v", p.Addr, request.AttestedData.Type)
+	}
 
 	return response, nil
 }
@@ -527,6 +529,7 @@ func (h *Handler) signCSRs(
 				return nil, err
 			}
 
+			h.Log.Debugf("Signing SVID for %v on request by %v", spiffeID, callerID)
 			svid, err := h.buildBaseSVID(csr)
 			if err != nil {
 				return nil, err
@@ -539,6 +542,7 @@ func (h *Handler) signCSRs(
 			}
 
 		} else {
+			h.Log.Debugf("Signing SVID for %v on request by %v", spiffeID, callerID)
 			svid, err := h.buildSVID(spiffeID, regEntriesMap, csr)
 			if err != nil {
 				return nil, err

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -83,7 +84,7 @@ func TestFetchBaseSVID(t *testing.T) {
 
 	data := getFetchBaseSVIDTestData()
 	setFetchBaseSVIDExpectations(suite, data)
-	response, err := suite.handler.FetchBaseSVID(nil, data.request)
+	response, err := suite.handler.FetchBaseSVID(context.Background(), data.request)
 	expected := getExpectedFetchBaseSVID(data.baseSpiffeID, data.generatedCert)
 
 	if err != nil {

--- a/pkg/server/plugin/upstreamca/disk/disk.go
+++ b/pkg/server/plugin/upstreamca/disk/disk.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/big"
 	"net/url"
 	"sync"
@@ -59,8 +58,6 @@ type diskPlugin struct {
 }
 
 func (m *diskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	log.Print("Starting Configure")
-
 	resp := &spi.ConfigureResponse{}
 
 	// Parse HCL config payload into config struct
@@ -124,21 +121,16 @@ func (m *diskPlugin) Configure(req *spi.ConfigureRequest) (*spi.ConfigureRespons
 	m.cert = cert
 	m.key = key
 
-	log.Print("Plugin successfully configured")
 	return &spi.ConfigureResponse{}, nil
 }
 
 func (*diskPlugin) GetPluginInfo(req *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	log.Print("Getting plugin information")
-
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
 func (m *diskPlugin) SubmitCSR(request *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
-
-	log.Print("Starting SubmitCSR")
 
 	if m.cert == nil {
 		return nil, errors.New("Invalid state: no cert")
@@ -199,8 +191,6 @@ func (m *diskPlugin) SubmitCSR(request *upstreamca.SubmitCSRRequest) (*upstreamc
 		return nil, err
 	}
 
-	log.Print("Successfully created certificate")
-
 	return &upstreamca.SubmitCSRResponse{
 		Cert:                cert,
 		UpstreamTrustBundle: m.cert.Raw,
@@ -231,8 +221,6 @@ func ParseSpiffeCsr(csrDER []byte, trustDomain string) (csr *x509.CertificateReq
 	if err != nil {
 		return nil, err
 	}
-
-	log.Printf("Parsing CSR with SPIFFE ID: '%v'", csrSpiffeID.String())
 
 	if csrSpiffeID.Scheme != "spiffe" {
 		return nil, fmt.Errorf("SPIFFE ID '%v' is not prefixed with the spiffe:// scheme.", csrSpiffeID)

--- a/script/e2e_test.sh
+++ b/script/e2e_test.sh
@@ -27,7 +27,7 @@ sleep 2
 
 TOKEN=$(./cmd/spire-server/spire-server token generate -spiffeID spiffe://example.org/agent | awk '{print $2}')
 ./cmd/spire-agent/spire-agent run -joinToken $TOKEN &
-sleep 8
+sleep 2
 
 set +e
 RESULT=$(./cmd/spire-agent/spire-agent api fetch)


### PR DESCRIPTION
This change is geared towards 1) removing noisy log lines, and 2) reducing the number of log lines that don't obey the configured level. Many now-builtin plugins used the log package, which our leveled logger wouldn't capture, and would be emitted in a different format than the standard log lines. Instead of logging from within the plugin, I have moved the invocations to the callsites. I have additionally removed noisy debug lines, since the DEBUG level should be geared towards information useful to an operator as opposed to a developer. Finally, now that we have the new cache manager code, I have reduced the sleep timer in the e2e tests since we no longer have to wait for one full cycle to collect all the SVIDs.

Before:
```
2018/03/13 01:04:30 Starting Configure
DEBU[0000] Setting umask to 63
INFO[0000] Starting plugin catalog                       subsystem_name=catalog
DEBU[0000] Configuring NodeAttestor plugin: join_token   subsystem_name=catalog
DEBU[0000] Configuring NodeResolver plugin: noop         subsystem_name=catalog
DEBU[0000] Configuring UpstreamCA plugin: disk           subsystem_name=catalog
2018/03/13 01:04:30 Starting Configure
2018/03/13 01:04:30 Plugin successfully configured
DEBU[0000] Configuring ControlPlaneCA plugin: memory     subsystem_name=catalog
2018/03/13 01:04:30 Starting Configure
DEBU[0000] Configuring DataStore plugin: sqlite          subsystem_name=catalog
2018/03/13 01:04:30 opening sqlite database with path file:./.data/datastore.sqlite3
INFO[0000] plugins started
DEBU[0000] Creating a new CA certificate                 subsystem_name=ca_manager
2018/03/13 01:04:30 Starting generation of CSR
2018/03/13 01:04:30 CSR with SPIFFE ID: 'spiffe://example.org' successfully generated
2018/03/13 01:04:30 Starting SubmitCSR
2018/03/13 01:04:30 Parsing CSR with SPIFFE ID: 'spiffe://example.org'
2018/03/13 01:04:30 Successfully created certificate
DEBU[0000] Activating new CA certificate                 subsystem_name=ca_manager
2018/03/13 01:04:31 Loading signing certificate
2018/03/13 01:04:31 Signing certificate with SPIFFE ID: 'spiffe://example.org' successfully loaded
DEBU[0000] Rotating server SVID                          subsystem_name=endpoints
2018/03/13 01:04:31 Starting SignCsr
2018/03/13 01:04:31 TTL is set to 0. Using default TTL: 3600
2018/03/13 01:04:31 Parsing CSR with SPIFFE ID: 'spiffe://example.org/spiffe/cp'
2018/03/13 01:04:31 Certificate successfully created
DEBU[0000] Initializing API endpoints                    subsystem_name=endpoints
INFO[0000] Starting HTTP server                          subsystem_name=endpoints
INFO[0000] Starting gRPC server                          subsystem_name=endpoints
2018/03/13 01:04:32 Starting Configure
Entry ID:	2d465ded-9cbb-4668-ae60-1de9821606a4
SPIFFE ID:	spiffe://example.org/test
Parent ID:	spiffe://example.org/agent
TTL:		3600
Selector:	unix:uid:0

2018/03/13 01:04:32 Starting Configure
INFO[0000] Starting plugin catalog                       subsystem_name=catalog
DEBU[0000] Configuring WorkloadAttestor plugin: unix     subsystem_name=catalog
DEBU[0000] Configuring WorkloadAttestor plugin: k8s      subsystem_name=catalog
DEBU[0000] Configuring NodeAttestor plugin: join_token   subsystem_name=catalog
DEBU[0000] Configuring KeyManager plugin: memory         subsystem_name=catalog
DEBU[0000] No pre-existing agent SVID found. Will perform node attestation
2018/03/13 01:04:33 Starting SignCsr
2018/03/13 01:04:33 TTL is set to 0. Using default TTL: 3600
2018/03/13 01:04:33 Parsing CSR with SPIFFE ID: 'spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a'
2018/03/13 01:04:33 Certificate successfully created
INFO[0002] Received node attestation request from spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a using strategy 'join_token' completed successfully.  subsystem_name=node_api
DEBU[0000] synchronize started for spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
DEBU[0000] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
DEBU[0000] update received: { regEntries: [{ spiffeID: spiffe://example.org/agent, parentID: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a, selectors: [type:"spiffe_id" value:"spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a" ]}], svids: [], lastBundle: bytes}  subsystem_name=manager
DEBU[0000] fetchUpdates finished                         subsystem_name=manager
DEBU[0000] checkExpiredCacheEntries started              subsystem_name=manager
DEBU[0000] checkExpiredCacheEntries finished             subsystem_name=manager
DEBU[0000] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0000] generating CSR for spiffeId: spiffe://example.org/agent  parentId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
DEBU[0000] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0000] processEntryRequests started                  subsystem_name=manager
DEBU[0000] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
2018/03/13 01:04:33 Starting SignCsr
2018/03/13 01:04:33 TTL is set to 0. Using default TTL: 3600
2018/03/13 01:04:33 Parsing CSR with SPIFFE ID: 'spiffe://example.org/agent'
2018/03/13 01:04:33 Certificate successfully created
DEBU[0000] update received: { regEntries: [{ spiffeID: spiffe://example.org/agent, parentID: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a, selectors: [type:"spiffe_id" value:"spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a" ]}], svids: [spiffe://example.org/agent: svid_cert:"0\202\002;0\202\001 ], lastBundle: bytes}  subsystem_name=manager
DEBU[0000] fetchUpdates finished                         subsystem_name=manager
DEBU[0000] agent alias detected: spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] updated CacheEntry for spiffeId: spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] processEntryRequests finished                 subsystem_name=manager
DEBU[0000] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0000] cache hit for spiffeId: spiffe://example.org/agent, parentId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a, selectors: [type:"spiffe_id" value:"spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a" ]  subsystem_name=manager
DEBU[0000] synchronize started for spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] update received: { regEntries: [{ spiffeID: spiffe://example.org/test, parentID: spiffe://example.org/agent, selectors: [type:"unix" value:"uid:0" ]}], svids: [], lastBundle: bytes}  subsystem_name=manager
DEBU[0000] fetchUpdates finished                         subsystem_name=manager
DEBU[0000] checkExpiredCacheEntries started              subsystem_name=manager
DEBU[0000] checkExpiredCacheEntries finished             subsystem_name=manager
DEBU[0000] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0000] generating CSR for spiffeId: spiffe://example.org/test  parentId: spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0000] processEntryRequests started                  subsystem_name=manager
DEBU[0000] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/agent  subsystem_name=manager
2018/03/13 01:04:33 Starting SignCsr
2018/03/13 01:04:33 Parsing CSR with SPIFFE ID: 'spiffe://example.org/test'
2018/03/13 01:04:33 Certificate successfully created
DEBU[0000] update received: { regEntries: [{ spiffeID: spiffe://example.org/test, parentID: spiffe://example.org/agent, selectors: [type:"unix" value:"uid:0" ]}], svids: [spiffe://example.org/test: svid_cert:"0\202\002:0\202\001 ], lastBundle: bytes}  subsystem_name=manager
DEBU[0000] fetchUpdates finished                         subsystem_name=manager
DEBU[0000] updated CacheEntry for spiffeId: spiffe://example.org/test  subsystem_name=manager
DEBU[0000] processEntryRequests finished                 subsystem_name=manager
DEBU[0000] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0000] cache hit for spiffeId: spiffe://example.org/test, parentId: spiffe://example.org/agent, selectors: [type:"unix" value:"uid:0" ]  subsystem_name=manager
DEBU[0000] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0000] processEntryRequests started                  subsystem_name=manager
DEBU[0000] processEntryRequests finished                 subsystem_name=manager
DEBU[0000] synchronize finished                          subsystem_name=manager
DEBU[0000] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0000] processEntryRequests started                  subsystem_name=manager
DEBU[0000] processEntryRequests finished                 subsystem_name=manager
DEBU[0000] synchronize finished                          subsystem_name=manager
DEBU[0005] synchronize started for spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
DEBU[0005] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a  subsystem_name=manager
DEBU[0005] update received: { regEntries: [{ spiffeID: spiffe://example.org/agent, parentID: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a, selectors: [type:"spiffe_id" value:"spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a" ]}], svids: [], lastBundle: bytes}  subsystem_name=manager
DEBU[0005] fetchUpdates finished                         subsystem_name=manager
DEBU[0005] checkExpiredCacheEntries started              subsystem_name=manager
DEBU[0005] checkExpiredCacheEntries finished             subsystem_name=manager
DEBU[0005] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0005] cache hit for spiffeId: spiffe://example.org/agent, parentId: spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a, selectors: [type:"spiffe_id" value:"spiffe://example.org/spire/agent/join_token/193d795d-c02c-43e8-84ed-888ae1ed7f3a" ]  subsystem_name=manager
DEBU[0005] synchronize started for spiffe://example.org/agent  subsystem_name=manager
DEBU[0005] fetchUpdates started using SVID and key for spiffeId: spiffe://example.org/agent  subsystem_name=manager
DEBU[0005] update received: { regEntries: [{ spiffeID: spiffe://example.org/test, parentID: spiffe://example.org/agent, selectors: [type:"unix" value:"uid:0" ]}], svids: [], lastBundle: bytes}  subsystem_name=manager
DEBU[0005] fetchUpdates finished                         subsystem_name=manager
DEBU[0005] checkExpiredCacheEntries started              subsystem_name=manager
DEBU[0005] checkExpiredCacheEntries finished             subsystem_name=manager
DEBU[0005] checkForNewCacheEntries started               subsystem_name=manager
DEBU[0005] cache hit for spiffeId: spiffe://example.org/test, parentId: spiffe://example.org/agent, selectors: [type:"unix" value:"uid:0" ]  subsystem_name=manager
DEBU[0005] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0005] processEntryRequests started                  subsystem_name=manager
DEBU[0005] processEntryRequests finished                 subsystem_name=manager
DEBU[0005] synchronize finished                          subsystem_name=manager
DEBU[0005] checkForNewCacheEntries finished              subsystem_name=manager
DEBU[0005] processEntryRequests started                  subsystem_name=manager
DEBU[0005] processEntryRequests finished                 subsystem_name=manager
DEBU[0005] synchronize finished                          subsystem_name=manager
2018/03/13 01:04:40 Attesting PID: 490
2018/03/13 01:04:40 Attesting PID: 490
2018/03/13 01:04:40 No kube pod entry found in /proc/490/cgroup
2018/03/13 01:04:40 Selectors found: [type:"unix" value:"uid:0"  type:"unix" value:"gid:0" ]
Fetched 1 bundle in 5.421627ms SPIFFE ID: spiffe://example.org/test SVID Valid After: 2018-03-13 01:04:32 +0000 UTC SVID Valid Until: 2018-03-13 02:04:33 +0000 UTC CA #1 Valid After: 2018-03-13 01:04:20 +0000 UTC CA #1 Valid Until: 2018-03-13 02:04:30 +0000 UTC


Test passed.

INFO[0010] Stopping HTTP server                          subsystem_name=endpoints
INFO[0007] Stopping plugin catalog                       subsystem_name=catalog
2018/03/13 01:04:40 [DEBUG] plugin: waiting for all plugin processes to complete...
INFO[0007] agent stopped gracefully
INFO[0010] Stopping gRPC server                          subsystem_name=endpoints
DEBU[0010] Stopping SVID rotator                         subsystem_name=endpoints
INFO[0010] Stopping plugin catalog                       subsystem_name=catalog
2018/03/13 01:04:40 [DEBUG] plugin: waiting for all plugin processes to complete...
```

After:
```
DEBU[0000] Setting umask to 63
INFO[0000] Starting plugin catalog                       subsystem_name=catalog
DEBU[0000] Configuring ControlPlaneCA plugin: memory     subsystem_name=catalog
DEBU[0000] Configuring DataStore plugin: sqlite          subsystem_name=catalog
2018/03/13 00:56:40 opening sqlite database with path file:./.data/datastore.sqlite3
DEBU[0000] Configuring NodeAttestor plugin: join_token   subsystem_name=catalog
DEBU[0000] Configuring NodeResolver plugin: noop         subsystem_name=catalog
DEBU[0000] Configuring UpstreamCA plugin: disk           subsystem_name=catalog
INFO[0000] plugins started
DEBU[0000] Creating a new CA certificate                 subsystem_name=ca_manager
DEBU[0000] Activating new CA certificate                 subsystem_name=ca_manager
DEBU[0000] Rotating server SVID                          subsystem_name=endpoints
DEBU[0000] Initializing API endpoints                    subsystem_name=endpoints
INFO[0000] Starting gRPC server                          subsystem_name=endpoints
INFO[0000] Starting HTTP server                          subsystem_name=endpoints
Entry ID:	1b5fd64d-1818-42fd-ae54-2a4e1ef591ea
SPIFFE ID:	spiffe://example.org/test
Parent ID:	spiffe://example.org/agent
TTL:		3600
Selector:	unix:uid:0

INFO[0000] Starting plugin catalog                       subsystem_name=catalog
DEBU[0000] Configuring NodeAttestor plugin: join_token   subsystem_name=catalog
DEBU[0000] Configuring KeyManager plugin: memory         subsystem_name=catalog
DEBU[0000] Configuring WorkloadAttestor plugin: k8s      subsystem_name=catalog
DEBU[0000] Configuring WorkloadAttestor plugin: unix     subsystem_name=catalog
INFO[0000] Performing node attestation
DEBU[0002] Signing CSR for Agent SVID spiffe://example.org/spire/agent/join_token/db475cd1-0c8e-433a-80b4-d4f0b793f469  subsystem_name=node_api
INFO[0002] Node attestation request from 127.0.0.1:40284 completed using strategy join_token  subsystem_name=node_api
DEBU[0000] Requesting SVID for spiffe://example.org/agent  subsystem_name=manager
DEBU[0002] Signing SVID for spiffe://example.org/agent on request by spiffe://example.org/spire/agent/join_token/db475cd1-0c8e-433a-80b4-d4f0b793f469  subsystem_name=node_api
DEBU[0000] Agent alias detected: spiffe://example.org/agent  subsystem_name=manager
DEBU[0000] Requesting SVID for spiffe://example.org/test  subsystem_name=manager
DEBU[0002] Signing SVID for spiffe://example.org/test on request by spiffe://example.org/agent  subsystem_name=node_api
INFO[0000] Starting workload API                         subsystem_name=endpoints
2018/03/13 00:56:44 Attesting PID: 3452
2018/03/13 00:56:44 Attesting PID: 3452
2018/03/13 00:56:44 No kube pod entry found in /proc/3452/cgroup
2018/03/13 00:56:44 Selectors found: [type:"unix" value:"uid:0"  type:"unix" value:"gid:0" ]
Fetched 1 bundle in 6.812841ms SPIFFE ID: spiffe://example.org/test SVID Valid After: 2018-03-13 00:56:41 +0000 UTC SVID Valid Until: 2018-03-13 01:56:42 +0000 UTC CA #1 Valid After: 2018-03-13 00:56:30 +0000 UTC CA #1 Valid Until: 2018-03-13 01:56:40 +0000 UTC


Test passed.

INFO[0002] Stopping plugin catalog                       subsystem_name=catalog
2018/03/13 00:56:44 [DEBUG] plugin: waiting for all plugin processes to complete...
INFO[0002] Cache manager stopped                         subsystem_name=manager
INFO[0004] Stopping plugin catalog                       subsystem_name=catalog
INFO[0002] Agent stopped gracefully
2018/03/13 00:56:44 [DEBUG] plugin: waiting for all plugin processes to complete...
INFO[0004] Stopping HTTP server                          subsystem_name=endpoints
DEBU[0004] Stopping SVID rotator                         subsystem_name=endpoints
INFO[0004] Stopping gRPC server                          subsystem_name=endpoints
```