### PR TITLE
Fix to the way subscribers were notified about cache entries updates and the way their channels were closed

### DIFF
--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -47,13 +47,13 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 	defer h.T.IncrCounterWithLabels([]string{"workload_api", "connections"}, -1, tLabels)
 
 	selectors := h.attest(pid)
-	done := make(chan struct{})
-	defer close(done)
-	subscription := h.Manager.Subscribe(selectors, done)
+
+	subscriber := h.Manager.Subscribe(selectors)
+	defer subscriber.Finish()
 
 	for {
 		select {
-		case update := <-subscription:
+		case update := <-subscriber.Updates():
 			h.T.IncrCounterWithLabels([]string{"workload_api", "update"}, 1, tLabels)
 
 			start := time.Now()

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -5,7 +5,14 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"fmt"
+	"github.com/spiffe/spire/test/util"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	testlog "github.com/sirupsen/logrus/hooks/test"
@@ -142,4 +149,139 @@ func TestCacheImpl_DeleteEntry(t *testing.T) {
 
 		})
 	}
+}
+
+func TestNotifySubscribersDoesntBlockOnSubscriberWrite(t *testing.T) {
+	cache := New(logger, nil)
+
+	e1 := &Entry{
+		RegistrationEntry: &common.RegistrationEntry{
+			Selectors: Selectors{
+				&common.Selector{Type: "unix", Value: "uid:1000"},
+			},
+			ParentId: "spiffe:parent1",
+			SpiffeId: "spiffe:test1",
+			EntryId:  "00000000-0000-0000-0000-000000000001",
+		},
+		SVID:       &x509.Certificate{},
+		PrivateKey: privateKey,
+	}
+	cache.SetEntry(e1)
+
+	e2 := &Entry{
+		RegistrationEntry: &common.RegistrationEntry{
+			Selectors: Selectors{
+				&common.Selector{Type: "unix", Value: "uid:1111"},
+			},
+			ParentId: "spiffe:parent2",
+			SpiffeId: "spiffe:test2",
+			EntryId:  "00000000-0000-0000-0000-000000000002",
+		},
+		SVID:       &x509.Certificate{},
+		PrivateKey: privateKey,
+	}
+	cache.SetEntry(e2)
+
+	sub1, err := NewSubscriber(Selectors{&common.Selector{Type: "unix", Value: "uid:1111"}})
+	assert.Nil(t, err)
+
+	sub2, err := NewSubscriber(Selectors{&common.Selector{Type: "unix", Value: "uid:1000"}})
+	assert.Nil(t, err)
+
+	cache.notifySubscribers([]*Subscriber{sub1, sub2})
+
+	util.RunWithTimeout(t, 5*time.Second, func() {
+		wu := <-sub2.Updates()
+		assert.Equal(t, 1, len(wu.Entries))
+		assert.Equal(t, e1, wu.Entries[0])
+	})
+
+	util.RunWithTimeout(t, 5*time.Second, func() {
+		wu := <-sub1.Updates()
+		assert.Equal(t, 1, len(wu.Entries))
+		assert.Equal(t, e2, wu.Entries[0])
+	})
+}
+
+func TestNotifySubscribersDoesntPileUpGoroutines(t *testing.T) {
+	cache := New(logger, nil)
+
+	e2 := &Entry{
+		RegistrationEntry: &common.RegistrationEntry{
+			Selectors: Selectors{
+				&common.Selector{Type: "unix", Value: "uid:1111"},
+			},
+			ParentId: "spiffe:parent2",
+			SpiffeId: "spiffe:test2",
+			EntryId:  "00000000-0000-0000-0000-000000000002",
+		},
+		SVID:       &x509.Certificate{},
+		PrivateKey: privateKey,
+	}
+	cache.SetEntry(e2)
+
+	sub1, err := NewSubscriber(Selectors{&common.Selector{Type: "unix", Value: "uid:1111"}})
+	assert.Nil(t, err)
+
+	util.RunWithTimeout(t, 5*time.Second, func() {
+		ng := runtime.NumGoroutine()
+		for i := 0; i < 1000; i++ {
+			cache.notifySubscribers([]*Subscriber{sub1})
+			assert.Equal(t, ng, runtime.NumGoroutine())
+		}
+	})
+}
+
+func TestNotifySubscribersNotifiesLatestUpdatesToSlowSubscriber(t *testing.T) {
+	cache := New(logger, nil)
+
+	sub, err := NewSubscriber(Selectors{&common.Selector{Type: "unix", Value: "uid:1111"}})
+	assert.Nil(t, err)
+
+	cache.Subscribe(sub)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	var i int
+
+	go func() {
+		defer wg.Done()
+		for i = 0; i < 1000; i++ {
+			e := &Entry{
+				RegistrationEntry: &common.RegistrationEntry{
+					Selectors: Selectors{
+						&common.Selector{Type: "unix", Value: "uid:1111"},
+					},
+					ParentId: "spiffe:parent2",
+					SpiffeId: fmt.Sprintf("spiffe:test2_%d", i),
+					EntryId:  "00000000-0000-0000-0000-000000000002",
+				},
+				SVID:       &x509.Certificate{},
+				PrivateKey: privateKey,
+			}
+			cache.SetEntry(e)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var lastI int = -1
+		for i != 1000 || len(sub.Updates()) != 0 {
+			wu := <-sub.Updates()
+			if len(wu.Entries) == 1 {
+				parts := strings.Split(wu.Entries[0].RegistrationEntry.SpiffeId, "_")
+				currentI, _ := strconv.Atoi(parts[1])
+				// SpiffeId suffixes should be always increasing.
+				assert.True(t, lastI < currentI)
+				lastI = currentI
+
+				fmt.Printf("%v\n", lastI)
+				time.Sleep(2 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Wait()
 }

--- a/pkg/agent/manager/cache/subscriber.go
+++ b/pkg/agent/manager/cache/subscriber.go
@@ -48,6 +48,7 @@ func (sub *Subscriber) Finish() {
 	sub.m.Lock()
 	defer sub.m.Unlock()
 	sub.active = false
+	close(sub.c)
 }
 
 type subscribers struct {
@@ -94,14 +95,12 @@ func (s *subscribers) GetAll() (subs []*Subscriber) {
 func (s *subscribers) remove(sub *Subscriber) {
 	s.m.Lock()
 	defer s.m.Unlock()
-	close(sub.c)
 	delete(s.sidMap, sub.sid)
 	for sel, sids := range s.selMap {
 		for i, uid := range sids {
 			if uid == sub.sid {
 				s.selMap[sel] = append(sids[:i], sids[i+1:]...)
 			}
-
 		}
 	}
 }

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -30,9 +30,9 @@ type Manager interface {
 	// Shutdown blocks until the manager stops.
 	Shutdown()
 
-	// Subscribe returns a channel on which cache entry updates are sent
+	// Subscribe returns a Subscriber on which cache entry updates are sent
 	// for a particular set of selectors.
-	Subscribe(key cache.Selectors, done chan struct{}) chan *cache.WorkloadUpdate
+	Subscribe(key cache.Selectors) *cache.Subscriber
 
 	// MatchingEntries takes a slice of selectors, and iterates over all the in force entries
 	// in order to find matching cache entries. A cache entry is matched when its RegistrationEntry's
@@ -112,17 +112,16 @@ func (m *manager) Shutdown() {
 	}
 }
 
-func (m *manager) Subscribe(selectors cache.Selectors, done chan struct{}) chan *cache.WorkloadUpdate {
+func (m *manager) Subscribe(selectors cache.Selectors) *cache.Subscriber {
 	// creates a subscriber
 	// adds it to the manager
-	// returns the added subscriber channel
-	sub, err := cache.NewSubscriber(selectors, done)
+	// returns the added subscriber
+	sub, err := cache.NewSubscriber(selectors)
 	if err != nil {
 		m.c.Log.Error(err)
 	}
 	m.cache.Subscribe(sub)
-
-	return sub.C
+	return sub
 }
 
 func (m *manager) MatchingEntries(selectors []*common.Selector) (entries []*cache.Entry) {


### PR DESCRIPTION
Fixes notifySubscribers to avoid several issues as described on #444.
Also this PR contains some changes to the way updates to subscribers were delivered, and the way subscribers were signaling their desire to stop receiving updates (done channel was replaced by a Finish function on the subscriber). Corresponding tests were added.
Fixes #444 
Fixes #443 

