### PR TITLE
Azure MSI node attestor agent and server plugin

### DIFF
--- a/doc/plugin_agent_nodeattestor_azure_msi.md
+++ b/doc/plugin_agent_nodeattestor_azure_msi.md
@@ -24,6 +24,12 @@ It is important to note that the resource ID MUST be for a well known Azure
 service, or an app ID for a registered app in Azure AD. Azure will not issue an
 MSI token for resources it does not know about.
 
+The resource ID that is chosen has security implications. If the server was
+compromised, the agent would be granting the compromised server access to
+whatever resource on behalf of the agent VM. If that is a concern for your
+deployment, you should register an application with Azure AD with a dummy
+URI that you can use as a resource instead to limit the scope of replay-ability.
+
 A sample configuration with the default resource ID (i.e. resource manager):
 
 ```

--- a/doc/plugin_agent_nodeattestor_azure_msi.md
+++ b/doc/plugin_agent_nodeattestor_azure_msi.md
@@ -1,0 +1,48 @@
+# Agent plugin: NodeAttestor "azure_msi"
+
+*Must be used in conjunction with the server-side azure_msi plugin*
+
+The `azure_msi` plugin attests nodes running in Microsoft Azure that have 
+Managed Service Identity (MSI) enabled. Agent nodes acquire a signed MSI token
+which is passed to the server. The server validates the signed MSI token and
+extracts the Tenant ID and Principal ID to for the agent SPIFFE ID. The SPIFFE
+ID has the form:
+
+```
+spiffe://<trust domain>/spire/agent/azure_msi/<tenant_id>/<principal_id>
+```
+
+The agent needs to be running in Azure, in a VM with MSI enabled, in order to
+perform node attestation.
+
+| Configuration   | Description | Default                 |
+| --------------- | ----------- | ----------------------- |
+| `trust_domain`  | The trust domain that the node belongs to. |  |
+| `resource_id`   | The resource ID (or audience) to request for the MSI token. The server will reject tokens with resource IDs it does not recognize | https://management.azure.com/ |
+
+It is important to note that the resource ID MUST be for a well known Azure
+service, or an app ID for a registered app in Azure AD. Azure will not issue an
+MSI token for resources it does not know about.
+
+A sample configuration with the default resource ID (i.e. resource manager):
+
+```
+    NodeAttestor "azure_msi" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+        }
+    }
+```
+
+A sample configuration with a custom resource ID:
+
+```
+    NodeAttestor "azure_msi" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+            resource_id = "http://example.org/app/"
+        }
+    }
+```

--- a/doc/plugin_server_nodeattestor_azure_msi.md
+++ b/doc/plugin_server_nodeattestor_azure_msi.md
@@ -1,0 +1,49 @@
+# Server plugin: NodeAttestor "azure_msi"
+
+*Must be used in conjunction with the agent-side azure_msi plugin*
+
+The `azure_msi` plugin attests nodes running in Microsoft Azure that have 
+Managed Service Identity (MSI) enabled. Agent nodes acquire a signed MSI token
+which is passed to the server. The server validates the signed MSI token and
+extracts the Tenant ID and Principal ID to for the agent SPIFFE ID. The SPIFFE
+ID has the form:
+
+```
+spiffe://<trust domain>/spire/agent/azure_msi/<tenant_id>/<principal_id>
+```
+
+The server does not need to be running in Azure in order to perform node
+attestation.
+
+| Configuration   | Description | Default                 |
+| --------------- | ----------- | ----------------------- |
+| `trust_domain`  | The trust domain that the node belongs to. |  |
+| `tenants`       | A map of tenants, keyed by tenant ID, that are authorized for attestation. Tokens for unspecified tenants are rejected. | |
+
+Each tenant in the main configuration supports the following
+
+| Configuration | Description | Default                 |
+| ------------- | ----------- | ----------------------- |
+| `resource_id` | The resource ID (or audience) for the tenant's MSI token. Tokens for a different resource ID are rejected | https://management.azure.com/ |
+
+It is important to note that the resource ID MUST be for a well known Azure
+service, or an app ID for a registered app in Azure AD. Azure will not issue an
+MSI token for resources it does not know about.
+
+A sample configuration:
+
+```
+    NodeAttestor "azure_msi" {
+        enabled = true
+        plugin_data {
+            trust_domain = "example.org"
+            tenants = {
+                // Tenant configured with the default resource id (i.e. the resource manager)
+                "9E85E111-1103-48FC-A933-9533FE47DE05" : {}
+                // Tenant configured with a custom resource id
+                "DD14E835-679A-4703-B4DE-8F00A20C732E" : {
+                    resource_id = "http://example.org/app/"
+                }
+        }
+    }
+```

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 35f27a42ef95c2096d1e978ff87429ab29a41fb0e5d4fd4f8ef3a89c2964ee5d
-updated: 2018-06-09T11:32:20.976069+02:00
+updated: 2018-07-31T08:34:53.388235-06:00
 imports:
 - name: github.com/armon/go-metrics
   version: 783273d703149aaeb9897cf58613d5af48861c25
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: c9af76f2478f81c6566d0f7f4d522254ec7c0b52
+  version: 123c8c8326730972861f45fe2e6e7b1d64b4d487
   subpackages:
   - aws
   - aws/awserr
@@ -27,6 +27,7 @@ imports:
   - aws/signer/v4
   - internal/sdkio
   - internal/sdkrand
+  - internal/sdkuri
   - internal/shareddefaults
   - private/protocol
   - private/protocol/ec2query
@@ -38,6 +39,10 @@ imports:
   - service/sts
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
+- name: github.com/davecgh/go-spew
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
+  subpackages:
+  - spew
 - name: github.com/dgrijalva/jwt-go
   version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/go-ini/ini
@@ -57,12 +62,14 @@ imports:
   - proto
   - protoc-gen-go
   - protoc-gen-go/descriptor
+  - protoc-gen-go/plugin
   - ptypes
   - ptypes/any
   - ptypes/duration
   - ptypes/empty
   - ptypes/struct
   - ptypes/timestamp
+  - ptypes/wrappers
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 8cc3a55af3bcf171a1c23a90c4df9cf591706104
   subpackages:
@@ -125,6 +132,10 @@ imports:
   version: 518dc677a1e1222682f4e7db06721942cb8e9e4c
 - name: github.com/mitchellh/go-testing-interface
   version: a61a99592b77c9ba629d254a693acffaeb4b7e28
+- name: github.com/pmezard/go-difflib
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  subpackages:
+  - difflib
 - name: github.com/posener/complete
   version: cdc49b71388c2ab059f57997ef2575c9e8b4f146
   subpackages:
@@ -158,9 +169,19 @@ imports:
   - uri
 - name: github.com/StackExchange/wmi
   version: 5d049714c4a64225c3c79a7cf7d02f7fb5b96338
+- name: github.com/stretchr/testify
+  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
+  subpackages:
+  - assert
+  - require
+  - suite
+- name: github.com/zeebo/errs
+  version: 63dc8634da43f7c647c5921505363588cb833d29
 - name: golang.org/x/crypto
   version: a6600008915114d9c087fad9f03d75087b1a74df
   subpackages:
+  - ed25519
+  - ed25519/internal/edwards25519
   - ssh/terminal
 - name: golang.org/x/net
   version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec
@@ -190,22 +211,23 @@ imports:
   - googleapis/api/annotations
   - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 7a6a684ca69eb4cae85ad0a484f2e531598c047b
+  version: 168a6198bcb0ef175f7dacec0b8691fc141dc9b8
   subpackages:
   - balancer
   - balancer/base
   - balancer/roundrobin
-  - channelz
   - codes
   - connectivity
   - credentials
   - encoding
   - encoding/proto
-  - grpclb/grpc_lb_v1/messages
   - grpclog
   - health
   - health/grpc_health_v1
   - internal
+  - internal/backoff
+  - internal/channelz
+  - internal/grpcrand
   - keepalive
   - metadata
   - naming
@@ -217,20 +239,12 @@ imports:
   - status
   - tap
   - transport
+- name: gopkg.in/square/go-jose.v2
+  version: 349dc03548930652802aadc09fb126e2b7cb6d80
+  subpackages:
+  - cipher
+  - json
+  - jwt
 - name: gopkg.in/tomb.v2
   version: d5d1b5820637886def9eef33e03a27a9f166942c
-testImports:
-- name: github.com/davecgh/go-spew
-  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
-  subpackages:
-  - spew
-- name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
-  subpackages:
-  - difflib
-- name: github.com/stretchr/testify
-  version: 87b1dfb5b2fa649f52695dd9eae19abe404a4308
-  subpackages:
-  - assert
-  - require
-  - suite
+testImports: []

--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/disk"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/aws"
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/azure"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/gcp"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/jointoken"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/x509pop"
@@ -51,6 +52,7 @@ var (
 			"join_token": nodeattestor.NewBuiltIn(jointoken.New()),
 			"gcp_iit":    nodeattestor.NewBuiltIn(gcp.NewIITAttestorPlugin()),
 			"x509pop":    nodeattestor.NewBuiltIn(x509pop.New()),
+			"azure_msi":  nodeattestor.NewBuiltIn(azure.NewMSIAttestorPlugin()),
 		},
 		WorkloadAttestorType: {
 			"k8s":  workloadattestor.NewBuiltIn(k8s.New()),

--- a/pkg/agent/plugin/nodeattestor/azure/msi.go
+++ b/pkg/agent/plugin/nodeattestor/azure/msi.go
@@ -1,0 +1,142 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	"github.com/spiffe/spire/proto/agent/nodeattestor"
+	"github.com/spiffe/spire/proto/common"
+	spi "github.com/spiffe/spire/proto/common/plugin"
+	"github.com/zeebo/errs"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+const (
+	pluginName = "azure_msi"
+)
+
+var (
+	msiError = errs.Class("azure-msi")
+)
+
+type MSIAttestorConfig struct {
+	TrustDomain string `hcl:"trust_domain"`
+
+	// ResourceID assigned to the MSI token. This value is the intended
+	// audience of the token, in other words, which service the token can be
+	// used to authenticate with. Ideally deployments use the ID of an
+	// application they registered with the active directory to limit the scope
+	// of use of the token. A bogus value cannot be used; Azure makes sure the
+	// resource ID is either an azure service ID or a registered app ID.
+	ResourceID string `hcl:"resource_id"`
+}
+
+type MSIAttestorPlugin struct {
+	mu     sync.RWMutex
+	config *MSIAttestorConfig
+
+	hooks struct {
+		fetchMSIToken func(context.Context, azure.HTTPClient, string) (string, error)
+	}
+}
+
+var _ nodeattestor.Plugin = (*MSIAttestorPlugin)(nil)
+
+func NewMSIAttestorPlugin() *MSIAttestorPlugin {
+	p := &MSIAttestorPlugin{}
+	p.hooks.fetchMSIToken = azure.FetchMSIToken
+	return p
+}
+
+func (p *MSIAttestorPlugin) FetchAttestationData(stream nodeattestor.FetchAttestationData_PluginStream) error {
+	config, err := p.getConfig()
+	if err != nil {
+		return err
+	}
+
+	// Obtain an MSI token from the Azure Instance Metadata Service
+	token, err := p.hooks.fetchMSIToken(stream.Context(), http.DefaultClient, config.ResourceID)
+	if err != nil {
+		return msiError.New("unable to fetch token: %v", err)
+	}
+
+	claims, err := getUnverifiedMSITokenClaims(token)
+	if err != nil {
+		return msiError.Wrap(err)
+	}
+
+	data, err := json.Marshal(azure.MSIAttestationData{
+		Token: token,
+	})
+	if err != nil {
+		return msiError.Wrap(err)
+	}
+
+	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+		AttestationData: &common.AttestationData{
+			Type: pluginName,
+			Data: data,
+		},
+		SpiffeId: claims.AgentID(config.TrustDomain),
+	})
+}
+
+func (p *MSIAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := new(MSIAttestorConfig)
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, msiError.New("unable to decode configuration: %v", err)
+	}
+	if config.TrustDomain == "" {
+		return nil, msiError.New("configuration missing trust domain")
+	}
+	if config.ResourceID == "" {
+		config.ResourceID = azure.DefaultMSIResourceID
+	}
+
+	p.setConfig(config)
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (p *MSIAttestorPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p *MSIAttestorPlugin) getConfig() (*MSIAttestorConfig, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.config == nil {
+		return nil, msiError.New("not configured")
+	}
+	return p.config, nil
+}
+
+func (p *MSIAttestorPlugin) setConfig(config *MSIAttestorConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config = config
+}
+
+func getUnverifiedMSITokenClaims(rawToken string) (*azure.MSITokenClaims, error) {
+	token, err := jwt.ParseSigned(rawToken)
+	if err != nil {
+		return nil, msiError.New("unable to parse token: %v", err)
+	}
+
+	claims := new(azure.MSITokenClaims)
+	if err := token.UnsafeClaimsWithoutVerification(claims); err != nil {
+		return nil, msiError.New("unable to parse token claims: %v", err)
+	}
+
+	if claims.Subject == "" {
+		return nil, msiError.New("token missing subject claim")
+	}
+	if claims.TenantID == "" {
+		return nil, msiError.New("token missing tenant ID claim")
+	}
+
+	return claims, nil
+}

--- a/pkg/agent/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/agent/plugin/nodeattestor/azure/msi_test.go
@@ -1,0 +1,170 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	"github.com/spiffe/spire/proto/agent/nodeattestor"
+	"github.com/spiffe/spire/proto/common/plugin"
+	"github.com/stretchr/testify/suite"
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+func TestMSIAttestorPlugin(t *testing.T) {
+	suite.Run(t, new(MSIAttestorSuite))
+}
+
+type MSIAttestorSuite struct {
+	suite.Suite
+
+	attestor *nodeattestor.BuiltIn
+
+	expectedResource string
+	token            string
+	tokenErr         error
+}
+
+func (s *MSIAttestorSuite) SetupTest() {
+	s.expectedResource = azure.DefaultMSIResourceID
+	s.token = ""
+	s.tokenErr = nil
+
+	s.newAttestor()
+
+	_, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `trust_domain = "example.org"`,
+	})
+	s.Require().NoError(err)
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataNotConfigured() {
+	s.newAttestor()
+	s.requireFetchError("azure-msi: not configured")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataFailedToObtainToken() {
+	s.tokenErr = errors.New("FAILED")
+	s.requireFetchError("azure-msi: unable to fetch token: FAILED")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataAccessTokenMalformed() {
+	s.token = ""
+	s.requireFetchError("azure-msi: unable to parse token")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataAccessTokenHasBadClaims() {
+	s.token = "e30.f32.baadf00d"
+	s.requireFetchError("azure-msi: unable to parse token claims")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataAccessTokenMissingPrincipalID() {
+	s.token = s.makeAccessToken("", "TENANTID")
+	s.requireFetchError("azure-msi: token missing subject claim")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataAccessTokenMissingTenantID() {
+	s.token = s.makeAccessToken("PRINCIPALID", "")
+	s.requireFetchError("azure-msi: token missing tenant ID claim")
+}
+
+func (s *MSIAttestorSuite) TestFetchAttestationDataSuccess() {
+	s.token = s.makeAccessToken("PRINCIPALID", "TENANTID")
+
+	stream, err := s.attestor.FetchAttestationData(context.Background())
+	s.Require().NoError(err)
+	s.Require().NotNil(stream)
+
+	resp, err := stream.Recv()
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	// assert attestation data
+	s.Require().Equal("spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID", resp.SpiffeId)
+	s.Require().NotNil(resp.AttestationData)
+	s.Require().Equal("azure_msi", resp.AttestationData.Type)
+	s.Require().JSONEq(fmt.Sprintf(`{"token": %q}`, s.token), string(resp.AttestationData.Data))
+
+	// node attestor should return EOF now
+	_, err = stream.Recv()
+	s.Require().Equal(io.EOF, err)
+}
+
+func (s *MSIAttestorSuite) TestConfigure() {
+	// malformed configuration
+	resp, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: "blah",
+	})
+	s.requireErrorContains(err, "azure-msi: unable to decode configuration")
+	s.Require().Nil(resp)
+
+	// missing trust domain
+	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{})
+	s.Require().EqualError(err, "azure-msi: configuration missing trust domain")
+	s.Require().Nil(resp)
+
+	// success
+	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `trust_domain = "example.org"`,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.ConfigureResponse{})
+}
+
+func (s *MSIAttestorSuite) TestGetPluginInfo() {
+	resp, err := s.attestor.GetPluginInfo(context.Background(), &plugin.GetPluginInfoRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.GetPluginInfoResponse{})
+}
+
+func (s *MSIAttestorSuite) newAttestor() {
+	attestor := NewMSIAttestorPlugin()
+	attestor.hooks.fetchMSIToken = func(ctx context.Context, httpClient azure.HTTPClient, resource string) (string, error) {
+		if httpClient != http.DefaultClient {
+			return "", errors.New("unexpected http client")
+		}
+		if resource != s.expectedResource {
+			return "", fmt.Errorf("expected resource %s; got %s", s.expectedResource, resource)
+		}
+		s.T().Logf("RETURNING %v %v", s.token, s.tokenErr)
+		return s.token, s.tokenErr
+	}
+	s.attestor = nodeattestor.NewBuiltIn(attestor)
+}
+
+func (s *MSIAttestorSuite) requireFetchError(contains string) {
+	stream, err := s.attestor.FetchAttestationData(context.Background())
+	s.Require().NoError(err)
+	s.Require().NotNil(stream)
+
+	resp, err := stream.Recv()
+	s.requireErrorContains(err, contains)
+	s.Require().Nil(resp)
+}
+
+func (s *MSIAttestorSuite) requireErrorContains(err error, contains string) {
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), contains)
+}
+
+func (s *MSIAttestorSuite) makeAccessToken(principalID, tenantID string) string {
+	claims := azure.MSITokenClaims{
+		Claims: jwt.Claims{
+			Subject: principalID,
+		},
+		TenantID: tenantID,
+	}
+
+	signingKey := jose.SigningKey{Algorithm: jose.HS256, Key: []byte("KEY")}
+	signer, err := jose.NewSigner(signingKey, nil)
+	s.Require().NoError(err)
+
+	token, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+	s.Require().NoError(err)
+	return token
+}

--- a/pkg/common/jwtutil/keyset.go
+++ b/pkg/common/jwtutil/keyset.go
@@ -1,0 +1,141 @@
+package jwtutil
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/zeebo/errs"
+	"gopkg.in/square/go-jose.v2"
+)
+
+type KeySetProvider interface {
+	GetKeySet(context.Context) (*jose.JSONWebKeySet, error)
+}
+
+type KeySetProviderFunc func(context.Context) (*jose.JSONWebKeySet, error)
+
+func (fn KeySetProviderFunc) GetKeySet(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	return fn(ctx)
+}
+
+type KeySetConfigURL string
+
+func (c KeySetConfigURL) GetKeySet(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	uri, err := FetchKeySetURI(ctx, string(c))
+	if err != nil {
+		return nil, err
+	}
+	return FetchKeySet(ctx, uri)
+}
+
+type CachingKeySetProvider struct {
+	provider        KeySetProvider
+	refreshInterval time.Duration
+
+	mu      sync.Mutex
+	updated time.Time
+	jwks    *jose.JSONWebKeySet
+
+	hooks struct {
+		now func() time.Time
+	}
+}
+
+func NewCachingKeySetProvider(provider KeySetProvider, refreshInterval time.Duration) *CachingKeySetProvider {
+	c := &CachingKeySetProvider{
+		provider:        provider,
+		refreshInterval: refreshInterval,
+	}
+	c.hooks.now = time.Now
+	return c
+}
+
+func (c *CachingKeySetProvider) GetKeySet(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.hooks.now()
+
+	if !c.updated.IsZero() && now.Sub(c.updated) < c.refreshInterval {
+		return c.jwks, nil
+	}
+
+	// refresh key set. if there is a failure, log and return the old set if
+	// available.
+	jwks, err := c.provider.GetKeySet(ctx)
+	if err == nil {
+		c.jwks = jwks
+		c.updated = now
+	} else {
+		logrus.Warnf("unable to refresh key set: %v", err)
+		if c.jwks == nil {
+			return nil, errs.Wrap(err)
+		}
+	}
+
+	return c.jwks, nil
+}
+
+func FetchKeySetURI(ctx context.Context, configURL string) (string, error) {
+	req, err := http.NewRequest("GET", configURL, nil)
+	if err != nil {
+		return "", errs.Wrap(err)
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", errs.Wrap(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", errs.New("unexpected status code %d: %s", resp.StatusCode, tryRead(resp.Body))
+	}
+
+	config := &struct {
+		JWKSURI string `json:"jwks_uri"`
+	}{}
+	if err := json.NewDecoder(resp.Body).Decode(config); err != nil {
+		return "", errs.New("failed to decode configuration: %v", err)
+	}
+	if config.JWKSURI == "" {
+		return "", errs.New("configuration missing JWKS URI")
+	}
+
+	return config.JWKSURI, nil
+}
+
+func FetchKeySet(ctx context.Context, jwksURI string) (*jose.JSONWebKeySet, error) {
+	req, err := http.NewRequest("GET", jwksURI, nil)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errs.New("unexpected status code %d: %s", resp.StatusCode, tryRead(resp.Body))
+	}
+
+	jwks := new(jose.JSONWebKeySet)
+	if err := json.NewDecoder(resp.Body).Decode(jwks); err != nil {
+		return nil, errs.New("failed to decode key set: %v", err)
+	}
+
+	return jwks, nil
+}
+
+func tryRead(r io.Reader) string {
+	b := make([]byte, 1024)
+	n, _ := r.Read(b)
+	return string(b[:n])
+}

--- a/pkg/common/jwtutil/keyset_test.go
+++ b/pkg/common/jwtutil/keyset_test.go
@@ -1,0 +1,148 @@
+package jwtutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	jose "gopkg.in/square/go-jose.v2"
+)
+
+func TestFetchKeySetURI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(jwksHandler))
+	defer server.Close()
+
+	// not found
+	uri, err := FetchKeySetURI(context.Background(), server.URL+"/whatever")
+	require.EqualError(t, err, "unexpected status code 404: not found\n")
+	require.Equal(t, "", uri)
+
+	// malformed response
+	uri, err = FetchKeySetURI(context.Background(), server.URL+"/malformed")
+	require.EqualError(t, err, "failed to decode configuration: unexpected EOF")
+	require.Equal(t, "", uri)
+
+	// no URL in response
+	uri, err = FetchKeySetURI(context.Background(), server.URL+"/empty")
+	require.EqualError(t, err, "configuration missing JWKS URI")
+	require.Equal(t, "", uri)
+
+	// success
+	uri, err = FetchKeySetURI(context.Background(), server.URL+"/config")
+	require.NoError(t, err)
+	require.Equal(t, "https://login.microsoftonline.com/common/discovery/keys", uri)
+}
+
+func TestFetchKeySet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(jwksHandler))
+	defer server.Close()
+
+	// not found
+	keySet, err := FetchKeySet(context.Background(), server.URL+"/whatever")
+	require.EqualError(t, err, "unexpected status code 404: not found\n")
+	require.Nil(t, keySet)
+
+	// malformed response
+	keySet, err = FetchKeySet(context.Background(), server.URL+"/malformed")
+	require.EqualError(t, err, "failed to decode key set: unexpected EOF")
+	require.Nil(t, keySet)
+
+	// success
+	keySet, err = FetchKeySet(context.Background(), server.URL+"/keys")
+	require.NoError(t, err)
+	require.NotNil(t, keySet)
+	keys := keySet.Key("TioGywwlhvdFbXZ813WpPay9AlU")
+	require.Len(t, keys, 1)
+}
+
+func TestCachingKeySetProvider(t *testing.T) {
+	a := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{KeyID: "A"}}}
+	b := &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{KeyID: "B"}}}
+
+	var providerJWKS *jose.JSONWebKeySet
+	var providerErr error
+	provider := func(ctx context.Context) (*jose.JSONWebKeySet, error) {
+		return providerJWKS, providerErr
+	}
+	now := time.Now()
+
+	// set up a new caching provider that refreshes every second
+	caching := NewCachingKeySetProvider(KeySetProviderFunc(provider), time.Second)
+	caching.hooks.now = func() time.Time {
+		return now
+	}
+
+	// fail the first attempt to get the keyset. should return an error since
+	// there is no keyset cached.
+	providerErr = errors.New("FAILED")
+	jwks, err := caching.GetKeySet(context.Background())
+	require.EqualError(t, err, "FAILED")
+	require.Nil(t, jwks)
+
+	// assert that this attempt successfully returns keyset "a"
+	providerErr = nil
+	providerJWKS = a
+	jwks, err = caching.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, a, jwks)
+
+	// assert that this attempt continues to return keyset "a" since it has
+	// been cached and the refresh interval has not elapsed
+	providerErr = nil
+	providerJWKS = b
+	jwks, err = caching.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, a, jwks)
+
+	// assert that this attempt continues to return keyset "a" since it has
+	// been cached and the refresh interval has not elapsed
+	providerErr = nil
+	providerJWKS = b
+	jwks, err = caching.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, a, jwks)
+
+	// move forward past the refresh interval
+	now = now.Add(time.Second)
+
+	// assert that this attempt continues to return keyset "a" even though
+	// the refresh interval has elapsed due to a failure from the wrapped
+	// provider.
+	providerErr = errors.New("FAILED")
+	providerJWKS = b
+	jwks, err = caching.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, a, jwks)
+
+	// assert that this attempt returns keyset "b"
+	providerErr = nil
+	providerJWKS = b
+	jwks, err = caching.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, b, jwks)
+}
+
+func jwksHandler(w http.ResponseWriter, req *http.Request) {
+	if req.Method != "GET" {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	switch req.URL.Path {
+	case "/config":
+		fmt.Fprint(w, `{"authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/authorize","token_endpoint":"https://login.microsoftonline.com/common/oauth2/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/common/discovery/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/common/oauth2/logout","response_types_supported":["code","id_token","code id_token","token id_token","token"],"scopes_supported":["openid"],"issuer":"https://sts.windows.net/{tenantid}/","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","amr","nonce","email","given_name","family_name","nickname"],"microsoft_multi_refresh_token":true,"check_session_iframe":"https://login.microsoftonline.com/common/oauth2/checksession","userinfo_endpoint":"https://login.microsoftonline.com/common/openid/userinfo","tenant_region_scope":null,"cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}`)
+	case "/keys":
+		fmt.Fprint(w, `{"keys":[{"kty":"RSA","use":"sig","kid":"TioGywwlhvdFbXZ813WpPay9AlU","x5t":"TioGywwlhvdFbXZ813WpPay9AlU","n":"vP3qtSGxB-MB7QlmeLsnmguri3_ebbsfBdKNk5Uz6YN80JDNMO8q-mbHr9UGYH5IB39wxz8Z-e1aX8NB5vTweCR3tQbNtXWtQ6zEfXmanAUAGNADmIVN3mLwGoxXPqy01VM_9ytLTpwowCibVWoCii5m_GLtVjyooXBZMGjwhLSmzfZ0ipjlen7q83LxZAYYSdV_kzHGtJKHHDrNMwzJfOgk-uvF73LSW4kX5zmtHLgRPY-Gkvqu2g2En4ShdpXTN0iNV6rZ5xIyhts_08G2oF2RBJEijhFj7NBkxMcX3NS7ZKkIqRvySriEhmSkZsSRqGg8gn8aVC2DqVuwRiimLw","e":"AQAB","x5c":["MIIDBTCCAe2gAwIBAgIQYbgOJ8Uror1IlEvjsPi7jzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDUxMTAwMDAwMFoXDTIwMDUxMTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALz96rUhsQfjAe0JZni7J5oLq4t/3m27HwXSjZOVM+mDfNCQzTDvKvpmx6/VBmB+SAd/cMc/GfntWl/DQeb08Hgkd7UGzbV1rUOsxH15mpwFABjQA5iFTd5i8BqMVz6stNVTP/crS06cKMAom1VqAoouZvxi7VY8qKFwWTBo8IS0ps32dIqY5Xp+6vNy8WQGGEnVf5MxxrSShxw6zTMMyXzoJPrrxe9y0luJF+c5rRy4ET2PhpL6rtoNhJ+EoXaV0zdIjVeq2ecSMobbP9PBtqBdkQSRIo4RY+zQZMTHF9zUu2SpCKkb8kq4hIZkpGbEkahoPIJ/GlQtg6lbsEYopi8CAwEAAaMhMB8wHQYDVR0OBBYEFIwrggJsAwub9JGBkbpcqnwD052FMA0GCSqGSIb3DQEBCwUAA4IBAQAN9cz2xcZe76AxjQAOgaGGMrpowwmDht5ssS4SrwoL1gDvEP/pn4tTdYpPTP18EC7YMg925nbLmqNM0VJvO7AJr1I6G/HbmrCyyhvmZYZnAJVwqFwsPK2lJ1K0sjriL/g1UI0BofFsWBxBMqaDOp7+PTz27Ssn7UOo5ghKCMWaijNl+nsjfDtIJhKjISW8KduL5DO7Q+9R5ec/AyjheOCTmEij8V6nVBX642z9ujU9xOUaZZux9usuEHDhf7kqnOw/9/WyKluHoLhxFkTCV2Y12HabDtKo5iOP+ukjzNzZkRoo74Fi0tFB+nB24fdrd2TrxaGau/KXRu5QbXataOjz"]},{"kty":"RSA","use":"sig","kid":"7_Zuf1tvkwLxYaHS3q6lUjUYIGw","x5t":"7_Zuf1tvkwLxYaHS3q6lUjUYIGw","n":"vVzG98jfA-7UcUZkvrCdId9ypfoOW97MsXXBupSzr8NLkaHG28eTr72crI24KPOeQQqqXptMiCdRu9M-vRRQpreF7Or8P2eQa7ipfwtU41VaRvneaOc3jmWdV84uHpVDsnz_1S3_JtueFyfZrXa9aJHRzrz31OC1Gn6LRuRP11iX7f_B8_z5sGqaiXCejvKiO_8PEzPzqbOFLuVbqZL3PNi12zLogdwXY_1chpzZNo_R59SkutBjzXC5MTeBSHazqPu2o0ftoorY80C7Fe3Ia1n2v5uDSAysNddUonKVA72bhnknS-7PzGAISUuDe4k84jyr-PRist7msfLrsAKDQw","e":"AQAB","x5c":["MIIDBTCCAe2gAwIBAgIQE7nbxEiAlqhFdKnsKV+nuTANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDYyMTAwMDAwMFoXDTIwMDYyMTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL1cxvfI3wPu1HFGZL6wnSHfcqX6DlvezLF1wbqUs6/DS5GhxtvHk6+9nKyNuCjznkEKql6bTIgnUbvTPr0UUKa3hezq/D9nkGu4qX8LVONVWkb53mjnN45lnVfOLh6VQ7J8/9Ut/ybbnhcn2a12vWiR0c6899TgtRp+i0bkT9dYl+3/wfP8+bBqmolwno7yojv/DxMz86mzhS7lW6mS9zzYtdsy6IHcF2P9XIac2TaP0efUpLrQY81wuTE3gUh2s6j7tqNH7aKK2PNAuxXtyGtZ9r+bg0gMrDXXVKJylQO9m4Z5J0vuz8xgCElLg3uJPOI8q/j0YrLe5rHy67ACg0MCAwEAAaMhMB8wHQYDVR0OBBYEFDnSNW3pMmrshl3iBAS4OSLCu/7GMA0GCSqGSIb3DQEBCwUAA4IBAQAFs3C5sfXSfoi7ea62flYEukqyVMhrDrpxRlvIuXqL11g8KEXlk8pS8gEnRtU6NBeHhMrhYSuiqj7/2jUT1BR3zJ2bChEyEpIgOFaiTUxq6tXdpWi/M7ibf8O/1sUtjgYktwJlSL6FEVAMFH82TxCoTWp2g5i2lmZQ7KxiKhG+Vl9nw1bPX57hkWWhR7Hpes0MbpGNZI2IEpZSjNG1IWPPOBcaOh4ed2WBQcLcaTuAaELlaxanQaC0B3029To80MnzpZuadaul3+jN7JQg0MpHdJJ8GMHAWe/IjXc0evJNhVUcKON41hzTu0R+Sze7xq1zGljQihJgcNpO9oReBUsX"]},{"kty":"RSA","use":"sig","kid":"2S4SCVGs8Sg9LS6AqLIq6DpW-g8","x5t":"2S4SCVGs8Sg9LS6AqLIq6DpW-g8","n":"oZ-QQrNuB4ei9ATYrT61ebPtvwwYWnsrTpp4ISSp6niZYb92XM0oUTNgqd_C1vGN8J-y9wCbaJWkpBf46CjdZehrqczPhzhHau8WcRXocSB1u_tuZhv1ooAZ4bAcy79UkeLiG60HkuTNJJC8CfaTp1R97szBhuk0Vz5yt4r5SpfewIlBCnZUYwkDS172H9WapQu-3P2Qjh0l-JLyCkdrhvizZUk0atq5_AIDKRU-A0pRGc-EZhUL0LqUMz6c6M2s_4GnQaScv44A5iZUDD15B6e8Apb2yARohkWmOnmRcTVfes8EkfxjzZEzm3cNkvP0ogILyISHKlkzy2OmlU6iXw","e":"AQAB","x5c":["MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE="]}]}`)
+	case "/malformed":
+		fmt.Fprint(w, "{")
+	case "/empty":
+		fmt.Fprint(w, "{}")
+	default:
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+}

