### PR TITLE
[#417] Ensure the agent's SVID is cached as soon as it's generated.

### DIFF
--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -71,7 +71,12 @@ type manager struct {
 }
 
 func (m *manager) Start() error {
-	err := m.synchronize(m.spiffeID)
+	err := m.storeSVID()
+	if err != nil {
+		m.c.Log.Warnf("Could not write SVID to %v: %v", m.svidCachePath, err)
+	}
+
+	err = m.synchronize(m.spiffeID)
 	if err != nil {
 		m.close(err)
 		return err


### PR DESCRIPTION
This commit updates the cache manager to call storeSVID() as soon as it starts.

Cache manager is in need of some readability and testability refactoring - it currently has no test coverage... Opened #418 to track.

Fixes #417

Signed-off-by: Evan Gilman <evan@scytale.io>