### PR TITLE
fix agent workload test

### DIFF
--- a/pkg/agent/attestor/workload/workload.go
+++ b/pkg/agent/attestor/workload/workload.go
@@ -21,6 +21,10 @@ type Attestor interface {
 }
 
 func New(config *Config) Attestor {
+	return newAttestor(config)
+}
+
+func newAttestor(config *Config) *attestor {
 	return &attestor{c: config}
 }
 


### PR DESCRIPTION
The agent workload test was not being run because the test suite was
never wired up. This commit wires up the test suite and fixes the broken
tests.

Signed-off-by: Andrew Harding <azdagron@gmail.com>