### PR TITLE
clear stale entries from agent cache

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -200,12 +200,9 @@ func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
 		t.Fatal("expected 2 entries")
 	}
 
-	err := compareRegistrationEntries(
+	compareRegistrationEntries(t,
 		regEntriesMap["resp2"],
 		[]*common.RegistrationEntry{me[0].RegistrationEntry, me[1].RegistrationEntry})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	util.RunWithTimeout(t, 5*time.Second, func() {
 		sub := m.SubscribeToCacheChanges(cache.Selectors{&common.Selector{Type: "unix", Value: "uid:1111"}})
@@ -223,12 +220,9 @@ func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
 			t.Fatal("received bundle should be equals to the server bundle")
 		}
 
-		err := compareRegistrationEntries(
+		compareRegistrationEntries(t,
 			regEntriesMap["resp2"],
 			[]*common.RegistrationEntry{u.Entries[0].RegistrationEntry, u.Entries[1].RegistrationEntry})
-		if err != nil {
-			t.Fatal(err)
-		}
 	})
 }
 
@@ -425,6 +419,62 @@ func TestSynchronization(t *testing.T) {
 	})
 }
 
+func TestSynchronizationClearsStaleCacheEntries(t *testing.T) {
+	dir := createTempDir(t)
+	defer removeTempDir(dir)
+
+	trustDomain := "example.org"
+
+	apiHandler := newMockNodeAPIHandler(&mockNodeAPIHandlerConfig{
+		t:                 t,
+		trustDomain:       trustDomain,
+		dir:               dir,
+		fetchSVIDResponse: fetchSVIDResponseForStaleCacheTest,
+		svidTTL:           3,
+	})
+	apiHandler.start()
+	defer apiHandler.stop()
+
+	baseSVID, baseSVIDKey := apiHandler.newSVID("spiffe://"+trustDomain+"/spire/agent/join_token/abcd", 1*time.Hour)
+
+	c := &Config{
+		ServerAddr: &net.UnixAddr{
+			Net:  "unix",
+			Name: apiHandler.sockPath,
+		},
+		SVID:            baseSVID,
+		SVIDKey:         baseSVIDKey,
+		Log:             testLogger,
+		TrustDomain:     url.URL{Host: trustDomain},
+		SVIDCachePath:   path.Join(dir, "svid.der"),
+		BundleCachePath: path.Join(dir, "bundle.der"),
+		Bundle:          apiHandler.bundle,
+		Tel:             &telemetry.Blackhole{},
+	}
+
+	m := newManager(t, c)
+
+	if err := m.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// after initialization, the cache should contain both resp1 and resp2
+	// entries.
+	compareRegistrationEntries(t,
+		append(regEntriesMap["resp1"], regEntriesMap["resp2"]...),
+		regEntriesFromCacheEntries(m.cache.Entries()))
+
+	// manually synchronize again
+	if err := m.synchronize(); err != nil {
+		t.Fatal(err)
+	}
+
+	// now the cache should have entries from resp2 removed
+	compareRegistrationEntries(t,
+		regEntriesMap["resp1"],
+		regEntriesFromCacheEntries(m.cache.Entries()))
+}
+
 func TestSubscribersGetUpToDateBundle(t *testing.T) {
 	dir := createTempDir(t)
 	defer removeTempDir(dir)
@@ -601,6 +651,25 @@ func fetchSVIDResponse(h *mockNodeAPIHandler, req *node.FetchSVIDRequest, stream
 	return stream.Send(newFetchSVIDResponse(resps, svids, h.bundle))
 }
 
+func fetchSVIDResponseForStaleCacheTest(h *mockNodeAPIHandler, req *node.FetchSVIDRequest, stream node.Node_FetchSVIDServer) error {
+	svids, err := h.makeSvids(req.Csrs)
+	if err != nil {
+		return err
+	}
+
+	switch h.reqCount {
+	case 1:
+		return stream.Send(newFetchSVIDResponse([]string{"resp1", "resp2"}, nil, h.bundle))
+	case 2:
+		return stream.Send(newFetchSVIDResponse([]string{"resp1", "resp2"}, svids, h.bundle))
+	case 3:
+		return stream.Send(newFetchSVIDResponse([]string{"resp1"}, nil, h.bundle))
+	case 4:
+		return stream.Send(newFetchSVIDResponse([]string{"resp1"}, svids, h.bundle))
+	}
+	return stream.Send(newFetchSVIDResponse(nil, nil, h.bundle))
+}
+
 func fetchSVIDResponseForTestSubscribersGetUpToDateBundle(h *mockNodeAPIHandler, req *node.FetchSVIDRequest, stream node.Node_FetchSVIDServer) error {
 	switch h.reqCount {
 	case 2:
@@ -665,9 +734,16 @@ func cacheEntriesAsMap(ces []*cache.Entry) (result map[string]*cache.Entry) {
 	return result
 }
 
-func compareRegistrationEntries(expected, actual []*common.RegistrationEntry) error {
+func regEntriesFromCacheEntries(ces []*cache.Entry) (result []*common.RegistrationEntry) {
+	for _, ce := range ces {
+		result = append(result, ce.RegistrationEntry)
+	}
+	return result
+}
+
+func compareRegistrationEntries(t *testing.T, expected, actual []*common.RegistrationEntry) {
 	if len(expected) != len(actual) {
-		return fmt.Errorf("entries count doesn't match, expected: %d, got: %d", len(expected), len(actual))
+		t.Fatalf("entries count doesn't match, expected: %d, got: %d", len(expected), len(actual))
 	}
 
 	expectedMap := regEntriesAsMap(expected)
@@ -676,14 +752,13 @@ func compareRegistrationEntries(expected, actual []*common.RegistrationEntry) er
 	for id, ee := range expectedMap {
 		ae, ok := actualMap[id]
 		if !ok {
-			return fmt.Errorf("entries should be equals, expected: %s, got: <none>", ee.String())
+			t.Fatalf("entries should be equals, expected: %s, got: <none>", ee.String())
 		}
 
 		if ee.String() != ae.String() {
-			return fmt.Errorf("entries should be equals, expected: %s, got: %s", ee.String(), ae.String())
+			t.Fatalf("entries should be equals, expected: %s, got: %s", ee.String(), ae.String())
 		}
 	}
-	return nil
 }
 
 type svidMap map[string]*node.Svid

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -24,6 +24,8 @@ func (m *manager) synchronize() (err error) {
 		return err
 	}
 
+	m.clearStaleCacheEntries(regEntries)
+
 	err = m.checkExpiredCacheEntries(cEntryRequests)
 	if err != nil {
 		return err
@@ -103,6 +105,14 @@ func (m *manager) updateEntriesSVIDs(entryRequestsMap map[string]*entryRequest, 
 		}
 	}
 	return nil
+}
+
+func (m *manager) clearStaleCacheEntries(regEntries map[string]*proto.RegistrationEntry) {
+	for _, entry := range m.cache.Entries() {
+		if _, ok := regEntries[entry.RegistrationEntry.EntryId]; !ok {
+			m.cache.DeleteEntry(entry.RegistrationEntry)
+		}
+	}
 }
 
 func (m *manager) checkExpiredCacheEntries(cEntryRequests entryRequests) error {


### PR DESCRIPTION
Updates the agent manager to clear out stale cache entries after syncing with the node API.

Fixes #480 

Signed-off-by: Andrew Harding <azdagron@gmail.com>