### PR TITLE
Fix rotation test shutdown

### DIFF
--- a/script/rotation_test.sh
+++ b/script/rotation_test.sh
@@ -37,6 +37,16 @@ TOKEN=$(./cmd/spire-server/spire-server token generate -spiffeID spiffe://exampl
 
 set +e
 
+function finish ()
+{
+    kill %2
+    kill %1
+    wait
+    rm bundle.0.pem
+    rm svid.0.pem
+    rm svid.0.key
+}
+
 while [ $? == 0 ]; do
     if [ $END -lt $(date +%s) ]; then
         finish
@@ -58,11 +68,3 @@ echo $RESULT
 echo
 echo "Test failed."
 
-function finish ()
-{
-    kill %2
-    kill %1
-    wait
-    rm bundle.0.pem
-    rm svid.0.pem
-}


### PR DESCRIPTION
I was getting some errors when trying to call the `finish` function with this script. Moving the function call after the declaration seems to clear it up. Also add the `svid.0.key` file cleanup which I forgot

Signed-off-by: Evan Gilman <evan@scytale.io>