--- a/pkg/common/jwtutil/keyset_test.go
+++ b/pkg/common/jwtutil/keyset_test.go
@@ -13,29 +13,29 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 )
 
-func TestFetchKeySetURI(t *testing.T) {
+func TestDiscoverKeySetURI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(jwksHandler))
 	defer server.Close()
 
 	// not found
-	uri, err := FetchKeySetURI(context.Background(), server.URL+"/whatever")
+	uri, err := DiscoverKeySetURI(context.Background(), server.URL+"/whatever")
 	require.EqualError(t, err, "unexpected status code 404: not found\n")
 	require.Equal(t, "", uri)
 
 	// malformed response
-	uri, err = FetchKeySetURI(context.Background(), server.URL+"/malformed")
+	uri, err = DiscoverKeySetURI(context.Background(), server.URL+"/malformed")
 	require.EqualError(t, err, "failed to decode configuration: unexpected EOF")
 	require.Equal(t, "", uri)
 
 	// no URL in response
-	uri, err = FetchKeySetURI(context.Background(), server.URL+"/empty")
+	uri, err = DiscoverKeySetURI(context.Background(), server.URL+"/empty")
 	require.EqualError(t, err, "configuration missing JWKS URI")
 	require.Equal(t, "", uri)
 
 	// success
