### PR TITLE
Introduce a configurable to allow distrubuting upstream CAs in the bundle

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -45,6 +45,7 @@ type serverConfig struct {
 	ServerSVIDTtl    int    `hcl:"server_svid_ttl"`
 	ConfigPath       string
 	Umask            string   `hcl:"umask"`
+	UpstreamBundle   bool     `hcl:"upstream_bundle"`
 	ProfilingEnabled bool     `hcl:"profiling_enabled"`
 	ProfilingPort    int      `hcl:"profiling_port"`
 	ProfilingFreq    int      `hcl:"profiling_freq"`
@@ -149,6 +150,7 @@ func parseFlags(args []string) (*runConfig, error) {
 	flags.StringVar(&c.Server.LogLevel, "logLevel", "", "DEBUG, INFO, WARN or ERROR")
 	flags.StringVar(&c.Server.ConfigPath, "config", defaultConfigPath, "Path to a SPIRE config file")
 	flags.StringVar(&c.Server.Umask, "umask", "", "Umask value to use for new files")
+	flags.BoolVar(&c.Server.UpstreamBundle, "upstreamBundle", false, "Include upstream CA certificates in the bundle")
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -217,6 +219,11 @@ func mergeConfig(orig *server.Config, cmd *runConfig) error {
 			return fmt.Errorf("Could not parse umask %s: %s", cmd.Server.Umask, err)
 		}
 		orig.Umask = int(umask)
+	}
+
+	// TODO: CLI should be able to override with `false` value
+	if cmd.Server.UpstreamBundle {
+		orig.UpstreamBundle = cmd.Server.UpstreamBundle
 	}
 
 	if cmd.Server.ProfilingEnabled {

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -19,6 +19,7 @@ a .conf file or passed as command line args, the command line configurations tak
 | `log_level`       | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>    | INFO                          |
 | `trust_domain`    | The trust domain that this server belongs to           |                               |
 | `umask`           | Umask value to use for new files                       | 0077                          |
+| `upstream_bundle` | Include upstream CA certificates in the trust bundle   | false                         |
 
 **Note:** Changing the umask may expose your signing authority to users other than the SPIRE
 agent/server.

--- a/pkg/server/ca/config.go
+++ b/pkg/server/ca/config.go
@@ -15,6 +15,8 @@ type Config struct {
 	Catalog     catalog.Catalog
 	TrustDomain url.URL
 
+	UpstreamBundle bool
+
 	Log logrus.FieldLogger
 }
 

--- a/pkg/server/plugin/datastore/sqlite/model_utils.go
+++ b/pkg/server/plugin/datastore/sqlite/model_utils.go
@@ -1,0 +1,19 @@
+package sqlite
+
+import (
+	"bytes"
+)
+
+func (b *Bundle) Append(cert CACert) {
+	b.CACerts = append(b.CACerts, cert)
+}
+
+func (b *Bundle) Contains(cert CACert) bool {
+	for _, c := range b.CACerts {
+		if bytes.Compare(c.Cert, cert.Cert) == 0 {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/server/plugin/datastore/sqlite/model_utils_test.go
+++ b/pkg/server/plugin/datastore/sqlite/model_utils_test.go
@@ -1,0 +1,46 @@
+package sqlite
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBundleAppend(t *testing.T) {
+	cert1 := CACert{
+		Cert: []byte{'a'},
+	}
+	cert2 := CACert{
+		Cert: []byte{'b'},
+	}
+
+	b := Bundle{
+		CACerts: []CACert{cert1},
+	}
+
+	expected := []CACert{cert1, cert2}
+	b.Append(cert2)
+	if !reflect.DeepEqual(b.CACerts, expected) {
+		t.Errorf("wanted: %v; got: %v", expected, b.CACerts)
+	}
+}
+
+func TestBundleContains(t *testing.T) {
+	cert1 := CACert{
+		Cert: []byte{'a'},
+	}
+	cert2 := CACert{
+		Cert: []byte{'b'},
+	}
+
+	b := Bundle{
+		CACerts: []CACert{cert1},
+	}
+
+	if !b.Contains(cert1) {
+		t.Error("wanted true; got false")
+	}
+
+	if b.Contains(cert2) {
+		t.Error("wanted false; got true")
+	}
+}

--- a/pkg/server/plugin/datastore/sqlite/sqlite.go
+++ b/pkg/server/plugin/datastore/sqlite/sqlite.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"bytes"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -125,18 +124,9 @@ func (ds *sqlitePlugin) AppendBundle(req *datastore.Bundle) (*datastore.Bundle, 
 	}
 	model.CACerts = caCerts
 
-	// Make sure we don't already have the certs stored
 	for _, newCA := range newModel.CACerts {
-		var found bool
-		for _, c := range model.CACerts {
-			if bytes.Compare(newCA.Cert, c.Cert) == 0 {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			model.CACerts = append(model.CACerts, newCA)
+		if !model.Contains(newCA) {
+			model.Append(newCA)
 		}
 	}
 

--- a/pkg/server/plugin/datastore/sqlite/sqlite_test.go
+++ b/pkg/server/plugin/datastore/sqlite/sqlite_test.go
@@ -57,6 +57,11 @@ func TestBundle_CRUD(t *testing.T) {
 	certs := append(bundle.CaCerts, cert.Raw...)
 	assert.Equal(t, certs, aresp.CaCerts)
 
+	// append identical
+	aresp, err = ds.AppendBundle(bundle2)
+	require.NoError(t, err)
+	assert.Equal(t, certs, aresp.CaCerts)
+
 	// append on a new bundle
 	bundle3 := &datastore.Bundle{
 		TrustDomain: "spiffe://bar/",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -44,6 +44,9 @@ type Config struct {
 	// Umask value to use
 	Umask int
 
+	// Include upstream CA certificates in the bundle
+	UpstreamBundle bool
+
 	// If true enables profiling.
 	ProfilingEnabled bool
 


### PR DESCRIPTION
OpenSSL, by default, will not validate an intermediate certificate as a root. Currently, we _always_ use the upstream CA to generate intermediate signing certs (we should probably introduce a change to allow us to disable this behavior in the future). In order to 1) support OpenSSL clients that don't have PARTIAL_CHAIN set, and 2) help with agent survivability, this commit introduces a configuration flag that instructs SPIRE server to include the upstream CA certificate(s) in the bundles it distributes.

I will note that currently, there is no way to _disable_ this behavior by CLI if it has been set in the config file. The behavior can only be _enabled_ by CLI. This is due to both the way that flags package handles bool options, as well as the way we merge config values from both file and CLI.

Disabled by default. Fixes #355