### PR TITLE
Update the agent's data_dir in our dev config

### DIFF
--- a/conf/agent/agent.conf
+++ b/conf/agent/agent.conf
@@ -1,7 +1,7 @@
 agent {
     bind_address = "127.0.0.1"
     bind_port = "8088"
-    data_dir = "."
+    data_dir = "./.data"
     log_level = "DEBUG"
     plugin_dir = "conf/agent/plugin"
     server_address = "127.0.0.1"


### PR DESCRIPTION
Currently, agent data_dir is CWD which, given normal dev workflow, is the root of the project. When running tests etc, the agent writes a certificate and a bundle to this directory, leaving the modifications behind for git to complain about.

Rather than adding these files to gitignore directly, change the data_dir to `.data`, which we 1) already use for server's datastore, and 2) already have added to .gitignore.

Signed-off-by: Evan Gilman <evan@scytale.io>