### PR TITLE
Set version number to latest

### DIFF
--- a/pkg/common/version/version.go
+++ b/pkg/common/version/version.go
@@ -3,7 +3,7 @@ package version
 import "fmt"
 
 const (
-	Base = "0.0.1"
+	Base = "0.5.2"
 )
 
 var (


### PR DESCRIPTION
Now that we have an actual version number, set it to the current. Last tag was 0.5.1. I suspect that we may cut 0.6.0 in the near future, but until we decide concretely what that should ship with, I think 0.5.2 makes sense.

Signed-off-by: Evan Gilman <evan@scytale.io>