### PR TITLE
Clean up workload attestor logging

### DIFF
--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -163,6 +163,7 @@ func (h *Handler) attest(pid int32) []*common.Selector {
 	}
 
 	h.T.AddSampleWithLabels([]string{"workload_api", "discovered_selectors"}, float32(len(selectors)), tLabels)
+	h.L.Debugf("PID %v attested to have selectors %v", pid, selectors)
 	return selectors
 }
 

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -3,7 +3,6 @@ package unix
 import (
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/shirou/gopsutil/process"
 	"github.com/spiffe/spire/proto/agent/workloadattestor"
@@ -16,8 +15,6 @@ type UnixPlugin struct{}
 const selectorType string = "unix"
 
 func (UnixPlugin) Attest(req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
-	log.Printf("Attesting PID: %v", req.Pid)
-
 	p, err := process.NewProcess(req.Pid)
 	resp := workloadattestor.AttestResponse{}
 
@@ -59,7 +56,6 @@ func (UnixPlugin) Attest(req *workloadattestor.AttestRequest) (*workloadattestor
 		return &resp, errors.New(fmt.Sprintf("Unable to get effective GID for PID: %v", req.Pid))
 	}
 
-	log.Printf("Selectors found: %v", resp.Selectors)
 	return &resp, nil
 }
 


### PR DESCRIPTION
Currently, both unix and k8s workload attestor log to stdout on every request. This includes PID, selectors, etc. It is quite noisy, repetitive (when both attestors are in use), and does not conform to our structured logging format.

This change removes the "happy path" logging from both workload attestors, keeping only log instances which may indicate error conditions. It also switches some of the error condition logging to return an error via grpc instead of log it. Additionally, since it can be useful for operators to know what selectors are being discovered, I have added a DEBUG line to the workload handler which logs PID and the full set of selectors discovered. Happy path now emits only structured well-formatted messages, and only emits one DEBUG line per attestation.

Signed-off-by: Evan Gilman <evan@scytale.io>