### PR TITLE
Update gRPC Dialer to take a func for transport credentials

### DIFF
--- a/pkg/agent/manager/comm.go
+++ b/pkg/agent/manager/comm.go
@@ -169,14 +169,14 @@ func (m *manager) newGRPCConn(svid *x509.Certificate, key *ecdsa.PrivateKey) (*g
 	}
 	tlsCert = append(tlsCert, tls.Certificate{Certificate: [][]byte{svid.Raw}, PrivateKey: key})
 	tlsConfig = spiffePeer.NewTLSConfig(tlsCert)
-	credentials := credentials.NewTLS(tlsConfig)
+	credFunc := func() (credentials.TransportCredentials, error) { return  credentials.NewTLS(tlsConfig), nil }
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TODO: Make this timeout configurable?
 	defer cancel()
 
 	config := grpcutil.GRPCDialerConfig{
 		Log:   m.c.Log,
-		Creds: credentials,
+		CredFunc: credFunc,
 	}
 	dialer := grpcutil.NewGRPCDialer(config)
 	conn, err := dialer.Dial(ctx, m.serverAddr)

--- a/pkg/common/grpcutil/dialer.go
+++ b/pkg/common/grpcutil/dialer.go
@@ -3,9 +3,11 @@ package grpcutil
 import (
 	"context"
 	"errors"
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"net"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -13,9 +15,9 @@ import (
 
 type GRPCDialerConfig struct {
 	// Log is used to log errors when used in non-blocking mode.
-	Log   logrus.FieldLogger
-	Creds credentials.TransportCredentials
-	Opts  []grpc.DialOption
+	Log      logrus.FieldLogger
+	CredFunc func() (credentials.TransportCredentials, error)
+	Opts     []grpc.DialOption
 }
 
 type Dialer interface {
@@ -23,27 +25,33 @@ type Dialer interface {
 }
 
 type grpcDialer struct {
-	log   logrus.FieldLogger
-	creds credentials.TransportCredentials
-	opts  []grpc.DialOption
+	log      logrus.FieldLogger
+	credFunc func() (credentials.TransportCredentials, error)
+	opts     []grpc.DialOption
 }
 
 func NewGRPCDialer(c GRPCDialerConfig) Dialer {
 	return &grpcDialer{
-		log:   c.Log,
-		creds: c.Creds,
-		opts:  append([]grpc.DialOption{}, c.Opts...),
+		log:      c.Log,
+		credFunc: c.CredFunc,
+		opts:     append([]grpc.DialOption{}, c.Opts...),
 	}
 }
 
 // Dial dials the given address, using TLS credentials, and logs information about connection
 // errors.
 func (d *grpcDialer) Dial(ctx context.Context, addr net.Addr) (*grpc.ClientConn, error) {
-	if d.creds == nil {
+	if d.credFunc == nil {
 		return nil, errors.New("credentials are required")
 	}
 
 	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
+		creds, err := d.credFunc()
+		if err != nil {
+			d.log.Errorf("Could not fetch transport credentials: %v", err)
+			return nil, fmt.Errorf("fetch transport credentials: %v", err)
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
@@ -53,7 +61,7 @@ func (d *grpcDialer) Dial(ctx context.Context, addr net.Addr) (*grpc.ClientConn,
 			return nil, err
 		}
 
-		conn, _, err = d.creds.ClientHandshake(ctx, address, conn)
+		conn, _, err = creds.ClientHandshake(ctx, address, conn)
 		if err != nil {
 			d.log.Error(err)
 			return nil, err

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -19,6 +19,7 @@ type Rotator interface {
 	Start() error
 	Stop()
 
+	State()     State
 	Subscribe() observer.Stream
 }
 
@@ -47,6 +48,10 @@ func (r *rotator) Start() error {
 
 func (r *rotator) Stop() {
 	close(r.stop)
+}
+
+func (r *rotator) State() State {
+	return r.state.Value().(State)
 }
 
 func (r *rotator) Subscribe() observer.Stream {


### PR DESCRIPTION
After a disconnection, the gRPC library will (by default) attempt to reconnect. In doing this however, it can obscure some of the underlying error conditions which cause the disconnect in the first place. Martin did some work to introduce a custom dialer which exposes a logger, so that we get to know the reason for dial failures.

As an add-on to that work, it's desirable to pick up the latest client credentials on every retry. A disconnect and subsequent retry on an existing dialer using old credentials will result in a permanent error rather than a recovery. In order to ensure that the dialer always has up-to-date credentials, this commit switches the GRPCDialer to accept a func which return active credentials, rather than accepting static credentials at the time of instantiation. This should allow for seamless client credential rotation _and_ the builtin gRPC retries.

In doing this work, I have found that the cache manager attempts to handle these kinds of failures already... I am not sure if that logic works when the connection is severed or not, but I left that stuff in place, and instead pass a static-ish function. I suspect that with future refactors, we will be able to better utilize this update.