### PR TITLE
move selector powerset expansion into datastore

### DIFF
--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -190,11 +190,6 @@ func TestFetchRegistrationEntries(t *testing.T) {
 				Type:  "a",
 				Value: "1",
 			},
-		}},
-	).Return(&datastore.ListSelectorEntriesResponse{}, nil)
-
-	suite.mockDataStore.EXPECT().ListMatchingEntries(gomock.Any(),
-		&datastore.ListSelectorEntriesRequest{Selectors: []*common.Selector{
 			{
 				Type:  "b",
 				Value: "2",
@@ -203,9 +198,6 @@ func TestFetchRegistrationEntries(t *testing.T) {
 	).Return(&datastore.ListSelectorEntriesResponse{
 		RegisteredEntryList: regEntries,
 	}, nil)
-
-	suite.mockDataStore.EXPECT().ListMatchingEntries(gomock.Any(),
-		gomock.Any()).Return(&datastore.ListSelectorEntriesResponse{}, nil)
 
 	suite.mockDataStore.EXPECT().ListParentIDEntries(gomock.Any(),
 		&datastore.ListParentIDEntriesRequest{ParentId: spiffeID},

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -938,7 +938,7 @@ func (sqlPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi
 	return &pluginInfo, nil
 }
 
-// listMatchingEntries finds registered entries containing all specified selectors.
+// listMatchingEntries finds registered entries containing exactly the specified selectors.
 func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*common.RegistrationEntry, error) {
 	if len(selectors) < 1 {
 		return nil, nil

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"math/rand"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -652,7 +654,8 @@ func Test_ListMatchingEntries(t *testing.T) {
 			},
 			expectedList: []*common.RegistrationEntry{
 				allEntries[0],
-				allEntries[3],
+				allEntries[1],
+				allEntries[2],
 			},
 		},
 		{
@@ -661,7 +664,7 @@ func Test_ListMatchingEntries(t *testing.T) {
 			selectors: []*common.Selector{
 				{Type: "d", Value: "4"},
 			},
-			expectedList: allEntries[3:],
+			expectedList: nil,
 		},
 	}
 	for _, test := range tests {
@@ -801,6 +804,85 @@ func Test_race(t *testing.T) {
 		ds.CreateAttestedNodeEntry(ctx, &datastore.CreateAttestedNodeEntryRequest{AttestedNodeEntry: entry})
 		ds.FetchAttestedNodeEntry(ctx, &datastore.FetchAttestedNodeEntryRequest{BaseSpiffeId: entry.BaseSpiffeId})
 	})
+}
+
+func Test_sortRegistrationEntries(t *testing.T) {
+	entries := []*common.RegistrationEntry{
+		// entries to assert that spiffe ids are compared for sorting first
+		{SpiffeId: "a", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "b", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "c", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		// entries to assert that parent ids are compared for sorting second
+		{SpiffeId: "x", ParentId: "a", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "b", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "c", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		// entries to assert that ttl is compared for sorting third
+		{SpiffeId: "x", ParentId: "x", Ttl: 10, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 20, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 30, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		// entries to assert that selector types are compared for sorting fourth
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "b", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "c", Value: "x"}}},
+		// entries to assert that selector values are included in selector sorting
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "a"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "b"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "c"}}},
+		// entry to assert that entries with more selectors come after entries with less
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "a"}, {Type: "a", Value: "b"}}},
+		// entry to assert that selectors get sorted as well
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "c"}, {Type: "a", Value: "a"}}},
+	}
+
+	expected := []*common.RegistrationEntry{
+		{SpiffeId: "a", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "b", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "c", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "a", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "b", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "c", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 10, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 20, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 30, Selectors: []*common.Selector{{Type: "x", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "b", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "c", Value: "x"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "a"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "b"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "x", Value: "c"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "a"}, {Type: "a", Value: "b"}}},
+		{SpiffeId: "x", ParentId: "x", Ttl: 90, Selectors: []*common.Selector{{Type: "a", Value: "a"}, {Type: "a", Value: "c"}}},
+	}
+
+	rnd := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+
+	var actual []*common.RegistrationEntry
+	for {
+		actual = shuffleRegistrationEntries(rnd, entries)
+		if !reflect.DeepEqual(actual, entries) {
+			break
+		}
+	}
+	sortRegistrationEntries(actual)
+	if !reflect.DeepEqual(actual, expected) {
+		t.Logf("ACTUAL:")
+		for i, entry := range actual {
+			t.Logf("[%d] %v", i, entry)
+		}
+		t.Logf("EXPECTED:")
+		for i, entry := range expected {
+			t.Logf("[%d] %v", i, entry)
+		}
+		t.Fatalf("failed to sort entries")
+	}
+}
+
+func shuffleRegistrationEntries(rnd *rand.Rand, rs []*common.RegistrationEntry) []*common.RegistrationEntry {
+	shuffled := make([]*common.RegistrationEntry, len(rs))
+	for i, v := range rnd.Perm(len(rs)) {
+		shuffled[v] = rs[i]
+	}
+	return shuffled
 }
 
 func createDefault(t *testing.T) datastore.DataStore {


### PR DESCRIPTION
This provides the rest of the fix to #159 by moving the power set expansion of the selector set into the datastore plugin. It does not do any work to try and optimize the GORM queries being used to find the matches.

It also fixes and expands the entry sorting algorithm. The current code does not do proper comparison across multiple dimensions. It also sorts the selectors within the registration entries for easier comparison (node handler currently sorts them to perform deduplication).
