### PR TITLE
command version strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,13 @@ binary_dirs := $(shell find cmd/* functional/tools/* -maxdepth 0 -type d)
 docker_volume := $(shell echo $${PWD%/src/*}):/root/go
 docker_image = spire-dev:latest
 gopath := $(shell go env GOPATH)
-githash := $(shell git rev-parse --short=8 HEAD)
+gittag := $(shell git tag --points-at)
 gitdirty := $(shell git status -s)
+# don't provide the git tag if the git status is dirty.
 ifneq ($(gitdirty),)
-	githash := $(githash)-dirty
+	gittag :=
 endif
-ldflags := '-X github.com/spiffe/spire/pkg/common/version.githash=$(githash)'
+ldflags := '-X github.com/spiffe/spire/pkg/common/version.gittag=$(gittag)'
 
 utils = github.com/golang/protobuf/protoc-gen-go \
 		github.com/grpc-ecosystem/grpc-gateway \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ binary_dirs := $(shell find cmd/* functional/tools/* -maxdepth 0 -type d)
 docker_volume := $(shell echo $${PWD%/src/*}):/root/go
 docker_image = spire-dev:latest
 gopath := $(shell go env GOPATH)
+githash := $(shell git rev-parse --short=8 HEAD)
+gitdirty := $(shell git status -s)
+ifneq ($(gitdirty),)
+	githash := $(githash)-dirty
+endif
+ldflags := '-X github.com/spiffe/spire/pkg/common/version.githash=$(githash)'
 
 utils = github.com/golang/protobuf/protoc-gen-go \
 		github.com/grpc-ecosystem/grpc-gateway \
@@ -45,7 +51,7 @@ vendor: glide.yaml glide.lock
 	$(docker) glide --home .cache install
 
 $(binary_dirs): noop
-	$(docker) /bin/sh -c "cd $@; go build -i"
+	$(docker) /bin/sh -c "cd $@; go build -i -ldflags $(ldflags)"
 
 artifact:
 	$(docker) ./build.sh artifact

--- a/cmd/spire-agent/cli/cli.go
+++ b/cmd/spire-agent/cli/cli.go
@@ -6,11 +6,11 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/api"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/run"
+	"github.com/spiffe/spire/pkg/common/version"
 )
 
 func Run(args []string) int {
-
-	c := cli.NewCLI("spire-agent", "0.0.1") //TODO expose version configuration
+	c := cli.NewCLI("spire-agent", version.Version())
 	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
 		"api fetch": func() (cli.Command, error) {

--- a/cmd/spire-server/cli/cli.go
+++ b/cmd/spire-server/cli/cli.go
@@ -8,10 +8,11 @@ import (
 	"github.com/spiffe/spire/cmd/spire-server/cli/entry"
 	"github.com/spiffe/spire/cmd/spire-server/cli/run"
 	"github.com/spiffe/spire/cmd/spire-server/cli/token"
+	"github.com/spiffe/spire/pkg/common/version"
 )
 
 func Run(args []string) int {
-	c := cli.NewCLI("spire-server", "0.0.1") //TODO expose version configuration
+	c := cli.NewCLI("spire-server", version.Version())
 	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
 		"bundle show": func() (cli.Command, error) {

--- a/functional/tools/stresstest/stresstest.go
+++ b/functional/tools/stresstest/stresstest.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/mitchellh/cli"
+	"github.com/spiffe/spire/pkg/common/version"
 )
 
 const (
@@ -19,7 +20,7 @@ func main() {
 		panic("Do not run this tool outside the Docker container")
 	}
 
-	c := cli.NewCLI("stresstest", "0.0.1") //TODO expose version configuration
+	c := cli.NewCLI("stresstest", version.Version())
 	c.Args = os.Args[1:]
 	c.Commands = map[string]cli.CommandFactory{
 		"run": func() (cli.Command, error) {

--- a/pkg/common/version/version.go
+++ b/pkg/common/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+import "fmt"
+
+const (
+	Base = "0.0.1"
+)
+
+var (
+	githash = ""
+)
+
+func Version() string {
+	if githash == "" {
+		return fmt.Sprintf("%s-dev", Base)
+	}
+	return fmt.Sprintf("%s (%s)", Base, githash)
+}

--- a/pkg/common/version/version.go
+++ b/pkg/common/version/version.go
@@ -7,12 +7,12 @@ const (
 )
 
 var (
-	githash = ""
+	gittag = ""
 )
 
 func Version() string {
-	if githash == "" {
+	if gittag == "" {
 		return fmt.Sprintf("%s-dev", Base)
 	}
-	return fmt.Sprintf("%s (%s)", Base, githash)
+	return Base
 }


### PR DESCRIPTION
provides non-placeholder version strings. binaries produced via standard
`go build|install` invocations get a `-dev` suffix (i.e. `1.2.3-dev`).
release binaries produced via the build.sh build script contain a short
git tag (i.e. `1.2.3 (a1b2c3d4)`). If the git status is not clean a
`-dirty` suffix is added to the hash (i.e. `1.2.3 (a1b2c3d4-dirty)`).

Signed-off-by: Andrew Harding <azdagron@gmail.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
CLI binaries (e.g. spire-agent, spire-server) expose individually hard coded version strings via the command line interface that can get out of sync. Additionally the version numbers do not reflect the state of the build environment.

**Description of change**
The change introduces a version package with a common method that all CLI binaries can use to get the version string.  An unexported `githash` variable can be manipulated via linker flags to influence the build number returned by the package.  If the `githash` variable is empty (the default), then the version string will be the base version + a `-dev` suffix, otherwise the version string contains the base version and the git hash in parenthesis. The official `build.sh` build script also detects the status of the git repository and will append `-dirty` to the githash it provides to the linker if the repository is not clean.