### PR TITLE
JWT-A-SVID signing support

### DIFF
--- a/pkg/agent/attestor/node/node.go
+++ b/pkg/agent/attestor/node/node.go
@@ -308,21 +308,21 @@ func (a *attestor) serverCredFunc(bundle []*x509.Certificate) func() (credential
 }
 
 func (a *attestor) parseAttestationResponse(id string, r *node.AttestResponse) (*x509.Certificate, []*x509.Certificate, error) {
-	if len(r.SvidUpdate.Svids) < 1 {
+	if len(r.Update.Svids) < 1 {
 		return nil, nil, errors.New("no svid received")
 	}
 
-	svidMsg, ok := r.SvidUpdate.Svids[id]
+	svidMsg, ok := r.Update.Svids[id]
 	if !ok {
 		return nil, nil, fmt.Errorf("incorrect svid: %s", id)
 	}
 
-	svid, err := x509.ParseCertificate(svidMsg.SvidCert)
+	svid, err := x509.ParseCertificate(svidMsg.Cert)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid svid: %v", err)
 	}
 
-	bundle, err := x509.ParseCertificates(r.SvidUpdate.Bundle)
+	bundle, err := x509.ParseCertificates(r.Update.Bundle)
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid bundle: %v", bundle)
 	}

--- a/pkg/agent/attestor/node/node_test.go
+++ b/pkg/agent/attestor/node/node_test.go
@@ -44,7 +44,7 @@ type NodeAttestorTestSuite struct {
 	keyManager   *mock_keymanager.MockKeyManager
 	nodeClient   *mock_node.MockNodeClient
 	config       *Config
-	expectation  *node.SvidUpdate
+	expectation  *node.X509SVIDUpdate
 }
 
 func (s *NodeAttestorTestSuite) SetupTest() {
@@ -247,11 +247,11 @@ func (s *NodeAttestorTestSuite) setAttestResponse(challenges []challengeResponse
 		}, nil)
 	}
 	stream.EXPECT().Recv().Return(&node.AttestResponse{
-		SvidUpdate: &node.SvidUpdate{
-			Svids: map[string]*node.Svid{
-				"spiffe://example.com/spire/agent/join_token/foobar": &node.Svid{
-					SvidCert: svid.Raw,
-					Ttl:      300,
+		Update: &node.X509SVIDUpdate{
+			Svids: map[string]*node.X509SVID{
+				"spiffe://example.com/spire/agent/join_token/foobar": &node.X509SVID{
+					Cert:      svid.Raw,
+					ExpiresAt: svid.NotAfter.Unix(),
 				}},
 		}}, nil)
 	stream.EXPECT().CloseSend()

--- a/pkg/agent/attestor/workload/workload_test.go
+++ b/pkg/agent/attestor/workload/workload_test.go
@@ -33,7 +33,7 @@ type WorkloadAttestorTestSuite struct {
 	ctrl *gomock.Controller
 
 	attestor    *attestor
-	expectation *node.SvidUpdate
+	expectation *node.X509SVIDUpdate
 	attestor1   *mock_workloadattestor.MockWorkloadAttestor
 	attestor2   *mock_workloadattestor.MockWorkloadAttestor
 }

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -28,8 +28,14 @@ var (
 	ErrUnableToGetStream = errors.New("unable to get a stream")
 )
 
+type JWTASVID struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
 type Client interface {
-	FetchUpdates(req *node.FetchX509SVIDRequest) (*Update, error)
+	FetchUpdates(ctx context.Context, req *node.FetchX509SVIDRequest) (*Update, error)
+	FetchJWTASVID(ctx context.Context, jsr *node.JSR) (*JWTASVID, error)
 
 	// Release releases any resources that were held by this Client, if any.
 	Release()
@@ -74,8 +80,8 @@ func (c *client) credsFunc() (credentials.TransportCredentials, error) {
 	return credentials.NewTLS(tlsConfig), nil
 }
 
-func (c *client) dial() (*grpc.ClientConn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TODO: Make this timeout configurable?
+func (c *client) dial(ctx context.Context) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second) // TODO: Make this timeout configurable?
 	defer cancel()
 
 	config := grpcutil.GRPCDialerConfig{
@@ -90,13 +96,13 @@ func (c *client) dial() (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
-func (c *client) FetchUpdates(req *node.FetchX509SVIDRequest) (*Update, error) {
-	nodeClient, err := c.newNodeClient()
+func (c *client) FetchUpdates(ctx context.Context, req *node.FetchX509SVIDRequest) (*Update, error) {
+	nodeClient, err := c.newNodeClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	stream, err := nodeClient.FetchX509SVID(context.Background())
+	stream, err := nodeClient.FetchX509SVID(ctx)
 	// We weren't able to get a stream...close the client and return the error.
 	if err != nil {
 		c.Release()
@@ -114,7 +120,7 @@ func (c *client) FetchUpdates(req *node.FetchX509SVIDRequest) (*Update, error) {
 	}
 
 	regEntries := map[string]*common.RegistrationEntry{}
-	svids := map[string]*node.Svid{}
+	svids := map[string]*node.X509SVID{}
 	var lastBundle []byte
 	// Read all the server responses from the stream.
 	for {
@@ -127,18 +133,45 @@ func (c *client) FetchUpdates(req *node.FetchX509SVIDRequest) (*Update, error) {
 			return &Update{regEntries, svids, lastBundle}, err
 		}
 
-		for _, re := range resp.SvidUpdate.RegistrationEntries {
+		for _, re := range resp.Update.RegistrationEntries {
 			regEntries[re.EntryId] = re
 		}
-		for spiffeid, svid := range resp.SvidUpdate.Svids {
+		for spiffeid, svid := range resp.Update.Svids {
 			svids[spiffeid] = svid
 		}
-		lastBundle = resp.SvidUpdate.Bundle
+		lastBundle = resp.Update.Bundle
 	}
 	return &Update{
 		Entries: regEntries,
 		SVIDs:   svids,
 		Bundle:  lastBundle,
+	}, nil
+}
+
+func (c *client) FetchJWTASVID(ctx context.Context, jsr *node.JSR) (*JWTASVID, error) {
+	nodeClient, err := c.newNodeClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := nodeClient.FetchJWTASVID(ctx, &node.FetchJWTASVIDRequest{
+		Jsr: jsr,
+	})
+	// We weren't able to make the request...close the client and return the error.
+	if err != nil {
+		c.Release()
+		c.c.Log.Errorf("%v: %v", ErrUnableToGetStream, err)
+		return nil, ErrUnableToGetStream
+	}
+
+	svid := response.GetSvid()
+	if svid == nil {
+		return nil, errors.New("JWTASVID response missing SVID")
+	}
+
+	return &JWTASVID{
+		Token:     svid.Token,
+		ExpiresAt: time.Unix(svid.ExpiresAt, 0),
 	}, nil
 }
 
@@ -152,7 +185,7 @@ func (c *client) Release() {
 	}
 }
 
-func (c *client) newNodeClient() (node.NodeClient, error) {
+func (c *client) newNodeClient(ctx context.Context) (node.NodeClient, error) {
 	if c.newNodeClientCallback != nil {
 		return c.newNodeClientCallback()
 	}
@@ -161,7 +194,7 @@ func (c *client) newNodeClient() (node.NodeClient, error) {
 	defer c.m.Unlock()
 
 	if c.conn == nil {
-		conn, err := c.dial()
+		conn, err := c.dial(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"io"
 	"testing"
 
@@ -34,14 +35,14 @@ func TestFetchUpdates(t *testing.T) {
 		Csrs: [][]byte{{1, 2, 3, 4}},
 	}
 	res := &node.FetchX509SVIDResponse{
-		SvidUpdate: &node.SvidUpdate{
+		Update: &node.X509SVIDUpdate{
 			Bundle: []byte{10, 20, 30, 40},
 			RegistrationEntries: []*common.RegistrationEntry{{
 				EntryId: "1",
 			}},
-			Svids: map[string]*node.Svid{
+			Svids: map[string]*node.X509SVID{
 				"someSpiffeId": {
-					SvidCert: []byte{11, 22, 33},
+					Cert: []byte{11, 22, 33},
 				},
 			},
 		},
@@ -53,12 +54,12 @@ func TestFetchUpdates(t *testing.T) {
 	nodeFsc.EXPECT().Recv().Return(res, nil)
 	nodeFsc.EXPECT().Recv().Return(nil, io.EOF)
 
-	update, err := client.FetchUpdates(req)
+	update, err := client.FetchUpdates(context.Background(), req)
 	require.Nil(t, err)
 
-	assert.Equal(t, res.SvidUpdate.Bundle, update.Bundle)
-	assert.Equal(t, res.SvidUpdate.Svids, update.SVIDs)
-	for _, entry := range res.SvidUpdate.RegistrationEntries {
+	assert.Equal(t, res.Update.Bundle, update.Bundle)
+	assert.Equal(t, res.Update.Svids, update.SVIDs)
+	for _, entry := range res.Update.RegistrationEntries {
 		assert.Equal(t, entry, update.Entries[entry.EntryId])
 	}
 	client.Release()

--- a/pkg/agent/client/update.go
+++ b/pkg/agent/client/update.go
@@ -10,7 +10,7 @@ import (
 
 type Update struct {
 	Entries map[string]*common.RegistrationEntry
-	SVIDs   map[string]*node.Svid
+	SVIDs   map[string]*node.X509SVID
 	Bundle  []byte
 }
 

--- a/pkg/agent/client/update_test.go
+++ b/pkg/agent/client/update_test.go
@@ -17,15 +17,15 @@ func TestString(t *testing.T) {
 	u := &Update{
 		Bundle:  []byte{1, 2, 3},
 		Entries: map[string]*common.RegistrationEntry{entries[0].EntryId: entries[0]},
-		SVIDs: map[string]*node.Svid{
+		SVIDs: map[string]*node.X509SVID{
 			"spiffe://example.org": {
-				SvidCert: []byte{4, 5},
-				Ttl:      5,
+				Cert:      []byte{4, 5},
+				ExpiresAt: 5,
 			},
 		},
 	}
 
-	expected := "{ Entries: [{ spiffeID: spiffe://example.org/spire/agent, parentID: spiffe://example.org/spire/agent/join_token/abcd, selectors: [type:\"spiffe_id\" value:\"spiffe://example.org/spire/agent/join_token/abcd\" ]}], SVIDs: [spiffe://example.org: svid_cert:\"\\004\\005\" ttl:5  ], Bundle: bytes}"
+	expected := "{ Entries: [{ spiffeID: spiffe://example.org/spire/agent, parentID: spiffe://example.org/spire/agent/join_token/abcd, selectors: [type:\"spiffe_id\" value:\"spiffe://example.org/spire/agent/join_token/abcd\" ]}], SVIDs: [spiffe://example.org: cert:\"\\004\\005\" expires_at:5  ], Bundle: bytes}"
 	if u.String() != expected {
 		t.Errorf("expected: %s, got: %s", expected, u.String())
 	}

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -71,7 +71,7 @@ func (m *manager) Initialize(ctx context.Context) error {
 	m.storeSVID(m.svid.State().SVID)
 	m.storeBundle(m.cache.Bundle())
 
-	return m.synchronize()
+	return m.synchronize(ctx)
 }
 
 func (m *manager) Run(ctx context.Context) error {
@@ -120,7 +120,7 @@ func (m *manager) runSynchronizer(ctx context.Context) error {
 	for {
 		select {
 		case <-t.C:
-			err := m.synchronize()
+			err := m.synchronize(ctx)
 			if err != nil {
 				// Just log the error to keep waiting for next sinchronization...
 				m.c.Log.Errorf("synchronize failed: %v", err)

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -168,7 +168,7 @@ func (s *RotatorTestSuite) TestRotateSVID() {
 
 	stream := s.r.Subscribe()
 	s.expectSVIDRotation(cert)
-	err = s.r.rotateSVID()
+	err = s.r.rotateSVID(context.Background())
 	s.Assert().NoError(err)
 	s.Require().True(stream.HasNext())
 
@@ -180,11 +180,11 @@ func (s *RotatorTestSuite) TestRotateSVID() {
 // the the provided certificate to the client.Client caller.
 func (s *RotatorTestSuite) expectSVIDRotation(cert *x509.Certificate) {
 	s.client.EXPECT().
-		FetchUpdates(gomock.Any()).
+		FetchUpdates(gomock.Any(), gomock.Any()).
 		Return(&client.Update{
-			SVIDs: map[string]*node.Svid{
+			SVIDs: map[string]*node.X509SVID{
 				s.r.c.SpiffeID: {
-					SvidCert: cert.Raw,
+					Cert: cert.Raw,
 				},
 			},
 		}, nil)

--- a/pkg/common/jwtsvid/common.go
+++ b/pkg/common/jwtsvid/common.go
@@ -1,0 +1,28 @@
+package jwtsvid
+
+import (
+	"crypto/ecdsa"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+)
+
+func audienceClaim(audience []string) interface{} {
+	if len(audience) == 1 {
+		return audience[0]
+	}
+	return audience
+}
+
+func ecdsaKeyMatches(privateKey *ecdsa.PrivateKey, publicKey *ecdsa.PublicKey) bool {
+	return publicKey.X.Cmp(privateKey.X) == 0 && publicKey.Y.Cmp(privateKey.Y) == 0
+}
+
+func GetTokenExpiry(token string) (time.Time, error) {
+	claims := new(jwt.StandardClaims)
+	_, _, err := new(jwt.Parser).ParseUnverified(token, claims)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(claims.ExpiresAt, 0), nil
+}

--- a/pkg/common/jwtsvid/keypair.go
+++ b/pkg/common/jwtsvid/keypair.go
@@ -1,0 +1,63 @@
+package jwtsvid
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"time"
+)
+
+var (
+	extKeyUsage pkix.Extension
+)
+
+func init() {
+	// create an empty ASN.1 sequence. this shouldn't fail.
+	emptySequence, err := asn1.Marshal([]interface{}{})
+	if err != nil {
+		panic(err)
+	}
+	// TODO: add the custom SPIFFE JWT-A-SVID ExtKeyUsage OID when available
+	extKeyUsage = pkix.Extension{
+		Id:       asn1.ObjectIdentifier{2, 5, 29, 37},
+		Critical: true,
+		Value:    emptySequence,
+	}
+}
+
+func GenerateKey() (*ecdsa.PrivateKey, error) {
+	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+}
+
+func CreateCertificateTemplate(parentCert *x509.Certificate) *x509.Certificate {
+	return &x509.Certificate{
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		BasicConstraintsValid: true,
+		IsCA:      false,
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		NotBefore: parentCert.NotBefore,
+		NotAfter:  parentCert.NotAfter,
+		URIs:      parentCert.URIs,
+		ExtraExtensions: []pkix.Extension{
+			extKeyUsage,
+		},
+	}
+}
+
+func ValidateSigningCertificate(cert *x509.Certificate) error {
+	if cert.IsCA {
+		return errors.New("signing certificate cannot be a CA")
+	}
+	if cert.KeyUsage != x509.KeyUsageDigitalSignature {
+		return errors.New("signing certificate keyUsage MUST be digitalSignature only")
+	}
+	if time.Now().After(cert.NotAfter) {
+		return errors.New("signing certificate is expired")
+	}
+
+	return nil
+}

--- a/pkg/common/jwtsvid/simple.go
+++ b/pkg/common/jwtsvid/simple.go
@@ -1,0 +1,130 @@
+package jwtsvid
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/spiffe/spire/pkg/common/idutil"
+)
+
+const (
+	certificateThumbprintHeader = "x5t#S256"
+)
+
+func SignSimpleToken(spiffeID string, audience []string, expires time.Time, privateKey *ecdsa.PrivateKey, cert *x509.Certificate) (string, error) {
+	// this might be overkill but better safe than sorry.
+	if publicKey, ok := cert.PublicKey.(*ecdsa.PublicKey); !ok || !ecdsaKeyMatches(privateKey, publicKey) {
+		return "", errors.New("certificate does not match private key")
+	}
+	if err := idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomainWorkload()); err != nil {
+		return "", err
+	}
+
+	// cap expiration to the signing certificate expiration, if necessary.
+	if expires.IsZero() {
+		return "", errors.New("expiration is required")
+	}
+	if !cert.NotAfter.IsZero() && expires.After(cert.NotAfter) {
+		expires = cert.NotAfter
+	}
+
+	if len(audience) == 0 {
+		return "", errors.New("audience is required")
+	}
+
+	claims := jwt.MapClaims{
+		"sub": spiffeID,
+		"exp": expires.Unix(),
+		"aud": audienceClaim(audience),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header[certificateThumbprintHeader] = certificateThumbprint(cert)
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", err
+	}
+	return signedToken, nil
+}
+
+type SimpleTrustBundle interface {
+	FindCertificate(ctx context.Context, thumbprint string) (*x509.Certificate, error)
+}
+
+type simpleTrustBundle struct {
+	lookup map[string]*x509.Certificate
+}
+
+func NewSimpleTrustBundle(certs []*x509.Certificate) SimpleTrustBundle {
+	t := &simpleTrustBundle{
+		lookup: make(map[string]*x509.Certificate),
+	}
+	for _, cert := range certs {
+		t.lookup[certificateThumbprint(cert)] = cert
+	}
+	return t
+}
+
+func (t *simpleTrustBundle) FindCertificate(ctx context.Context, thumbprint string) (*x509.Certificate, error) {
+	cert := t.lookup[thumbprint]
+	if cert == nil {
+		return nil, errors.New("signing certificate not found in trust bundle")
+	}
+	return cert, nil
+}
+
+func ValidateSimpleToken(ctx context.Context, token string, trustBundle SimpleTrustBundle, audience string) (jwt.MapClaims, error) {
+	claims := make(jwt.MapClaims)
+	if _, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (interface{}, error) {
+		if t.Method.Alg() != jwt.SigningMethodES256.Alg() {
+			return nil, fmt.Errorf("unexpected token signature algorithm: %s", t.Method.Alg())
+		}
+		thumbprint, _ := t.Header[certificateThumbprintHeader].(string)
+		if thumbprint == "" {
+			return nil, errors.New("token missing certificate thumbprint")
+		}
+		cert, err := trustBundle.FindCertificate(ctx, thumbprint)
+		if err != nil {
+			return nil, err
+		}
+		if err := ValidateSigningCertificate(cert); err != nil {
+			return nil, err
+		}
+		return cert.PublicKey, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	switch audienceClaim := claims["aud"].(type) {
+	case []interface{}:
+		found := false
+		for _, audValue := range audienceClaim {
+			if aud, ok := audValue.(string); ok && aud == audience {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("expected audience %q (audience=%q)", audience, audienceClaim)
+		}
+	case string:
+		if audienceClaim != audience {
+			return nil, fmt.Errorf("expected audience %q (audience=%q)", audience, audienceClaim)
+		}
+	default:
+		return nil, errors.New("missing audience claim")
+	}
+	return claims, nil
+}
+
+func certificateThumbprint(cert *x509.Certificate) string {
+	hash := sha256.Sum256(cert.Raw)
+	return base64.URLEncoding.EncodeToString(hash[:])
+}

--- a/pkg/common/jwtsvid/simple_test.go
+++ b/pkg/common/jwtsvid/simple_test.go
@@ -1,0 +1,224 @@
+package jwtsvid
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	fakeSpiffeID = "spiffe://example.org/blog"
+)
+
+var (
+	ctx           = context.Background()
+	fakeAudience  = []string{"AUDIENCE"}
+	fakeAudiences = []string{"AUDIENCE1", "AUDIENCE2"}
+
+	keyPEM = []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgt/OIyb8Ossz/5bNk
+XtnzFe1T2d0D9quX9Loi1O55b8yhRANCAATDe/2d6z+P095I3dIkocKr4b3zAy+1
+qQDuoXqa8i3YOPk5fLib4ORzqD9NJFcrKjI+LLtipQe9yu/eY1K0yhBa
+-----END PRIVATE KEY-----
+`)
+
+	expiredKeyPEM = []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgNp9vQd+cdlQhou4s
+6WFzVoRLAJP5pnWDISjqlvVIC02hRANCAASRSf3EdTX910uhqorzehrqi9I48rj5
+cM3DIfiWwosiykmhI0BmwtTWVD0kIFm7Mhf5XXP03Dj76UjImTLiQduQ
+-----END PRIVATE KEY-----
+`)
+)
+
+func TestSimpleToken(t *testing.T) {
+	suite.Run(t, new(SimpleTokenSuite))
+}
+
+type SimpleTokenSuite struct {
+	suite.Suite
+
+	cert          *x509.Certificate
+	key           *ecdsa.PrivateKey
+	bundle        SimpleTrustBundle
+	expiredCert   *x509.Certificate
+	expiredKey    *ecdsa.PrivateKey
+	expiredBundle SimpleTrustBundle
+}
+
+func (s *SimpleTokenSuite) SetupTest() {
+	s.key = s.loadKey(keyPEM)
+	s.cert = s.signCert(s.key, createCertificateTemplate(time.Hour))
+	s.bundle = NewSimpleTrustBundle([]*x509.Certificate{s.cert})
+	s.expiredKey = s.loadKey(expiredKeyPEM)
+	s.expiredCert = s.signCert(s.expiredKey, createCertificateTemplate(-time.Hour))
+	s.expiredBundle = NewSimpleTrustBundle([]*x509.Certificate{s.expiredCert})
+}
+
+func (s *SimpleTokenSuite) loadKey(pemBytes []byte) *ecdsa.PrivateKey {
+	block, rest := pem.Decode(pemBytes)
+	s.Require().Empty(rest)
+	s.Require().NotNil(block)
+	rawKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	s.Require().NoError(err)
+	key, ok := rawKey.(*ecdsa.PrivateKey)
+	s.Require().True(ok)
+	return key
+}
+
+func (s *SimpleTokenSuite) signCert(key *ecdsa.PrivateKey, template *x509.Certificate) *x509.Certificate {
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	s.Require().NoError(err)
+	cert, err := x509.ParseCertificate(certDER)
+	s.Require().NoError(err)
+	return cert
+}
+
+func (s *SimpleTokenSuite) TestSignAndValidate() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.bundle, fakeAudience[0])
+	s.Require().NoError(err)
+	s.Require().NotEmpty(claims)
+}
+
+func (s *SimpleTokenSuite) TestSignAndValidateWithAudienceList() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudiences, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.bundle, fakeAudiences[0])
+	s.Require().NoError(err)
+	s.Require().NotEmpty(claims)
+}
+
+func (s *SimpleTokenSuite) TestSignWithNoExpiration() {
+	_, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Time{}, s.key, s.cert)
+	s.Require().EqualError(err, "expiration is required")
+}
+
+func (s *SimpleTokenSuite) TestSignMismatchedKeypair() {
+	_, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now(), s.expiredKey, s.cert)
+	s.Require().EqualError(err, "certificate does not match private key")
+
+	_, err = SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now(), s.key, s.expiredCert)
+	s.Require().EqualError(err, "certificate does not match private key")
+}
+
+func (s *SimpleTokenSuite) TestSignInvalidSpiffeID() {
+	// missing ID
+	_, err := SignSimpleToken("", fakeAudience, time.Now(), s.key, s.cert)
+	s.requireErrorContains(err, "is not a valid workload SPIFFE ID: SPIFFE ID is empty")
+
+	// only workload spiffe ID's are acceptable subjects
+	_, err = SignSimpleToken("spiffe://example.org", fakeAudience, time.Now(), s.key, s.cert)
+	s.requireErrorContains(err, "is not a valid workload SPIFFE ID: path is empty")
+}
+
+func (s *SimpleTokenSuite) TestSignNoAudience() {
+	_, err := SignSimpleToken(fakeSpiffeID, nil, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().EqualError(err, "audience is required")
+}
+
+func (s *SimpleTokenSuite) TestValidateBadAlgorithm() {
+	token := jwt.New(jwt.SigningMethodHS256)
+	tokenString, err := token.SignedString([]byte("BLAH"))
+	s.Require().NoError(err)
+
+	claims, err := ValidateSimpleToken(ctx, tokenString, s.bundle, fakeAudience[0])
+	s.Require().EqualError(err, "unexpected token signature algorithm: HS256")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateMissingThumbprint() {
+	token := jwt.New(jwt.SigningMethodES256)
+	tokenString, err := token.SignedString(s.key)
+	s.Require().NoError(err)
+
+	claims, err := ValidateSimpleToken(ctx, tokenString, s.bundle, fakeAudience[0])
+	s.Require().EqualError(err, "token missing certificate thumbprint")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateExpiredToken() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now().Add(-time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.bundle, fakeAudience[0])
+	s.Require().EqualError(err, "Token is expired")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateNoAudience() {
+	token := jwt.New(jwt.SigningMethodES256)
+	token.Header["x5t#S256"] = certificateThumbprint(s.cert)
+	tokenString, err := token.SignedString(s.key)
+	s.Require().NoError(err)
+
+	claims, err := ValidateSimpleToken(ctx, tokenString, s.bundle, "FOO")
+	s.Require().EqualError(err, "missing audience claim")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateUnexpectedAudience() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.bundle, "FOO")
+	s.Require().EqualError(err, `expected audience "FOO" (audience="AUDIENCE")`)
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateUnexpectedAudienceList() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudiences, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.bundle, "AUDIENCE3")
+	s.Require().EqualError(err, `expected audience "AUDIENCE3" (audience=["AUDIENCE1" "AUDIENCE2"])`)
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateCertificateNotFound() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now().Add(time.Hour), s.key, s.cert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.expiredBundle, fakeAudience[0])
+	s.Require().EqualError(err, "signing certificate not found in trust bundle")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) TestValidateCertificateExpired() {
+	token, err := SignSimpleToken(fakeSpiffeID, fakeAudience, time.Now().Add(time.Hour), s.expiredKey, s.expiredCert)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(token)
+
+	claims, err := ValidateSimpleToken(ctx, token, s.expiredBundle, fakeAudience[0])
+	s.Require().EqualError(err, "signing certificate is expired")
+	s.Require().Nil(claims)
+}
+
+func (s *SimpleTokenSuite) requireErrorContains(err error, contains string) {
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), contains)
+}
+
+func createCertificateTemplate(notAfter time.Duration) *x509.Certificate {
+	template := CreateCertificateTemplate(&x509.Certificate{
+		NotAfter: time.Now().Add(notAfter),
+	})
+	template.SerialNumber = big.NewInt(1)
+	return template
+}

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -94,10 +94,8 @@ func (s *EndpointsTestSuite) TestListenAndServe() {
 	// Expectations
 	cert, _, err := util.LoadSVIDFixture()
 	require.NoError(s.T(), err)
-	csrResp := &ca.SignCsrResponse{SignedCertificate: cert.Raw}
-	certResp := &ca.FetchCertificateResponse{StoredIntermediateCert: cert.Raw}
-	s.ca.EXPECT().SignCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
-	s.ca.EXPECT().FetchCertificate(gomock.Any(), gomock.Any()).Return(certResp, nil)
+	csrResp := &ca.SignX509SvidCsrResponse{SignedCertificate: cert.Raw}
+	s.ca.EXPECT().SignX509SvidCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
 
 	ctx, cancel := context.WithCancel(ctx)
 	errChan := make(chan error)
@@ -125,10 +123,8 @@ func (s *EndpointsTestSuite) TestGRPCHook() {
 	// Set all expectations for running gRPC server
 	cert, _, err := util.LoadSVIDFixture()
 	require.NoError(s.T(), err)
-	csrResp := &ca.SignCsrResponse{SignedCertificate: cert.Raw}
-	certResp := &ca.FetchCertificateResponse{StoredIntermediateCert: cert.Raw}
-	s.ca.EXPECT().SignCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
-	s.ca.EXPECT().FetchCertificate(gomock.Any(), gomock.Any()).Return(certResp, nil)
+	csrResp := &ca.SignX509SvidCsrResponse{SignedCertificate: cert.Raw}
+	s.ca.EXPECT().SignX509SvidCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
 
 	snitchChan := make(chan struct{}, 1)
 	hook := func(g *grpc.Server) error {
@@ -153,10 +149,8 @@ func (s *EndpointsTestSuite) TestGRPCHookFailure() {
 	// Set all expectations for running gRPC server
 	cert, _, err := util.LoadSVIDFixture()
 	require.NoError(s.T(), err)
-	csrResp := &ca.SignCsrResponse{SignedCertificate: cert.Raw}
-	certResp := &ca.FetchCertificateResponse{StoredIntermediateCert: cert.Raw}
-	s.ca.EXPECT().SignCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
-	s.ca.EXPECT().FetchCertificate(gomock.Any(), gomock.Any()).Return(certResp, nil)
+	csrResp := &ca.SignX509SvidCsrResponse{SignedCertificate: cert.Raw}
+	s.ca.EXPECT().SignX509SvidCsr(gomock.Any(), gomock.Any()).Return(csrResp, nil)
 
 	hook := func(_ *grpc.Server) error { return errors.New("i'm an error") }
 	s.e.c.GRPCHook = hook

--- a/pkg/server/plugin/ca/memory/memory.go
+++ b/pkg/server/plugin/ca/memory/memory.go
@@ -5,13 +5,16 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/hashicorp/hcl"
 
+	"github.com/spiffe/spire/pkg/common/jwtsvid"
 	"github.com/spiffe/spire/pkg/common/x509svid"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	spi "github.com/spiffe/spire/proto/common/plugin"
@@ -41,21 +44,36 @@ type configuration struct {
 	DefaultTTL   int               `hcl:"default_ttl" json:"default_ttl"`
 }
 
+type keypairs struct {
+	x509Key  *ecdsa.PrivateKey
+	x509Cert *x509.Certificate
+	serverCA *x509svid.ServerCA
+	jwtKey   *ecdsa.PrivateKey
+	jwtCert  *x509.Certificate
+}
+
 type MemoryPlugin struct {
 	serialNumber x509util.SerialNumber
 
-	mtx sync.RWMutex
-	// everything below is protected by the mutex
-	config   *configuration
-	newKey   *ecdsa.PrivateKey
-	keypair  *x509util.MemoryKeypair
-	serverCA *x509svid.ServerCA
+	mtx     sync.RWMutex
+	config  *configuration
+	current *keypairs
+	next    *keypairs
+
+	// test hooks
+	hooks struct {
+		now func() time.Time
+	}
 }
 
+var _ ca.ServerCA = (*MemoryPlugin)(nil)
+
 func New() *MemoryPlugin {
-	return &MemoryPlugin{
+	m := &MemoryPlugin{
 		serialNumber: x509util.NewSerialNumber(),
 	}
+	m.hooks.now = time.Now
+	return m
 }
 
 func NewWithDefault() *MemoryPlugin {
@@ -75,12 +93,11 @@ func (m *MemoryPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest)
 	// Parse HCL config payload into config struct
 	config := &configuration{}
 	if err := hcl.Decode(&config, req.Configuration); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to decode configuration: %v", err)
 	}
 	if config.TrustDomain == "" {
 		return nil, errors.New("trust domain is required")
 	}
-
 	m.configure(config)
 	return &spi.ConfigureResponse{}, nil
 }
@@ -89,54 +106,77 @@ func (m *MemoryPlugin) configure(config *configuration) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 	m.config = config
-	m.initializeCA()
-}
-
-func (m *MemoryPlugin) initializeCA() {
-	if m.keypair == nil {
-		m.serverCA = nil
-		return
+	if m.current != nil {
+		m.current.serverCA = m.newServerCA(x509util.NewMemoryKeypair(m.current.x509Cert, m.current.x509Key))
 	}
-
-	m.serverCA = x509svid.NewServerCA(m.keypair, m.config.TrustDomain,
-		x509svid.ServerCAOptions{
-			TTL:          time.Duration(m.config.DefaultTTL) * time.Second,
-			Backdate:     time.Duration(m.config.BackdateSecs) * time.Second,
-			SerialNumber: m.serialNumber,
-		})
 }
 
 func (*MemoryPlugin) GetPluginInfo(ctx context.Context, req *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func (m *MemoryPlugin) SignCsr(ctx context.Context, request *ca.SignCsrRequest) (*ca.SignCsrResponse, error) {
+func (m *MemoryPlugin) SignX509SvidCsr(ctx context.Context, request *ca.SignX509SvidCsrRequest) (*ca.SignX509SvidCsrResponse, error) {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()
 
-	if m.serverCA == nil {
+	if m.current == nil {
 		return nil, errors.New("invalid state: no certificate loaded")
 	}
 
-	cert, err := m.serverCA.SignCSR(ctx, request.Csr, time.Duration(request.Ttl)*time.Second)
+	cert, err := m.current.serverCA.SignCSR(ctx, request.Csr, time.Duration(request.Ttl)*time.Second)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ca.SignCsrResponse{SignedCertificate: cert.Raw}, nil
+	return &ca.SignX509SvidCsrResponse{SignedCertificate: cert.Raw}, nil
+}
+
+func (m *MemoryPlugin) SignJwtSvid(ctx context.Context, request *ca.SignJwtSvidRequest) (*ca.SignJwtSvidResponse, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	switch {
+	case m.current == nil:
+		return nil, errors.New("Invalid state: no certificate")
+	case request.SpiffeId == "":
+		return nil, errors.New("Invalid request: SPIFFE ID is required")
+	case len(request.Audience) == 0:
+		return nil, errors.New("Invalid request: at least one audience is required")
+	case request.Ttl < 0:
+		return nil, errors.New("Invalid request: TTL is invalid")
+	}
+
+	if request.Ttl == 0 {
+		request.Ttl = int32(m.config.DefaultTTL)
+	}
+	ttl := time.Duration(request.Ttl) * time.Second
+	if ttl == 0 {
+		ttl = x509svid.DefaultServerCATTL
+	}
+
+	token, err := jwtsvid.SignSimpleToken(
+		request.SpiffeId, request.Audience,
+		m.hooks.now().Add(ttl),
+		m.current.jwtKey, m.current.jwtCert)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build JWT-SVID: %v", err)
+	}
+
+	return &ca.SignJwtSvidResponse{
+		SignedJwt: token,
+	}, nil
 }
 
 func (m *MemoryPlugin) GenerateCsr(ctx context.Context, req *ca.GenerateCsrRequest) (*ca.GenerateCsrResponse, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	newKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	x509Key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		return nil, errors.New("generate private key: " + err.Error())
+		return nil, fmt.Errorf("Can't generate X509-SVID CA private key: %v", err)
 	}
-	m.newKey = newKey
 
-	csr, err := x509svid.GenerateServerCACSR(newKey, m.config.TrustDomain,
+	csr, err := x509svid.GenerateServerCACSR(x509Key, m.config.TrustDomain,
 		x509svid.ServerCACSROptions{
 			Subject: pkix.Name{
 				Country:      m.config.CertSubject.Country,
@@ -145,31 +185,17 @@ func (m *MemoryPlugin) GenerateCsr(ctx context.Context, req *ca.GenerateCsrReque
 			},
 		})
 
+	m.next = &keypairs{
+		x509Key: x509Key,
+	}
 	return &ca.GenerateCsrResponse{Csr: csr}, nil
-}
-
-func (m *MemoryPlugin) FetchCertificate(ctx context.Context, request *ca.FetchCertificateRequest) (*ca.FetchCertificateResponse, error) {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	if m.keypair == nil {
-		// return empty result if uninitialized.
-		return &ca.FetchCertificateResponse{}, nil
-	}
-
-	cert, err := m.keypair.GetCertificate(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ca.FetchCertificateResponse{StoredIntermediateCert: cert.Raw}, nil
 }
 
 func (m *MemoryPlugin) LoadCertificate(ctx context.Context, request *ca.LoadCertificateRequest) (response *ca.LoadCertificateResponse, err error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	if m.newKey == nil {
+	if m.next == nil {
 		return nil, errors.New("invalid state: no private key")
 	}
 
@@ -178,8 +204,80 @@ func (m *MemoryPlugin) LoadCertificate(ctx context.Context, request *ca.LoadCert
 		return nil, err
 	}
 
-	m.keypair = x509util.NewMemoryKeypair(cert, m.newKey)
-	m.initializeCA()
+	keypair := x509util.NewMemoryKeypair(cert, m.next.x509Key)
+
+	jwtCert, jwtKey, err := m.generateJWTKeypair(ctx, cert, keypair)
+	if err != nil {
+		return nil, err
+	}
+
+	m.next.x509Cert = cert
+	m.next.serverCA = m.newServerCA(keypair)
+	m.next.jwtCert = jwtCert
+	m.next.jwtKey = jwtKey
+
+	// swap in the new keypairs
+	m.current, m.next = m.next, nil
 
 	return &ca.LoadCertificateResponse{}, nil
+}
+
+// getX509SVIDCertificate returns the X509-SVID signing certificate.
+func (m *MemoryPlugin) getX509SVIDCertificate() (*x509.Certificate, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	if m.current == nil {
+		return nil, errors.New("no certificate loaded")
+	}
+
+	return m.current.x509Cert, nil
+}
+
+// getJWTASVIDCertificate returns the JWT-A-SVID signing certificate.
+func (m *MemoryPlugin) getJWTASVIDCertificate() (*x509.Certificate, error) {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+
+	if m.current == nil {
+		return nil, errors.New("no certificate loaded")
+	}
+
+	return m.current.jwtCert, nil
+}
+
+func (m *MemoryPlugin) generateJWTKeypair(ctx context.Context, parentCert *x509.Certificate, keypair x509util.Keypair) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	jwtKey, err := jwtsvid.GenerateKey()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create JWT key: %v", err)
+	}
+
+	serialNumber, err := m.serialNumber.NextNumber(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template := jwtsvid.CreateCertificateTemplate(parentCert)
+	template.SerialNumber = serialNumber
+
+	certBytes, err := keypair.CreateCertificate(ctx, template, &jwtKey.PublicKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to create JWT cert: %v", err)
+	}
+
+	jwtCert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return jwtCert, jwtKey, nil
+}
+
+func (m *MemoryPlugin) newServerCA(keypair x509util.Keypair) *x509svid.ServerCA {
+	return x509svid.NewServerCA(keypair,
+		m.config.TrustDomain,
+		x509svid.ServerCAOptions{
+			TTL:          time.Duration(m.config.DefaultTTL) * time.Second,
+			Backdate:     time.Duration(m.config.BackdateSecs) * time.Second,
+			SerialNumber: m.serialNumber,
+		})
 }

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -104,8 +104,9 @@ func (r *rotator) rotateSVID(ctx context.Context) error {
 	ca := r.c.Catalog.CAs()[0]
 
 	// Sign the CSR
-	csrReq := &ca_pb.SignCsrRequest{Csr: csr}
-	csrRes, err := ca.SignCsr(ctx, csrReq)
+	csrRes, err := ca.SignX509SvidCsr(ctx, &ca_pb.SignX509SvidCsrRequest{
+		Csr: csr,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/server/svid/rotator_test.go
+++ b/pkg/server/svid/rotator_test.go
@@ -167,9 +167,9 @@ func (s *RotatorTestSuite) TestRotateSVID() {
 // expectSVIDRotation sets the appropriate expectations for an SVID rotation, and returns
 // the the provided certificate to the CA caller
 func (s *RotatorTestSuite) expectSVIDRotation(cert *x509.Certificate) {
-	signedCert := &ca.SignCsrResponse{
+	signedCert := &ca.SignX509SvidCsrResponse{
 		SignedCertificate: cert.Raw,
 	}
 
-	s.ca.EXPECT().SignCsr(gomock.Any(), gomock.Any()).Return(signedCert, nil)
+	s.ca.EXPECT().SignX509SvidCsr(gomock.Any(), gomock.Any()).Return(signedCert, nil)
 }

--- a/proto/api/node/README_pb.md
+++ b/proto/api/node/README_pb.md
@@ -21,11 +21,15 @@
     - [FetchFederatedBundleRequest](#spire.api.node.FetchFederatedBundleRequest)
     - [FetchFederatedBundleResponse](#spire.api.node.FetchFederatedBundleResponse)
     - [FetchFederatedBundleResponse.FederatedBundlesEntry](#spire.api.node.FetchFederatedBundleResponse.FederatedBundlesEntry)
+    - [FetchJWTASVIDRequest](#spire.api.node.FetchJWTASVIDRequest)
+    - [FetchJWTASVIDResponse](#spire.api.node.FetchJWTASVIDResponse)
     - [FetchX509SVIDRequest](#spire.api.node.FetchX509SVIDRequest)
     - [FetchX509SVIDResponse](#spire.api.node.FetchX509SVIDResponse)
-    - [Svid](#spire.api.node.Svid)
-    - [SvidUpdate](#spire.api.node.SvidUpdate)
-    - [SvidUpdate.SvidsEntry](#spire.api.node.SvidUpdate.SvidsEntry)
+    - [JSR](#spire.api.node.JSR)
+    - [JWTASVID](#spire.api.node.JWTASVID)
+    - [X509SVID](#spire.api.node.X509SVID)
+    - [X509SVIDUpdate](#spire.api.node.X509SVIDUpdate)
+    - [X509SVIDUpdate.SvidsEntry](#spire.api.node.X509SVIDUpdate.SvidsEntry)
   
   
   
@@ -179,8 +183,8 @@ all current Registration Entries which are relevant to the caller SPIFFE ID
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| svid_update | [SvidUpdate](#spire.api.node.SvidUpdate) |  | It includes a map of signed SVIDs and an array of all current Registration Entries which are relevant to the caller SPIFFE ID. |
-| challenge | [bytes](#bytes) |  | This is a challenge issued by the server to the node. If populated, the node is expected to respond with another AttestRequest with the response. This field is mutually exclusive with the svid_update field. |
+| update | [X509SVIDUpdate](#spire.api.node.X509SVIDUpdate) |  | It includes a map of signed SVIDs and an array of all current Registration Entries which are relevant to the caller SPIFFE ID. |
+| challenge | [bytes](#bytes) |  | This is a challenge issued by the server to the node. If populated, the node is expected to respond with another AttestRequest with the response. This field is mutually exclusive with the update field. |
 
 
 
@@ -233,6 +237,36 @@ Represents a response with a map of SPIFFE Id, Federated CA Bundle.
 
 
 
+<a name="spire.api.node.FetchJWTASVIDRequest"/>
+
+### FetchJWTASVIDRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| jsr | [JSR](#spire.api.node.JSR) |  | The JWT signing request |
+
+
+
+
+
+
+<a name="spire.api.node.FetchJWTASVIDResponse"/>
+
+### FetchJWTASVIDResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| svid | [JWTASVID](#spire.api.node.JWTASVID) |  | The signed JWT-A-SVID |
+
+
+
+
+
+
 <a name="spire.api.node.FetchX509SVIDRequest"/>
 
 ### FetchX509SVIDRequest
@@ -257,40 +291,72 @@ of all current Registration Entries which are relevant to the caller SPIFFE ID.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| svid_update | [SvidUpdate](#spire.api.node.SvidUpdate) |  | It includes a map of signed SVIDs and an array of all current Registration Entries which are relevant to the caller SPIFFE ID. |
+| update | [X509SVIDUpdate](#spire.api.node.X509SVIDUpdate) |  | It includes a map of signed SVIDs and an array of all current Registration Entries which are relevant to the caller SPIFFE ID. |
 
 
 
 
 
 
-<a name="spire.api.node.Svid"/>
+<a name="spire.api.node.JSR"/>
 
-### Svid
+### JSR
+JSR is a JWT SVID signing request.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  | SPIFFE ID of the workload |
+| audience | [string](#string) | repeated | List of intended audience |
+
+
+
+
+
+
+<a name="spire.api.node.JWTASVID"/>
+
+### JWTASVID
+JWTASVID is a signed JWT-A-SVID with fields lifted out for convenience.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  | JWT-A-SVID JWT token |
+| expires_at | [int64](#int64) |  | SVID expiration timestamp (seconds since Unix epoch) |
+
+
+
+
+
+
+<a name="spire.api.node.X509SVID"/>
+
+### X509SVID
 A type which contains the &#34;Spiffe Verifiable Identity Document&#34; and
 a TTL indicating when the SVID expires.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| svid_cert | [bytes](#bytes) |  | Spiffe Verifiable Identity Document. |
-| ttl | [int32](#int32) |  | SVID expiration. |
+| cert | [bytes](#bytes) |  | X509 SVID (ASN.1 encoding) |
+| expires_at | [int64](#int64) |  | SVID expiration timestamp (in seconds since Unix epoch) |
 
 
 
 
 
 
-<a name="spire.api.node.SvidUpdate"/>
+<a name="spire.api.node.X509SVIDUpdate"/>
 
-### SvidUpdate
+### X509SVIDUpdate
 A message returned by the Spire Server, which includes a map of signed SVIDs and
 a list of all current Registration Entries which are relevant to the caller SPIFFE ID.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| svids | [SvidUpdate.SvidsEntry](#spire.api.node.SvidUpdate.SvidsEntry) | repeated | A map containing SVID values and corresponding SPIFFE IDs as the keys. Map[SPIFFE_ID] =&gt; SVID. |
+| svids | [X509SVIDUpdate.SvidsEntry](#spire.api.node.X509SVIDUpdate.SvidsEntry) | repeated | A map containing SVID values and corresponding SPIFFE IDs as the keys. Map[SPIFFE_ID] =&gt; SVID. |
 | bundle | [bytes](#bytes) |  | Latest SPIRE Server bundle |
 | registration_entries | [.spire.common.RegistrationEntry](#spire.api.node..spire.common.RegistrationEntry) | repeated | A type representing a curated record that the Spire Server uses to set up and manage the various registered nodes and workloads that are controlled by it. |
 
@@ -299,16 +365,16 @@ a list of all current Registration Entries which are relevant to the caller SPIF
 
 
 
-<a name="spire.api.node.SvidUpdate.SvidsEntry"/>
+<a name="spire.api.node.X509SVIDUpdate.SvidsEntry"/>
 
-### SvidUpdate.SvidsEntry
+### X509SVIDUpdate.SvidsEntry
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | key | [string](#string) |  |  |
-| value | [Svid](#spire.api.node.Svid) |  |  |
+| value | [X509SVID](#spire.api.node.X509SVID) |  |  |
 
 
 
@@ -330,6 +396,7 @@ a list of all current Registration Entries which are relevant to the caller SPIF
 | ----------- | ------------ | ------------- | ------------|
 | Attest | [AttestRequest](#spire.api.node.AttestRequest) | [AttestResponse](#spire.api.node.AttestRequest) | Attest the node, get base node SVID. |
 | FetchX509SVID | [FetchX509SVIDRequest](#spire.api.node.FetchX509SVIDRequest) | [FetchX509SVIDResponse](#spire.api.node.FetchX509SVIDRequest) | Get Workload, Node Agent certs and CA trust bundles. Also used for rotation Base Node SVID or the Registered Node SVID used for this call) List can be empty to allow Node Agent cache refresh). |
+| FetchJWTASVID | [FetchJWTASVIDRequest](#spire.api.node.FetchJWTASVIDRequest) | [FetchJWTASVIDResponse](#spire.api.node.FetchJWTASVIDRequest) | Fetches a signed JWT-A-SVID for a workload intended for a specific audience. |
 | FetchFederatedBundle | [FetchFederatedBundleRequest](#spire.api.node.FetchFederatedBundleRequest) | [FetchFederatedBundleResponse](#spire.api.node.FetchFederatedBundleRequest) | Called by the Node Agent to fetch the named Federated CA Bundle. Used in the event that authorized workloads reference a Federated Bundle. |
 
  

--- a/proto/api/node/node.pb.go
+++ b/proto/api/node/node.pb.go
@@ -44,60 +44,60 @@ type RegistrationEntries = common.RegistrationEntries
 
 // A type which contains the "Spiffe Verifiable Identity Document" and
 // a TTL indicating when the SVID expires.
-type Svid struct {
-	// Spiffe Verifiable Identity Document.
-	SvidCert []byte `protobuf:"bytes,1,opt,name=svid_cert,json=svidCert,proto3" json:"svid_cert,omitempty"`
-	// SVID expiration.
-	Ttl                  int32    `protobuf:"varint,2,opt,name=ttl" json:"ttl,omitempty"`
+type X509SVID struct {
+	// X509 SVID (ASN.1 encoding)
+	Cert []byte `protobuf:"bytes,1,opt,name=cert,proto3" json:"cert,omitempty"`
+	// SVID expiration timestamp (in seconds since Unix epoch)
+	ExpiresAt            int64    `protobuf:"varint,2,opt,name=expires_at,json=expiresAt" json:"expires_at,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *Svid) Reset()         { *m = Svid{} }
-func (m *Svid) String() string { return proto.CompactTextString(m) }
-func (*Svid) ProtoMessage()    {}
-func (*Svid) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{0}
+func (m *X509SVID) Reset()         { *m = X509SVID{} }
+func (m *X509SVID) String() string { return proto.CompactTextString(m) }
+func (*X509SVID) ProtoMessage()    {}
+func (*X509SVID) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{0}
 }
-func (m *Svid) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Svid.Unmarshal(m, b)
+func (m *X509SVID) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_X509SVID.Unmarshal(m, b)
 }
-func (m *Svid) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Svid.Marshal(b, m, deterministic)
+func (m *X509SVID) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_X509SVID.Marshal(b, m, deterministic)
 }
-func (dst *Svid) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Svid.Merge(dst, src)
+func (dst *X509SVID) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_X509SVID.Merge(dst, src)
 }
-func (m *Svid) XXX_Size() int {
-	return xxx_messageInfo_Svid.Size(m)
+func (m *X509SVID) XXX_Size() int {
+	return xxx_messageInfo_X509SVID.Size(m)
 }
-func (m *Svid) XXX_DiscardUnknown() {
-	xxx_messageInfo_Svid.DiscardUnknown(m)
+func (m *X509SVID) XXX_DiscardUnknown() {
+	xxx_messageInfo_X509SVID.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Svid proto.InternalMessageInfo
+var xxx_messageInfo_X509SVID proto.InternalMessageInfo
 
-func (m *Svid) GetSvidCert() []byte {
+func (m *X509SVID) GetCert() []byte {
 	if m != nil {
-		return m.SvidCert
+		return m.Cert
 	}
 	return nil
 }
 
-func (m *Svid) GetTtl() int32 {
+func (m *X509SVID) GetExpiresAt() int64 {
 	if m != nil {
-		return m.Ttl
+		return m.ExpiresAt
 	}
 	return 0
 }
 
 // A message returned by the Spire Server, which includes a map of signed SVIDs and
 // a list of all current Registration Entries which are relevant to the caller SPIFFE ID.
-type SvidUpdate struct {
+type X509SVIDUpdate struct {
 	// A map containing SVID values and corresponding SPIFFE IDs as the
 	// keys. Map[SPIFFE_ID] => SVID.
-	Svids map[string]*Svid `protobuf:"bytes,1,rep,name=svids" json:"svids,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Svids map[string]*X509SVID `protobuf:"bytes,1,rep,name=svids" json:"svids,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Latest SPIRE Server bundle
 	Bundle []byte `protobuf:"bytes,2,opt,name=bundle,proto3" json:"bundle,omitempty"`
 	// A type representing a curated record that the Spire Server uses to set up
@@ -108,49 +108,147 @@ type SvidUpdate struct {
 	XXX_sizecache        int32                       `json:"-"`
 }
 
-func (m *SvidUpdate) Reset()         { *m = SvidUpdate{} }
-func (m *SvidUpdate) String() string { return proto.CompactTextString(m) }
-func (*SvidUpdate) ProtoMessage()    {}
-func (*SvidUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{1}
+func (m *X509SVIDUpdate) Reset()         { *m = X509SVIDUpdate{} }
+func (m *X509SVIDUpdate) String() string { return proto.CompactTextString(m) }
+func (*X509SVIDUpdate) ProtoMessage()    {}
+func (*X509SVIDUpdate) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{1}
 }
-func (m *SvidUpdate) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SvidUpdate.Unmarshal(m, b)
+func (m *X509SVIDUpdate) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_X509SVIDUpdate.Unmarshal(m, b)
 }
-func (m *SvidUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SvidUpdate.Marshal(b, m, deterministic)
+func (m *X509SVIDUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_X509SVIDUpdate.Marshal(b, m, deterministic)
 }
-func (dst *SvidUpdate) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SvidUpdate.Merge(dst, src)
+func (dst *X509SVIDUpdate) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_X509SVIDUpdate.Merge(dst, src)
 }
-func (m *SvidUpdate) XXX_Size() int {
-	return xxx_messageInfo_SvidUpdate.Size(m)
+func (m *X509SVIDUpdate) XXX_Size() int {
+	return xxx_messageInfo_X509SVIDUpdate.Size(m)
 }
-func (m *SvidUpdate) XXX_DiscardUnknown() {
-	xxx_messageInfo_SvidUpdate.DiscardUnknown(m)
+func (m *X509SVIDUpdate) XXX_DiscardUnknown() {
+	xxx_messageInfo_X509SVIDUpdate.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SvidUpdate proto.InternalMessageInfo
+var xxx_messageInfo_X509SVIDUpdate proto.InternalMessageInfo
 
-func (m *SvidUpdate) GetSvids() map[string]*Svid {
+func (m *X509SVIDUpdate) GetSvids() map[string]*X509SVID {
 	if m != nil {
 		return m.Svids
 	}
 	return nil
 }
 
-func (m *SvidUpdate) GetBundle() []byte {
+func (m *X509SVIDUpdate) GetBundle() []byte {
 	if m != nil {
 		return m.Bundle
 	}
 	return nil
 }
 
-func (m *SvidUpdate) GetRegistrationEntries() []*common.RegistrationEntry {
+func (m *X509SVIDUpdate) GetRegistrationEntries() []*common.RegistrationEntry {
 	if m != nil {
 		return m.RegistrationEntries
 	}
 	return nil
+}
+
+// JSR is a JWT SVID signing request.
+type JSR struct {
+	// SPIFFE ID of the workload
+	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	// List of intended audience
+	Audience             []string `protobuf:"bytes,2,rep,name=audience" json:"audience,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *JSR) Reset()         { *m = JSR{} }
+func (m *JSR) String() string { return proto.CompactTextString(m) }
+func (*JSR) ProtoMessage()    {}
+func (*JSR) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{2}
+}
+func (m *JSR) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_JSR.Unmarshal(m, b)
+}
+func (m *JSR) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_JSR.Marshal(b, m, deterministic)
+}
+func (dst *JSR) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JSR.Merge(dst, src)
+}
+func (m *JSR) XXX_Size() int {
+	return xxx_messageInfo_JSR.Size(m)
+}
+func (m *JSR) XXX_DiscardUnknown() {
+	xxx_messageInfo_JSR.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_JSR proto.InternalMessageInfo
+
+func (m *JSR) GetSpiffeId() string {
+	if m != nil {
+		return m.SpiffeId
+	}
+	return ""
+}
+
+func (m *JSR) GetAudience() []string {
+	if m != nil {
+		return m.Audience
+	}
+	return nil
+}
+
+// JWTASVID is a signed JWT-A-SVID with fields lifted out for convenience.
+type JWTASVID struct {
+	// JWT-A-SVID JWT token
+	Token string `protobuf:"bytes,1,opt,name=token" json:"token,omitempty"`
+	// SVID expiration timestamp (seconds since Unix epoch)
+	ExpiresAt            int64    `protobuf:"varint,2,opt,name=expires_at,json=expiresAt" json:"expires_at,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *JWTASVID) Reset()         { *m = JWTASVID{} }
+func (m *JWTASVID) String() string { return proto.CompactTextString(m) }
+func (*JWTASVID) ProtoMessage()    {}
+func (*JWTASVID) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{3}
+}
+func (m *JWTASVID) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_JWTASVID.Unmarshal(m, b)
+}
+func (m *JWTASVID) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_JWTASVID.Marshal(b, m, deterministic)
+}
+func (dst *JWTASVID) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JWTASVID.Merge(dst, src)
+}
+func (m *JWTASVID) XXX_Size() int {
+	return xxx_messageInfo_JWTASVID.Size(m)
+}
+func (m *JWTASVID) XXX_DiscardUnknown() {
+	xxx_messageInfo_JWTASVID.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_JWTASVID proto.InternalMessageInfo
+
+func (m *JWTASVID) GetToken() string {
+	if m != nil {
+		return m.Token
+	}
+	return ""
+}
+
+func (m *JWTASVID) GetExpiresAt() int64 {
+	if m != nil {
+		return m.ExpiresAt
+	}
+	return 0
 }
 
 // Represents a request to attest the node.
@@ -170,7 +268,7 @@ func (m *AttestRequest) Reset()         { *m = AttestRequest{} }
 func (m *AttestRequest) String() string { return proto.CompactTextString(m) }
 func (*AttestRequest) ProtoMessage()    {}
 func (*AttestRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{2}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{4}
 }
 func (m *AttestRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AttestRequest.Unmarshal(m, b)
@@ -216,10 +314,10 @@ func (m *AttestRequest) GetResponse() []byte {
 type AttestResponse struct {
 	// It includes a map of signed SVIDs and an array of all current
 	// Registration Entries which are relevant to the caller SPIFFE ID.
-	SvidUpdate *SvidUpdate `protobuf:"bytes,1,opt,name=svid_update,json=svidUpdate" json:"svid_update,omitempty"`
+	Update *X509SVIDUpdate `protobuf:"bytes,1,opt,name=update" json:"update,omitempty"`
 	// This is a challenge issued by the server to the node. If populated, the
 	// node is expected to respond with another AttestRequest with the response.
-	// This field is mutually exclusive with the svid_update field.
+	// This field is mutually exclusive with the update field.
 	Challenge            []byte   `protobuf:"bytes,2,opt,name=challenge,proto3" json:"challenge,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -230,7 +328,7 @@ func (m *AttestResponse) Reset()         { *m = AttestResponse{} }
 func (m *AttestResponse) String() string { return proto.CompactTextString(m) }
 func (*AttestResponse) ProtoMessage()    {}
 func (*AttestResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{3}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{5}
 }
 func (m *AttestResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AttestResponse.Unmarshal(m, b)
@@ -250,9 +348,9 @@ func (m *AttestResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_AttestResponse proto.InternalMessageInfo
 
-func (m *AttestResponse) GetSvidUpdate() *SvidUpdate {
+func (m *AttestResponse) GetUpdate() *X509SVIDUpdate {
 	if m != nil {
-		return m.SvidUpdate
+		return m.Update
 	}
 	return nil
 }
@@ -277,7 +375,7 @@ func (m *FetchX509SVIDRequest) Reset()         { *m = FetchX509SVIDRequest{} }
 func (m *FetchX509SVIDRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchX509SVIDRequest) ProtoMessage()    {}
 func (*FetchX509SVIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{4}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{6}
 }
 func (m *FetchX509SVIDRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchX509SVIDRequest.Unmarshal(m, b)
@@ -309,17 +407,17 @@ func (m *FetchX509SVIDRequest) GetCsrs() [][]byte {
 type FetchX509SVIDResponse struct {
 	// It includes a map of signed SVIDs and an array of all current Registration
 	// Entries which are relevant to the caller SPIFFE ID.
-	SvidUpdate           *SvidUpdate `protobuf:"bytes,1,opt,name=svid_update,json=svidUpdate" json:"svid_update,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}    `json:"-"`
-	XXX_unrecognized     []byte      `json:"-"`
-	XXX_sizecache        int32       `json:"-"`
+	Update               *X509SVIDUpdate `protobuf:"bytes,1,opt,name=update" json:"update,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
 }
 
 func (m *FetchX509SVIDResponse) Reset()         { *m = FetchX509SVIDResponse{} }
 func (m *FetchX509SVIDResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchX509SVIDResponse) ProtoMessage()    {}
 func (*FetchX509SVIDResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{5}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{7}
 }
 func (m *FetchX509SVIDResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchX509SVIDResponse.Unmarshal(m, b)
@@ -339,9 +437,87 @@ func (m *FetchX509SVIDResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FetchX509SVIDResponse proto.InternalMessageInfo
 
-func (m *FetchX509SVIDResponse) GetSvidUpdate() *SvidUpdate {
+func (m *FetchX509SVIDResponse) GetUpdate() *X509SVIDUpdate {
 	if m != nil {
-		return m.SvidUpdate
+		return m.Update
+	}
+	return nil
+}
+
+type FetchJWTASVIDRequest struct {
+	// The JWT signing request
+	Jsr                  *JSR     `protobuf:"bytes,1,opt,name=jsr" json:"jsr,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *FetchJWTASVIDRequest) Reset()         { *m = FetchJWTASVIDRequest{} }
+func (m *FetchJWTASVIDRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchJWTASVIDRequest) ProtoMessage()    {}
+func (*FetchJWTASVIDRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{8}
+}
+func (m *FetchJWTASVIDRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchJWTASVIDRequest.Unmarshal(m, b)
+}
+func (m *FetchJWTASVIDRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchJWTASVIDRequest.Marshal(b, m, deterministic)
+}
+func (dst *FetchJWTASVIDRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchJWTASVIDRequest.Merge(dst, src)
+}
+func (m *FetchJWTASVIDRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchJWTASVIDRequest.Size(m)
+}
+func (m *FetchJWTASVIDRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchJWTASVIDRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchJWTASVIDRequest proto.InternalMessageInfo
+
+func (m *FetchJWTASVIDRequest) GetJsr() *JSR {
+	if m != nil {
+		return m.Jsr
+	}
+	return nil
+}
+
+type FetchJWTASVIDResponse struct {
+	// The signed JWT-A-SVID
+	Svid                 *JWTASVID `protobuf:"bytes,1,opt,name=svid" json:"svid,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
+	XXX_unrecognized     []byte    `json:"-"`
+	XXX_sizecache        int32     `json:"-"`
+}
+
+func (m *FetchJWTASVIDResponse) Reset()         { *m = FetchJWTASVIDResponse{} }
+func (m *FetchJWTASVIDResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchJWTASVIDResponse) ProtoMessage()    {}
+func (*FetchJWTASVIDResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{9}
+}
+func (m *FetchJWTASVIDResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchJWTASVIDResponse.Unmarshal(m, b)
+}
+func (m *FetchJWTASVIDResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchJWTASVIDResponse.Marshal(b, m, deterministic)
+}
+func (dst *FetchJWTASVIDResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchJWTASVIDResponse.Merge(dst, src)
+}
+func (m *FetchJWTASVIDResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchJWTASVIDResponse.Size(m)
+}
+func (m *FetchJWTASVIDResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchJWTASVIDResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchJWTASVIDResponse proto.InternalMessageInfo
+
+func (m *FetchJWTASVIDResponse) GetSvid() *JWTASVID {
+	if m != nil {
+		return m.Svid
 	}
 	return nil
 }
@@ -359,7 +535,7 @@ func (m *FetchFederatedBundleRequest) Reset()         { *m = FetchFederatedBundl
 func (m *FetchFederatedBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchFederatedBundleRequest) ProtoMessage()    {}
 func (*FetchFederatedBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{6}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{10}
 }
 func (m *FetchFederatedBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchFederatedBundleRequest.Unmarshal(m, b)
@@ -399,7 +575,7 @@ func (m *FetchFederatedBundleResponse) Reset()         { *m = FetchFederatedBund
 func (m *FetchFederatedBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchFederatedBundleResponse) ProtoMessage()    {}
 func (*FetchFederatedBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_4be23de3db683a67, []int{7}
+	return fileDescriptor_node_1061ec7dc6cce0b0, []int{11}
 }
 func (m *FetchFederatedBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchFederatedBundleResponse.Unmarshal(m, b)
@@ -427,13 +603,17 @@ func (m *FetchFederatedBundleResponse) GetFederatedBundles() map[string][]byte {
 }
 
 func init() {
-	proto.RegisterType((*Svid)(nil), "spire.api.node.Svid")
-	proto.RegisterType((*SvidUpdate)(nil), "spire.api.node.SvidUpdate")
-	proto.RegisterMapType((map[string]*Svid)(nil), "spire.api.node.SvidUpdate.SvidsEntry")
+	proto.RegisterType((*X509SVID)(nil), "spire.api.node.X509SVID")
+	proto.RegisterType((*X509SVIDUpdate)(nil), "spire.api.node.X509SVIDUpdate")
+	proto.RegisterMapType((map[string]*X509SVID)(nil), "spire.api.node.X509SVIDUpdate.SvidsEntry")
+	proto.RegisterType((*JSR)(nil), "spire.api.node.JSR")
+	proto.RegisterType((*JWTASVID)(nil), "spire.api.node.JWTASVID")
 	proto.RegisterType((*AttestRequest)(nil), "spire.api.node.AttestRequest")
 	proto.RegisterType((*AttestResponse)(nil), "spire.api.node.AttestResponse")
 	proto.RegisterType((*FetchX509SVIDRequest)(nil), "spire.api.node.FetchX509SVIDRequest")
 	proto.RegisterType((*FetchX509SVIDResponse)(nil), "spire.api.node.FetchX509SVIDResponse")
+	proto.RegisterType((*FetchJWTASVIDRequest)(nil), "spire.api.node.FetchJWTASVIDRequest")
+	proto.RegisterType((*FetchJWTASVIDResponse)(nil), "spire.api.node.FetchJWTASVIDResponse")
 	proto.RegisterType((*FetchFederatedBundleRequest)(nil), "spire.api.node.FetchFederatedBundleRequest")
 	proto.RegisterType((*FetchFederatedBundleResponse)(nil), "spire.api.node.FetchFederatedBundleResponse")
 	proto.RegisterMapType((map[string][]byte)(nil), "spire.api.node.FetchFederatedBundleResponse.FederatedBundlesEntry")
@@ -456,6 +636,8 @@ type NodeClient interface {
 	// Base Node SVID or the Registered Node SVID used for this call)
 	// List can be empty to allow Node Agent cache refresh).
 	FetchX509SVID(ctx context.Context, opts ...grpc.CallOption) (Node_FetchX509SVIDClient, error)
+	// Fetches a signed JWT-A-SVID for a workload intended for a specific audience.
+	FetchJWTASVID(ctx context.Context, in *FetchJWTASVIDRequest, opts ...grpc.CallOption) (*FetchJWTASVIDResponse, error)
 	// Called by the Node Agent to fetch the named Federated CA Bundle.
 	// Used in the event that authorized workloads reference a Federated Bundle.
 	FetchFederatedBundle(ctx context.Context, in *FetchFederatedBundleRequest, opts ...grpc.CallOption) (*FetchFederatedBundleResponse, error)
@@ -531,6 +713,15 @@ func (x *nodeFetchX509SVIDClient) Recv() (*FetchX509SVIDResponse, error) {
 	return m, nil
 }
 
+func (c *nodeClient) FetchJWTASVID(ctx context.Context, in *FetchJWTASVIDRequest, opts ...grpc.CallOption) (*FetchJWTASVIDResponse, error) {
+	out := new(FetchJWTASVIDResponse)
+	err := grpc.Invoke(ctx, "/spire.api.node.Node/FetchJWTASVID", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *nodeClient) FetchFederatedBundle(ctx context.Context, in *FetchFederatedBundleRequest, opts ...grpc.CallOption) (*FetchFederatedBundleResponse, error) {
 	out := new(FetchFederatedBundleResponse)
 	err := grpc.Invoke(ctx, "/spire.api.node.Node/FetchFederatedBundle", in, out, c.cc, opts...)
@@ -549,6 +740,8 @@ type NodeServer interface {
 	// Base Node SVID or the Registered Node SVID used for this call)
 	// List can be empty to allow Node Agent cache refresh).
 	FetchX509SVID(Node_FetchX509SVIDServer) error
+	// Fetches a signed JWT-A-SVID for a workload intended for a specific audience.
+	FetchJWTASVID(context.Context, *FetchJWTASVIDRequest) (*FetchJWTASVIDResponse, error)
 	// Called by the Node Agent to fetch the named Federated CA Bundle.
 	// Used in the event that authorized workloads reference a Federated Bundle.
 	FetchFederatedBundle(context.Context, *FetchFederatedBundleRequest) (*FetchFederatedBundleResponse, error)
@@ -610,6 +803,24 @@ func (x *nodeFetchX509SVIDServer) Recv() (*FetchX509SVIDRequest, error) {
 	return m, nil
 }
 
+func _Node_FetchJWTASVID_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchJWTASVIDRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NodeServer).FetchJWTASVID(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.api.node.Node/FetchJWTASVID",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NodeServer).FetchJWTASVID(ctx, req.(*FetchJWTASVIDRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Node_FetchFederatedBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(FetchFederatedBundleRequest)
 	if err := dec(in); err != nil {
@@ -633,6 +844,10 @@ var _Node_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*NodeServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "FetchJWTASVID",
+			Handler:    _Node_FetchJWTASVID_Handler,
+		},
+		{
 			MethodName: "FetchFederatedBundle",
 			Handler:    _Node_FetchFederatedBundle_Handler,
 		},
@@ -654,45 +869,51 @@ var _Node_serviceDesc = grpc.ServiceDesc{
 	Metadata: "node.proto",
 }
 
-func init() { proto.RegisterFile("node.proto", fileDescriptor_node_4be23de3db683a67) }
+func init() { proto.RegisterFile("node.proto", fileDescriptor_node_1061ec7dc6cce0b0) }
 
-var fileDescriptor_node_4be23de3db683a67 = []byte{
-	// 583 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0x6f, 0x6f, 0x12, 0x4f,
-	0x10, 0xfe, 0x1d, 0x50, 0x02, 0x03, 0xed, 0x0f, 0x57, 0x34, 0x97, 0x6b, 0xab, 0xe4, 0x62, 0x13,
-	0x52, 0xcd, 0x51, 0x31, 0x4d, 0xb4, 0x7d, 0x55, 0x5a, 0x1b, 0x1b, 0x93, 0xc6, 0x6c, 0xd5, 0x18,
-	0xdf, 0xe0, 0x72, 0x37, 0xc0, 0xa5, 0x70, 0x77, 0xdd, 0x5d, 0x48, 0xfa, 0x01, 0x8c, 0x5f, 0xc5,
-	0x0f, 0xe4, 0x07, 0x32, 0xbb, 0x7b, 0x17, 0xe0, 0x42, 0xfd, 0x93, 0xf8, 0x8a, 0xd9, 0x67, 0x9f,
-	0x9d, 0x79, 0x66, 0xe6, 0xe1, 0x00, 0xa2, 0x38, 0x40, 0x2f, 0xe1, 0xb1, 0x8c, 0xc9, 0x96, 0x48,
-	0x42, 0x8e, 0x1e, 0x4b, 0x42, 0x4f, 0xa1, 0xce, 0xf3, 0x51, 0x28, 0xc7, 0xb3, 0x81, 0xe7, 0xc7,
-	0xd3, 0x8e, 0x48, 0xc2, 0xe1, 0x10, 0x3b, 0x9a, 0xd1, 0xd1, 0xf4, 0x8e, 0x1f, 0x4f, 0xa7, 0x71,
-	0x94, 0xfe, 0x98, 0x14, 0xee, 0x21, 0x94, 0xae, 0xe6, 0x61, 0x40, 0xb6, 0xa1, 0x2a, 0xe6, 0x61,
-	0xd0, 0xf7, 0x91, 0x4b, 0xdb, 0x6a, 0x59, 0xed, 0x3a, 0xad, 0x28, 0xe0, 0x14, 0xb9, 0x24, 0x0d,
-	0x28, 0x4a, 0x39, 0xb1, 0x0b, 0x2d, 0xab, 0xbd, 0x41, 0x55, 0xe8, 0x7e, 0x2d, 0x00, 0xa8, 0x77,
-	0x1f, 0x92, 0x80, 0x49, 0x24, 0xc7, 0xb0, 0xa1, 0xc8, 0xc2, 0xb6, 0x5a, 0xc5, 0x76, 0xad, 0xbb,
-	0xe7, 0xad, 0x0a, 0xf3, 0x16, 0x54, 0x1d, 0x8a, 0xd7, 0x91, 0xe4, 0xb7, 0xd4, 0xbc, 0x21, 0x0f,
-	0xa1, 0x3c, 0x98, 0x45, 0xc1, 0x04, 0x75, 0x81, 0x3a, 0x4d, 0x4f, 0x84, 0x42, 0x93, 0xe3, 0x28,
-	0x14, 0x92, 0x33, 0x19, 0xc6, 0x51, 0x1f, 0x23, 0xc9, 0x43, 0x14, 0x76, 0x51, 0xd7, 0x78, 0x9c,
-	0xd6, 0x48, 0xbb, 0xa1, 0x4b, 0x4c, 0x93, 0xfd, 0x3e, 0xcf, 0x41, 0x21, 0x0a, 0xe7, 0xd2, 0xc8,
-	0x36, 0x02, 0x54, 0x5f, 0xd7, 0x78, 0xab, 0xdb, 0xad, 0x52, 0x15, 0x92, 0x7d, 0xd8, 0x98, 0xb3,
-	0xc9, 0xcc, 0x48, 0xa9, 0x75, 0x9b, 0xeb, 0x1a, 0xa1, 0x86, 0x72, 0x54, 0x78, 0x69, 0xb9, 0xdf,
-	0x2c, 0xd8, 0x3c, 0x91, 0x12, 0x85, 0xa4, 0x78, 0x33, 0x43, 0x21, 0xc9, 0x1b, 0x68, 0x30, 0x0d,
-	0x18, 0xd1, 0x01, 0x93, 0x4c, 0x17, 0xa8, 0x75, 0x77, 0x57, 0x15, 0x9f, 0x2c, 0x58, 0x67, 0x4c,
-	0x32, 0xfa, 0x3f, 0x5b, 0x05, 0x94, 0x3a, 0x5f, 0xf0, 0x74, 0x28, 0x2a, 0x24, 0x0e, 0x54, 0x38,
-	0x8a, 0x24, 0x8e, 0x04, 0xda, 0x45, 0xb3, 0xa3, 0xec, 0xec, 0x5e, 0xc3, 0x56, 0x26, 0xc4, 0x20,
-	0xe4, 0x18, 0x6a, 0x7a, 0xa5, 0x33, 0x3d, 0xf8, 0x54, 0x84, 0x73, 0xf7, 0x6a, 0x28, 0x88, 0xc5,
-	0x46, 0x77, 0xa0, 0xea, 0x8f, 0xd9, 0x64, 0x82, 0xd1, 0x28, 0xdb, 0xcb, 0x02, 0x70, 0xf7, 0xa1,
-	0x79, 0x8e, 0xd2, 0x1f, 0x7f, 0x3a, 0x3c, 0x78, 0x75, 0xf5, 0xf1, 0xe2, 0x2c, 0x6b, 0x9e, 0x40,
-	0xc9, 0x17, 0x5c, 0xd8, 0x85, 0x56, 0xb1, 0x5d, 0xa7, 0x3a, 0x76, 0xdf, 0xc3, 0x83, 0x1c, 0xf7,
-	0x1f, 0xe8, 0x73, 0x8f, 0x60, 0x5b, 0x67, 0x3d, 0xc7, 0x00, 0x39, 0x93, 0x18, 0xf4, 0xb4, 0x69,
-	0x32, 0x21, 0xca, 0xce, 0xfa, 0x0f, 0xd0, 0x0f, 0x03, 0x6d, 0xca, 0x2a, 0xad, 0x18, 0xe0, 0x22,
-	0x70, 0x7f, 0x58, 0xb0, 0xb3, 0xfe, 0x71, 0xaa, 0x2c, 0x86, 0x7b, 0xc3, 0xec, 0xaa, 0x6f, 0xdc,
-	0x98, 0x59, 0xbb, 0x97, 0xd7, 0xf7, 0xab, 0x44, 0x5e, 0x0e, 0x4f, 0x7d, 0xdf, 0x18, 0xe6, 0x60,
-	0xe7, 0x54, 0xcd, 0x68, 0x0d, 0x75, 0x8d, 0x43, 0x9b, 0xcb, 0x0e, 0xad, 0x2f, 0x79, 0xb1, 0xfb,
-	0xbd, 0x00, 0xa5, 0xcb, 0x38, 0x40, 0xf2, 0x16, 0xca, 0xc6, 0x0a, 0x64, 0x37, 0xaf, 0x76, 0xc5,
-	0xab, 0xce, 0xa3, 0xbb, 0xae, 0x8d, 0xfc, 0xb6, 0x75, 0x60, 0x91, 0x2f, 0xb0, 0xb9, 0xb2, 0x3e,
-	0xf2, 0x64, 0xed, 0x04, 0x72, 0x4e, 0x70, 0xf6, 0x7e, 0xc3, 0x5a, 0xaa, 0x70, 0x93, 0x9a, 0x29,
-	0x37, 0x01, 0xf2, 0xf4, 0xcf, 0x46, 0x6d, 0xea, 0x3d, 0xfb, 0x9b, 0xbd, 0xf4, 0xca, 0x9f, 0x4b,
-	0x8a, 0xf4, 0xee, 0xbf, 0x41, 0x59, 0x7f, 0x06, 0x5f, 0xfc, 0x0c, 0x00, 0x00, 0xff, 0xff, 0xfc,
-	0x7e, 0x82, 0x00, 0x57, 0x05, 0x00, 0x00,
+var fileDescriptor_node_1061ec7dc6cce0b0 = []byte{
+	// 683 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x55, 0xfb, 0x4f, 0x13, 0x4b,
+	0x14, 0xbe, 0xcb, 0x96, 0xa6, 0x3d, 0x3c, 0x2e, 0x77, 0xe8, 0xbd, 0x69, 0xca, 0xe3, 0x92, 0x8d,
+	0x24, 0x55, 0xc9, 0x16, 0x6b, 0x34, 0x4a, 0x82, 0xa4, 0x08, 0x44, 0x30, 0x51, 0x33, 0xf5, 0x15,
+	0x63, 0x52, 0x87, 0xdd, 0x53, 0x58, 0x29, 0xbb, 0x65, 0x66, 0x4a, 0xe4, 0x1f, 0xd0, 0x9f, 0xfd,
+	0xdf, 0xfc, 0x83, 0xcc, 0x3c, 0xb6, 0x8f, 0xa5, 0x80, 0xc6, 0x9f, 0x3a, 0x73, 0xe6, 0x9b, 0xef,
+	0x7c, 0x73, 0xce, 0x77, 0xba, 0x00, 0x71, 0x12, 0xa2, 0xdf, 0xe5, 0x89, 0x4c, 0xc8, 0xac, 0xe8,
+	0x46, 0x1c, 0x7d, 0xd6, 0x8d, 0x7c, 0x15, 0xad, 0xdc, 0x3b, 0x8a, 0xe4, 0x71, 0xef, 0xd0, 0x0f,
+	0x92, 0xd3, 0x9a, 0xe8, 0x46, 0xed, 0x36, 0xd6, 0x34, 0xa2, 0xa6, 0xe1, 0xb5, 0x20, 0x39, 0x3d,
+	0x4d, 0x62, 0xfb, 0x63, 0x28, 0xbc, 0x4d, 0x28, 0xbc, 0x7f, 0xb0, 0xfe, 0xb8, 0xf9, 0x76, 0x7f,
+	0x87, 0x10, 0xc8, 0x05, 0xc8, 0x65, 0xd9, 0x59, 0x71, 0xaa, 0xd3, 0x54, 0xaf, 0xc9, 0x12, 0x00,
+	0x7e, 0x51, 0x1c, 0xa2, 0xc5, 0x64, 0x79, 0x62, 0xc5, 0xa9, 0xba, 0xb4, 0x68, 0x23, 0x0d, 0xe9,
+	0x7d, 0x9f, 0x80, 0xd9, 0xf4, 0xfe, 0x9b, 0x6e, 0xc8, 0x24, 0x92, 0x2d, 0x98, 0x14, 0xe7, 0x51,
+	0x28, 0xca, 0xce, 0x8a, 0x5b, 0x9d, 0xaa, 0xdf, 0xf6, 0x47, 0x45, 0xfa, 0xa3, 0x70, 0xbf, 0xa9,
+	0xb0, 0xbb, 0xb1, 0xe4, 0x17, 0xd4, 0xdc, 0x23, 0xff, 0x41, 0xfe, 0xb0, 0x17, 0x87, 0x1d, 0xd4,
+	0xe9, 0xa6, 0xa9, 0xdd, 0x11, 0x0a, 0x25, 0x8e, 0x47, 0x91, 0x90, 0x9c, 0xc9, 0x28, 0x89, 0x5b,
+	0x18, 0x4b, 0x1e, 0xa1, 0x28, 0xbb, 0x3a, 0xcf, 0xff, 0x36, 0x8f, 0x7d, 0x1d, 0x1d, 0x42, 0x1a,
+	0xf6, 0x79, 0x9e, 0x09, 0x45, 0x28, 0x2a, 0x14, 0x60, 0x20, 0x80, 0xcc, 0x81, 0x7b, 0x82, 0x17,
+	0xfa, 0xfd, 0x45, 0xaa, 0x96, 0xc4, 0x87, 0xc9, 0x73, 0xd6, 0xe9, 0x19, 0x29, 0x53, 0xf5, 0xf2,
+	0x55, 0x8f, 0xa1, 0x06, 0xb6, 0x31, 0xf1, 0xc8, 0xf1, 0x9e, 0x80, 0x7b, 0xd0, 0xa4, 0x64, 0x01,
+	0x8a, 0xa6, 0x07, 0xad, 0x28, 0xb4, 0x94, 0x05, 0x13, 0xd8, 0x0f, 0x49, 0x05, 0x0a, 0xac, 0x17,
+	0x46, 0x18, 0x07, 0x8a, 0xda, 0x55, 0x67, 0xe9, 0xde, 0xdb, 0x82, 0xc2, 0xc1, 0xbb, 0xd7, 0x0d,
+	0xdd, 0x92, 0x12, 0x4c, 0xca, 0xe4, 0x04, 0x63, 0x4b, 0x60, 0x36, 0x37, 0x35, 0xe5, 0x9b, 0x03,
+	0x33, 0x0d, 0x29, 0x51, 0x48, 0x8a, 0x67, 0x3d, 0x14, 0x92, 0x3c, 0x83, 0x39, 0xa6, 0x03, 0xa6,
+	0x72, 0x21, 0x93, 0x4c, 0x33, 0x4e, 0xd5, 0x97, 0x46, 0xcb, 0xd6, 0x18, 0xa0, 0x76, 0x98, 0x64,
+	0xf4, 0x6f, 0x36, 0x1a, 0x50, 0x25, 0x0a, 0x04, 0xb7, 0x9d, 0x51, 0x4b, 0xf5, 0x14, 0x8e, 0xa2,
+	0x9b, 0xc4, 0x02, 0xcb, 0xae, 0x0e, 0xf7, 0xf7, 0x5e, 0x1b, 0x66, 0x53, 0x21, 0x26, 0x42, 0x1e,
+	0x42, 0xbe, 0xa7, 0x1b, 0x6f, 0xf3, 0x2f, 0x5f, 0x6f, 0x0f, 0x6a, 0xd1, 0x64, 0x11, 0x8a, 0xc1,
+	0x31, 0xeb, 0x74, 0x30, 0x3e, 0x4a, 0x7d, 0x31, 0x08, 0x78, 0x77, 0xa0, 0xb4, 0x87, 0x32, 0x38,
+	0xee, 0xb7, 0xc3, 0xbe, 0x5b, 0x39, 0x5a, 0x70, 0xa1, 0x4b, 0xac, 0x1c, 0x2d, 0xb8, 0xf0, 0x5e,
+	0xc2, 0xbf, 0x19, 0xec, 0x9f, 0x49, 0xf3, 0x36, 0x6d, 0xf2, 0xb4, 0x69, 0x69, 0xf2, 0x55, 0x70,
+	0x3f, 0x0b, 0x6e, 0xc9, 0xe6, 0xb3, 0x64, 0x07, 0x4d, 0x4a, 0xd5, 0xb9, 0xb7, 0x6b, 0xf5, 0x0c,
+	0xae, 0x5b, 0x3d, 0x6b, 0x90, 0x53, 0x03, 0x61, 0x09, 0x2e, 0x59, 0xaf, 0x8f, 0xd7, 0x28, 0x6f,
+	0x03, 0x16, 0x34, 0xcd, 0x1e, 0x86, 0xc8, 0x99, 0xc4, 0x70, 0x5b, 0x4f, 0x4d, 0x2a, 0x26, 0xe3,
+	0x46, 0x77, 0xd8, 0x8d, 0xde, 0x0f, 0x07, 0x16, 0xc7, 0x5f, 0xb6, 0x52, 0x12, 0xf8, 0xa7, 0x9d,
+	0x1e, 0xb5, 0xcc, 0x38, 0xa6, 0xf3, 0xbd, 0x9d, 0xd5, 0x75, 0x1d, 0x91, 0x9f, 0x89, 0xdb, 0xc1,
+	0x9f, 0x6b, 0x67, 0xc2, 0x95, 0xa7, 0xaa, 0x28, 0x63, 0xa0, 0x63, 0x46, 0xb4, 0x34, 0x3c, 0xa2,
+	0xd3, 0x43, 0x83, 0x58, 0xff, 0xea, 0x42, 0xee, 0x45, 0x12, 0x22, 0x79, 0x0e, 0x79, 0x63, 0x43,
+	0xb2, 0x94, 0x55, 0x3b, 0x32, 0x27, 0x95, 0xe5, 0xab, 0x8e, 0x8d, 0xfc, 0xaa, 0xb3, 0xee, 0x90,
+	0x4f, 0x30, 0x33, 0xe2, 0x1f, 0x72, 0x6b, 0x6c, 0x05, 0x32, 0x56, 0xac, 0xac, 0xde, 0x80, 0x1a,
+	0xca, 0xf0, 0xd1, 0x66, 0xe8, 0xff, 0x0b, 0x8c, 0xcf, 0x90, 0xf1, 0xdb, 0x15, 0x19, 0x2e, 0xd9,
+	0xea, 0xcc, 0xda, 0x35, 0x53, 0x5f, 0x72, 0xf7, 0xd7, 0x1a, 0x69, 0x72, 0xad, 0xfd, 0x4e, 0xd7,
+	0xb7, 0xf3, 0x1f, 0x72, 0x0a, 0xf4, 0xea, 0xaf, 0xc3, 0xbc, 0xfe, 0xea, 0xdc, 0xff, 0x19, 0x00,
+	0x00, 0xff, 0xff, 0x98, 0x0b, 0x2c, 0x90, 0xc6, 0x06, 0x00, 0x00,
 }

--- a/proto/api/node/node.proto
+++ b/proto/api/node/node.proto
@@ -11,20 +11,20 @@ import public "github.com/spiffe/spire/proto/common/common.proto";
 
 // A type which contains the "Spiffe Verifiable Identity Document" and
 // a TTL indicating when the SVID expires.
-message Svid {
-    // Spiffe Verifiable Identity Document.
-    bytes svid_cert = 1;
+message X509SVID {
+    // X509 SVID (ASN.1 encoding)
+    bytes cert = 1;
 
-    // SVID expiration.
-    int32 ttl = 2;
+    // SVID expiration timestamp (in seconds since Unix epoch)
+    int64 expires_at = 2;
 }
 
 // A message returned by the Spire Server, which includes a map of signed SVIDs and
 //a list of all current Registration Entries which are relevant to the caller SPIFFE ID.
-message SvidUpdate {
+message X509SVIDUpdate {
     // A map containing SVID values and corresponding SPIFFE IDs as the
     // keys. Map[SPIFFE_ID] => SVID.
-    map<string, Svid>  svids = 1;
+    map<string, X509SVID> svids = 1;
 
     // Latest SPIRE Server bundle
     bytes bundle = 2;
@@ -32,6 +32,24 @@ message SvidUpdate {
     // A type representing a curated record that the Spire Server uses to set up
     //and manage the various registered nodes and workloads that are controlled by it.
     repeated spire.common.RegistrationEntry registration_entries = 3;
+}
+
+// JSR is a JWT SVID signing request.
+message JSR {
+     // SPIFFE ID of the workload
+    string spiffe_id = 1;
+
+    // List of intended audience
+    repeated string audience = 2;
+}
+
+// JWTASVID is a signed JWT-A-SVID with fields lifted out for convenience.
+message JWTASVID {
+    // JWT-A-SVID JWT token
+    string token = 1;
+
+    // SVID expiration timestamp (seconds since Unix epoch)
+    int64 expires_at = 2;
 }
 
 // Represents a request to attest the node.
@@ -51,11 +69,11 @@ message AttestRequest {
 message AttestResponse {
     // It includes a map of signed SVIDs and an array of all current
     // Registration Entries which are relevant to the caller SPIFFE ID.
-    SvidUpdate svid_update = 1;
+    X509SVIDUpdate update = 1;
 
     // This is a challenge issued by the server to the node. If populated, the
     // node is expected to respond with another AttestRequest with the response.
-    // This field is mutually exclusive with the svid_update field.
+    // This field is mutually exclusive with the update field.
     bytes challenge = 2;
 }
 
@@ -70,7 +88,17 @@ message FetchX509SVIDRequest {
 message FetchX509SVIDResponse {
     // It includes a map of signed SVIDs and an array of all current Registration
     // Entries which are relevant to the caller SPIFFE ID.
-    SvidUpdate svid_update = 1;
+    X509SVIDUpdate update = 1;
+}
+
+message FetchJWTASVIDRequest {
+    // The JWT signing request
+    JSR jsr = 1;
+}
+
+message FetchJWTASVIDResponse {
+    // The signed JWT-A-SVID
+    JWTASVID svid = 1;
 }
 
 // Represents a request with an array of SPIFFE Ids.
@@ -93,6 +121,9 @@ service Node {
     // Base Node SVID or the Registered Node SVID used for this call)
     // List can be empty to allow Node Agent cache refresh).
     rpc FetchX509SVID(stream FetchX509SVIDRequest) returns (stream FetchX509SVIDResponse);
+
+    // Fetches a signed JWT-A-SVID for a workload intended for a specific audience.
+    rpc FetchJWTASVID(FetchJWTASVIDRequest) returns (FetchJWTASVIDResponse);
 
     // Called by the Node Agent to fetch the named Federated CA Bundle.
     // Used in the event that authorized workloads reference a Federated Bundle.

--- a/proto/server/ca/README_pb.md
+++ b/proto/server/ca/README_pb.md
@@ -14,14 +14,14 @@
   
 
 - [ca.proto](#ca.proto)
-    - [FetchCertificateRequest](#spire.server.ca.FetchCertificateRequest)
-    - [FetchCertificateResponse](#spire.server.ca.FetchCertificateResponse)
     - [GenerateCsrRequest](#spire.server.ca.GenerateCsrRequest)
     - [GenerateCsrResponse](#spire.server.ca.GenerateCsrResponse)
     - [LoadCertificateRequest](#spire.server.ca.LoadCertificateRequest)
     - [LoadCertificateResponse](#spire.server.ca.LoadCertificateResponse)
-    - [SignCsrRequest](#spire.server.ca.SignCsrRequest)
-    - [SignCsrResponse](#spire.server.ca.SignCsrResponse)
+    - [SignJwtSvidRequest](#spire.server.ca.SignJwtSvidRequest)
+    - [SignJwtSvidResponse](#spire.server.ca.SignJwtSvidResponse)
+    - [SignX509SvidCsrRequest](#spire.server.ca.SignX509SvidCsrRequest)
+    - [SignX509SvidCsrResponse](#spire.server.ca.SignX509SvidCsrResponse)
   
   
   
@@ -119,31 +119,6 @@ Represents the plugin metadata.
 
 
 
-<a name="spire.server.ca.FetchCertificateRequest"/>
-
-### FetchCertificateRequest
-Represents an empty request.
-
-
-
-
-
-
-<a name="spire.server.ca.FetchCertificateResponse"/>
-
-### FetchCertificateResponse
-Represents a response with a stored intermediate certificate.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| storedIntermediateCert | [bytes](#bytes) |  | Stored intermediate certificate. |
-
-
-
-
-
-
 <a name="spire.server.ca.GenerateCsrRequest"/>
 
 ### GenerateCsrRequest
@@ -194,9 +169,41 @@ Represents an empty response.
 
 
 
-<a name="spire.server.ca.SignCsrRequest"/>
+<a name="spire.server.ca.SignJwtSvidRequest"/>
 
-### SignCsrRequest
+### SignJwtSvidRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  | SPIFFE ID to embed in the subject claim of the JWT |
+| ttl | [int32](#int32) |  | token time-to-live (in seconds) |
+| audience | [string](#string) | repeated | token audience |
+
+
+
+
+
+
+<a name="spire.server.ca.SignJwtSvidResponse"/>
+
+### SignJwtSvidResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| signed_jwt | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.ca.SignX509SvidCsrRequest"/>
+
+### SignX509SvidCsrRequest
 Represents a request with a certificate signing request.
 
 
@@ -210,15 +217,15 @@ Represents a request with a certificate signing request.
 
 
 
-<a name="spire.server.ca.SignCsrResponse"/>
+<a name="spire.server.ca.SignX509SvidCsrResponse"/>
 
-### SignCsrResponse
+### SignX509SvidCsrResponse
 Represents a response with a signed certificate.
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| signedCertificate | [bytes](#bytes) |  | Signed certificate. |
+| signed_certificate | [bytes](#bytes) |  | Signed certificate. |
 
 
 
@@ -238,9 +245,9 @@ Represents a response with a signed certificate.
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| SignCsr | [SignCsrRequest](#spire.server.ca.SignCsrRequest) | [SignCsrResponse](#spire.server.ca.SignCsrRequest) | Interface will take in a CSR and sign it with the stored intermediate certificate. |
+| SignX509SvidCsr | [SignX509SvidCsrRequest](#spire.server.ca.SignX509SvidCsrRequest) | [SignX509SvidCsrResponse](#spire.server.ca.SignX509SvidCsrRequest) | SignX509SvidCsr will take in a CSR and sign it with the stored intermediate certificate. |
+| SignJwtSvid | [SignJwtSvidRequest](#spire.server.ca.SignJwtSvidRequest) | [SignJwtSvidResponse](#spire.server.ca.SignJwtSvidRequest) | SignJwtSvid will sign a JWT-A-SVID with the stored intermediate certificate. |
 | GenerateCsr | [GenerateCsrRequest](#spire.server.ca.GenerateCsrRequest) | [GenerateCsrResponse](#spire.server.ca.GenerateCsrRequest) | Used for generating a CSR for the intermediate signing certificate. The CSR will then be submitted to the CA plugin for signing. |
-| FetchCertificate | [FetchCertificateRequest](#spire.server.ca.FetchCertificateRequest) | [FetchCertificateResponse](#spire.server.ca.FetchCertificateRequest) | Used to read the stored Intermediate Server cert. |
 | LoadCertificate | [LoadCertificateRequest](#spire.server.ca.LoadCertificateRequest) | [LoadCertificateResponse](#spire.server.ca.LoadCertificateRequest) | Used for setting/storing the signed intermediate certificate. |
 | Configure | [spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureRequest) | Responsible for configuration of the plugin. |
 | GetPluginInfo | [spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoRequest) | Returns the version and related metadata of the installed plugin. |

--- a/proto/server/ca/ca.pb.go
+++ b/proto/server/ca/ca.pb.go
@@ -37,7 +37,7 @@ type GetPluginInfoRequest = plugin.GetPluginInfoRequest
 type GetPluginInfoResponse = plugin.GetPluginInfoResponse
 
 // * Represents a request with a certificate signing request.
-type SignCsrRequest struct {
+type SignX509SvidCsrRequest struct {
 	// * Certificate signing request.
 	Csr []byte `protobuf:"bytes,1,opt,name=csr,proto3" json:"csr,omitempty"`
 	// * TTL
@@ -47,38 +47,38 @@ type SignCsrRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SignCsrRequest) Reset()         { *m = SignCsrRequest{} }
-func (m *SignCsrRequest) String() string { return proto.CompactTextString(m) }
-func (*SignCsrRequest) ProtoMessage()    {}
-func (*SignCsrRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{0}
+func (m *SignX509SvidCsrRequest) Reset()         { *m = SignX509SvidCsrRequest{} }
+func (m *SignX509SvidCsrRequest) String() string { return proto.CompactTextString(m) }
+func (*SignX509SvidCsrRequest) ProtoMessage()    {}
+func (*SignX509SvidCsrRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ca_727e435acfe15d82, []int{0}
 }
-func (m *SignCsrRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SignCsrRequest.Unmarshal(m, b)
+func (m *SignX509SvidCsrRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SignX509SvidCsrRequest.Unmarshal(m, b)
 }
-func (m *SignCsrRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SignCsrRequest.Marshal(b, m, deterministic)
+func (m *SignX509SvidCsrRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SignX509SvidCsrRequest.Marshal(b, m, deterministic)
 }
-func (dst *SignCsrRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SignCsrRequest.Merge(dst, src)
+func (dst *SignX509SvidCsrRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SignX509SvidCsrRequest.Merge(dst, src)
 }
-func (m *SignCsrRequest) XXX_Size() int {
-	return xxx_messageInfo_SignCsrRequest.Size(m)
+func (m *SignX509SvidCsrRequest) XXX_Size() int {
+	return xxx_messageInfo_SignX509SvidCsrRequest.Size(m)
 }
-func (m *SignCsrRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_SignCsrRequest.DiscardUnknown(m)
+func (m *SignX509SvidCsrRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SignX509SvidCsrRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SignCsrRequest proto.InternalMessageInfo
+var xxx_messageInfo_SignX509SvidCsrRequest proto.InternalMessageInfo
 
-func (m *SignCsrRequest) GetCsr() []byte {
+func (m *SignX509SvidCsrRequest) GetCsr() []byte {
 	if m != nil {
 		return m.Csr
 	}
 	return nil
 }
 
-func (m *SignCsrRequest) GetTtl() int32 {
+func (m *SignX509SvidCsrRequest) GetTtl() int32 {
 	if m != nil {
 		return m.Ttl
 	}
@@ -86,39 +86,39 @@ func (m *SignCsrRequest) GetTtl() int32 {
 }
 
 // * Represents a response with a signed certificate.
-type SignCsrResponse struct {
+type SignX509SvidCsrResponse struct {
 	// * Signed certificate.
-	SignedCertificate    []byte   `protobuf:"bytes,1,opt,name=signedCertificate,proto3" json:"signedCertificate,omitempty"`
+	SignedCertificate    []byte   `protobuf:"bytes,1,opt,name=signed_certificate,json=signedCertificate,proto3" json:"signed_certificate,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *SignCsrResponse) Reset()         { *m = SignCsrResponse{} }
-func (m *SignCsrResponse) String() string { return proto.CompactTextString(m) }
-func (*SignCsrResponse) ProtoMessage()    {}
-func (*SignCsrResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{1}
+func (m *SignX509SvidCsrResponse) Reset()         { *m = SignX509SvidCsrResponse{} }
+func (m *SignX509SvidCsrResponse) String() string { return proto.CompactTextString(m) }
+func (*SignX509SvidCsrResponse) ProtoMessage()    {}
+func (*SignX509SvidCsrResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ca_727e435acfe15d82, []int{1}
 }
-func (m *SignCsrResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_SignCsrResponse.Unmarshal(m, b)
+func (m *SignX509SvidCsrResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SignX509SvidCsrResponse.Unmarshal(m, b)
 }
-func (m *SignCsrResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_SignCsrResponse.Marshal(b, m, deterministic)
+func (m *SignX509SvidCsrResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SignX509SvidCsrResponse.Marshal(b, m, deterministic)
 }
-func (dst *SignCsrResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SignCsrResponse.Merge(dst, src)
+func (dst *SignX509SvidCsrResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SignX509SvidCsrResponse.Merge(dst, src)
 }
-func (m *SignCsrResponse) XXX_Size() int {
-	return xxx_messageInfo_SignCsrResponse.Size(m)
+func (m *SignX509SvidCsrResponse) XXX_Size() int {
+	return xxx_messageInfo_SignX509SvidCsrResponse.Size(m)
 }
-func (m *SignCsrResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_SignCsrResponse.DiscardUnknown(m)
+func (m *SignX509SvidCsrResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SignX509SvidCsrResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_SignCsrResponse proto.InternalMessageInfo
+var xxx_messageInfo_SignX509SvidCsrResponse proto.InternalMessageInfo
 
-func (m *SignCsrResponse) GetSignedCertificate() []byte {
+func (m *SignX509SvidCsrResponse) GetSignedCertificate() []byte {
 	if m != nil {
 		return m.SignedCertificate
 	}
@@ -136,7 +136,7 @@ func (m *GenerateCsrRequest) Reset()         { *m = GenerateCsrRequest{} }
 func (m *GenerateCsrRequest) String() string { return proto.CompactTextString(m) }
 func (*GenerateCsrRequest) ProtoMessage()    {}
 func (*GenerateCsrRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{2}
+	return fileDescriptor_ca_727e435acfe15d82, []int{2}
 }
 func (m *GenerateCsrRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateCsrRequest.Unmarshal(m, b)
@@ -169,7 +169,7 @@ func (m *GenerateCsrResponse) Reset()         { *m = GenerateCsrResponse{} }
 func (m *GenerateCsrResponse) String() string { return proto.CompactTextString(m) }
 func (*GenerateCsrResponse) ProtoMessage()    {}
 func (*GenerateCsrResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{3}
+	return fileDescriptor_ca_727e435acfe15d82, []int{3}
 }
 func (m *GenerateCsrResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateCsrResponse.Unmarshal(m, b)
@@ -196,75 +196,99 @@ func (m *GenerateCsrResponse) GetCsr() []byte {
 	return nil
 }
 
-// * Represents an empty request.
-type FetchCertificateRequest struct {
+type SignJwtSvidRequest struct {
+	// * SPIFFE ID to embed in the subject claim of the JWT
+	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	// * token time-to-live (in seconds)
+	Ttl int32 `protobuf:"varint,2,opt,name=ttl" json:"ttl,omitempty"`
+	// * token audience
+	Audience             []string `protobuf:"bytes,3,rep,name=audience" json:"audience,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *FetchCertificateRequest) Reset()         { *m = FetchCertificateRequest{} }
-func (m *FetchCertificateRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchCertificateRequest) ProtoMessage()    {}
-func (*FetchCertificateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{4}
+func (m *SignJwtSvidRequest) Reset()         { *m = SignJwtSvidRequest{} }
+func (m *SignJwtSvidRequest) String() string { return proto.CompactTextString(m) }
+func (*SignJwtSvidRequest) ProtoMessage()    {}
+func (*SignJwtSvidRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ca_727e435acfe15d82, []int{4}
 }
-func (m *FetchCertificateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchCertificateRequest.Unmarshal(m, b)
+func (m *SignJwtSvidRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SignJwtSvidRequest.Unmarshal(m, b)
 }
-func (m *FetchCertificateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchCertificateRequest.Marshal(b, m, deterministic)
+func (m *SignJwtSvidRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SignJwtSvidRequest.Marshal(b, m, deterministic)
 }
-func (dst *FetchCertificateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchCertificateRequest.Merge(dst, src)
+func (dst *SignJwtSvidRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SignJwtSvidRequest.Merge(dst, src)
 }
-func (m *FetchCertificateRequest) XXX_Size() int {
-	return xxx_messageInfo_FetchCertificateRequest.Size(m)
+func (m *SignJwtSvidRequest) XXX_Size() int {
+	return xxx_messageInfo_SignJwtSvidRequest.Size(m)
 }
-func (m *FetchCertificateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchCertificateRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_FetchCertificateRequest proto.InternalMessageInfo
-
-// * Represents a response with a stored intermediate certificate.
-type FetchCertificateResponse struct {
-	// * Stored intermediate certificate.
-	StoredIntermediateCert []byte   `protobuf:"bytes,1,opt,name=storedIntermediateCert,proto3" json:"storedIntermediateCert,omitempty"`
-	XXX_NoUnkeyedLiteral   struct{} `json:"-"`
-	XXX_unrecognized       []byte   `json:"-"`
-	XXX_sizecache          int32    `json:"-"`
+func (m *SignJwtSvidRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SignJwtSvidRequest.DiscardUnknown(m)
 }
 
-func (m *FetchCertificateResponse) Reset()         { *m = FetchCertificateResponse{} }
-func (m *FetchCertificateResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchCertificateResponse) ProtoMessage()    {}
-func (*FetchCertificateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{5}
-}
-func (m *FetchCertificateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchCertificateResponse.Unmarshal(m, b)
-}
-func (m *FetchCertificateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchCertificateResponse.Marshal(b, m, deterministic)
-}
-func (dst *FetchCertificateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchCertificateResponse.Merge(dst, src)
-}
-func (m *FetchCertificateResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchCertificateResponse.Size(m)
-}
-func (m *FetchCertificateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchCertificateResponse.DiscardUnknown(m)
-}
+var xxx_messageInfo_SignJwtSvidRequest proto.InternalMessageInfo
 
-var xxx_messageInfo_FetchCertificateResponse proto.InternalMessageInfo
-
-func (m *FetchCertificateResponse) GetStoredIntermediateCert() []byte {
+func (m *SignJwtSvidRequest) GetSpiffeId() string {
 	if m != nil {
-		return m.StoredIntermediateCert
+		return m.SpiffeId
+	}
+	return ""
+}
+
+func (m *SignJwtSvidRequest) GetTtl() int32 {
+	if m != nil {
+		return m.Ttl
+	}
+	return 0
+}
+
+func (m *SignJwtSvidRequest) GetAudience() []string {
+	if m != nil {
+		return m.Audience
 	}
 	return nil
+}
+
+type SignJwtSvidResponse struct {
+	SignedJwt            string   `protobuf:"bytes,1,opt,name=signed_jwt,json=signedJwt" json:"signed_jwt,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SignJwtSvidResponse) Reset()         { *m = SignJwtSvidResponse{} }
+func (m *SignJwtSvidResponse) String() string { return proto.CompactTextString(m) }
+func (*SignJwtSvidResponse) ProtoMessage()    {}
+func (*SignJwtSvidResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_ca_727e435acfe15d82, []int{5}
+}
+func (m *SignJwtSvidResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SignJwtSvidResponse.Unmarshal(m, b)
+}
+func (m *SignJwtSvidResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SignJwtSvidResponse.Marshal(b, m, deterministic)
+}
+func (dst *SignJwtSvidResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SignJwtSvidResponse.Merge(dst, src)
+}
+func (m *SignJwtSvidResponse) XXX_Size() int {
+	return xxx_messageInfo_SignJwtSvidResponse.Size(m)
+}
+func (m *SignJwtSvidResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SignJwtSvidResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SignJwtSvidResponse proto.InternalMessageInfo
+
+func (m *SignJwtSvidResponse) GetSignedJwt() string {
+	if m != nil {
+		return m.SignedJwt
+	}
+	return ""
 }
 
 // * Represents a request with a signed intermediate certificate.
@@ -280,7 +304,7 @@ func (m *LoadCertificateRequest) Reset()         { *m = LoadCertificateRequest{}
 func (m *LoadCertificateRequest) String() string { return proto.CompactTextString(m) }
 func (*LoadCertificateRequest) ProtoMessage()    {}
 func (*LoadCertificateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{6}
+	return fileDescriptor_ca_727e435acfe15d82, []int{6}
 }
 func (m *LoadCertificateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoadCertificateRequest.Unmarshal(m, b)
@@ -318,7 +342,7 @@ func (m *LoadCertificateResponse) Reset()         { *m = LoadCertificateResponse
 func (m *LoadCertificateResponse) String() string { return proto.CompactTextString(m) }
 func (*LoadCertificateResponse) ProtoMessage()    {}
 func (*LoadCertificateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_ca_57dbdb4225bd218f, []int{7}
+	return fileDescriptor_ca_727e435acfe15d82, []int{7}
 }
 func (m *LoadCertificateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LoadCertificateResponse.Unmarshal(m, b)
@@ -339,12 +363,12 @@ func (m *LoadCertificateResponse) XXX_DiscardUnknown() {
 var xxx_messageInfo_LoadCertificateResponse proto.InternalMessageInfo
 
 func init() {
-	proto.RegisterType((*SignCsrRequest)(nil), "spire.server.ca.SignCsrRequest")
-	proto.RegisterType((*SignCsrResponse)(nil), "spire.server.ca.SignCsrResponse")
+	proto.RegisterType((*SignX509SvidCsrRequest)(nil), "spire.server.ca.SignX509SvidCsrRequest")
+	proto.RegisterType((*SignX509SvidCsrResponse)(nil), "spire.server.ca.SignX509SvidCsrResponse")
 	proto.RegisterType((*GenerateCsrRequest)(nil), "spire.server.ca.GenerateCsrRequest")
 	proto.RegisterType((*GenerateCsrResponse)(nil), "spire.server.ca.GenerateCsrResponse")
-	proto.RegisterType((*FetchCertificateRequest)(nil), "spire.server.ca.FetchCertificateRequest")
-	proto.RegisterType((*FetchCertificateResponse)(nil), "spire.server.ca.FetchCertificateResponse")
+	proto.RegisterType((*SignJwtSvidRequest)(nil), "spire.server.ca.SignJwtSvidRequest")
+	proto.RegisterType((*SignJwtSvidResponse)(nil), "spire.server.ca.SignJwtSvidResponse")
 	proto.RegisterType((*LoadCertificateRequest)(nil), "spire.server.ca.LoadCertificateRequest")
 	proto.RegisterType((*LoadCertificateResponse)(nil), "spire.server.ca.LoadCertificateResponse")
 }
@@ -360,17 +384,17 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for ServerCA service
 
 type ServerCAClient interface {
-	// * Interface will take in a CSR and sign it with the stored intermediate certificate.
-	SignCsr(ctx context.Context, in *SignCsrRequest, opts ...grpc.CallOption) (*SignCsrResponse, error)
+	// * SignX509SvidCsr will take in a CSR and sign it with the stored intermediate certificate.
+	SignX509SvidCsr(ctx context.Context, in *SignX509SvidCsrRequest, opts ...grpc.CallOption) (*SignX509SvidCsrResponse, error)
+	// * SignJwtSvid will sign a JWT-A-SVID with the stored intermediate certificate.
+	SignJwtSvid(ctx context.Context, in *SignJwtSvidRequest, opts ...grpc.CallOption) (*SignJwtSvidResponse, error)
 	// * Used for generating a CSR for the intermediate signing certificate. The CSR will then be submitted to the CA plugin for signing.
 	GenerateCsr(ctx context.Context, in *GenerateCsrRequest, opts ...grpc.CallOption) (*GenerateCsrResponse, error)
-	// * Used to read the stored Intermediate Server cert.
-	FetchCertificate(ctx context.Context, in *FetchCertificateRequest, opts ...grpc.CallOption) (*FetchCertificateResponse, error)
 	// * Used for setting/storing the signed intermediate certificate.
 	LoadCertificate(ctx context.Context, in *LoadCertificateRequest, opts ...grpc.CallOption) (*LoadCertificateResponse, error)
 	// * Responsible for configuration of the plugin.
 	Configure(ctx context.Context, in *plugin.ConfigureRequest, opts ...grpc.CallOption) (*plugin.ConfigureResponse, error)
-	// * Returns the  version and related metadata of the installed plugin.
+	// * Returns the version and related metadata of the installed plugin.
 	GetPluginInfo(ctx context.Context, in *plugin.GetPluginInfoRequest, opts ...grpc.CallOption) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -382,9 +406,18 @@ func NewServerCAClient(cc *grpc.ClientConn) ServerCAClient {
 	return &serverCAClient{cc}
 }
 
-func (c *serverCAClient) SignCsr(ctx context.Context, in *SignCsrRequest, opts ...grpc.CallOption) (*SignCsrResponse, error) {
-	out := new(SignCsrResponse)
-	err := grpc.Invoke(ctx, "/spire.server.ca.ServerCA/SignCsr", in, out, c.cc, opts...)
+func (c *serverCAClient) SignX509SvidCsr(ctx context.Context, in *SignX509SvidCsrRequest, opts ...grpc.CallOption) (*SignX509SvidCsrResponse, error) {
+	out := new(SignX509SvidCsrResponse)
+	err := grpc.Invoke(ctx, "/spire.server.ca.ServerCA/SignX509SvidCsr", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *serverCAClient) SignJwtSvid(ctx context.Context, in *SignJwtSvidRequest, opts ...grpc.CallOption) (*SignJwtSvidResponse, error) {
+	out := new(SignJwtSvidResponse)
+	err := grpc.Invoke(ctx, "/spire.server.ca.ServerCA/SignJwtSvid", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -394,15 +427,6 @@ func (c *serverCAClient) SignCsr(ctx context.Context, in *SignCsrRequest, opts .
 func (c *serverCAClient) GenerateCsr(ctx context.Context, in *GenerateCsrRequest, opts ...grpc.CallOption) (*GenerateCsrResponse, error) {
 	out := new(GenerateCsrResponse)
 	err := grpc.Invoke(ctx, "/spire.server.ca.ServerCA/GenerateCsr", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *serverCAClient) FetchCertificate(ctx context.Context, in *FetchCertificateRequest, opts ...grpc.CallOption) (*FetchCertificateResponse, error) {
-	out := new(FetchCertificateResponse)
-	err := grpc.Invoke(ctx, "/spire.server.ca.ServerCA/FetchCertificate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -439,17 +463,17 @@ func (c *serverCAClient) GetPluginInfo(ctx context.Context, in *plugin.GetPlugin
 // Server API for ServerCA service
 
 type ServerCAServer interface {
-	// * Interface will take in a CSR and sign it with the stored intermediate certificate.
-	SignCsr(context.Context, *SignCsrRequest) (*SignCsrResponse, error)
+	// * SignX509SvidCsr will take in a CSR and sign it with the stored intermediate certificate.
+	SignX509SvidCsr(context.Context, *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error)
+	// * SignJwtSvid will sign a JWT-A-SVID with the stored intermediate certificate.
+	SignJwtSvid(context.Context, *SignJwtSvidRequest) (*SignJwtSvidResponse, error)
 	// * Used for generating a CSR for the intermediate signing certificate. The CSR will then be submitted to the CA plugin for signing.
 	GenerateCsr(context.Context, *GenerateCsrRequest) (*GenerateCsrResponse, error)
-	// * Used to read the stored Intermediate Server cert.
-	FetchCertificate(context.Context, *FetchCertificateRequest) (*FetchCertificateResponse, error)
 	// * Used for setting/storing the signed intermediate certificate.
 	LoadCertificate(context.Context, *LoadCertificateRequest) (*LoadCertificateResponse, error)
 	// * Responsible for configuration of the plugin.
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
-	// * Returns the  version and related metadata of the installed plugin.
+	// * Returns the version and related metadata of the installed plugin.
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -457,20 +481,38 @@ func RegisterServerCAServer(s *grpc.Server, srv ServerCAServer) {
 	s.RegisterService(&_ServerCA_serviceDesc, srv)
 }
 
-func _ServerCA_SignCsr_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(SignCsrRequest)
+func _ServerCA_SignX509SvidCsr_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignX509SvidCsrRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ServerCAServer).SignCsr(ctx, in)
+		return srv.(ServerCAServer).SignX509SvidCsr(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.ca.ServerCA/SignCsr",
+		FullMethod: "/spire.server.ca.ServerCA/SignX509SvidCsr",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ServerCAServer).SignCsr(ctx, req.(*SignCsrRequest))
+		return srv.(ServerCAServer).SignX509SvidCsr(ctx, req.(*SignX509SvidCsrRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _ServerCA_SignJwtSvid_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SignJwtSvidRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ServerCAServer).SignJwtSvid(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.server.ca.ServerCA/SignJwtSvid",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ServerCAServer).SignJwtSvid(ctx, req.(*SignJwtSvidRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -489,24 +531,6 @@ func _ServerCA_GenerateCsr_Handler(srv interface{}, ctx context.Context, dec fun
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ServerCAServer).GenerateCsr(ctx, req.(*GenerateCsrRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _ServerCA_FetchCertificate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(FetchCertificateRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ServerCAServer).FetchCertificate(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.ca.ServerCA/FetchCertificate",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ServerCAServer).FetchCertificate(ctx, req.(*FetchCertificateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -570,16 +594,16 @@ var _ServerCA_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*ServerCAServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "SignCsr",
-			Handler:    _ServerCA_SignCsr_Handler,
+			MethodName: "SignX509SvidCsr",
+			Handler:    _ServerCA_SignX509SvidCsr_Handler,
+		},
+		{
+			MethodName: "SignJwtSvid",
+			Handler:    _ServerCA_SignJwtSvid_Handler,
 		},
 		{
 			MethodName: "GenerateCsr",
 			Handler:    _ServerCA_GenerateCsr_Handler,
-		},
-		{
-			MethodName: "FetchCertificate",
-			Handler:    _ServerCA_FetchCertificate_Handler,
 		},
 		{
 			MethodName: "LoadCertificate",
@@ -598,34 +622,37 @@ var _ServerCA_serviceDesc = grpc.ServiceDesc{
 	Metadata: "ca.proto",
 }
 
-func init() { proto.RegisterFile("ca.proto", fileDescriptor_ca_57dbdb4225bd218f) }
+func init() { proto.RegisterFile("ca.proto", fileDescriptor_ca_727e435acfe15d82) }
 
-var fileDescriptor_ca_57dbdb4225bd218f = []byte{
-	// 412 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0x4f, 0x8f, 0xd3, 0x30,
-	0x10, 0xc5, 0xe9, 0xb2, 0xc0, 0x32, 0xfc, 0xe9, 0x62, 0xd0, 0x52, 0x72, 0xa1, 0x0a, 0x7f, 0x9a,
-	0x22, 0x94, 0x48, 0x80, 0x10, 0x37, 0x04, 0x91, 0xa8, 0x2a, 0xf5, 0x50, 0xa5, 0x17, 0xd4, 0x5b,
-	0xea, 0x4c, 0x52, 0x4b, 0x8d, 0x1d, 0x6c, 0x87, 0x6f, 0xc8, 0xf7, 0x42, 0x49, 0x9c, 0xd2, 0xd6,
-	0x0d, 0xed, 0x29, 0x91, 0xe7, 0xcd, 0xef, 0xd9, 0xf3, 0x34, 0x70, 0x45, 0x63, 0xbf, 0x90, 0x42,
-	0x0b, 0xd2, 0x57, 0x05, 0x93, 0xe8, 0x2b, 0x94, 0xbf, 0x51, 0xfa, 0x34, 0x76, 0xbe, 0x64, 0x4c,
-	0xaf, 0xcb, 0x95, 0x4f, 0x45, 0x1e, 0xa8, 0x82, 0xa5, 0x29, 0x06, 0xb5, 0x24, 0xa8, 0xf5, 0x01,
-	0x15, 0x79, 0x2e, 0x78, 0x50, 0x6c, 0xca, 0x8c, 0xb5, 0x9f, 0x06, 0xe5, 0x7e, 0x82, 0xc7, 0x0b,
-	0x96, 0xf1, 0x50, 0xc9, 0x08, 0x7f, 0x95, 0xa8, 0x34, 0xb9, 0x86, 0xdb, 0x54, 0xc9, 0x41, 0x6f,
-	0xd8, 0xf3, 0x1e, 0x46, 0xd5, 0x6f, 0x75, 0xa2, 0xf5, 0x66, 0x70, 0x31, 0xec, 0x79, 0x77, 0xa2,
-	0xea, 0xd7, 0xfd, 0x0a, 0xfd, 0x6d, 0x97, 0x2a, 0x04, 0x57, 0x48, 0xde, 0xc3, 0x13, 0xc5, 0x32,
-	0x8e, 0x49, 0x88, 0x52, 0xb3, 0x94, 0xd1, 0x58, 0xa3, 0x81, 0xd8, 0x05, 0xf7, 0x19, 0x90, 0x09,
-	0x72, 0x94, 0xb1, 0xc6, 0x7f, 0xd6, 0xee, 0x08, 0x9e, 0xee, 0x9d, 0x1a, 0xb4, 0x75, 0x23, 0xf7,
-	0x05, 0x3c, 0xff, 0x81, 0x9a, 0xae, 0x77, 0x90, 0x2d, 0x23, 0x82, 0x81, 0x5d, 0x32, 0xa0, 0xcf,
-	0x70, 0xa3, 0xb4, 0x90, 0x98, 0x4c, 0xb9, 0x46, 0x99, 0x63, 0xc2, 0x2a, 0x27, 0x94, 0xda, 0xb0,
-	0x3b, 0xaa, 0xee, 0x1c, 0x6e, 0x66, 0x22, 0x4e, 0x6c, 0xb7, 0x9a, 0x58, 0x3f, 0xae, 0x93, 0x78,
-	0xb4, 0x5a, 0x3d, 0xc0, 0x22, 0x36, 0x97, 0xfc, 0xf0, 0xe7, 0x12, 0xae, 0x16, 0x75, 0xb2, 0xe1,
-	0x37, 0x32, 0x83, 0x7b, 0x66, 0xd0, 0xe4, 0xa5, 0x7f, 0x90, 0xba, 0xbf, 0x1f, 0x9c, 0x33, 0xec,
-	0x16, 0x98, 0xf7, 0xff, 0x84, 0x07, 0x3b, 0xf3, 0x25, 0xaf, 0xac, 0x06, 0x3b, 0x13, 0xe7, 0xf5,
-	0xff, 0x45, 0x86, 0x9c, 0xc1, 0xf5, 0xe1, 0xd4, 0x89, 0x67, 0x75, 0x76, 0x64, 0xe6, 0x8c, 0xcf,
-	0x50, 0x1a, 0xa3, 0x04, 0xfa, 0x07, 0x83, 0x23, 0x23, 0xab, 0xfb, 0x78, 0x58, 0x8e, 0x77, 0x5a,
-	0x68, 0x5c, 0x96, 0x70, 0x3f, 0x14, 0x3c, 0x65, 0x59, 0x29, 0x91, 0xbc, 0x31, 0x6d, 0xcd, 0x16,
-	0xf9, 0x66, 0x7d, 0xb6, 0xf5, 0x96, 0xfe, 0xf6, 0x94, 0xcc, 0xb0, 0x53, 0x78, 0x34, 0x41, 0x3d,
-	0xaf, 0xcb, 0x53, 0x9e, 0x0a, 0x32, 0x3e, 0xda, 0xb8, 0xa7, 0x69, 0x3d, 0xde, 0x9d, 0x23, 0x6d,
-	0x7c, 0xbe, 0x5f, 0x2e, 0x2f, 0x68, 0x3c, 0xbf, 0xb5, 0xba, 0x5b, 0x2f, 0xfa, 0xc7, 0xbf, 0x01,
-	0x00, 0x00, 0xff, 0xff, 0xaa, 0xf6, 0x00, 0x38, 0x3f, 0x04, 0x00, 0x00,
+var fileDescriptor_ca_727e435acfe15d82 = []byte{
+	// 463 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0x4d, 0x6f, 0xd3, 0x40,
+	0x10, 0x25, 0x4d, 0x41, 0xc9, 0x00, 0x0a, 0x6c, 0x51, 0x1a, 0x82, 0x90, 0x22, 0xf3, 0xd1, 0x80,
+	0x84, 0x8d, 0xf8, 0x12, 0x48, 0x5c, 0x20, 0x87, 0x92, 0x8a, 0x43, 0x94, 0x5c, 0xaa, 0x5e, 0x22,
+	0x77, 0x77, 0x6c, 0x16, 0x35, 0xbb, 0x66, 0x77, 0xdd, 0xfc, 0x4b, 0x7e, 0x13, 0xb2, 0x77, 0x4d,
+	0xe2, 0x78, 0x4b, 0x39, 0xc5, 0x99, 0x79, 0xf3, 0xe6, 0xbd, 0x99, 0xb1, 0xa1, 0x43, 0xe3, 0x30,
+	0x53, 0xd2, 0x48, 0xd2, 0xd3, 0x19, 0x57, 0x18, 0x6a, 0x54, 0x97, 0xa8, 0x42, 0x1a, 0x0f, 0x3f,
+	0xa6, 0xdc, 0xfc, 0xc8, 0xcf, 0x43, 0x2a, 0x57, 0x91, 0xce, 0x78, 0x92, 0x60, 0x54, 0x42, 0xa2,
+	0x12, 0x1f, 0x51, 0xb9, 0x5a, 0x49, 0x11, 0x65, 0x17, 0x79, 0xca, 0xab, 0x1f, 0x4b, 0x15, 0x7c,
+	0x86, 0xfe, 0x82, 0xa7, 0xe2, 0xf4, 0xfd, 0xeb, 0x4f, 0x8b, 0x4b, 0xce, 0x26, 0x5a, 0xcd, 0xf1,
+	0x57, 0x8e, 0xda, 0x90, 0x7b, 0xd0, 0xa6, 0x5a, 0x0d, 0x5a, 0xa3, 0xd6, 0xf8, 0xce, 0xbc, 0x78,
+	0x2c, 0x22, 0xc6, 0x5c, 0x0c, 0xf6, 0x46, 0xad, 0xf1, 0xcd, 0x79, 0xf1, 0x18, 0x7c, 0x83, 0xc3,
+	0x46, 0xb5, 0xce, 0xa4, 0xd0, 0x48, 0x5e, 0x01, 0xd1, 0x3c, 0x15, 0xc8, 0x96, 0x14, 0x95, 0xe1,
+	0x09, 0xa7, 0xb1, 0x41, 0xc7, 0x76, 0xdf, 0x66, 0x26, 0x9b, 0x44, 0xf0, 0x00, 0xc8, 0x31, 0x0a,
+	0x54, 0xb1, 0xc1, 0x8d, 0x86, 0xe0, 0x08, 0x0e, 0x6a, 0x51, 0xc7, 0xdd, 0x90, 0x16, 0x2c, 0x81,
+	0x14, 0x42, 0x4e, 0xd6, 0xa6, 0xd0, 0x51, 0x59, 0x78, 0x04, 0x5d, 0x3b, 0x8d, 0x25, 0x67, 0x25,
+	0xba, 0x3b, 0xef, 0xd8, 0xc0, 0x94, 0x35, 0xdd, 0x90, 0x21, 0x74, 0xe2, 0x9c, 0x71, 0x14, 0x14,
+	0x07, 0xed, 0x51, 0xbb, 0x40, 0x57, 0xff, 0x83, 0x77, 0x70, 0x50, 0x6b, 0xe0, 0x94, 0x3c, 0x06,
+	0x70, 0x2e, 0x7f, 0xae, 0x8d, 0x6b, 0xd1, 0xb5, 0x91, 0x93, 0xb5, 0x09, 0x66, 0xd0, 0xff, 0x2e,
+	0xe3, 0x6d, 0xa3, 0x95, 0xb4, 0x0f, 0xd0, 0xb7, 0xb0, 0xa9, 0x30, 0xa8, 0x56, 0xc8, 0x78, 0xe1,
+	0x11, 0x95, 0x71, 0xae, 0xae, 0xc8, 0x06, 0x0f, 0xe1, 0xb0, 0xc1, 0x68, 0xb5, 0xbc, 0xf9, 0xbd,
+	0x0f, 0x9d, 0x45, 0x79, 0x12, 0x93, 0x2f, 0x84, 0x41, 0x6f, 0x67, 0x33, 0xe4, 0x28, 0xdc, 0x39,
+	0x9b, 0xd0, 0xbf, 0xf9, 0xe1, 0xf8, 0x7a, 0xa0, 0xb3, 0x7f, 0x0a, 0xb7, 0xb7, 0xa6, 0x42, 0x9e,
+	0x78, 0x0b, 0xeb, 0x4b, 0x19, 0x3e, 0xfd, 0x37, 0x68, 0xc3, 0xbc, 0xb5, 0x79, 0x0f, 0x73, 0xf3,
+	0x5a, 0x3c, 0xcc, 0xbe, 0xe3, 0x61, 0xd0, 0xdb, 0x99, 0xa0, 0x67, 0x32, 0xfe, 0xad, 0x79, 0x26,
+	0x73, 0xc5, 0x32, 0xc8, 0x19, 0x74, 0x27, 0x52, 0x24, 0x3c, 0xcd, 0x15, 0x92, 0x67, 0xae, 0xcc,
+	0xbe, 0x87, 0xa1, 0x7b, 0x01, 0xff, 0xe6, 0x2b, 0xf6, 0xe7, 0xd7, 0xc1, 0x1c, 0x77, 0x02, 0x77,
+	0x8f, 0xd1, 0xcc, 0xca, 0xf4, 0x54, 0x24, 0x92, 0xbc, 0xf0, 0x16, 0xd6, 0x30, 0x55, 0x8f, 0x97,
+	0xff, 0x03, 0xb5, 0x7d, 0xbe, 0xee, 0x9f, 0xed, 0xd1, 0x78, 0x76, 0xe3, 0xfc, 0x56, 0xf9, 0xa9,
+	0x78, 0xfb, 0x27, 0x00, 0x00, 0xff, 0xff, 0xe4, 0xb2, 0xad, 0xef, 0x81, 0x04, 0x00, 0x00,
 }

--- a/proto/server/ca/ca.proto
+++ b/proto/server/ca/ca.proto
@@ -11,7 +11,7 @@ option go_package = "ca";
 import public "github.com/spiffe/spire/proto/common/plugin/plugin.proto";
 
 /** Represents a request with a certificate signing request. */
-message SignCsrRequest {
+message SignX509SvidCsrRequest {
     /** Certificate signing request. */
     bytes csr = 1;
     /** TTL */
@@ -19,9 +19,9 @@ message SignCsrRequest {
 }
 
 /** Represents a response with a signed certificate. */
-message SignCsrResponse {
+message SignX509SvidCsrResponse {
     /** Signed certificate. */
-    bytes signedCertificate = 1;
+    bytes signed_certificate = 1;
 }
 
 /** Represents an empty request. */
@@ -34,14 +34,17 @@ message GenerateCsrResponse {
     bytes csr = 1;
 }
 
-/** Represents an empty request. */
-message FetchCertificateRequest {
+message SignJwtSvidRequest {
+    /** SPIFFE ID to embed in the subject claim of the JWT */
+    string spiffe_id = 1;
+    /** token time-to-live (in seconds) */
+    int32 ttl = 2;
+    /** token audience */
+    repeated string audience = 3;
 }
 
-/** Represents a response with a stored intermediate certificate. */
-message FetchCertificateResponse {
-    /** Stored intermediate certificate. */
-    bytes storedIntermediateCert = 1;
+message SignJwtSvidResponse {
+    string signed_jwt = 1;
 }
 
 /** Represents a request with a signed intermediate certificate. */
@@ -55,17 +58,17 @@ message LoadCertificateResponse {
 }
 
 service ServerCA {
-    /** Interface will take in a CSR and sign it with the stored intermediate certificate. */
-    rpc SignCsr(SignCsrRequest) returns (SignCsrResponse);
+    /** SignX509SvidCsr will take in a CSR and sign it with the stored intermediate certificate. */
+    rpc SignX509SvidCsr(SignX509SvidCsrRequest) returns (SignX509SvidCsrResponse);
+    /** SignJwtSvid will sign a JWT-A-SVID with the stored intermediate certificate. */
+    rpc SignJwtSvid(SignJwtSvidRequest) returns (SignJwtSvidResponse);
     /** Used for generating a CSR for the intermediate signing certificate. The CSR will then be submitted to the CA plugin for signing. */
     rpc GenerateCsr(GenerateCsrRequest) returns (GenerateCsrResponse);
-    /** Used to read the stored Intermediate Server cert. */
-    rpc FetchCertificate(FetchCertificateRequest) returns (FetchCertificateResponse);
     /** Used for setting/storing the signed intermediate certificate. */
     rpc LoadCertificate(LoadCertificateRequest) returns (LoadCertificateResponse);
 
     /** Responsible for configuration of the plugin. */
     rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);
-    /** Returns the  version and related metadata of the installed plugin. */
+    /** Returns the version and related metadata of the installed plugin. */
     rpc GetPluginInfo(spire.common.plugin.GetPluginInfoRequest) returns (spire.common.plugin.GetPluginInfoResponse);
 }

--- a/proto/server/ca/serverca.go
+++ b/proto/server/ca/serverca.go
@@ -12,17 +12,17 @@ import (
 
 // ServerCA is the interface used by all non-catalog components.
 type ServerCA interface {
-	SignCsr(context.Context, *SignCsrRequest) (*SignCsrResponse, error)
+	SignX509SvidCsr(context.Context, *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error)
+	SignJwtSvid(context.Context, *SignJwtSvidRequest) (*SignJwtSvidResponse, error)
 	GenerateCsr(context.Context, *GenerateCsrRequest) (*GenerateCsrResponse, error)
-	FetchCertificate(context.Context, *FetchCertificateRequest) (*FetchCertificateResponse, error)
 	LoadCertificate(context.Context, *LoadCertificateRequest) (*LoadCertificateResponse, error)
 }
 
 // Plugin is the interface implemented by plugin implementations
 type Plugin interface {
-	SignCsr(context.Context, *SignCsrRequest) (*SignCsrResponse, error)
+	SignX509SvidCsr(context.Context, *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error)
+	SignJwtSvid(context.Context, *SignJwtSvidRequest) (*SignJwtSvidResponse, error)
 	GenerateCsr(context.Context, *GenerateCsrRequest) (*GenerateCsrResponse, error)
-	FetchCertificate(context.Context, *FetchCertificateRequest) (*FetchCertificateResponse, error)
 	LoadCertificate(context.Context, *LoadCertificateRequest) (*LoadCertificateResponse, error)
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
@@ -40,8 +40,16 @@ func NewBuiltIn(plugin Plugin) *BuiltIn {
 	}
 }
 
-func (b BuiltIn) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResponse, error) {
-	resp, err := b.plugin.SignCsr(ctx, req)
+func (b BuiltIn) SignX509SvidCsr(ctx context.Context, req *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error) {
+	resp, err := b.plugin.SignX509SvidCsr(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (b BuiltIn) SignJwtSvid(ctx context.Context, req *SignJwtSvidRequest) (*SignJwtSvidResponse, error) {
+	resp, err := b.plugin.SignJwtSvid(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -50,14 +58,6 @@ func (b BuiltIn) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResp
 
 func (b BuiltIn) GenerateCsr(ctx context.Context, req *GenerateCsrRequest) (*GenerateCsrResponse, error) {
 	resp, err := b.plugin.GenerateCsr(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) FetchCertificate(ctx context.Context, req *FetchCertificateRequest) (*FetchCertificateResponse, error) {
-	resp, err := b.plugin.FetchCertificate(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -119,14 +119,14 @@ type GRPCServer struct {
 	Plugin Plugin
 }
 
-func (s *GRPCServer) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResponse, error) {
-	return s.Plugin.SignCsr(ctx, req)
+func (s *GRPCServer) SignX509SvidCsr(ctx context.Context, req *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error) {
+	return s.Plugin.SignX509SvidCsr(ctx, req)
+}
+func (s *GRPCServer) SignJwtSvid(ctx context.Context, req *SignJwtSvidRequest) (*SignJwtSvidResponse, error) {
+	return s.Plugin.SignJwtSvid(ctx, req)
 }
 func (s *GRPCServer) GenerateCsr(ctx context.Context, req *GenerateCsrRequest) (*GenerateCsrResponse, error) {
 	return s.Plugin.GenerateCsr(ctx, req)
-}
-func (s *GRPCServer) FetchCertificate(ctx context.Context, req *FetchCertificateRequest) (*FetchCertificateResponse, error) {
-	return s.Plugin.FetchCertificate(ctx, req)
 }
 func (s *GRPCServer) LoadCertificate(ctx context.Context, req *LoadCertificateRequest) (*LoadCertificateResponse, error) {
 	return s.Plugin.LoadCertificate(ctx, req)
@@ -142,14 +142,14 @@ type GRPCClient struct {
 	client ServerCAClient
 }
 
-func (c *GRPCClient) SignCsr(ctx context.Context, req *SignCsrRequest) (*SignCsrResponse, error) {
-	return c.client.SignCsr(ctx, req)
+func (c *GRPCClient) SignX509SvidCsr(ctx context.Context, req *SignX509SvidCsrRequest) (*SignX509SvidCsrResponse, error) {
+	return c.client.SignX509SvidCsr(ctx, req)
+}
+func (c *GRPCClient) SignJwtSvid(ctx context.Context, req *SignJwtSvidRequest) (*SignJwtSvidResponse, error) {
+	return c.client.SignJwtSvid(ctx, req)
 }
 func (c *GRPCClient) GenerateCsr(ctx context.Context, req *GenerateCsrRequest) (*GenerateCsrResponse, error) {
 	return c.client.GenerateCsr(ctx, req)
-}
-func (c *GRPCClient) FetchCertificate(ctx context.Context, req *FetchCertificateRequest) (*FetchCertificateResponse, error) {
-	return c.client.FetchCertificate(ctx, req)
 }
 func (c *GRPCClient) LoadCertificate(ctx context.Context, req *LoadCertificateRequest) (*LoadCertificateResponse, error) {
 	return c.client.LoadCertificate(ctx, req)

--- a/test/fakes/fakeupstreamca/fakeupstreamca.go
+++ b/test/fakes/fakeupstreamca/fakeupstreamca.go
@@ -1,0 +1,87 @@
+package fakeupstreamca
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/spiffe/spire/pkg/common/x509svid"
+	"github.com/spiffe/spire/pkg/common/x509util"
+	"github.com/spiffe/spire/proto/server/upstreamca"
+)
+
+var (
+	keyPEM = []byte(`-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgt/OIyb8Ossz/5bNk
+XtnzFe1T2d0D9quX9Loi1O55b8yhRANCAATDe/2d6z+P095I3dIkocKr4b3zAy+1
+qQDuoXqa8i3YOPk5fLib4ORzqD9NJFcrKjI+LLtipQe9yu/eY1K0yhBa
+-----END PRIVATE KEY-----
+`)
+)
+
+type FakeUpstreamCA struct {
+	cert       *x509.Certificate
+	upstreamCA *x509svid.UpstreamCA
+}
+
+func New(trustDomain string) (*FakeUpstreamCA, error) {
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, errors.New("unable to decode key PEM")
+	}
+	rawKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse key: %v", err)
+	}
+	key, ok := rawKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("expected ECDSA key; got %T", rawKey)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "FAKEUPSTREAMCA",
+		},
+		NotAfter: time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return nil, fmt.Errorf("unable to self-sign certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, err
+	}
+
+	upstreamCA := x509svid.NewUpstreamCA(
+		x509util.NewMemoryKeypair(cert, key),
+		trustDomain,
+		x509svid.UpstreamCAOptions{})
+
+	return &FakeUpstreamCA{
+		cert:       cert,
+		upstreamCA: upstreamCA,
+	}, nil
+}
+
+func (m *FakeUpstreamCA) SubmitCSR(ctx context.Context, request *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
+	cert, err := m.upstreamCA.SignCSR(ctx, request.Csr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &upstreamca.SubmitCSRResponse{
+		Cert:                cert.Raw,
+		UpstreamTrustBundle: m.cert.Raw,
+	}, nil
+}

--- a/test/mock/agent/client/client_mock.go
+++ b/test/mock/agent/client/client_mock.go
@@ -5,11 +5,11 @@
 package mock_client
 
 import (
-	reflect "reflect"
-
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	client "github.com/spiffe/spire/pkg/agent/client"
 	node "github.com/spiffe/spire/proto/api/node"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface
@@ -35,17 +35,30 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// FetchJWTASVID mocks base method
+func (m *MockClient) FetchJWTASVID(arg0 context.Context, arg1 *node.JSR) (*client.JWTASVID, error) {
+	ret := m.ctrl.Call(m, "FetchJWTASVID", arg0, arg1)
+	ret0, _ := ret[0].(*client.JWTASVID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchJWTASVID indicates an expected call of FetchJWTASVID
+func (mr *MockClientMockRecorder) FetchJWTASVID(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJWTASVID", reflect.TypeOf((*MockClient)(nil).FetchJWTASVID), arg0, arg1)
+}
+
 // FetchUpdates mocks base method
-func (m *MockClient) FetchUpdates(arg0 *node.FetchX509SVIDRequest) (*client.Update, error) {
-	ret := m.ctrl.Call(m, "FetchUpdates", arg0)
+func (m *MockClient) FetchUpdates(arg0 context.Context, arg1 *node.FetchX509SVIDRequest) (*client.Update, error) {
+	ret := m.ctrl.Call(m, "FetchUpdates", arg0, arg1)
 	ret0, _ := ret[0].(*client.Update)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchUpdates indicates an expected call of FetchUpdates
-func (mr *MockClientMockRecorder) FetchUpdates(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUpdates", reflect.TypeOf((*MockClient)(nil).FetchUpdates), arg0)
+func (mr *MockClientMockRecorder) FetchUpdates(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUpdates", reflect.TypeOf((*MockClient)(nil).FetchUpdates), arg0, arg1)
 }
 
 // Release mocks base method

--- a/test/mock/agent/client/generate.go
+++ b/test/mock/agent/client/generate.go
@@ -1,0 +1,3 @@
+package mock_client
+
+//go:generate sh -c "mockgen github.com/spiffe/spire/pkg/agent/client Client > client_mock.go"

--- a/test/mock/proto/api/node/node.go
+++ b/test/mock/proto/api/node/node.go
@@ -72,6 +72,24 @@ func (mr *MockNodeClientMockRecorder) FetchFederatedBundle(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchFederatedBundle", reflect.TypeOf((*MockNodeClient)(nil).FetchFederatedBundle), varargs...)
 }
 
+// FetchJWTASVID mocks base method
+func (m *MockNodeClient) FetchJWTASVID(arg0 context.Context, arg1 *node.FetchJWTASVIDRequest, arg2 ...grpc.CallOption) (*node.FetchJWTASVIDResponse, error) {
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "FetchJWTASVID", varargs...)
+	ret0, _ := ret[0].(*node.FetchJWTASVIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchJWTASVID indicates an expected call of FetchJWTASVID
+func (mr *MockNodeClientMockRecorder) FetchJWTASVID(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJWTASVID", reflect.TypeOf((*MockNodeClient)(nil).FetchJWTASVID), varargs...)
+}
+
 // FetchX509SVID mocks base method
 func (m *MockNodeClient) FetchX509SVID(arg0 context.Context, arg1 ...grpc.CallOption) (node.Node_FetchX509SVIDClient, error) {
 	varargs := []interface{}{arg0}
@@ -496,6 +514,19 @@ func (m *MockNodeServer) FetchFederatedBundle(arg0 context.Context, arg1 *node.F
 // FetchFederatedBundle indicates an expected call of FetchFederatedBundle
 func (mr *MockNodeServerMockRecorder) FetchFederatedBundle(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchFederatedBundle", reflect.TypeOf((*MockNodeServer)(nil).FetchFederatedBundle), arg0, arg1)
+}
+
+// FetchJWTASVID mocks base method
+func (m *MockNodeServer) FetchJWTASVID(arg0 context.Context, arg1 *node.FetchJWTASVIDRequest) (*node.FetchJWTASVIDResponse, error) {
+	ret := m.ctrl.Call(m, "FetchJWTASVID", arg0, arg1)
+	ret0, _ := ret[0].(*node.FetchJWTASVIDResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchJWTASVID indicates an expected call of FetchJWTASVID
+func (mr *MockNodeServerMockRecorder) FetchJWTASVID(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJWTASVID", reflect.TypeOf((*MockNodeServer)(nil).FetchJWTASVID), arg0, arg1)
 }
 
 // FetchX509SVID mocks base method

--- a/test/mock/proto/server/ca/ca.go
+++ b/test/mock/proto/server/ca/ca.go
@@ -35,19 +35,6 @@ func (m *MockServerCA) EXPECT() *MockServerCAMockRecorder {
 	return m.recorder
 }
 
-// FetchCertificate mocks base method
-func (m *MockServerCA) FetchCertificate(arg0 context.Context, arg1 *ca.FetchCertificateRequest) (*ca.FetchCertificateResponse, error) {
-	ret := m.ctrl.Call(m, "FetchCertificate", arg0, arg1)
-	ret0, _ := ret[0].(*ca.FetchCertificateResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchCertificate indicates an expected call of FetchCertificate
-func (mr *MockServerCAMockRecorder) FetchCertificate(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchCertificate", reflect.TypeOf((*MockServerCA)(nil).FetchCertificate), arg0, arg1)
-}
-
 // GenerateCsr mocks base method
 func (m *MockServerCA) GenerateCsr(arg0 context.Context, arg1 *ca.GenerateCsrRequest) (*ca.GenerateCsrResponse, error) {
 	ret := m.ctrl.Call(m, "GenerateCsr", arg0, arg1)
@@ -74,17 +61,30 @@ func (mr *MockServerCAMockRecorder) LoadCertificate(arg0, arg1 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCertificate", reflect.TypeOf((*MockServerCA)(nil).LoadCertificate), arg0, arg1)
 }
 
-// SignCsr mocks base method
-func (m *MockServerCA) SignCsr(arg0 context.Context, arg1 *ca.SignCsrRequest) (*ca.SignCsrResponse, error) {
-	ret := m.ctrl.Call(m, "SignCsr", arg0, arg1)
-	ret0, _ := ret[0].(*ca.SignCsrResponse)
+// SignJwtSvid mocks base method
+func (m *MockServerCA) SignJwtSvid(arg0 context.Context, arg1 *ca.SignJwtSvidRequest) (*ca.SignJwtSvidResponse, error) {
+	ret := m.ctrl.Call(m, "SignJwtSvid", arg0, arg1)
+	ret0, _ := ret[0].(*ca.SignJwtSvidResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SignCsr indicates an expected call of SignCsr
-func (mr *MockServerCAMockRecorder) SignCsr(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignCsr", reflect.TypeOf((*MockServerCA)(nil).SignCsr), arg0, arg1)
+// SignJwtSvid indicates an expected call of SignJwtSvid
+func (mr *MockServerCAMockRecorder) SignJwtSvid(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJwtSvid", reflect.TypeOf((*MockServerCA)(nil).SignJwtSvid), arg0, arg1)
+}
+
+// SignX509SvidCsr mocks base method
+func (m *MockServerCA) SignX509SvidCsr(arg0 context.Context, arg1 *ca.SignX509SvidCsrRequest) (*ca.SignX509SvidCsrResponse, error) {
+	ret := m.ctrl.Call(m, "SignX509SvidCsr", arg0, arg1)
+	ret0, _ := ret[0].(*ca.SignX509SvidCsrResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignX509SvidCsr indicates an expected call of SignX509SvidCsr
+func (mr *MockServerCAMockRecorder) SignX509SvidCsr(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignX509SvidCsr", reflect.TypeOf((*MockServerCA)(nil).SignX509SvidCsr), arg0, arg1)
 }
 
 // MockPlugin is a mock of Plugin interface
@@ -121,19 +121,6 @@ func (m *MockPlugin) Configure(arg0 context.Context, arg1 *plugin.ConfigureReque
 // Configure indicates an expected call of Configure
 func (mr *MockPluginMockRecorder) Configure(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockPlugin)(nil).Configure), arg0, arg1)
-}
-
-// FetchCertificate mocks base method
-func (m *MockPlugin) FetchCertificate(arg0 context.Context, arg1 *ca.FetchCertificateRequest) (*ca.FetchCertificateResponse, error) {
-	ret := m.ctrl.Call(m, "FetchCertificate", arg0, arg1)
-	ret0, _ := ret[0].(*ca.FetchCertificateResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchCertificate indicates an expected call of FetchCertificate
-func (mr *MockPluginMockRecorder) FetchCertificate(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchCertificate", reflect.TypeOf((*MockPlugin)(nil).FetchCertificate), arg0, arg1)
 }
 
 // GenerateCsr mocks base method
@@ -175,15 +162,28 @@ func (mr *MockPluginMockRecorder) LoadCertificate(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadCertificate", reflect.TypeOf((*MockPlugin)(nil).LoadCertificate), arg0, arg1)
 }
 
-// SignCsr mocks base method
-func (m *MockPlugin) SignCsr(arg0 context.Context, arg1 *ca.SignCsrRequest) (*ca.SignCsrResponse, error) {
-	ret := m.ctrl.Call(m, "SignCsr", arg0, arg1)
-	ret0, _ := ret[0].(*ca.SignCsrResponse)
+// SignJwtSvid mocks base method
+func (m *MockPlugin) SignJwtSvid(arg0 context.Context, arg1 *ca.SignJwtSvidRequest) (*ca.SignJwtSvidResponse, error) {
+	ret := m.ctrl.Call(m, "SignJwtSvid", arg0, arg1)
+	ret0, _ := ret[0].(*ca.SignJwtSvidResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SignCsr indicates an expected call of SignCsr
-func (mr *MockPluginMockRecorder) SignCsr(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignCsr", reflect.TypeOf((*MockPlugin)(nil).SignCsr), arg0, arg1)
+// SignJwtSvid indicates an expected call of SignJwtSvid
+func (mr *MockPluginMockRecorder) SignJwtSvid(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignJwtSvid", reflect.TypeOf((*MockPlugin)(nil).SignJwtSvid), arg0, arg1)
+}
+
+// SignX509SvidCsr mocks base method
+func (m *MockPlugin) SignX509SvidCsr(arg0 context.Context, arg1 *ca.SignX509SvidCsrRequest) (*ca.SignX509SvidCsrResponse, error) {
+	ret := m.ctrl.Call(m, "SignX509SvidCsr", arg0, arg1)
+	ret0, _ := ret[0].(*ca.SignX509SvidCsrResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignX509SvidCsr indicates an expected call of SignX509SvidCsr
+func (mr *MockPluginMockRecorder) SignX509SvidCsr(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignX509SvidCsr", reflect.TypeOf((*MockPlugin)(nil).SignX509SvidCsr), arg0, arg1)
 }


### PR DESCRIPTION
- Adds new method to the ServerCA plugin interface to support JWT-A-SVID signing
- Removed the unused FetchCertificate method from the ServerCA plugin interface
- Adds new method to the Node API to support JWT signing. Renames existing API to distinguish between X509-SVID methods and JWT-A-SVID methods.
- Changes Node API to return the expiration timestamp instead of the TTL of the SVID so the agent doesn't have to remember the SVID minting time to know when expiration happens.


Signed-off-by: Andrew Harding <azdagron@gmail.com>