### PR TITLE
skip anti-tampering mechanism when ephemeral volumes detected

### DIFF
--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -155,7 +155,8 @@ func (p *IIDAttestorPlugin) Attest(req *nodeattestor.AttestRequest) (*nodeattest
 
 	ifaceZeroAttachTime := instance.NetworkInterfaces[0].Attachment.AttachTime
 
-	if p.skipBlockDevice != true {
+	// skip anti-tampering mechanism when RootDeviceType is instance-store
+	if *instance.RootDeviceType != ec2.DeviceTypeInstanceStore && p.skipBlockDevice != true {
 		rootDeviceIndex := -1
 		for i, bdm := range instance.BlockDeviceMappings {
 			if *bdm.DeviceName == *instance.RootDeviceName {


### PR DESCRIPTION
skip anti-tampering mechanism when ephemeral volumes detected

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
The AWS node attestor has an anti-tampering mechanism which checks to make sure that the underlying root volume has not been detached prior to attestation. Unfortunately, this seems to break on instances with ephemeral root volumes.

**Description of change**
refactored aws_iid note attesto to skip anti-tampering mechanism  when instance-store is detected, `skipBlockDevice` configuration added by 411.
Now there are 2 ways to avoid  anti-tampering mechanism:
- AWS instance Root Device Type is not "instance-store"
- skipBlockDevice is set as true (as a boolean skipBlockDevice is false as default)

**Which issue this PR fixes**
fixes #410 
 
