### PR TITLE
Ensure gRPC error messages are logged at the error level

### DIFF
--- a/pkg/agent/attestor/attestor.go
+++ b/pkg/agent/attestor/attestor.go
@@ -214,7 +214,7 @@ func (a *attestor) newSVID(key *ecdsa.PrivateKey, bundle []*x509.Certificate) (*
 
 func (a *attestor) serverConn(bundle []*x509.Certificate) (*grpc.ClientConn, error) {
 	config := grpcutil.GRPCDialerConfig{
-		Log:      a.c.Log,
+		Log:      grpcutil.LoggerFromFieldLogger(a.c.Log),
 		CredFunc: a.serverCredFunc(bundle),
 	}
 

--- a/pkg/agent/manager/comm.go
+++ b/pkg/agent/manager/comm.go
@@ -169,13 +169,13 @@ func (m *manager) newGRPCConn(svid *x509.Certificate, key *ecdsa.PrivateKey) (*g
 	}
 	tlsCert = append(tlsCert, tls.Certificate{Certificate: [][]byte{svid.Raw}, PrivateKey: key})
 	tlsConfig = spiffePeer.NewTLSConfig(tlsCert)
-	credFunc := func() (credentials.TransportCredentials, error) { return  credentials.NewTLS(tlsConfig), nil }
+	credFunc := func() (credentials.TransportCredentials, error) { return credentials.NewTLS(tlsConfig), nil }
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TODO: Make this timeout configurable?
 	defer cancel()
 
 	config := grpcutil.GRPCDialerConfig{
-		Log:   m.c.Log,
+		Log:      grpcutil.LoggerFromFieldLogger(m.c.Log),
 		CredFunc: credFunc,
 	}
 	dialer := grpcutil.NewGRPCDialer(config)

--- a/pkg/common/grpcutil/log.go
+++ b/pkg/common/grpcutil/log.go
@@ -6,7 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func LoggerFromFieldLogger(fl logrus.FieldLogger) *log.Logger {
+func LoggerFromFieldLogger(fl logrus.FieldLogger) logrus.StdLogger {
 	errWriter := fl.WithFields(logrus.Fields{}).WriterLevel(logrus.ErrorLevel)
 	return log.New(errWriter, "", 0)
 }

--- a/pkg/common/grpcutil/log.go
+++ b/pkg/common/grpcutil/log.go
@@ -1,0 +1,12 @@
+package grpcutil
+
+import (
+	"log"
+
+	"github.com/sirupsen/logrus"
+)
+
+func LoggerFromFieldLogger(fl logrus.FieldLogger) *log.Logger {
+	errWriter := fl.WithFields(logrus.Fields{}).WriterLevel(logrus.ErrorLevel)
+	return log.New(errWriter, "", 0)
+}


### PR DESCRIPTION
Pull #437 switched the grpcutil dialer to use a stdlib logger interface instead of the logrus field logger. This is desirable because we want to use the dialer in many places, not all of which have access to a full-blown logrus instance (e.g. the cli utilities).

This introduces a new problem though: logrus `Print` methods are hardcoded to log at info level, and these are the methods which are compat with the standard logger. Anything coming from the gRPC dialer should be an error and not info level.

This commit works around this issue by creating standard logger instances backed by a logrus io writer which is hardcoded to write at the error level instad of the info level.

Signed-off-by: Evan Gilman <evan@scytale.io>