### PR TITLE
Fix join token delete bug

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -714,22 +714,34 @@ func Test_RegisterAndFetchToken(t *testing.T) {
 func Test_DeleteToken(t *testing.T) {
 	ds := createDefault(t)
 	now := time.Now().Unix()
-	req := &datastore.JoinToken{
+	req1 := &datastore.JoinToken{
 		Token:  "foobar",
 		Expiry: now,
 	}
-	_, err := ds.RegisterToken(req)
+	_, err := ds.RegisterToken(req1)
+	require.NoError(t, err)
+
+	req2 := &datastore.JoinToken{
+		Token:  "batbaz",
+		Expiry: now,
+	}
+	_, err = ds.RegisterToken(req2)
 	require.NoError(t, err)
 
 	// Don't need expiry for delete
-	req.Expiry = 0
-	_, err = ds.DeleteToken(req)
+	req1.Expiry = 0
+	_, err = ds.DeleteToken(req1)
 	require.NoError(t, err)
 
 	// Should not be able to fetch after delete
-	resp, err := ds.FetchToken(req)
+	resp, err := ds.FetchToken(req1)
 	require.NoError(t, err)
 	assert.Equal(t, "", resp.Token)
+
+	// Second token should still be present
+	resp, err = ds.FetchToken(req2)
+	require.NoError(t, err)
+	assert.Equal(t, req2.Token, resp.Token)
 }
 
 func Test_PruneTokens(t *testing.T) {


### PR DESCRIPTION
There was a bug in join token delete code within datastore plugin which
resulted in _all_ tokens being deleted. This was due to the fact that
gorm will delete everything if we ask it to delete a record without a
primary key specified.

A previous version of myself didn't realize that the token is
not the primary key - instead, gorm creates one transparently. This
commit fixes the bug by first fetching the token, then deleting it.

Signed-off-by: Evan Gilman <evan@scytale.io>