### PR TITLE
fix CA activation bug

### DIFF
--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -88,15 +88,18 @@ func (m *manager) caRotate(ctx context.Context) error {
 	ttl := time.Until(m.caCert.NotAfter)
 	lifetime := m.caCert.NotAfter.Sub(m.caCert.NotBefore)
 	if (ttl < lifetime/2) && m.nextCACert == nil {
-		return m.prepareNextCA(ctx)
+		if err := m.prepareNextCA(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Activate the new CA once the current one is 5/6ths of the way to expiration
 	if ttl < lifetime/6 {
-		return m.activateNextCA(ctx)
+		if err := m.activateNextCA(ctx); err != nil {
+			return err
+		}
 	}
 
-	// Nothing to see here, move along now...
 	return nil
 }
 


### PR DESCRIPTION
The CA rotation check happens on an interval (default 1m). If the new CA
should be both prepared and rotated on the same check (due to a small
enough ttl) then there is a bug that would prepare on the first check
and wait to activate until the next check. The CA would expire between
the two checks.

This PR fixes the bug by allowing for both preparation and activation
during the same rotation check.

Signed-off-by: Andrew Harding <azdagron@gmail.com>

fixes #501 