### PR TITLE
fix test teardown and get tests passing

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -56,7 +56,7 @@ func (s *AgentTestSuite) SetupTest() {
 	s.agent = New(config)
 }
 
-func (s *AgentTestSuite) TeardownTest() {
+func (s *AgentTestSuite) TearDownTest() {
 	os.RemoveAll(s.agent.c.DataDir)
 	s.ctrl.Finish()
 }

--- a/pkg/agent/attestor/workload/workload_test.go
+++ b/pkg/agent/attestor/workload/workload_test.go
@@ -49,7 +49,7 @@ func (s *WorkloadAttestorTestSuite) SetupTest() {
 	}
 }
 
-func (s *WorkloadAttestorTestSuite) TeardownTest() {
+func (s *WorkloadAttestorTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 

--- a/pkg/agent/catalog/catalog_test.go
+++ b/pkg/agent/catalog/catalog_test.go
@@ -71,7 +71,7 @@ func (c *AgentCatalogTestSuite) SetupTest() {
 	c.logHook = logHook
 }
 
-func (c *AgentCatalogTestSuite) TeardownTest() {
+func (c *AgentCatalogTestSuite) TearDownTest() {
 	c.ctrl.Finish()
 }
 

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -68,7 +68,7 @@ func TestWorkloadServer(t *testing.T) {
 	suite.Run(t, new(HandlerTestSuite))
 }
 
-func (s *HandlerTestSuite) TeardownTest() {
+func (s *HandlerTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -58,14 +58,14 @@ func (s *RotatorTestSuite) SetupTest() {
 	s.r.client = s.client
 }
 
-func (s *RotatorTestSuite) TeardownTest() {
+func (s *RotatorTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 
 func (s *RotatorTestSuite) TestRun() {
 	cert, key, err := util.LoadSVIDFixture()
 	s.Require().NoError(err)
-	s.expectSVIDRotation(cert)
+	s.client.EXPECT().Release()
 
 	state := State{
 		SVID: cert,

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -60,7 +60,7 @@ func (c *CatalogTestSuite) SetupTest() {
 	c.logHook = logHook
 }
 
-func (c *CatalogTestSuite) TeardownTest() {
+func (c *CatalogTestSuite) TearDownTest() {
 	c.ctrl.Finish()
 }
 

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -87,7 +87,7 @@ func (c *ServerCatalogTestSuite) SetupTest() {
 	c.logHook = logHook
 }
 
-func (c *ServerCatalogTestSuite) TeardownTest() {
+func (c *ServerCatalogTestSuite) TearDownTest() {
 	c.ctrl.Finish()
 }
 

--- a/pkg/server/svid/rotator_test.go
+++ b/pkg/server/svid/rotator_test.go
@@ -57,7 +57,7 @@ func (s *RotatorTestSuite) SetupTest() {
 	s.r = NewRotator(c)
 }
 
-func (s *RotatorTestSuite) TeardownTest() {
+func (s *RotatorTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 
@@ -169,11 +169,7 @@ func (s *RotatorTestSuite) expectSVIDRotation(cert *x509.Certificate) {
 	signedCert := &ca.SignCsrResponse{
 		SignedCertificate: cert.Raw,
 	}
-	caCert := &ca.FetchCertificateResponse{
-		StoredIntermediateCert: cert.Raw,
-	}
 
 	s.catalog.EXPECT().CAs().Return([]ca.ServerCa{s.ca})
 	s.ca.EXPECT().SignCsr(gomock.Any(), gomock.Any()).Return(signedCert, nil)
-	s.ca.EXPECT().FetchCertificate(gomock.Any(), gomock.Any()).Return(caCert, nil)
 }


### PR DESCRIPTION
A typo of the suite TearDownTest method on a number of suites was
skipping assertion of mock expectations and general test cleanup. Fixed
the typo's and got the tests passing.

Signed-off-by: Andrew Harding <azdagron@gmail.com>
