### PR TITLE
Update aws_iid attestor name

### DIFF
--- a/pkg/agent/plugin/nodeattestor/aws/iid.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	pluginName                  = "aws_iid_attestor"
+	pluginName                  = "aws_iid"
 	defaultIdentityDocumentUrl  = "http://169.254.169.254/latest/dynamic/instance-identity/document"
 	defaultIdentitySignatureUrl = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
 )

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	pluginName = "aws_iid_attestor"
+	pluginName = "aws_iid"
 
 	accessIDVarName  = "AWS_ACCESS_KEY_ID"
 	secretKeyVarName = "AWS_SECRET_ACCESS_KEY"


### PR DESCRIPTION
When the AWS attestor was merged as a builtin, the name was changed but the plugin was never updated to reflect the change, so attested_data routing in the server broke as a result.

Related to https://github.com/spiffe/spire/issues/120

Signed-off-by: Evan Gilman <evan@scytale.io>