### PR TITLE
Minor fixes

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -20,12 +20,9 @@ import (
 )
 
 const (
-	defaultConfigPath   = "conf/server/server.conf"
-	defaultBindAddress  = "127.0.0.1"
-	defaultBindPort     = 8081
-	defaultBindHTTPPort = 8080
-	defaultLogLevel     = "INFO"
-	defaultUmask        = 0077
+	defaultConfigPath = "conf/server/server.conf"
+	defaultLogLevel   = "INFO"
+	defaultUmask      = 0077
 )
 
 // runConfig represents available configurables for file and CLI options

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -16,9 +16,9 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/proto/api/workload"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // Handler implements the Workload API interface
@@ -39,12 +39,12 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok || len(md["workload.spiffe.io"]) != 1 || md["workload.spiffe.io"][0] != "true" {
-		return grpc.Errorf(codes.InvalidArgument, "Security header missing from request")
+		return status.Errorf(codes.InvalidArgument, "Security header missing from request")
 	}
 
 	pid, err := h.callerPID(ctx)
 	if err != nil {
-		return grpc.Errorf(codes.Internal, "Is this a supported system? Please report this bug: %v", err)
+		return status.Errorf(codes.Internal, "Is this a supported system? Please report this bug: %v", err)
 	}
 
 	tLabels := []telemetry.Label{{workloadPid, string(pid)}}
@@ -86,12 +86,12 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 
 func (h *Handler) sendResponse(update *cache.WorkloadUpdate, stream workload.SpiffeWorkloadAPI_FetchX509SVIDServer) error {
 	if len(update.Entries) == 0 {
-		return grpc.Errorf(codes.PermissionDenied, "no identity issued")
+		return status.Errorf(codes.PermissionDenied, "no identity issued")
 	}
 
 	resp, err := h.composeResponse(update)
 	if err != nil {
-		return grpc.Errorf(codes.Unavailable, "Could not serialize response: %v", err)
+		return status.Errorf(codes.Unavailable, "Could not serialize response: %v", err)
 	}
 
 	return stream.Send(resp)

--- a/test/util/cert_generation.go
+++ b/test/util/cert_generation.go
@@ -70,7 +70,7 @@ func Sign(req, parent *x509.Certificate, signerPrivateKey interface{}) (*x509.Ce
 
 	publicKey, ok := req.PublicKey.(crypto.PublicKey)
 	if !ok {
-		key, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Removed some unused constants.
Replaced the use of grpc.Errorf by status.Errorf.
Replaced use of elliptic.P224 for elliptic.P256 in util.Sign.