### PR TITLE
Increase CA expiry check frequency

### DIFF
--- a/pkg/server/ca/config.go
+++ b/pkg/server/ca/config.go
@@ -26,7 +26,7 @@ func New(c *Config) *manager {
 		t:   new(tomb.Tomb),
 		mtx: new(sync.RWMutex),
 
-		rotateTicker: time.NewTicker(30 * time.Minute),
+		rotateTicker: time.NewTicker(1 * time.Minute),
 		pruneTicker:  time.NewTicker(6 * time.Hour),
 	}
 }


### PR DESCRIPTION
In testing CA rotation, it is useful to set low CA TTLs. This was previously set at 30m because it seemed like a reasonable real-world value. While that remains to be (mostly) true, the cost of performing this check more often is very low (0?), and increasing the frequency will allow users to set aggressive rotation strategies, in addition to easing the testing of CA rotation.

Signed-off-by: Evan Gilman <evan@scytale.io>