### PR TITLE
Update codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-* @kunzimariano @evan2645 @walmav @paul-argeniss @amartinezfayo @y2bishop2y 
+* @evan2645 @walmav @amartinezfayo @martincapello @marcosdy
 
 # infrastructure maintenance
-build.sh        @drrt
-Dockerfile      @drrt
-Makefile        @drrt
-README.md       @drrt
-CONTRIBUTING.md @drrt
+build.sh        @drrt @evan2645 @amartinezfayo @martincapello
+Dockerfile      @drrt @evan2645 @amartinezfayo @martincapello
+Makefile        @drrt @evan2645 @amartinezfayo @martincapello
+README.md       @drrt @evan2645 @amartinezfayo @martincapello
+CONTRIBUTING.md @drrt @evan2645 @amartinezfayo @martincapello


### PR DESCRIPTION
This commit juggles around some of the SPIRE maintainers. I have verified with all those listed that they are willing and able. I have also removed folks who are no longer actively contributing to SPIRE.

@drrt I have left you as a build/infra reviewer because you know most of these things, but have added myself and a couple others so we don't need to block on you for silly stuff.