### PR TITLE
fix gcp server plugin key retrieval

### DIFF
--- a/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever.go
+++ b/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever.go
@@ -22,6 +22,13 @@ type googlePublicKeyRetriever struct {
 	certificates map[string]*x509.Certificate
 }
 
+func newGooglePublicKeyRetriever(url string) *googlePublicKeyRetriever {
+	return &googlePublicKeyRetriever{
+		url:          url,
+		certificates: make(map[string]*x509.Certificate),
+	}
+}
+
 func (r *googlePublicKeyRetriever) retrieveKey(token *jwt.Token) (interface{}, error) {
 	if token.Header["kid"] == nil {
 		return nil, errors.New("token is missing kid value")
@@ -45,7 +52,7 @@ func (r *googlePublicKeyRetriever) retrieveKey(token *jwt.Token) (interface{}, e
 	}
 	cert, ok := r.certificates[kid]
 	if !ok {
-		return nil, errors.New("no certificate found for kid")
+		return nil, errors.New("no public key found for kid")
 	}
 	return cert.PublicKey, nil
 }

--- a/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
@@ -48,7 +48,6 @@ func TestGooglePublicKeyRetriever(t *testing.T) {
 	_, err = retriever.retrieveKey(emptyKid)
 	require.EqualError(err, "token has unexpected kid value")
 
-	// token has malformed kid
 	token := jwt.New(jwt.SigningMethodRS256)
 	token.Header["kid"] = "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77"
 

--- a/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
@@ -2,23 +2,103 @@ package gcp
 
 import (
 	"crypto/x509"
-	"sync"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSuccesfullyRetrieveGooglePublicKeys(t *testing.T) {
+func TestGooglePublicKeyRetriever(t *testing.T) {
+	require := require.New(t)
+
+	expires := ""
+	status := http.StatusOK
+	body := ""
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Expires", expires)
+			w.WriteHeader(status)
+			w.Write([]byte(body))
+		}))
+	defer server.Close()
+
 	retriever := &googlePublicKeyRetriever{
 		certificates: make(map[string]*x509.Certificate),
-		mtx:          &sync.Mutex{},
+		url:          server.URL,
 	}
 
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Header["kid"] = "1923397381d9574bb873202a90c32b7ceeaed027"
+	// token has no kid
+	noKid := jwt.New(jwt.SigningMethodRS256)
+	_, err := retriever.retrieveKey(noKid)
+	require.EqualError(err, "token is missing kid value")
 
+	// kid is not a string
+	badKid := jwt.New(jwt.SigningMethodRS256)
+	badKid.Header["kid"] = 3
+	_, err = retriever.retrieveKey(badKid)
+	require.EqualError(err, "token has unexpected kid value")
+
+	// kid is empty
+	emptyKid := jwt.New(jwt.SigningMethodRS256)
+	emptyKid.Header["kid"] = ""
+	_, err = retriever.retrieveKey(emptyKid)
+	require.EqualError(err, "token has unexpected kid value")
+
+	// token has malformed kid
+	token := jwt.New(jwt.SigningMethodRS256)
+	token.Header["kid"] = "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77"
+
+	// bad status
+	status = http.StatusBadGateway
+	_, err = retriever.retrieveKey(token)
+	require.EqualError(err, "unexpected status code: 502")
+
+	// malformed body
+	status = http.StatusOK
+	body = ""
+	_, err = retriever.retrieveKey(token)
+	require.EqualError(err, "unable to unmarshal certificate response: unexpected end of JSON input")
+
+	// bad PEM block
+	body = `{
+		"badPEM": ""
+}`
+	_, err = retriever.retrieveKey(token)
+	require.EqualError(err, "unable to unmarshal certificate response: malformed PEM block")
+
+	// malformed certificate PEM
+	body = `{
+		"malformedCertPEM": "-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n"
+}`
+	_, err = retriever.retrieveKey(token)
+	require.EqualError(err, "unable to unmarshal certificate response: malformed certificate PEM")
+
+	// success
+	expires = "Thu, 21 Jun 2018 01:53:33 GMT"
+	body = `{
+ "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIILeRWqluroKYwDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xODA2MTAxNDQ5MDhaFw0xODA2MjcwMzA0MDhaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIuVjK7H3j1vupL4N2pM2N1lvg22qI0f4m\n3sO1HGZ9b1dks5DpDY1iCY972HLLkYcbtbfOx3pD6vOrl4ZE0RTHXvrsrV1Lk+2R\nVY+I8b8zusOoK7cewuYpAqFGMdhoJaXk26IwHmZeg+FLCsd3bJ4YTtAchXv8KJAV\nzXFCxd6IL6dN4miEk7ccj3vDQZcTykeyktir2gbzt/kgfEWvz1pubBG6D4PtBZDJ\nblvh2h7hkv7nYn7xYd3naQasZ+7hDJXzegBp3cj/1D7KJY5dSv/QYivPPj/67keC\nph7Geh0WFllJoq5FKD9vmoKc+FbyAEMsAeSZDNAxpaw3XgvSmiRtAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQCogSpXj7bMqLHLafWUrzTQvbCFxs6M\nn3bhNjgZdvYuzaTotBhk1FI8hsszT7zh7euN6LLo/yf2qnr6yhch6YpRx4hux6cD\nShsPCML4ktcTNq1B+Q3BACDySA331AfcJKyPYvzwL+vi6656cntu0BhZ4+3KS+1R\nPOktwnRJLG9c6nLYkEyHy7ze4FT+eM/ML3hcZb20NHc1lP1XTwfbvyTwS7q19Afw\nOnvfOVsCPbIx8EdKenrsKnzgbPdswXbZkMifMvU/ky7Y2uKpuVlyb8yP2Qb3UsTM\nJh+1YTuprOIc7zhcvtr4ID+ax3hJgzenKWeCZWkvSLKZLHv2mdFd7AI4\n-----END CERTIFICATE-----\n",
+ "dad44739576485ec30d228842e73ace0bc367bc4": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIIS2LhfmO8/CkwDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xODA2MTgxNDQ5MDhaFw0xODA3MDUwMzA0MDhaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT/x9qpZjjHwsJquI/q0huq3Zq1QzadIoC\n5Nvns1hlg4Z5Riji5oSEmMXqwnZ2M5J2mP5rvTMRqaGUcbIKyDM2uhBfvShovTnM\nvXBXRD1M8drWpGhtUNIGCWGYksd8RH0vSaT2OiRcmFakvs0VTurIoIPuDB7zg1Hg\nLt6Ze19AbMVLhVwqrE07Xu7CZErPH9kzLhK3330oQME8K26rxca+MxhkTZF+Tr4t\nZyYC0nsI45LXJ8R8CBu8IBsMqchmqiM+6yf/mNFQ6i0l3ZPcaCdIwQWfUbUMYruE\n0csEqrOKZ4QxNCmeFhds/CpNsACWXeu0pXg8IznzlBOxXRTdTlVpAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQCMJRcKLymRgqa7qvAqcNK5NerBpMn8\nBEz2J3jw8iuvEXo5tAqwOwzGR5YoM1EgH1F/MxNLnn6CGcpg+MV1rKTWP1aoWiu4\nBfzJngH0SPNDWWs9ZkYlaMnX0NK3d3zLMyUEx8PqTtazQLxK1FUJM3/KcyU77bt1\noUFGPua5/C6Kza/w2aQZSa7KRwgGGj+tjTtmXWVsEQcgWAiE4ZNDD/4cHrSYx3qk\nN/CVZRbq0t7fWXH8ezY3dTNptP9lqxyrfFLlRc5ddsBPuYSFeQ+wtxfR/+SD7WgD\njmifOam88PHhHbYbECt4n9b1OQg7lv0H8cm2/URjHAOP03CAYlb+t3UL\n-----END CERTIFICATE-----\n"
+}`
 	key, err := retriever.retrieveKey(token)
-	require.NotNil(t, key)
-	require.NoError(t, err)
+	require.NotNil(key)
+	require.NoError(err)
+	require.Equal("2018-06-21T01:53:33Z", retriever.expiry.Format(time.RFC3339))
+
+	// uses cached values if not expired
+	body = `{`
+	key, err = retriever.retrieveKey(token)
+	require.NotNil(key)
+	require.NoError(err)
+	require.Equal("2018-06-21T01:53:33Z", retriever.expiry.Format(time.RFC3339))
+
+	// cache gets completely replaced when refreshed
+	retriever.expiry = time.Now().Add(-time.Second)
+	body = `{}`
+	key, err = retriever.retrieveKey(token)
+	require.Nil(key)
+	require.EqualError(err, "no certificate found for kid")
 }

--- a/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
@@ -1,103 +1,136 @@
 package gcp
 
 import (
-	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestGooglePublicKeyRetriever(t *testing.T) {
-	require := require.New(t)
-
-	expires := ""
-	status := http.StatusOK
-	body := ""
-
-	server := httptest.NewServer(http.HandlerFunc(
-		func(w http.ResponseWriter, req *http.Request) {
-			w.Header().Set("Expires", expires)
-			w.WriteHeader(status)
-			w.Write([]byte(body))
-		}))
-	defer server.Close()
-
-	retriever := &googlePublicKeyRetriever{
-		certificates: make(map[string]*x509.Certificate),
-		url:          server.URL,
-	}
-
-	// token has no kid
-	noKid := jwt.New(jwt.SigningMethodRS256)
-	_, err := retriever.retrieveKey(noKid)
-	require.EqualError(err, "token is missing kid value")
-
-	// kid is not a string
-	badKid := jwt.New(jwt.SigningMethodRS256)
-	badKid.Header["kid"] = 3
-	_, err = retriever.retrieveKey(badKid)
-	require.EqualError(err, "token has unexpected kid value")
-
-	// kid is empty
-	emptyKid := jwt.New(jwt.SigningMethodRS256)
-	emptyKid.Header["kid"] = ""
-	_, err = retriever.retrieveKey(emptyKid)
-	require.EqualError(err, "token has unexpected kid value")
-
-	token := jwt.New(jwt.SigningMethodRS256)
-	token.Header["kid"] = "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77"
-
-	// bad status
-	status = http.StatusBadGateway
-	_, err = retriever.retrieveKey(token)
-	require.EqualError(err, "unexpected status code: 502")
-
-	// malformed body
-	status = http.StatusOK
-	body = ""
-	_, err = retriever.retrieveKey(token)
-	require.EqualError(err, "unable to unmarshal certificate response: unexpected end of JSON input")
-
-	// bad PEM block
-	body = `{
-		"badPEM": ""
-}`
-	_, err = retriever.retrieveKey(token)
-	require.EqualError(err, "unable to unmarshal certificate response: malformed PEM block")
-
-	// malformed certificate PEM
-	body = `{
-		"malformedCertPEM": "-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n"
-}`
-	_, err = retriever.retrieveKey(token)
-	require.EqualError(err, "unable to unmarshal certificate response: malformed certificate PEM")
-
-	// success
-	expires = "Thu, 21 Jun 2018 01:53:33 GMT"
-	body = `{
+const (
+	publicKeyPayload = `{
  "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIILeRWqluroKYwDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xODA2MTAxNDQ5MDhaFw0xODA2MjcwMzA0MDhaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIuVjK7H3j1vupL4N2pM2N1lvg22qI0f4m\n3sO1HGZ9b1dks5DpDY1iCY972HLLkYcbtbfOx3pD6vOrl4ZE0RTHXvrsrV1Lk+2R\nVY+I8b8zusOoK7cewuYpAqFGMdhoJaXk26IwHmZeg+FLCsd3bJ4YTtAchXv8KJAV\nzXFCxd6IL6dN4miEk7ccj3vDQZcTykeyktir2gbzt/kgfEWvz1pubBG6D4PtBZDJ\nblvh2h7hkv7nYn7xYd3naQasZ+7hDJXzegBp3cj/1D7KJY5dSv/QYivPPj/67keC\nph7Geh0WFllJoq5FKD9vmoKc+FbyAEMsAeSZDNAxpaw3XgvSmiRtAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQCogSpXj7bMqLHLafWUrzTQvbCFxs6M\nn3bhNjgZdvYuzaTotBhk1FI8hsszT7zh7euN6LLo/yf2qnr6yhch6YpRx4hux6cD\nShsPCML4ktcTNq1B+Q3BACDySA331AfcJKyPYvzwL+vi6656cntu0BhZ4+3KS+1R\nPOktwnRJLG9c6nLYkEyHy7ze4FT+eM/ML3hcZb20NHc1lP1XTwfbvyTwS7q19Afw\nOnvfOVsCPbIx8EdKenrsKnzgbPdswXbZkMifMvU/ky7Y2uKpuVlyb8yP2Qb3UsTM\nJh+1YTuprOIc7zhcvtr4ID+ax3hJgzenKWeCZWkvSLKZLHv2mdFd7AI4\n-----END CERTIFICATE-----\n",
  "dad44739576485ec30d228842e73ace0bc367bc4": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIIS2LhfmO8/CkwDQYJKoZIhvcNAQEFBQAwNjE0MDIGA1UE\nAxMrZmVkZXJhdGVkLXNpZ25vbi5zeXN0ZW0uZ3NlcnZpY2VhY2NvdW50LmNvbTAe\nFw0xODA2MTgxNDQ5MDhaFw0xODA3MDUwMzA0MDhaMDYxNDAyBgNVBAMTK2ZlZGVy\nYXRlZC1zaWdub24uc3lzdGVtLmdzZXJ2aWNlYWNjb3VudC5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDT/x9qpZjjHwsJquI/q0huq3Zq1QzadIoC\n5Nvns1hlg4Z5Riji5oSEmMXqwnZ2M5J2mP5rvTMRqaGUcbIKyDM2uhBfvShovTnM\nvXBXRD1M8drWpGhtUNIGCWGYksd8RH0vSaT2OiRcmFakvs0VTurIoIPuDB7zg1Hg\nLt6Ze19AbMVLhVwqrE07Xu7CZErPH9kzLhK3330oQME8K26rxca+MxhkTZF+Tr4t\nZyYC0nsI45LXJ8R8CBu8IBsMqchmqiM+6yf/mNFQ6i0l3ZPcaCdIwQWfUbUMYruE\n0csEqrOKZ4QxNCmeFhds/CpNsACWXeu0pXg8IznzlBOxXRTdTlVpAgMBAAGjODA2\nMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBYGA1UdJQEB/wQMMAoGCCsG\nAQUFBwMCMA0GCSqGSIb3DQEBBQUAA4IBAQCMJRcKLymRgqa7qvAqcNK5NerBpMn8\nBEz2J3jw8iuvEXo5tAqwOwzGR5YoM1EgH1F/MxNLnn6CGcpg+MV1rKTWP1aoWiu4\nBfzJngH0SPNDWWs9ZkYlaMnX0NK3d3zLMyUEx8PqTtazQLxK1FUJM3/KcyU77bt1\noUFGPua5/C6Kza/w2aQZSa7KRwgGGj+tjTtmXWVsEQcgWAiE4ZNDD/4cHrSYx3qk\nN/CVZRbq0t7fWXH8ezY3dTNptP9lqxyrfFLlRc5ddsBPuYSFeQ+wtxfR/+SD7WgD\njmifOam88PHhHbYbECt4n9b1OQg7lv0H8cm2/URjHAOP03CAYlb+t3UL\n-----END CERTIFICATE-----\n"
 }`
-	key, err := retriever.retrieveKey(token)
-	require.NotNil(key)
-	require.NoError(err)
-	require.Equal("2018-06-21T01:53:33Z", retriever.expiry.Format(time.RFC3339))
+)
 
-	// uses cached values if not expired
-	body = `{`
-	key, err = retriever.retrieveKey(token)
-	require.NotNil(key)
-	require.NoError(err)
-	require.Equal("2018-06-21T01:53:33Z", retriever.expiry.Format(time.RFC3339))
+func TestGooglePublicKeyRetriever(t *testing.T) {
+	suite.Run(t, new(GooglePublicKeyRetrieverSuite))
+}
 
-	// cache gets completely replaced when refreshed
-	retriever.expiry = time.Now().Add(-time.Second)
-	body = `{}`
-	key, err = retriever.retrieveKey(token)
-	require.Nil(key)
-	require.EqualError(err, "no certificate found for kid")
+type GooglePublicKeyRetrieverSuite struct {
+	suite.Suite
+	server    *httptest.Server
+	retriever *googlePublicKeyRetriever
+	token     *jwt.Token
+	expires   string
+	status    int
+	body      string
+}
+
+func (s *GooglePublicKeyRetrieverSuite) SetupTest() {
+	s.server = httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("Expires", s.expires)
+			w.WriteHeader(s.status)
+			w.Write([]byte(s.body))
+		}))
+	s.retriever = newGooglePublicKeyRetriever(s.server.URL)
+	s.token = jwt.New(jwt.SigningMethodRS256)
+	s.token.Header["kid"] = "7ddf54d3032d1f0d48c3618892ca74c1ac30ad77"
+	s.status = http.StatusOK
+	s.body = publicKeyPayload
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TearDownTest() {
+	s.server.Close()
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestTokenHasNoKid() {
+	delete(s.token.Header, "kid")
+	_, err := s.retriever.retrieveKey(s.token)
+	s.EqualError(err, "token is missing kid value")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestTokenKidIsNotString() {
+	s.token.Header["kid"] = 3
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "token has unexpected kid value")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestTokenKidIsEmpty() {
+	s.token.Header["kid"] = ""
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "token has unexpected kid value")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestUnexpectedStatusCode() {
+	s.status = http.StatusBadGateway
+	s.body = "{}"
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "unexpected status code: 502")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestMalformedHTTPBody() {
+	s.body = "{"
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "unable to unmarshal certificate response: unexpected end of JSON input")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestMalformedPEMBlock() {
+	s.body = `{
+		"someid": "NOT A PEM BLOCK"
+	}`
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "unable to unmarshal certificate response: malformed PEM block")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestMalformedCertificatePEM() {
+	s.body = `{
+		"malformedCertPEM": "-----BEGIN CERTIFICATE-----\nZm9v\n-----END CERTIFICATE-----\n"
+}`
+	_, err := s.retriever.retrieveKey(s.token)
+	s.Require().EqualError(err, "unable to unmarshal certificate response: malformed certificate PEM")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestSuccess() {
+	s.body = publicKeyPayload
+	s.expires = "Thu, 21 Jun 2018 01:53:33 GMT"
+
+	key, err := s.retriever.retrieveKey(s.token)
+	s.Require().NotNil(key)
+	s.Require().NoError(err)
+	s.Require().Equal("2018-06-21T01:53:33Z", s.retriever.expiry.Format(time.RFC3339))
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestCacheUsedIfNotExpired() {
+	// the endpoint will return a good body but since the cache is not
+	// yet expired, the (empty) cache will be used.
+	s.body = publicKeyPayload
+
+	s.retriever.expiry = time.Now().Add(time.Minute)
+
+	key, err := s.retriever.retrieveKey(s.token)
+	s.Require().Nil(key)
+	s.Require().EqualError(err, "no public key found for kid")
+}
+
+func (s *GooglePublicKeyRetrieverSuite) TestCacheReplacedWhenRefreshed() {
+	// first request primes the cache
+	s.body = publicKeyPayload
+	key, err := s.retriever.retrieveKey(s.token)
+	s.Require().NotNil(key)
+	s.Require().NoError(err)
+
+	// expire the cache
+	s.retriever.expiry = time.Now().Add(-time.Minute)
+
+	// cache contents should be replaced (with no certs)
+	s.body = `{}`
+	key, err = s.retriever.retrieveKey(s.token)
+	s.Require().Nil(key)
+	s.Require().EqualError(err, "no public key found for kid")
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit.go
@@ -35,7 +35,7 @@ type IITAttestorPlugin struct {
 	trustDomain        string
 	projectIDWhitelist []string
 	tokenKeyRetriever  tokenKeyRetriever
-	mtx                *sync.Mutex
+	mtx                sync.Mutex
 }
 
 func (p *IITAttestorPlugin) spiffeID(gcpAccountID string, gcpInstanceID string) *url.URL {
@@ -140,7 +140,7 @@ func NewInstanceIdentityToken() nodeattestor.Plugin {
 	return &IITAttestorPlugin{
 		tokenKeyRetriever: &googlePublicKeyRetriever{
 			certificates: make(map[string]*x509.Certificate),
-			mtx:          &sync.Mutex{},
+			url:          googleCertURL,
 		},
 	}
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"crypto/x509"
 	"fmt"
 	"net/url"
 	"path"
@@ -138,9 +137,6 @@ func (*IITAttestorPlugin) GetPluginInfo(ctx context.Context, req *spi.GetPluginI
 
 func NewInstanceIdentityToken() nodeattestor.Plugin {
 	return &IITAttestorPlugin{
-		tokenKeyRetriever: &googlePublicKeyRetriever{
-			certificates: make(map[string]*x509.Certificate),
-			url:          googleCertURL,
-		},
+		tokenKeyRetriever: newGooglePublicKeyRetriever(googleCertURL),
 	}
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync"
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -46,7 +45,6 @@ func buildToken() *jwt.Token {
 func buildIITPlugin() *IITAttestorPlugin {
 	return &IITAttestorPlugin{
 		tokenKeyRetriever:  &staticKeyRetriever{key: "secret"},
-		mtx:                &sync.Mutex{},
 		projectIDWhitelist: []string{"project-123"},
 	}
 }


### PR DESCRIPTION
- extra validation around token values to mitigate panics
- fixed panic if the certificate for the kid was not found
- fixed race when refreshing cache
- cache is now replaced completely when a new list is downloaded
- tests no longer hit the network
- improved server response handling

Signed-off-by: Andrew Harding <azdagron@gmail.com>