-	uri, err = FetchKeySetURI(context.Background(), server.URL+"/config")
+	uri, err = DiscoverKeySetURI(context.Background(), server.URL+wellKnownOpenIdConfiguration)
 	require.NoError(t, err)
-	require.Equal(t, "https://login.microsoftonline.com/common/discovery/keys", uri)
+	require.Equal(t, fmt.Sprintf("%s/keys", server.URL), uri)
 }
 
 func TestFetchKeySet(t *testing.T) {
@@ -58,6 +58,18 @@ func TestFetchKeySet(t *testing.T) {
 	require.NotNil(t, keySet)
 	keys := keySet.Key("TioGywwlhvdFbXZ813WpPay9AlU")
 	require.Len(t, keys, 1)
+}
+
+func TestOIDCIssuer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(jwksHandler))
+	defer server.Close()
+
+	// Other tests exercise the discovery functionality. This test simply
+	// asserts that the URI for the OIDC server is crafted correctly.
+	provider := OIDCIssuer(server.URL)
+	keySet, err := provider.GetKeySet(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, keySet)
 }
 
 func TestCachingKeySetProvider(t *testing.T) {
@@ -133,8 +145,8 @@ func jwksHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	switch req.URL.Path {
-	case "/config":
-		fmt.Fprint(w, `{"authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/authorize","token_endpoint":"https://login.microsoftonline.com/common/oauth2/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt","client_secret_basic"],"jwks_uri":"https://login.microsoftonline.com/common/discovery/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/common/oauth2/logout","response_types_supported":["code","id_token","code id_token","token id_token","token"],"scopes_supported":["openid"],"issuer":"https://sts.windows.net/{tenantid}/","claims_supported":["sub","iss","cloud_instance_name","cloud_instance_host_name","cloud_graph_host_name","msgraph_host","aud","exp","iat","auth_time","acr","amr","nonce","email","given_name","family_name","nickname"],"microsoft_multi_refresh_token":true,"check_session_iframe":"https://login.microsoftonline.com/common/oauth2/checksession","userinfo_endpoint":"https://login.microsoftonline.com/common/openid/userinfo","tenant_region_scope":null,"cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net","msgraph_host":"graph.microsoft.com","rbac_url":"https://pas.windows.net"}`)
+	case wellKnownOpenIdConfiguration:
+		fmt.Fprintf(w, `{"jwks_uri":"http://%s/keys"}`, req.Host)
 	case "/keys":
 		fmt.Fprint(w, `{"keys":[{"kty":"RSA","use":"sig","kid":"TioGywwlhvdFbXZ813WpPay9AlU","x5t":"TioGywwlhvdFbXZ813WpPay9AlU","n":"vP3qtSGxB-MB7QlmeLsnmguri3_ebbsfBdKNk5Uz6YN80JDNMO8q-mbHr9UGYH5IB39wxz8Z-e1aX8NB5vTweCR3tQbNtXWtQ6zEfXmanAUAGNADmIVN3mLwGoxXPqy01VM_9ytLTpwowCibVWoCii5m_GLtVjyooXBZMGjwhLSmzfZ0ipjlen7q83LxZAYYSdV_kzHGtJKHHDrNMwzJfOgk-uvF73LSW4kX5zmtHLgRPY-Gkvqu2g2En4ShdpXTN0iNV6rZ5xIyhts_08G2oF2RBJEijhFj7NBkxMcX3NS7ZKkIqRvySriEhmSkZsSRqGg8gn8aVC2DqVuwRiimLw","e":"AQAB","x5c":["MIIDBTCCAe2gAwIBAgIQYbgOJ8Uror1IlEvjsPi7jzANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDUxMTAwMDAwMFoXDTIwMDUxMTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALz96rUhsQfjAe0JZni7J5oLq4t/3m27HwXSjZOVM+mDfNCQzTDvKvpmx6/VBmB+SAd/cMc/GfntWl/DQeb08Hgkd7UGzbV1rUOsxH15mpwFABjQA5iFTd5i8BqMVz6stNVTP/crS06cKMAom1VqAoouZvxi7VY8qKFwWTBo8IS0ps32dIqY5Xp+6vNy8WQGGEnVf5MxxrSShxw6zTMMyXzoJPrrxe9y0luJF+c5rRy4ET2PhpL6rtoNhJ+EoXaV0zdIjVeq2ecSMobbP9PBtqBdkQSRIo4RY+zQZMTHF9zUu2SpCKkb8kq4hIZkpGbEkahoPIJ/GlQtg6lbsEYopi8CAwEAAaMhMB8wHQYDVR0OBBYEFIwrggJsAwub9JGBkbpcqnwD052FMA0GCSqGSIb3DQEBCwUAA4IBAQAN9cz2xcZe76AxjQAOgaGGMrpowwmDht5ssS4SrwoL1gDvEP/pn4tTdYpPTP18EC7YMg925nbLmqNM0VJvO7AJr1I6G/HbmrCyyhvmZYZnAJVwqFwsPK2lJ1K0sjriL/g1UI0BofFsWBxBMqaDOp7+PTz27Ssn7UOo5ghKCMWaijNl+nsjfDtIJhKjISW8KduL5DO7Q+9R5ec/AyjheOCTmEij8V6nVBX642z9ujU9xOUaZZux9usuEHDhf7kqnOw/9/WyKluHoLhxFkTCV2Y12HabDtKo5iOP+ukjzNzZkRoo74Fi0tFB+nB24fdrd2TrxaGau/KXRu5QbXataOjz"]},{"kty":"RSA","use":"sig","kid":"7_Zuf1tvkwLxYaHS3q6lUjUYIGw","x5t":"7_Zuf1tvkwLxYaHS3q6lUjUYIGw","n":"vVzG98jfA-7UcUZkvrCdId9ypfoOW97MsXXBupSzr8NLkaHG28eTr72crI24KPOeQQqqXptMiCdRu9M-vRRQpreF7Or8P2eQa7ipfwtU41VaRvneaOc3jmWdV84uHpVDsnz_1S3_JtueFyfZrXa9aJHRzrz31OC1Gn6LRuRP11iX7f_B8_z5sGqaiXCejvKiO_8PEzPzqbOFLuVbqZL3PNi12zLogdwXY_1chpzZNo_R59SkutBjzXC5MTeBSHazqPu2o0ftoorY80C7Fe3Ia1n2v5uDSAysNddUonKVA72bhnknS-7PzGAISUuDe4k84jyr-PRist7msfLrsAKDQw","e":"AQAB","x5c":["MIIDBTCCAe2gAwIBAgIQE7nbxEiAlqhFdKnsKV+nuTANBgkqhkiG9w0BAQsFADAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MB4XDTE4MDYyMTAwMDAwMFoXDTIwMDYyMTAwMDAwMFowLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL1cxvfI3wPu1HFGZL6wnSHfcqX6DlvezLF1wbqUs6/DS5GhxtvHk6+9nKyNuCjznkEKql6bTIgnUbvTPr0UUKa3hezq/D9nkGu4qX8LVONVWkb53mjnN45lnVfOLh6VQ7J8/9Ut/ybbnhcn2a12vWiR0c6899TgtRp+i0bkT9dYl+3/wfP8+bBqmolwno7yojv/DxMz86mzhS7lW6mS9zzYtdsy6IHcF2P9XIac2TaP0efUpLrQY81wuTE3gUh2s6j7tqNH7aKK2PNAuxXtyGtZ9r+bg0gMrDXXVKJylQO9m4Z5J0vuz8xgCElLg3uJPOI8q/j0YrLe5rHy67ACg0MCAwEAAaMhMB8wHQYDVR0OBBYEFDnSNW3pMmrshl3iBAS4OSLCu/7GMA0GCSqGSIb3DQEBCwUAA4IBAQAFs3C5sfXSfoi7ea62flYEukqyVMhrDrpxRlvIuXqL11g8KEXlk8pS8gEnRtU6NBeHhMrhYSuiqj7/2jUT1BR3zJ2bChEyEpIgOFaiTUxq6tXdpWi/M7ibf8O/1sUtjgYktwJlSL6FEVAMFH82TxCoTWp2g5i2lmZQ7KxiKhG+Vl9nw1bPX57hkWWhR7Hpes0MbpGNZI2IEpZSjNG1IWPPOBcaOh4ed2WBQcLcaTuAaELlaxanQaC0B3029To80MnzpZuadaul3+jN7JQg0MpHdJJ8GMHAWe/IjXc0evJNhVUcKON41hzTu0R+Sze7xq1zGljQihJgcNpO9oReBUsX"]},{"kty":"RSA","use":"sig","kid":"2S4SCVGs8Sg9LS6AqLIq6DpW-g8","x5t":"2S4SCVGs8Sg9LS6AqLIq6DpW-g8","n":"oZ-QQrNuB4ei9ATYrT61ebPtvwwYWnsrTpp4ISSp6niZYb92XM0oUTNgqd_C1vGN8J-y9wCbaJWkpBf46CjdZehrqczPhzhHau8WcRXocSB1u_tuZhv1ooAZ4bAcy79UkeLiG60HkuTNJJC8CfaTp1R97szBhuk0Vz5yt4r5SpfewIlBCnZUYwkDS172H9WapQu-3P2Qjh0l-JLyCkdrhvizZUk0atq5_AIDKRU-A0pRGc-EZhUL0LqUMz6c6M2s_4GnQaScv44A5iZUDD15B6e8Apb2yARohkWmOnmRcTVfes8EkfxjzZEzm3cNkvP0ogILyISHKlkzy2OmlU6iXw","e":"AQAB","x5c":["MIIDKDCCAhCgAwIBAgIQBHJvVNxP1oZO4HYKh+rypDANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwHhcNMTYxMTE2MDgwMDAwWhcNMTgxMTE2MDgwMDAwWjAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQChn5BCs24Hh6L0BNitPrV5s+2/DBhaeytOmnghJKnqeJlhv3ZczShRM2Cp38LW8Y3wn7L3AJtolaSkF/joKN1l6GupzM+HOEdq7xZxFehxIHW7+25mG/WigBnhsBzLv1SR4uIbrQeS5M0kkLwJ9pOnVH3uzMGG6TRXPnK3ivlKl97AiUEKdlRjCQNLXvYf1ZqlC77c/ZCOHSX4kvIKR2uG+LNlSTRq2rn8AgMpFT4DSlEZz4RmFQvQupQzPpzozaz/gadBpJy/jgDmJlQMPXkHp7wClvbIBGiGRaY6eZFxNV96zwSR/GPNkTObdw2S8/SiAgvIhIcqWTPLY6aVTqJfAgMBAAGjWDBWMFQGA1UdAQRNMEuAEDUj0BrjP0RTbmoRPTRMY3WhJTAjMSEwHwYDVQQDExhsb2dpbi5taWNyb3NvZnRvbmxpbmUudXOCEARyb1TcT9aGTuB2Cofq8qQwDQYJKoZIhvcNAQELBQADggEBAGnLhDHVz2gLDiu9L34V3ro/6xZDiSWhGyHcGqky7UlzQH3pT5so8iF5P0WzYqVtogPsyC2LPJYSTt2vmQugD4xlu/wbvMFLcV0hmNoTKCF1QTVtEQiAiy0Aq+eoF7Al5fV1S3Sune0uQHimuUFHCmUuF190MLcHcdWnPAmzIc8fv7quRUUsExXmxSX2ktUYQXzqFyIOSnDCuWFm6tpfK5JXS8fW5bpqTlrysXXz/OW/8NFGq/alfjrya4ojrOYLpunGriEtNPwK7hxj1AlCYEWaRHRXaUIW1ByoSff/6Y6+ZhXPUe0cDlNRt/qIz5aflwO7+W8baTS4O8m/icu7ItE="]}]}`)
 	case "/malformed":

--- a/pkg/common/plugin/azure/msi.go
+++ b/pkg/common/plugin/azure/msi.go
@@ -1,0 +1,89 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/zeebo/errs"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+const (
+	// DefaultMSIResourceID is the default resource ID to use as the intended
+	// audience of the MSI token. The current value is the service ID for the
+	// Resource Manager API.
+	DefaultMSIResourceID = "https://management.azure.com/"
+)
+
+type MSIAttestationData struct {
+	Token string `json:"token"`
+}
+
+type MSITokenClaims struct {
+	jwt.Claims
+	TenantID string `json:"tid,omitempty"`
+}
+
+func (c *MSITokenClaims) AgentID(trustDomain string) string {
+	u := url.URL{
+		Scheme: "spiffe",
+		Host:   trustDomain,
+		Path:   path.Join("spire", "agent", "azure_msi", c.TenantID, c.Subject),
+	}
+	return u.String()
+}
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type HTTPClientFunc func(*http.Request) (*http.Response, error)
+
+func (fn HTTPClientFunc) Do(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func FetchMSIToken(ctx context.Context, cl HTTPClient, resource string) (string, error) {
+	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01", nil)
+	if err != nil {
+		return "", errs.Wrap(err)
+	}
+	req.Header.Add("Metadata", "true")
+
+	q := req.URL.Query()
+	q.Set("resource", resource)
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := cl.Do(req)
+	if err != nil {
+		return "", errs.Wrap(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", errs.New("unexpected status code %d: %s", resp.StatusCode, tryRead(resp.Body))
+	}
+
+	r := struct {
+		AccessToken string `json:"access_token"`
+	}{}
+
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return "", errs.New("unable to decode response: %v", err)
+	}
+
+	if r.AccessToken == "" {
+		return "", errs.New("response missing access token")
+	}
+
+	return r.AccessToken, nil
+}
+
+func tryRead(r io.Reader) string {
+	b := make([]byte, 1024)
+	n, _ := r.Read(b)
+	return string(b[:n])
+}

--- a/pkg/common/plugin/azure/msi_test.go
+++ b/pkg/common/plugin/azure/msi_test.go
@@ -1,0 +1,79 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+func TestMSITokenClaims(t *testing.T) {
+	claims := MSITokenClaims{
+		Claims: jwt.Claims{
+			Subject: "PRINCIPALID",
+		},
+		TenantID: "TENANTID",
+	}
+	require.Equal(t, "spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID", claims.AgentID("example.org"))
+}
+
+func TestFetchMSIToken(t *testing.T) {
+	ctx := context.Background()
+
+	// unexpected status
+	token, err := FetchMSIToken(ctx, fakeHTTPClient(http.StatusBadRequest, "ERROR"), "RESOURCE")
+	require.EqualError(t, err, "unexpected status code 400: ERROR")
+	require.Empty(t, token)
+
+	// empty response
+	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, ""), "RESOURCE")
+	require.EqualError(t, err, "unable to decode response: EOF")
+	require.Empty(t, token)
+
+	// malformed response
+	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, "{"), "RESOURCE")
+	require.EqualError(t, err, "unable to decode response: unexpected EOF")
+	require.Empty(t, token)
+
+	// no access token
+	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, "{}"), "RESOURCE")
+	require.EqualError(t, err, "response missing access token")
+	require.Empty(t, token)
+
+	// success
+	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, `{"access_token": "ASDF"}`), "RESOURCE")
+	require.NoError(t, err)
+	require.Equal(t, "ASDF", token)
+}
+
+func fakeHTTPClient(statusCode int, body string) HTTPClient {
+	return HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		// assert the expected request values
+		if req.Method != "GET" {
+			return nil, fmt.Errorf("unexpected method %q", req.Method)
+		}
+		if req.URL.Path != "/metadata/identity/oauth2/token" {
+			return nil, fmt.Errorf("unexpected path %q", req.URL.Path)
+		}
+		if v := req.URL.Query().Get("api-version"); v != "2018-02-01" {
+			return nil, fmt.Errorf("unexpected api version %q", v)
+		}
+		if v := req.URL.Query().Get("resource"); v != "RESOURCE" {
+			return nil, fmt.Errorf("unexpected resource %q", v)
+		}
+		if v := req.Header.Get("metadata"); v != "true" {
+			return nil, fmt.Errorf("unexpected metadata header %q", v)
+		}
+
+		// return the response
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       ioutil.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+}

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore/sql"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/aws"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/azure"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/gcp"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/jointoken"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/x509pop"
@@ -59,6 +60,7 @@ var (
 			"join_token": nodeattestor.NewBuiltIn(jointoken.New()),
 			"gcp_iit":    nodeattestor.NewBuiltIn(gcp.NewIITAttestorPlugin()),
 			"x509pop":    nodeattestor.NewBuiltIn(x509pop.New()),
+			"azure_msi":  nodeattestor.NewBuiltIn(azure.NewMSIAttestorPlugin()),
 		},
 		NodeResolverType: {
 			"noop": noderesolver.NewBuiltIn(noop.New()),

--- a/pkg/server/plugin/nodeattestor/azure/msi.go
+++ b/pkg/server/plugin/nodeattestor/azure/msi.go
@@ -1,0 +1,193 @@
+package azure
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire/pkg/common/jwtutil"
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	spi "github.com/spiffe/spire/proto/common/plugin"
+	"github.com/spiffe/spire/proto/server/nodeattestor"
+	"github.com/zeebo/errs"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+const (
+	pluginName = "azure_msi"
+
+	tokenLeeway           = time.Minute * 5
+	keySetRefreshInterval = time.Hour
+	azureConfigURL        = "https://login.microsoftonline.com/common/.well-known/openid-configuration"
+)
+
+var (
+	msiError = errs.Class("azure-msi")
+)
+
+type TenantConfig struct {
+	ResourceID string `hcl:"resource_id"`
+}
+
+type MSIAttestorConfig struct {
+	TrustDomain string                   `hcl:"trust_domain"`
+	Tenants     map[string]*TenantConfig `hcl:"tenants"`
+}
+
+type MSIAttestorPlugin struct {
+	mu     sync.RWMutex
+	config *MSIAttestorConfig
+
+	hooks struct {
+		now            func() time.Time
+		keySetProvider jwtutil.KeySetProvider
+	}
+}
+
+var _ nodeattestor.Plugin = (*MSIAttestorPlugin)(nil)
+
+func NewMSIAttestorPlugin() *MSIAttestorPlugin {
+	p := &MSIAttestorPlugin{}
+	p.hooks.now = time.Now
+	p.hooks.keySetProvider = jwtutil.NewCachingKeySetProvider(jwtutil.KeySetConfigURL(azureConfigURL), keySetRefreshInterval)
+	return p
+}
+
+func (p *MSIAttestorPlugin) Attest(stream nodeattestor.Attest_PluginStream) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return msiError.Wrap(err)
+	}
+
+	config, err := p.getConfig()
+	if err != nil {
+		return err
+	}
+
+	if req.AttestedBefore {
+		return msiError.New("node has already attested")
+	}
+
+	if req.AttestationData == nil {
+		return msiError.New("missing attestation data")
+	}
+
+	if dataType := req.AttestationData.Type; dataType != pluginName {
+		return msiError.New("unexpected attestation data type %q", dataType)
+	}
+
+	if req.AttestationData.Data == nil {
+		return msiError.New("missing attestation data payload")
+	}
+
+	attestationData := new(azure.MSIAttestationData)
+	if err := json.Unmarshal(req.AttestationData.Data, attestationData); err != nil {
+		return msiError.New("failed to unmarshal data payload: %v", err)
+	}
+
+	if attestationData.Token == "" {
+		return msiError.New("missing token from attestation data")
+	}
+
+	keySet, err := p.hooks.keySetProvider.GetKeySet(stream.Context())
+	if err != nil {
+		return msiError.New("unable to obtain JWKS: %v", err)
+	}
+
+	token, err := jwt.ParseSigned(attestationData.Token)
+	if err != nil {
+		return msiError.New("unable to parse token: %v", err)
+	}
+
+	keyID, ok := getTokenKeyID(token)
+	if !ok {
+		return msiError.New("token missing key id")
+	}
+
+	keys := keySet.Key(keyID)
+	if len(keys) == 0 {
+		return msiError.New("key id %q not found", keyID)
+	}
+
+	claims := new(azure.MSITokenClaims)
+	if err := token.Claims(&keys[0], claims); err != nil {
+		return msiError.New("unable to verify token: %v", err)
+	}
+
+	// make sure tenant id is present and authorized
+	if claims.TenantID == "" {
+		return msiError.New("token missing tenant ID claim")
+	}
+	tenant, ok := config.Tenants[claims.TenantID]
+	if !ok {
+		return msiError.New("tenant ID is not authorized")
+	}
+
+	if err := claims.ValidateWithLeeway(jwt.Expected{
+		Audience: []string{tenant.ResourceID},
+		Time:     p.hooks.now(),
+	}, tokenLeeway); err != nil {
+		return msiError.New("unable to validate token claims: %v", err)
+	}
+
+	// make sure principal id is in subject claim
+	if claims.Subject == "" {
+		return msiError.New("token missing subject claim")
+	}
+
+	return stream.Send(&nodeattestor.AttestResponse{
+		Valid:        true,
+		BaseSPIFFEID: claims.AgentID(config.TrustDomain),
+	})
+}
+
+func (p *MSIAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := new(MSIAttestorConfig)
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, msiError.New("unable to decode configuration: %v", err)
+	}
+	if config.TrustDomain == "" {
+		return nil, msiError.New("configuration missing trust domain")
+	}
+	if len(config.Tenants) == 0 {
+		return nil, msiError.New("configuration must have at least one tenant")
+	}
+	for _, tenant := range config.Tenants {
+		if tenant.ResourceID == "" {
+			tenant.ResourceID = azure.DefaultMSIResourceID
+		}
+	}
+
+	p.setConfig(config)
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (p *MSIAttestorPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p *MSIAttestorPlugin) getConfig() (*MSIAttestorConfig, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.config == nil {
+		return nil, msiError.New("not configured")
+	}
+	return p.config, nil
+}
+
+func (p *MSIAttestorPlugin) setConfig(config *MSIAttestorConfig) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.config = config
+}
+
+func getTokenKeyID(token *jwt.JSONWebToken) (string, bool) {
+	for _, h := range token.Headers {
+		if h.KeyID != "" {
+			return h.KeyID, true
+		}
+	}
+	return "", false
+}

