### PR TITLE
Added support for mysql

### DIFF
--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -57,3 +57,27 @@ connection_string="dbname=postgres user=postgres password=password host=localhos
   the server was signed by a trusted CA and the server host name
   matches the one in the certificate)
 
+### `database_type = "mysql"`
+
+This configuration is valid for MySQL and mariadb.
+The `connection_string` for the PostreSQL database connection is kind of DB URL as
+
+```
+[username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
+```
+
+#### example
+```
+connection_string="mysql:password@tcp(localhost:3306)/mysql?charset=utf8&parseTime=True&multiStatements=true&loc=Local"
+```
+
+Read MySQL driver for more `connection_string` options [here](https://github.com/go-sql-driver/mysql)
+
+#### Configuration Options
+* dbname - The name of the database to connect to
+* username - The user to sign in as
+* password - The user's password
+* address - The host to connect to. Values that start with / are for unix
+  domain sockets. (default is localhost)
+
+You may configure SSL/TLS mode via [tls](https://github.com/go-sql-driver/mysql#tls) params

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 35f27a42ef95c2096d1e978ff87429ab29a41fb0e5d4fd4f8ef3a89c2964ee5d
-updated: 2018-06-09T11:32:20.976069+02:00
+updated: 2018-07-08T20:01:05.195972481-03:00
 imports:
 - name: github.com/armon/go-metrics
   version: 783273d703149aaeb9897cf58613d5af48861c25
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: c9af76f2478f81c6566d0f7f4d522254ec7c0b52
+  version: 16cb9f62f8a8b7af4f38725567f5ce762e1d562b
   subpackages:
   - aws
   - aws/awserr
@@ -38,6 +38,10 @@ imports:
   - service/sts
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
+- name: github.com/davecgh/go-spew
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  subpackages:
+  - spew
 - name: github.com/dgrijalva/jwt-go
   version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/go-ini/ini
@@ -46,6 +50,8 @@ imports:
   version: a41e3c4b706f6ae8dfbff342b06e40fa4d2d0506
   subpackages:
   - oleutil
+- name: github.com/go-sql-driver/mysql
+  version: d743639f9cefbadabe171d5fe22c9008b06dd2f5
 - name: github.com/golang/mock
   version: 87106cff4623c0d8f41c0fef931007bc18b61f78
   subpackages:
@@ -57,12 +63,14 @@ imports:
   - proto
   - protoc-gen-go
   - protoc-gen-go/descriptor
+  - protoc-gen-go/plugin
   - ptypes
   - ptypes/any
   - ptypes/duration
   - ptypes/empty
   - ptypes/struct
   - ptypes/timestamp
+  - ptypes/wrappers
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 8cc3a55af3bcf171a1c23a90c4df9cf591706104
   subpackages:
@@ -102,6 +110,7 @@ imports:
 - name: github.com/jinzhu/gorm
   version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
   subpackages:
+  - dialects/mysql
   - dialects/postgres
   - dialects/sqlite
 - name: github.com/jinzhu/inflection
@@ -125,6 +134,10 @@ imports:
   version: 518dc677a1e1222682f4e7db06721942cb8e9e4c
 - name: github.com/mitchellh/go-testing-interface
   version: a61a99592b77c9ba629d254a693acffaeb4b7e28
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
 - name: github.com/posener/complete
   version: cdc49b71388c2ab059f57997ef2575c9e8b4f146
   subpackages:
@@ -158,6 +171,12 @@ imports:
   - uri
 - name: github.com/StackExchange/wmi
   version: 5d049714c4a64225c3c79a7cf7d02f7fb5b96338
+- name: github.com/stretchr/testify
+  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
+  subpackages:
+  - assert
+  - require
+  - suite
 - name: golang.org/x/crypto
   version: a6600008915114d9c087fad9f03d75087b1a74df
   subpackages:
@@ -184,28 +203,33 @@ imports:
   - transform
   - unicode/bidi
   - unicode/norm
+- name: google.golang.org/appengine
+  version: b1f26356af11148e710935ed1ac8a7f5702c7612
+  subpackages:
+  - cloudsql
 - name: google.golang.org/genproto
   version: a8101f21cf983e773d0c1133ebc5424792003214
   subpackages:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 7a6a684ca69eb4cae85ad0a484f2e531598c047b
+  version: 168a6198bcb0ef175f7dacec0b8691fc141dc9b8
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
-  - channelz
   - codes
   - connectivity
   - credentials
   - encoding
   - encoding/proto
-  - grpclb/grpc_lb_v1/messages
   - grpclog
   - health
   - health/grpc_health_v1
   - internal
+  - internal/backoff
+  - internal/channelz
+  - internal/grpcrand
   - keepalive
   - metadata
   - naming
@@ -219,18 +243,4 @@ imports:
   - transport
 - name: gopkg.in/tomb.v2
   version: d5d1b5820637886def9eef33e03a27a9f166942c
-testImports:
-- name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
-  subpackages:
-  - difflib
-- name: github.com/stretchr/testify
-  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
-  subpackages:
-  - assert
-  - require
-  - suite
+testImports: []

--- a/pkg/server/plugin/datastore/sql/models.go
+++ b/pkg/server/plugin/datastore/sql/models.go
@@ -6,20 +6,20 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-type CACert struct {
-	gorm.Model
-
-	Cert   []byte    `gorm:"not null"`
-	Expiry time.Time `gorm:"not null;index"`
-
-	BundleID uint `gorm:"not null;index" sql:"type:integer REFERENCES bundles(id)"`
-}
-
 type Bundle struct {
 	gorm.Model
 
 	TrustDomain string `gorm:"not null;unique_index"`
 	CACerts     []CACert
+}
+
+type CACert struct {
+	gorm.Model
+
+	Cert   []byte    `gorm:"size:4095;not null"`
+	Expiry time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index"`
+
+	BundleID uint `gorm:"index" sql:"NOT NULL, FOREIGN KEY (bundle_id) REFERENCES bundles(id)"`
 }
 
 type AttestedNodeEntry struct {

--- a/pkg/server/plugin/datastore/sql/mysql.go
+++ b/pkg/server/plugin/datastore/sql/mysql.go
@@ -1,0 +1,16 @@
+package sql
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+)
+
+type mysql struct {}
+
+func (my mysql) connect(connectionString string) (*gorm.DB, error) {
+	db, err := gorm.Open("mysql", connectionString)
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -1134,6 +1134,8 @@ func (ds *sqlPlugin) restart() error {
 		db, err = sqlite{}.connect(ds.ConnectionString)
 	case "postgres":
 		db, err = postgres{}.connect(ds.ConnectionString)
+	case "mysql":
+		db, err = mysql{}.connect(ds.ConnectionString)
 	default:
 		return fmt.Errorf("unsupported database_type: %v", ds.DatabaseType)
 	}

--- a/script/e2e_test.sh
+++ b/script/e2e_test.sh
@@ -6,7 +6,7 @@
 # code 0 if all steps are completed successfully.
 #
 # If a running docker system is available from the machine this test will also create a new PostgreSQL instance
-# as a docker container. This database instance is then used to run the e2e test with PostgreSQL as a datastore. 
+# as a docker container. This database instance is then used to run the e2e test with PostgreSQL as a datastore.
 #
 # PLEASE NOTE: This script must be run from the project root, and will remove the
 # default datastore file before beginning in order to ensure accurate resutls.
@@ -49,7 +49,7 @@ run_test() {
     ./cmd/spire-server/spire-server entry create \
     -spiffeID spiffe://example.org/test \
     -parentID spiffe://example.org/agent \
-    -selector unix:uid:$(id -u) 
+    -selector unix:uid:$(id -u)
 
     TOKEN=$(./cmd/spire-server/spire-server token generate -spiffeID spiffe://example.org/agent | awk '{print $2}')
     ./cmd/spire-agent/spire-agent run -joinToken $TOKEN &
@@ -86,3 +86,5 @@ run_test() {
 
 run_e2e_test "conf/server/server.conf"
 run_docker_test "test/configs/server/postgres.conf" "-e POSTGRES_PASSWORD=password -p 5432:5432 -d postgres"
+run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=rootpassword -p 3306:3306 -d mariadb:5.5"
+run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 3306:3306 -d mysql:5.7.22"

--- a/test/configs/server/mysql.conf
+++ b/test/configs/server/mysql.conf
@@ -1,0 +1,57 @@
+server {
+    bind_address = "127.0.0.1"
+    bind_port = "8081"
+    bind_http_port = "8080"
+    trust_domain = "example.org"
+    plugin_dir = "conf/server/plugin"
+    log_level = "DEBUG"
+    umask = ""
+    upstream_bundle = true
+}
+
+plugins {
+    ServerCA "memory" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org",
+            key_size = 2048,
+            backdate_seconds = 1,
+            default_ttl = 3600,
+            cert_subject = {
+                Country = ["US"],
+                Organization = ["SPIFFE"],
+                CommonName = "",
+            }
+        }
+    }
+
+    DataStore "sql" {
+        enabled = true
+        plugin_data {
+            database_type = "mysql"
+            connection_string = "mysql:password@tcp(localhost:3306)/mysql?charset=utf8&parseTime=True&multiStatements=true&loc=Local"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+        }
+    }
+
+    NodeResolver "noop" {
+        enabled = true
+        plugin_data {}
+    }
+
+    UpstreamCA "disk" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+            ttl = "1h"
+            key_file_path = "conf/server/dummy_upstream_ca.key"
+            cert_file_path = "conf/server/dummy_upstream_ca.crt"
+        }
+    }
+}


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Added support to MySQL/MariaDB in plug-in SQL.

**Description of change**
Added initializer and example configuration for MySQL connection.
Rewrites model to support `REFERENCES` in standard SQL language

**Which issue this PR fixes**
Just an improvement.

Added support for mysql (and mariadb) on sql server plugin.
Added test for mysql:5.7.22 and mariadb:5.5.
Added documentation for configura sql plugin using mysql.

Signed-off-by: amonetta <agustin.monetta@gmail.com>