### PR TITLE
[#420] Fix the upstream_bundle configurable

### DIFF
--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -6,6 +6,7 @@ server {
     plugin_dir = "conf/server/plugin"
     log_level = "DEBUG"
     umask = ""
+    upstream_bundle = true
 }
 
 plugins {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,9 +208,10 @@ func (s *Server) startCAManager() error {
 	defer s.m.Unlock()
 
 	config := &ca.Config{
-		Catalog:     s.Catalog,
-		TrustDomain: s.Config.TrustDomain,
-		Log:         s.Config.Log.WithField("subsystem_name", "ca_manager"),
+		Catalog:        s.Catalog,
+		TrustDomain:    s.Config.TrustDomain,
+		Log:            s.Config.Log.WithField("subsystem_name", "ca_manager"),
+		UpstreamBundle: s.Config.UpstreamBundle,
 	}
 
 	s.caManager = ca.New(config)


### PR DESCRIPTION
Turns out that everything works, the only problem is that the server's configurable is not passed to the CA manager when it is initialized. This change does just that. It also sets this option by default in the dev config, which should alleviate some hardships around server restarts. Fixes #420

```
Received 1 bundle after 7.326471ms

SPIFFE ID:		spiffe://example.org/test
SVID Valid After:	2018-04-10 23:47:17 +0000 UTC
SVID Valid Until:	2018-04-10 23:48:18 +0000 UTC
CA #1 Valid After:	2018-04-10 23:47:06 +0000 UTC
CA #1 Valid Until:	2018-04-11 00:47:16 +0000 UTC
CA #2 Valid After:	2018-02-09 23:20:33 +0000 UTC
CA #2 Valid Until:	2023-02-08 23:20:33 +0000 UTC
```

Signed-off-by: Evan Gilman <evan@scytale.io>