--- a/pkg/server/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/server/plugin/nodeattestor/azure/msi_test.go
@@ -1,0 +1,345 @@
+package azure
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spiffe/spire/pkg/common/jwtutil"
+	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	"github.com/spiffe/spire/proto/common"
+	"github.com/spiffe/spire/proto/common/plugin"
+	"github.com/spiffe/spire/proto/server/nodeattestor"
+	"github.com/stretchr/testify/suite"
+	jose "gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+var (
+	// Azure MSI tokens are RSA signed
+	keyPEM = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBywIBAAJhAKC4t/KjGW7qAuK89ZQGasYlI1octSwElSGioJag1w7s/d2EXjtY
+4FDYOYa8bKB3wC6rIzPDKUR783fZ3gJmvdI8TLlnj25wyPApVkRXC3ZQxYj5/hcG
+aQuNWr6zrY8C8QIDAQABAmB95nViQtWHhxTfnPobDLPTp//7dQWPB7/y6zw1AqW0
+8X0ka66Net+tNNRLcYr+YQ8Sv4suvGVo3NXBNU+jJVys2s+kB2vvfh5w/mpaEyM1
+C3UGsX8WWcRvxkxQhwR5VmECMQDWAufI9k7mfo8kjPcFcxKZbwiklTn0p6IVNXIf
+cA7f210xizyPm2NDUvs1v+f6Yw0CMQDAQT1zR4qlTm4tufG0+IlfPaP9FxvTl+ox
+dxnOm4DzNx14+seX6Mont4ucrrFnNnUCMQC3u8zVGqnId3VbMu7MreuU8N+htUAJ
+jHW58aWl2eXbSJCs/VYkEIra/P4ROk3mCG0CMQC3mpaRDXW/QRO/36CR7/lhV4DR
+J8yPWrlx3AhtY9zWaYBgFT+gN9U38PYIAF2z8DECMHNJ/MNm0Keasv9K3sfrCpL6
+bpR/VgtruOOSiOvJJ9xOAKCSsyeVpZdHrWlY7fkCKg==
+-----END RSA PRIVATE KEY-----`)
+)
+
+const (
+	resourceID = "https://example.org/app/"
+)
+
+func TestMSIAttestorPlugin(t *testing.T) {
+	suite.Run(t, new(MSIAttestorSuite))
+}
+
+type MSIAttestorSuite struct {
+	suite.Suite
+
+	attestor *nodeattestor.BuiltIn
+	key      *rsa.PrivateKey
+	jwks     *jose.JSONWebKeySet
+	now      time.Time
+}
+
+func (s *MSIAttestorSuite) SetupTest() {
+	// load up the signer used for JWT signing
+	var err error
+	s.key, err = pemutil.ParseRSAPrivateKey(keyPEM)
+	s.Require().NoError(err)
+	s.jwks = new(jose.JSONWebKeySet)
+	s.now = time.Now()
+
+	s.attestor = s.newAttestor()
+	s.configureAttestor()
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWhenNotConfigured() {
+	resp, err := s.doAttestOnAttestor(s.newAttestor(), &nodeattestor.AttestRequest{})
+	s.Require().EqualError(err, "azure-msi: not configured")
+	s.Require().Nil(resp)
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWhenAttestedBefore() {
+	s.requireAttestError(&nodeattestor.AttestRequest{AttestedBefore: true},
+		"azure-msi: node has already attested")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithNoAttestationData() {
+	s.requireAttestError(&nodeattestor.AttestRequest{},
+		"azure-msi: missing attestation data")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithWrongAttestationDataType() {
+	s.requireAttestError(&nodeattestor.AttestRequest{
+		AttestationData: &common.AttestationData{
+			Type: "blah",
+		},
+	}, `azure-msi: unexpected attestation data type "blah"`)
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithNoAttestationDataPayload() {
+	s.requireAttestError(&nodeattestor.AttestRequest{
+		AttestationData: &common.AttestationData{
+			Type: "azure_msi",
+		},
+	}, "azure-msi: missing attestation data payload")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithMalformedAttestationDataPayload() {
+	s.requireAttestError(&nodeattestor.AttestRequest{
+		AttestationData: &common.AttestationData{
+			Type: "azure_msi",
+			Data: []byte("{"),
+		},
+	}, "azure-msi: failed to unmarshal data payload")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithNoToken() {
+	s.requireAttestError(makeAttestRequest(""),
+		"azure-msi: missing token from attestation data")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithMalformedToken() {
+	s.requireAttestError(makeAttestRequest("blah"),
+		"azure-msi: unable to parse token")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsIfTokenKeyIDMissing() {
+	s.requireAttestError(s.signAttestRequest("", "", "", ""),
+		"azure-msi: token missing key id")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsIfTokenKeyIDNotFound() {
+	s.requireAttestError(s.signAttestRequest("KEYID", "", "", ""),
+		`azure-msi: key id "KEYID" not found`)
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsWithBadSignature() {
+	s.addKey("KEYID")
+
+	// sign a token and replace the signature
+	token := s.signToken("KEYID", "", "", "")
+	parts := strings.Split(token, ".")
+	s.Require().Len(parts, 3)
+	parts[2] = "aaaa"
+	token = strings.Join(parts, ".")
+
+	s.requireAttestError(makeAttestRequest(token),
+		"unable to verify token")
+}
+
+func (s *MSIAttestorSuite) TestAttestFailsClaimValidation() {
+	s.addKey("KEYID")
+
+	// missing tenant id claim
+	s.requireAttestError(s.signAttestRequest("KEYID", resourceID, "", "PRINCIPALID"),
+		"token missing tenant ID claim")
+
+	// unauthorized tenant id claim
+	s.requireAttestError(s.signAttestRequest("KEYID", resourceID, "BADTENANTID", "PRINCIPALID"),
+		"tenant ID is not authorized")
+
+	// no audience
+	s.requireAttestError(s.signAttestRequest("KEYID", "", "TENANTID", "PRINCIPALID"),
+		"invalid audience claim")
+
+	// wrong audience
+	s.requireAttestError(s.signAttestRequest("KEYID", "FOO", "TENANTID", "PRINCIPALID"),
+		"invalid audience claim")
+
+	// missing principal id (sub) claim
+	s.requireAttestError(s.signAttestRequest("KEYID", resourceID, "TENANTID", ""),
+		"token missing subject claim")
+}
+
+func (s *MSIAttestorSuite) TestAttestTokenExpiration() {
+	s.addKey("KEYID")
+	token := s.signAttestRequest("KEYID", resourceID, "TENANTID", "PRINCIPALID")
+
+	// within 5m leeway (token expires at 1m + 5m leeway = 6m)
+	s.adjustTime(6 * time.Minute)
+	_, err := s.doAttest(token)
+	s.Require().NotNil(err)
+
+	// just after 5m leeway
+	s.adjustTime(time.Second)
+	s.requireAttestError(token, "token is expired")
+}
+
+func (s *MSIAttestorSuite) TestAttestSuccess() {
+	s.addKey("KEYID")
+
+	// Success against TENANTID, which uses the custom resource ID
+	resp, err := s.doAttest(s.signAttestRequest("KEYID", resourceID, "TENANTID", "PRINCIPALID"))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().True(resp.Valid)
+	s.Require().Equal(resp.BaseSPIFFEID, "spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID")
+	s.Require().Nil(resp.Challenge)
+
+	// Success against TENANTID2, which uses the default resource ID
+	resp, err = s.doAttest(s.signAttestRequest("KEYID", azure.DefaultMSIResourceID, "TENANTID2", "PRINCIPALID"))
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().True(resp.Valid)
+	s.Require().Equal(resp.BaseSPIFFEID, "spiffe://example.org/spire/agent/azure_msi/TENANTID2/PRINCIPALID")
+	s.Require().Nil(resp.Challenge)
+}
+
+func (s *MSIAttestorSuite) TestConfigure() {
+	// malformed configuration
+	resp, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: "blah",
+	})
+	s.requireErrorContains(err, "azure-msi: unable to decode configuration")
+	s.Require().Nil(resp)
+
+	// missing trust domain
+	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{})
+	s.Require().EqualError(err, "azure-msi: configuration missing trust domain")
+	s.Require().Nil(resp)
+
+	// missing tenants
+	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `trust_domain = "example.org"`,
+	})
+	s.Require().EqualError(err, "azure-msi: configuration must have at least one tenant")
+	s.Require().Nil(resp)
+
+	// success
+	s.configureAttestor()
+}
+
+func (s *MSIAttestorSuite) TestGetPluginInfo() {
+	resp, err := s.attestor.GetPluginInfo(context.Background(), &plugin.GetPluginInfoRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.GetPluginInfoResponse{})
+}
+
+func (s *MSIAttestorSuite) adjustTime(d time.Duration) {
+	s.now = s.now.Add(d)
+}
+
+func (s *MSIAttestorSuite) newSigner(keyID string) jose.Signer {
+	signer, err := jose.NewSigner(jose.SigningKey{
+		Algorithm: "RS256",
+		Key: jose.JSONWebKey{
+			Key:   s.key,
+			KeyID: keyID,
+		},
+	}, nil)
+	s.Require().NoError(err)
+	return signer
+}
+
+func (s *MSIAttestorSuite) signToken(keyID, audience, tenantID, principalID string) string {
+	builder := jwt.Signed(s.newSigner(keyID))
+
+	// build up standard claims
+	claims := jwt.Claims{
+		Subject:   principalID,
+		NotBefore: jwt.NewNumericDate(s.now),
+		Expiry:    jwt.NewNumericDate(s.now.Add(time.Minute)),
+	}
+	if audience != "" {
+		claims.Audience = []string{audience}
+	}
+	builder = builder.Claims(claims)
+
+	// add the tenant id claim
+	if tenantID != "" {
+		builder = builder.Claims(map[string]interface{}{
+			"tid": tenantID,
+		})
+	}
+
+	token, err := builder.CompactSerialize()
+	s.Require().NoError(err)
+	return token
+}
+
+func (s *MSIAttestorSuite) signAttestRequest(keyID, audience, tenantID, principalID string) *nodeattestor.AttestRequest {
+	return makeAttestRequest(s.signToken(keyID, audience, tenantID, principalID))
+}
+
+func (s *MSIAttestorSuite) addKey(keyID string) {
+	s.jwks.Keys = append(s.jwks.Keys, jose.JSONWebKey{
+		Key:   s.key.Public(),
+		KeyID: keyID,
+	})
+}
+
+func (s *MSIAttestorSuite) newAttestor() *nodeattestor.BuiltIn {
+	attestor := NewMSIAttestorPlugin()
+	attestor.hooks.now = func() time.Time {
+		return s.now
+	}
+	attestor.hooks.keySetProvider = jwtutil.KeySetProviderFunc(func(ctx context.Context) (*jose.JSONWebKeySet, error) {
+		return s.jwks, nil
+	})
+	return nodeattestor.NewBuiltIn(attestor)
+}
+
+func (s *MSIAttestorSuite) configureAttestor() {
+	resp, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `
+		trust_domain = "example.org"
+		tenants = {
+			"TENANTID" = {
+				resource_id = "https://example.org/app/"
+			}
+			"TENANTID2" = {}
+		}
+		`,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.ConfigureResponse{})
+}
+
+func (s *MSIAttestorSuite) doAttest(req *nodeattestor.AttestRequest) (*nodeattestor.AttestResponse, error) {
+	return s.doAttestOnAttestor(s.attestor, req)
+}
+
+func (s *MSIAttestorSuite) doAttestOnAttestor(attestor *nodeattestor.BuiltIn, req *nodeattestor.AttestRequest) (*nodeattestor.AttestResponse, error) {
+	stream, err := attestor.Attest(context.Background())
+	s.Require().NoError(err)
+
+	err = stream.Send(req)
+	s.Require().NoError(err)
+
+	err = stream.CloseSend()
+	s.Require().NoError(err)
+
+	return stream.Recv()
+}
+
+func (s *MSIAttestorSuite) requireAttestError(req *nodeattestor.AttestRequest, contains string) {
+	resp, err := s.doAttest(req)
+	s.requireErrorContains(err, contains)
+	s.Require().Nil(resp)
+}
+
+func (s *MSIAttestorSuite) requireErrorContains(err error, contains string) {
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), contains)
+}
+
+func makeAttestRequest(token string) *nodeattestor.AttestRequest {
+	return &nodeattestor.AttestRequest{
+		AttestationData: &common.AttestationData{
+			Type: "azure_msi",
+			Data: []byte(fmt.Sprintf(`{"token": %q}`, token)),
+		},
+	}
+}


### PR DESCRIPTION
This PR provides Azure MSI-based node attestation. Agents, that run on an Azure VM with MSI support, request a signed MSI token from the Instance Metadata Service. The token is passed to the server which validates the signature and extracts out the Azure Tenant ID and Principal Id, which can be used to uniquely identify the Agent VM.

Server's do not need to be running inside of Azure to perform attestation and can be configured to support more than one Azure tenant.

Signed-off-by: Andrew Harding <azdagron@gmail.com>