### PR TITLE
Remove -s flag from gofmt githook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,7 +13,7 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
 [ -z "$gofiles" ] && exit 0
 
-unformatted=$(gofmt -l -s $gofiles)
+unformatted=$(gofmt -l $gofiles)
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not gofmt'd. Print message and fail.


### PR DESCRIPTION
The `-s` flag was added to the gofmt githook with the intention of making the code a little more readable and concise. The most frequently affected code includes struct literals which don't require the fields to be explicitly named.

Unfortunately, the latest version of proto gen disallows this, as it interferes with backwards compatibility. As a result, protobuf messages must explicitly name all fields in its struct literals.

Rather than have some structs which appear that they can omit field names but don't, and others that do, let's keep things consistent. This change removes the `-s` flag from the githook.