### PR TITLE
Fix bundle rotation in agent

### DIFF
--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -38,6 +38,10 @@ type Cache interface {
 	IsEmpty() bool
 	// Register a Subscriber and return WorkloadUpdate on the subscriber's channel
 	Subscribe(sub *Subscriber)
+	// Set the bundle
+	SetBundle([]*x509.Certificate)
+	// Retrieve the bundle
+	Bundle() []*x509.Certificate
 }
 
 type cacheImpl struct {
@@ -59,13 +63,13 @@ func New(log logrus.FieldLogger, bundle []*x509.Certificate) Cache {
 	}
 }
 
-func (c *cacheImpl) SetServerBundle(bundle []*x509.Certificate) {
+func (c *cacheImpl) SetBundle(bundle []*x509.Certificate) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.bundle = bundle
 }
 
-func (c *cacheImpl) serverBundle() []*x509.Certificate {
+func (c *cacheImpl) Bundle() []*x509.Certificate {
 	c.m.Lock()
 	defer c.m.Unlock()
 	return c.bundle

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -53,7 +53,6 @@ func New(c *Config) (Manager, error) {
 		// Copy SVID into the manager to facilitate rotation
 		svid:            c.SVID,
 		svidKey:         c.SVIDKey,
-		bundle:          c.Bundle,
 		spiffeID:        spiffeID,
 		serverSPIFFEID:  "spiffe://" + c.TrustDomain.Host + "/spiffe/cp",
 		serverAddr:      c.ServerAddr,

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -57,7 +57,6 @@ type manager struct {
 	mtx     *sync.RWMutex
 	svid    *x509.Certificate
 	svidKey *ecdsa.PrivateKey
-	bundle  []*x509.Certificate // Latest CA bundle
 
 	spiffeID       string
 	serverSPIFFEID string
@@ -200,18 +199,14 @@ func (m *manager) setBaseSVIDEntry(svid *x509.Certificate, key *ecdsa.PrivateKey
 }
 
 func (m *manager) bundleAsCertPool() *x509.CertPool {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
 	certPool := x509.NewCertPool()
-	for _, cert := range m.bundle {
+	for _, cert := range m.cache.Bundle() {
 		certPool.AddCert(cert)
 	}
 	return certPool
 }
 
 func (m *manager) setBundle(bundle []*x509.Certificate) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	m.bundle = bundle
+	m.cache.SetBundle(bundle)
 	m.storeBundle()
 }

--- a/pkg/agent/manager/storage.go
+++ b/pkg/agent/manager/storage.go
@@ -33,7 +33,7 @@ func ReadBundle(bundleCachePath string) ([]*x509.Certificate, error) {
 func (m *manager) storeBundle() error {
 	// Write all certs to data bytes buffer.
 	data := &bytes.Buffer{}
-	for _, cert := range m.bundle {
+	for _, cert := range m.cache.Bundle() {
 		data.Write(cert.Raw)
 	}
 


### PR DESCRIPTION
The agent had a bug in which two copies of the bundle were kept - one in the manager and one in the cache, and some things referred to one while others referred to the other. This commit moves to a single source of truth (the bundle in the cache) and changes references to point there. This required adding two new methods to the cache interface, as bundle get/set was not previously exposed other than during init.

Currently cache manager has no testing - Martin is working on #418 to fix that. As part of his work, we will add test case for bundle rotation. As a result, this change doesn't ship with a test.

Fixes #406 (... though I'm not quite sure why!)
Fixes #428

Signed-off-by: Evan Gilman <evan@scytale.io>