### PR TITLE
Allow gRPC endpoints to be customizable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ artifact:
 	$(docker) ./build.sh artifact
 
 test:
-	$(docker) go test -race $$(glide novendor)
+	$(docker) go test -race -timeout 8m $$(glide novendor)
 
 race-test:
 	$(docker) go test -race $$(glide novendor)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -82,7 +82,7 @@ func (a *Agent) run() error {
 		return err
 	}
 
-	a.t.Go(func() error { return a.startEndpoints(bundle) })
+	a.t.Go(a.startEndpoints)
 	a.t.Go(a.superviseManager)
 
 	<-a.t.Dying()
@@ -246,10 +246,8 @@ func (a *Agent) startManager(svid *x509.Certificate, key *ecdsa.PrivateKey, bund
 	return a.Manager.Start()
 }
 
-// TODO: Shouldn't need to pass bundle here
-func (a *Agent) startEndpoints(bundle []*x509.Certificate) error {
+func (a *Agent) startEndpoints() error {
 	config := &endpoints.Config{
-		Bundle:   bundle,
 		BindAddr: a.c.BindAddress,
 		Catalog:  a.Catalog,
 		Manager:  a.Manager,

--- a/pkg/agent/endpoints/config.go
+++ b/pkg/agent/endpoints/config.go
@@ -1,7 +1,6 @@
 package endpoints
 
 import (
-	"crypto/x509"
 	"net"
 
 	"github.com/sirupsen/logrus"
@@ -9,12 +8,15 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 
+	"google.golang.org/grpc"
+
 	tomb "gopkg.in/tomb.v2"
 )
 
 type Config struct {
-	Bundle   []*x509.Certificate
 	BindAddr *net.UnixAddr
+
+	GRPCHook func(*grpc.Server) error
 
 	Catalog catalog.Catalog
 	Manager manager.Manager

--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -37,6 +37,13 @@ func (e *endpoints) Start() error {
 		return err
 	}
 
+	if e.c.GRPCHook != nil {
+		err = e.c.GRPCHook(e.grpc)
+		if err != nil {
+			return fmt.Errorf("call grpc hook: %v", err)
+		}
+	}
+
 	e.c.Log.Info("Starting workload API")
 	e.t.Go(func() error { return e.start(l) })
 	return nil

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -9,6 +9,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/server/catalog"
 
+	"google.golang.org/grpc"
+
 	"gopkg.in/tomb.v2"
 )
 
@@ -16,6 +18,9 @@ type Config struct {
 	// Addresses to bind the servers to
 	GRPCAddr *net.TCPAddr
 	HTTPAddr *net.TCPAddr
+
+	// A hook allowing the consumer to customize the gRPC server before it starts.
+	GRPCHook func(*grpc.Server) error
 
 	// The server's configured trust domain. Used for validation, server SVID, etc.
 	TrustDomain url.URL

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -191,6 +191,13 @@ func (e *endpoints) startGRPCServer() error {
 		return err
 	}
 
+	if e.c.GRPCHook != nil {
+		err := e.c.GRPCHook(e.grpcServer)
+		if err != nil {
+			return fmt.Errorf("call grpc hook: %v", err)
+		}
+	}
+
 	// Skip use of tomb here so we don't pollute a clean shutdown with errors
 	e.c.Log.Info("Starting gRPC server")
 	errChan := make(chan error)

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -272,7 +272,9 @@ func (s *EndpointsTestSuite) expectSVIDRotation(cert *x509.Certificate) {
 		StoredIntermediateCert: cert.Raw,
 	}
 
-	s.catalog.EXPECT().CAs().Return([]ca.ControlPlaneCa{s.ca})
-	s.ca.EXPECT().SignCsr(gomock.Any()).Return(signedCert, nil)
-	s.ca.EXPECT().FetchCertificate(gomock.Any()).Return(caCert, nil)
+	// TODO: Why is .AnyTimes() required here?
+	// TODO: See my commit message
+	s.catalog.EXPECT().CAs().Return([]ca.ControlPlaneCa{s.ca}).AnyTimes()
+	s.ca.EXPECT().SignCsr(gomock.Any()).Return(signedCert, nil).AnyTimes()
+	s.ca.EXPECT().FetchCertificate(gomock.Any()).Return(caCert, nil).AnyTimes()
 }


### PR DESCRIPTION
Consumers of the endpoints package may wish to customize the gRPC server, however most customizations must be done before the server has started. Expose a configurable hook in the endpoints package which will be called prior to starting the server, allowing consumers to customize the grpc server as they need.