### PR TITLE
Ensure a `.data` directory is available in release

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -236,6 +236,9 @@ build_artifact() {
 	rm -rf $(dirname $_tmp)
 	mkdir -p $_tmp
 
+	# ensure empty .data dir is available
+	mkdir $_tmp/.data
+
 	# we munge the file structure a bit here
 	for _n in $_binaries; do
 		if [[ $_n == *cmd/* ]]; then


### PR DESCRIPTION
Our current releases ship with a server config that uses the `.data`
directory for data storage. Our artifact, however, does not ship with
this directory, forcing the user to create it. Instead, include the
empty `.data` directory in the tarball for user convenience.

See #476

Signed-off-by: Evan Gilman <evan@scytale.io>