### PR TITLE
Azure MSI node resolver plugin

### DIFF
--- a/doc/plugin_server_noderesolver_azure_msi.md
+++ b/doc/plugin_server_noderesolver_azure_msi.md
@@ -17,13 +17,18 @@ The set of selectors current supported:
 | Virtual Network        | `virtual-network:frontend:vnet`                        | The name of the virtual network (e.g. `vnet`) qualified by the resource group (e.g. `frontend`)
 | Virtual Network Subnet | `virtual-network:frontend:vnet:default`                | The name of the virtual network subnet (e.g. `default`) qualfied by the virtual network and resource group
 
+All of the selectors have the type `azure_msi`.
+
 The server plugin does not need to be running in Azure in order to perform node
 resolution. The plugin can be configured to authenticate with Azure services
-using either MSI or credentials for an application registered in an Azure AD tenant.
+using either MSI or credentials for an application registered in an Azure AD
+tenant. If MSI is used for authentication, only resolver will only be able to
+resolve nodes within the same tenant.
+
 
 | Configuration   | Description | Default                 |
 | --------------- | ----------- | ----------------------- |
-| `use_msi`       | Whether or not to use MSI to authenticate to Azure services. If true, the `tenants` map must be empty. | |
+| `use_msi`       | Whether or not to use MSI to authenticate to Azure services. If true, the `tenants` map must be empty. | false |
 | `tenants`       | A map of tenants, keyed by tenant ID. `use_msi` must be false if this value is set. | |
 
 Each tenant in the tenant configuration map supports the following:

--- a/doc/plugin_server_noderesolver_azure_msi.md
+++ b/doc/plugin_server_noderesolver_azure_msi.md
@@ -1,0 +1,51 @@
+# Server plugin: NodeResolver "azure_msi"
+
+*Must be used in conjunction with the server azure_msi nodeattestor plugin*
+
+The `azure_msi` plugin attests resolves nodes running in Microsoft Azure that
+have attested using Managed Service Identity (MSI). The resolver extracts the
+Tenant ID and Principal ID from the agent SPIFFE ID and uses the various Azure
+services to get information for building a set of selectors.
+
+The set of selectors current supported:
+
+| Selector               | Example                                                | Description                                                |
+| ---------------------- | ------------------------------------------------------ | -----------------------------------------------------------|
+| Subscription ID        | `subscription-id:d5b40d61-272e-48da-beb9-05f295c42bd6` | The subscription the node belongs to |
+| Virtual Machine Name   | `vm-name:frontend:blog`                                | The name of the virtual machine (e.g. `blog`) qualified by the resource group (e.g. `frontend`)
+| Network Security Group | `network-security-group:frontend:webservers`           | The name of the network security group (e.g. `webservers`) qualified by the resource group (e.g. `frontend`)
+| Virtual Network        | `virtual-network:frontend:vnet`                        | The name of the virtual network (e.g. `vnet`) qualified by the resource group (e.g. `frontend`)
+| Virtual Network Subnet | `virtual-network:frontend:vnet:default`                | The name of the virtual network subnet (e.g. `default`) qualfied by the virtual network and resource group
+
+The server plugin does not need to be running in Azure in order to perform node
+resolution. The plugin can be configured to authenticate with Azure services
+using either MSI or credentials for an application registered in an Azure AD tenant.
+
+| Configuration   | Description | Default                 |
+| --------------- | ----------- | ----------------------- |
+| `use_msi`       | Whether or not to use MSI to authenticate to Azure services. If true, the `tenants` map must be empty. | |
+| `tenants`       | A map of tenants, keyed by tenant ID. `use_msi` must be false if this value is set. | |
+
+Each tenant in the tenant configuration map supports the following:
+
+| Configuration | Description | Default                 |
+| ------------- | ----------- | ----------------------- |
+| `subscription_id` | The subscription the tenant resides in | |
+| `app_id` | The application id | |
+| `app_secret` | The application secret | |
+
+A sample configuration:
+
+```
+    NodeResolver "azure_msi" {
+        enabled = true
+        plugin_data {
+            use_msi = false
+            tenants = {
+                subscription_id = SUBSCRIPTION_ID
+                app_id = APP_ID
+                app_secret = APP_SECRET
+            }
+        }
+    }
+```

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 35f27a42ef95c2096d1e978ff87429ab29a41fb0e5d4fd4f8ef3a89c2964ee5d
-updated: 2018-07-31T08:34:53.388235-06:00
+updated: 2018-07-31T10:13:45.167019-06:00
 imports:
 - name: github.com/armon/go-metrics
   version: 783273d703149aaeb9897cf58613d5af48861c25
@@ -37,6 +37,24 @@ imports:
   - private/protocol/xml/xmlutil
   - service/ec2
   - service/sts
+- name: github.com/Azure/azure-sdk-for-go
+  version: 4e8cbbfb1aeab140cd0fa97fd16b64ee18c3ca6a
+  subpackages:
+  - services/compute/mgmt/2017-12-01/compute
+  - services/resources/mgmt/2018-02-01/resources
+  - version
+- name: github.com/Azure/go-autorest
+  version: dd94e014aaf16d1df746762e392aa201c1b4c461
+  subpackages:
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/azure/auth
+  - autorest/date
+  - autorest/to
+  - autorest/validation
+  - logger
+  - version
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
 - name: github.com/davecgh/go-spew
@@ -45,6 +63,8 @@ imports:
   - spew
 - name: github.com/dgrijalva/jwt-go
   version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
+- name: github.com/dimchansky/utfbom
+  version: 5448fe645cb1964ba70ac8f9f2ffe975e61a536c
 - name: github.com/go-ini/ini
   version: 32e4be5f41bb918afb6e37c07426e2ddbcb6647e
 - name: github.com/go-ole/go-ole
@@ -182,6 +202,8 @@ imports:
   subpackages:
   - ed25519
   - ed25519/internal/edwards25519
+  - pkcs12
+  - pkcs12/internal/rc2
   - ssh/terminal
 - name: golang.org/x/net
   version: 5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec

--- a/pkg/common/plugin/azure/msi_test.go
+++ b/pkg/common/plugin/azure/msi_test.go
@@ -26,32 +26,95 @@ func TestFetchMSIToken(t *testing.T) {
 	ctx := context.Background()
 
 	// unexpected status
-	token, err := FetchMSIToken(ctx, fakeHTTPClient(http.StatusBadRequest, "ERROR"), "RESOURCE")
+	token, err := FetchMSIToken(ctx, fakeTokenHTTPClient(http.StatusBadRequest, "ERROR"), "RESOURCE")
 	require.EqualError(t, err, "unexpected status code 400: ERROR")
 	require.Empty(t, token)
 
 	// empty response
-	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, ""), "RESOURCE")
+	token, err = FetchMSIToken(ctx, fakeTokenHTTPClient(http.StatusOK, ""), "RESOURCE")
 	require.EqualError(t, err, "unable to decode response: EOF")
 	require.Empty(t, token)
 
 	// malformed response
-	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, "{"), "RESOURCE")
+	token, err = FetchMSIToken(ctx, fakeTokenHTTPClient(http.StatusOK, "{"), "RESOURCE")
 	require.EqualError(t, err, "unable to decode response: unexpected EOF")
 	require.Empty(t, token)
 
 	// no access token
-	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, "{}"), "RESOURCE")
+	token, err = FetchMSIToken(ctx, fakeTokenHTTPClient(http.StatusOK, "{}"), "RESOURCE")
 	require.EqualError(t, err, "response missing access token")
 	require.Empty(t, token)
 
 	// success
-	token, err = FetchMSIToken(ctx, fakeHTTPClient(http.StatusOK, `{"access_token": "ASDF"}`), "RESOURCE")
+	token, err = FetchMSIToken(ctx, fakeTokenHTTPClient(http.StatusOK, `{"access_token": "ASDF"}`), "RESOURCE")
 	require.NoError(t, err)
 	require.Equal(t, "ASDF", token)
 }
 
-func fakeHTTPClient(statusCode int, body string) HTTPClient {
+func TestFetchInstanceMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	// unexpected status
+	metadata, err := FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusBadRequest, "ERROR"))
+	require.EqualError(t, err, "unexpected status code 400: ERROR")
+	require.Nil(t, metadata)
+
+	// empty response
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, ""))
+	require.EqualError(t, err, "unable to decode response: EOF")
+	require.Nil(t, metadata)
+
+	// malformed response
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, "{"))
+	require.EqualError(t, err, "unable to decode response: unexpected EOF")
+	require.Nil(t, metadata)
+
+	// no instance name
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, `{
+		"compute": {
+			"subscriptionId": "SUBSCRIPTION",
+			"resourceGroupName": "RESOURCEGROUP"
+		}}`))
+	require.EqualError(t, err, "response missing instance name")
+	require.Nil(t, metadata)
+
+	// no subscription id
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, `{
+		"compute": {
+			"name": "NAME",
+			"resourceGroupName": "RESOURCEGROUP"
+		}}`))
+	require.EqualError(t, err, "response missing instance subscription id")
+	require.Nil(t, metadata)
+
+	// no resource group name
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, `{
+		"compute": {
+			"name": "NAME",
+			"subscriptionId": "SUBSCRIPTION"
+		}}`))
+	require.EqualError(t, err, "response missing instance resource group name")
+	require.Nil(t, metadata)
+
+	// success
+	expected := &InstanceMetadata{
+		Compute: ComputeMetadata{
+			Name:              "NAME",
+			SubscriptionID:    "SUBSCRIPTION",
+			ResourceGroupName: "RESOURCEGROUP",
+		},
+	}
+	metadata, err = FetchInstanceMetadata(ctx, fakeMetadataHTTPClient(http.StatusOK, `{
+		"compute": {
+			"name": "NAME",
+			"subscriptionId": "SUBSCRIPTION",
+			"resourceGroupName": "RESOURCEGROUP"
+		}}`))
+	require.NoError(t, err)
+	require.Equal(t, expected, metadata)
+}
+
+func fakeTokenHTTPClient(statusCode int, body string) HTTPClient {
 	return HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
 		// assert the expected request values
 		if req.Method != "GET" {
@@ -65,6 +128,30 @@ func fakeHTTPClient(statusCode int, body string) HTTPClient {
 		}
 		if v := req.URL.Query().Get("resource"); v != "RESOURCE" {
 			return nil, fmt.Errorf("unexpected resource %q", v)
+		}
+		if v := req.Header.Get("metadata"); v != "true" {
+			return nil, fmt.Errorf("unexpected metadata header %q", v)
+		}
+
+		// return the response
+		return &http.Response{
+			StatusCode: statusCode,
+			Body:       ioutil.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+}
+
+func fakeMetadataHTTPClient(statusCode int, body string) HTTPClient {
+	return HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+		// assert the expected request values
+		if req.Method != "GET" {
+			return nil, fmt.Errorf("unexpected method %q", req.Method)
+		}
+		if req.URL.Path != "/metadata/instance" {
+			return nil, fmt.Errorf("unexpected path %q", req.URL.Path)
+		}
+		if v := req.URL.Query().Get("api-version"); v != "2017-08-01" {
+			return nil, fmt.Errorf("unexpected api version %q", v)
 		}
 		if v := req.Header.Get("metadata"); v != "true" {
 			return nil, fmt.Errorf("unexpected metadata header %q", v)

--- a/pkg/server/plugin/noderesolver/azure/client.go
+++ b/pkg/server/plugin/noderesolver/azure/client.go
@@ -1,0 +1,89 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/zeebo/errs"
+)
+
+// apiClient is an interface representing all of the API methods the resolver
+// needs to do its job.
+type apiClient interface {
+	SubscriptionID() string
+	GetVirtualMachineResourceID(ctx context.Context, principalID string) (string, error)
+	GetVirtualMachine(ctx context.Context, resourceGroup string, name string) (*compute.VirtualMachine, error)
+	GetNetworkInterface(ctx context.Context, resourceGroup string, name string) (*network.Interface, error)
+}
+
+// azureClient implements apiClient using Azure SDK client implementations
+type azureClient struct {
+	subscriptionID string
+	r              resources.Client
+	v              compute.VirtualMachinesClient
+	n              network.InterfacesClient
+}
+
+func newAzureClient(subscriptionID string, authorizer autorest.Authorizer) apiClient {
+	r := resources.NewClient(subscriptionID)
+	r.Authorizer = authorizer
+
+	v := compute.NewVirtualMachinesClient(subscriptionID)
+	v.Authorizer = authorizer
+
+	n := network.NewInterfacesClient(subscriptionID)
+	n.Authorizer = authorizer
+
+	return &azureClient{
+		subscriptionID: subscriptionID,
+		r:              r,
+		v:              v,
+		n:              n,
+	}
+}
+
+func (c *azureClient) SubscriptionID() string {
+	return c.subscriptionID
+}
+
+func (c *azureClient) GetVirtualMachineResourceID(ctx context.Context, principalID string) (string, error) {
+	filter := fmt.Sprintf("resourceType eq 'Microsoft.Compute/virtualMachines' and identity/principalId eq '%s'", principalID)
+	result, err := c.r.List(ctx, filter, "", nil)
+	if err != nil {
+		return "", errs.Wrap(err)
+	}
+
+	values := result.Values()
+	if len(values) == 0 {
+		return "", errs.New("principal %q not found", principalID)
+	}
+	if len(values) > 1 {
+		return "", errs.New("expected one result at most", principalID)
+	}
+	if values[0].ID == nil || *values[0].ID == "" {
+		return "", errs.New("resource missing ID")
+	}
+
+	return *values[0].ID, nil
+
+}
+
+func (c *azureClient) GetVirtualMachine(ctx context.Context, resourceGroup string, name string) (*compute.VirtualMachine, error) {
+	vm, err := c.v.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	return &vm, nil
+}
+
+func (c *azureClient) GetNetworkInterface(ctx context.Context, resourceGroup string, name string) (*network.Interface, error) {
+	ni, err := c.n.Get(ctx, resourceGroup, name, "")
+	if err != nil {
+		return nil, errs.Wrap(err)
+	}
+	return &ni, nil
+}

--- a/pkg/server/plugin/noderesolver/azure/msi.go
+++ b/pkg/server/plugin/noderesolver/azure/msi.go
@@ -1,0 +1,312 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/hashicorp/hcl"
+	"github.com/sirupsen/logrus"
+	"github.com/zeebo/errs"
+
+	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	"github.com/spiffe/spire/proto/common"
+	spi "github.com/spiffe/spire/proto/common/plugin"
+	"github.com/spiffe/spire/proto/server/noderesolver"
+)
+
+const (
+	pluginName = "azure_msi"
+)
+
+var (
+	msiError = errs.Class("azure-msi")
+
+	reAgentIDPath            = regexp.MustCompile(`^/spire/agent/azure_msi/([^/]+)/([^/]+)`)
+	reVirtualMachineID       = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Compute/virtualMachines/([^/]+)$`)
+	reNetworkSecurityGroupID = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Network/networkSecurityGroups/([^/]+)$`)
+	reNetworkInterfaceID     = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Network/networkInterfaces/([^/]+)$`)
+	reVirtualNetworkSubnetID = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Network/virtualNetworks/([^/]+)/subnets/([^/]+)$`)
+)
+
+type TenantConfig struct {
+	SubscriptionId string `hcl:"subscription_id" json:"subscription_id"`
+	AppId          string `hcl:"app_id" json:"app_id"`
+	AppSecret      string `hcl:"app_secret" json:"app_secret"`
+}
+
+type MSIResolverConfig struct {
+	UseMSI  bool                    `hcl:"use_msi" json:"use_msi"`
+	Tenants map[string]TenantConfig `hcl:"tenants" json:"tenants"`
+}
+
+type MSIResolverPlugin struct {
+	mu            sync.RWMutex
+	msiClient     apiClient
+	tenantClients map[string]apiClient
+
+	hooks struct {
+		newClient             func(string, autorest.Authorizer) apiClient
+		fetchInstanceMetadata func(context.Context, azure.HTTPClient) (*azure.InstanceMetadata, error)
+	}
+}
+
+var _ noderesolver.Plugin = (*MSIResolverPlugin)(nil)
+
+func NewMSIResolverPlugin() *MSIResolverPlugin {
+	p := &MSIResolverPlugin{}
+	p.hooks.newClient = newAzureClient
+	p.hooks.fetchInstanceMetadata = azure.FetchInstanceMetadata
+	return p
+}
+
+func (p *MSIResolverPlugin) Resolve(ctx context.Context, req *noderesolver.ResolveRequest) (*noderesolver.ResolveResponse, error) {
+	resp := &noderesolver.ResolveResponse{
+		Map: make(map[string]*common.Selectors),
+	}
+	for _, spiffeID := range req.BaseSpiffeIdList {
+		selectors, err := p.resolveSpiffeID(ctx, spiffeID)
+		if err != nil {
+			return nil, err
+		}
+		if selectors != nil {
+			resp.Map[spiffeID] = selectors
+		}
+	}
+
+	return resp, nil
+}
+
+func (p *MSIResolverPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := new(MSIResolverConfig)
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, msiError.New("unable to decode configuration: %v", err)
+	}
+
+	var msiClient apiClient
+	var tenantClients map[string]apiClient
+
+	if config.UseMSI {
+		if len(config.Tenants) > 0 {
+			return nil, msiError.New("configuration cannot have tenants when using MSI")
+		}
+		instanceMetadata, err := p.hooks.fetchInstanceMetadata(ctx, http.DefaultClient)
+		if err != nil {
+			return nil, msiError.Wrap(err)
+		}
+		authorizer, err := auth.NewMSIConfig().Authorizer()
+		if err != nil {
+			return nil, msiError.Wrap(err)
+		}
+		msiClient = p.hooks.newClient(instanceMetadata.Compute.SubscriptionID, authorizer)
+	} else {
+		if len(config.Tenants) == 0 {
+			return nil, msiError.New("configuration must have at least one tenant when not using MSI")
+		}
+		tenantClients = make(map[string]apiClient)
+		for tenantID, tenant := range config.Tenants {
+			if tenant.SubscriptionId == "" {
+				return nil, msiError.New("misconfigured tenant %q: missing subscription id", tenantID)
+			}
+			if tenant.AppId == "" {
+				return nil, msiError.New("misconfigured tenant %q: missing app id", tenantID)
+			}
+			if tenant.AppSecret == "" {
+				return nil, msiError.New("misconfigured tenant %q: missing app secret", tenantID)
+			}
+			authorizer, err := auth.NewClientCredentialsConfig(tenant.AppId, tenant.AppSecret, tenantID).Authorizer()
+			if err != nil {
+				return nil, msiError.Wrap(err)
+			}
+			tenantClients[tenantID] = p.hooks.newClient(tenant.SubscriptionId, authorizer)
+		}
+	}
+
+	p.setClients(msiClient, tenantClients)
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (p *MSIResolverPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p *MSIResolverPlugin) getClient(tenantID string) (apiClient, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	switch {
+	case p.msiClient != nil:
+		return p.msiClient, nil
+	case p.tenantClients != nil:
+		client, ok := p.tenantClients[tenantID]
+		if !ok {
+			return nil, msiError.New("not configured for tenant %q", tenantID)
+		}
+		return client, nil
+	default:
+		return nil, msiError.New("not configured")
+	}
+}
+
+func (p *MSIResolverPlugin) setClients(msiClient apiClient, tenantClients map[string]apiClient) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.msiClient = msiClient
+	p.tenantClients = tenantClients
+}
+
+func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string) (*common.Selectors, error) {
+	// parse out the tenant ID and principal ID from the token
+	u, err := idutil.ParseSpiffeID(spiffeID, idutil.AllowAnyTrustDomainAgent())
+	if err != nil {
+		return nil, msiError.Wrap(err)
+	}
+
+	tenantID, principalID, err := parseAgentIDPath(u.Path)
+	if err != nil {
+		logrus.Warnf("unrecognized Agent ID %q", spiffeID)
+		return nil, nil
+	}
+
+	client, err := p.getClient(tenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Retrieve the resource belonging to the principal id.
+	vmResourceID, err := client.GetVirtualMachineResourceID(ctx, principalID)
+	if err != nil {
+		return nil, msiError.New("unable to get resource for principal %q: %v", principalID, err)
+	}
+
+	// parse out the resource group and vm name from the resource ID
+	vmResourceGroup, vmName, err := parseVirtualMachineID(vmResourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// build up a unique map of selectors. this is easier than deduping
+	// individual selectors (e.g. the virtual network for each interface)
+	selectorMap := make(map[string]bool)
+	addSelector := func(parts ...string) {
+		selectorMap[strings.Join(parts, ":")] = true
+	}
+
+	addSelector("subscription-id", client.SubscriptionID())
+	addSelector("vm-name", vmResourceGroup, vmName)
+
+	// pull the VM information
+	vm, err := client.GetVirtualMachine(ctx, vmResourceGroup, vmName)
+	if err != nil {
+		return nil, msiError.New("unable to get virtual machine %q: %v", resourceGroupName(vmResourceGroup, vmName), err)
+	}
+
+	if np := vm.NetworkProfile; np != nil {
+		if nis := np.NetworkInterfaces; nis != nil {
+			for _, ni := range *nis {
+				if ni.ID == nil {
+					continue
+				}
+				niResourceGroup, niName, err := parseNetworkInterfaceID(*ni.ID)
+				if err != nil {
+					return nil, err
+				}
+				networkInterface, err := client.GetNetworkInterface(ctx, niResourceGroup, niName)
+				if err != nil {
+					return nil, msiError.New("unable to get network interface %q: %v", resourceGroupName(niResourceGroup, niName), err)
+				}
+
+				if nsg := networkInterface.NetworkSecurityGroup; nsg != nil && nsg.ID != nil {
+					nsgResourceGroup, nsgName, err := parseNetworkSecurityGroupID(*nsg.ID)
+					if err != nil {
+						return nil, err
+					}
+					addSelector("network-security-group", nsgResourceGroup, nsgName)
+				}
+
+				if ipcs := networkInterface.IPConfigurations; ipcs != nil {
+					for _, ipc := range *ipcs {
+						if props := ipc.InterfaceIPConfigurationPropertiesFormat; props != nil {
+							if subnet := props.Subnet; subnet != nil && subnet.ID != nil {
+								subResourceGroup, subVirtualNetwork, subName, err := parseVirtualNetworkSubnetID(*subnet.ID)
+								if err != nil {
+									return nil, err
+								}
+								addSelector("virtual-network", subResourceGroup, subVirtualNetwork)
+								addSelector("virtual-network-subnet", subResourceGroup, subVirtualNetwork, subName)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// sort and return selectors
+	selectorValues := make([]string, 0, len(selectorMap))
+	for selectorValue := range selectorMap {
+		selectorValues = append(selectorValues, selectorValue)
+	}
+	sort.Strings(selectorValues)
+
+	selectors := &common.Selectors{}
+	for _, selectorValue := range selectorValues {
+		selectors.Entries = append(selectors.Entries, &common.Selector{
+			Type:  pluginName,
+			Value: selectorValue,
+		})
+	}
+
+	return selectors, nil
+}
+
+func parseAgentIDPath(path string) (tenantID, principalID string, err error) {
+	m := reAgentIDPath.FindStringSubmatch(path)
+	if m == nil {
+		return "", "", msiError.New("malformed agent ID path %q", path)
+	}
+	return m[1], m[2], nil
+}
+
+func parseVirtualMachineID(id string) (resourceGroup, name string, err error) {
+	m := reVirtualMachineID.FindStringSubmatch(id)
+	if m == nil {
+		return "", "", msiError.New("malformed virtual machine ID %q", id)
+	}
+	return m[1], m[2], nil
+}
+
+func parseNetworkSecurityGroupID(id string) (resourceGroup, name string, err error) {
+	m := reNetworkSecurityGroupID.FindStringSubmatch(id)
+	if m == nil {
+		return "", "", msiError.New("malformed network security group ID %q", id)
+	}
+	return m[1], m[2], nil
+}
+
+func parseNetworkInterfaceID(id string) (resourceGroup, name string, err error) {
+	m := reNetworkInterfaceID.FindStringSubmatch(id)
+	if m == nil {
+		return "", "", msiError.New("malformed network interface ID %q", id)
+	}
+	return m[1], m[2], nil
+}
+
+func parseVirtualNetworkSubnetID(id string) (resourceGroup, networkName, subnetName string, err error) {
+	m := reVirtualNetworkSubnetID.FindStringSubmatch(id)
+	if m == nil {
+		return "", "", "", msiError.New("malformed virtual network subnet ID %q", id)
+	}
+	return m[1], m[2], m[3], nil
+}
+
+func resourceGroupName(resourceGroup, name string) string {
+	return fmt.Sprintf("%s:%s", resourceGroup, name)
+}

--- a/pkg/server/plugin/noderesolver/azure/msi_test.go
+++ b/pkg/server/plugin/noderesolver/azure/msi_test.go
@@ -1,0 +1,397 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	"github.com/spiffe/spire/proto/common"
+	"github.com/spiffe/spire/proto/common/plugin"
+	"github.com/spiffe/spire/proto/server/noderesolver"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	azureAgentID = "spiffe://example.org/spire/agent/azure_msi/TENANT/PRINCIPAL"
+	vmResourceID = "/subscriptions/SUBSCRIPTIONID/resourceGroups/RESOURCEGROUP/providers/Microsoft.Compute/virtualMachines/VIRTUALMACHINE"
+)
+
+var (
+	// these are vars because the address is needed
+	niResourceID        = "/subscriptions/SUBSCRIPTIONID/resourceGroups/RESOURCEGROUP/providers/Microsoft.Network/networkInterfaces/NETWORKINTERFACE"
+	nsgResourceID       = "/subscriptions/SUBSCRIPTIONID/resourceGroups/NSGRESOURCEGROUP/providers/Microsoft.Network/networkSecurityGroups/NETWORKSECURITYGROUP"
+	subnetResourceID    = "/subscriptions/SUBSCRIPTIONID/resourceGroups/NETRESOURCEGROUP/providers/Microsoft.Network/virtualNetworks/VIRTUALNETWORK/subnets/SUBNET"
+	malformedResourceID = "MALFORMEDRESOURCEID"
+
+	// these are expected selectors
+	vmSelectors = []string{
+		"subscription-id:SUBSCRIPTION",
+		"vm-name:RESOURCEGROUP:VIRTUALMACHINE",
+	}
+	niSelectors = []string{
+		"network-security-group:NSGRESOURCEGROUP:NETWORKSECURITYGROUP",
+		"virtual-network:NETRESOURCEGROUP:VIRTUALNETWORK",
+		"virtual-network-subnet:NETRESOURCEGROUP:VIRTUALNETWORK:SUBNET",
+	}
+)
+
+func TestMSIResolver(t *testing.T) {
+	suite.Run(t, new(MSIResolverSuite))
+}
+
+type MSIResolverSuite struct {
+	suite.Suite
+
+	api *fakeAPIClient
+
+	resolver *noderesolver.BuiltIn
+}
+
+func (s *MSIResolverSuite) SetupTest() {
+	// set up the API with an initial view of the virtual machine
+	s.api = newFakeAPIClient(s.T())
+
+	resolver := NewMSIResolverPlugin()
+	resolver.hooks.newClient = func(string, autorest.Authorizer) apiClient {
+		return s.api
+	}
+	resolver.hooks.fetchInstanceMetadata = func(context.Context, azure.HTTPClient) (*azure.InstanceMetadata, error) {
+		return &azure.InstanceMetadata{
+			Compute: azure.ComputeMetadata{
+				SubscriptionID: "SUBSCRIPTION",
+			},
+		}, nil
+	}
+	s.resolver = noderesolver.NewBuiltIn(resolver)
+	s.configureResolverWithTenant()
+}
+
+func (s *MSIResolverSuite) TestResolveWithEmptyRequest() {
+	resp, err := s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Empty(resp.Map)
+}
+
+func (s *MSIResolverSuite) TestResolveWithNonAgentID() {
+	s.assertResolveFailure("spiffe://example.org/spire/server/whatever",
+		`azure-msi: "spiffe://example.org/spire/server/whatever" is not a valid agent SPIFFE ID`)
+}
+
+func (s *MSIResolverSuite) TestResolveWithNonAzureAgentID() {
+	// agent ID's that aren't recognized by the resolver are simply ignored
+	resp, err := s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{
+		BaseSpiffeIdList: []string{"spiffe://example.org/spire/agent/whatever"},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Empty(resp.Map)
+}
+
+func (s *MSIResolverSuite) TestResolveWithUnrecognizedTenant() {
+	s.assertResolveFailure("spiffe://example.org/spire/agent/azure_msi/SOMEOTHERTENANT/PRINCIPAL",
+		`azure-msi: not configured for tenant "SOMEOTHERTENANT"`)
+}
+
+func (s *MSIResolverSuite) TestResolveWithNoVirtualMachineResource() {
+	s.api.SetVirtualMachineResourceID("PRINCIPAL", "")
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: unable to get resource for principal "PRINCIPAL": not found`)
+}
+
+func (s *MSIResolverSuite) TestResolveWithMalformedResourceID() {
+	s.api.SetVirtualMachineResourceID("PRINCIPAL", malformedResourceID)
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: malformed virtual machine ID "MALFORMEDRESOURCEID"`)
+}
+
+func (s *MSIResolverSuite) TestResolveWithNoVirtualMachineInfo() {
+	s.api.SetVirtualMachineResourceID("PRINCIPAL", vmResourceID)
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: unable to get virtual machine "RESOURCEGROUP:VIRTUALMACHINE"`)
+}
+
+func (s *MSIResolverSuite) TestResolveVirtualMachine() {
+	vm := &compute.VirtualMachine{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{},
+	}
+	s.setVirtualMachine(vm)
+
+	// no network profile
+	s.assertResolveSuccess(vmSelectors)
+
+	// network profile with no interfaces
+	vm.NetworkProfile = &compute.NetworkProfile{}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network profile with empty interface
+	vm.NetworkProfile.NetworkInterfaces = &[]compute.NetworkInterfaceReference{{}}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network profile with interface with malformed ID
+	vm.NetworkProfile.NetworkInterfaces = &[]compute.NetworkInterfaceReference{{ID: &malformedResourceID}}
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: malformed network interface ID "MALFORMEDRESOURCEID"`)
+
+	// network profile with interface with no interface info
+	vm.NetworkProfile.NetworkInterfaces = &[]compute.NetworkInterfaceReference{{ID: &niResourceID}}
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: unable to get network interface "RESOURCEGROUP:NETWORKINTERFACE"`)
+
+	// network interface with no security group or ip config
+	ni := &network.Interface{
+		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{},
+	}
+	s.setNetworkInterface(ni)
+	s.assertResolveSuccess(vmSelectors)
+
+	// network interface with malformed security group
+	ni.NetworkSecurityGroup = &network.SecurityGroup{ID: &malformedResourceID}
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: malformed network security group ID "MALFORMEDRESOURCEID"`)
+	ni.NetworkSecurityGroup = nil
+
+	// network interface with no ip configuration
+	ni.IPConfigurations = &[]network.InterfaceIPConfiguration{}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network interface with empty ip configuration
+	ni.IPConfigurations = &[]network.InterfaceIPConfiguration{{}}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network interface with empty ip configuration properties
+	props := new(network.InterfaceIPConfigurationPropertiesFormat)
+	ni.IPConfigurations = &[]network.InterfaceIPConfiguration{{InterfaceIPConfigurationPropertiesFormat: props}}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network interface with subnet with no ID
+	props.Subnet = &network.Subnet{}
+	s.assertResolveSuccess(vmSelectors)
+
+	// network interface with subnet with malformed ID
+	props.Subnet.ID = &malformedResourceID
+	s.assertResolveFailure(azureAgentID,
+		`azure-msi: malformed virtual network subnet ID "MALFORMEDRESOURCEID"`)
+
+	// network interface with good subnet and security group
+	ni.NetworkSecurityGroup = &network.SecurityGroup{ID: &nsgResourceID}
+	props.Subnet.ID = &subnetResourceID
+	s.assertResolveSuccess(vmSelectors, niSelectors)
+}
+
+func (s *MSIResolverSuite) TestConfigure() {
+	resp, err := s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: "blah",
+	})
+	s.requireErrorContains(err, "azure-msi: unable to decode configuration")
+	s.Require().Nil(resp)
+
+	// no tenants (not using MSI)
+	resp, err = s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{})
+	s.Require().EqualError(err, "azure-msi: configuration must have at least one tenant when not using MSI")
+	s.Require().Nil(resp)
+
+	// tenant missing subscription id
+	resp, err = s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `tenants = {
+			TENANT = {
+				app_id = "APPID"
+				app_secret = "APPSECRET"
+			}
+		}`})
+	s.Require().EqualError(err, `azure-msi: misconfigured tenant "TENANT": missing subscription id`)
+	s.Require().Nil(resp)
+
+	// tenant missing app id
+	resp, err = s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `tenants = {
+			TENANT = {
+				subscription_id = "SUBSCRIPTION"
+				app_secret = "APPSECRET"
+			}
+		}`})
+	s.Require().EqualError(err, `azure-msi: misconfigured tenant "TENANT": missing app id`)
+	s.Require().Nil(resp)
+
+	// tenant missing app secret
+	resp, err = s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `tenants = {
+			TENANT = {
+				subscription_id = "SUBSCRIPTION"
+				app_id = "APPID"
+			}
+		}`})
+	s.Require().EqualError(err, `azure-msi: misconfigured tenant "TENANT": missing app secret`)
+	s.Require().Nil(resp)
+
+	// success with tenant configuration
+	s.configureResolverWithTenant()
+
+	// both MSI and tenant
+	resp, err = s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `
+		use_msi = true
+		tenants = {
+			TENANT = {}
+		}`})
+	s.Require().EqualError(err, "azure-msi: configuration cannot have tenants when using MSI")
+	s.Require().Nil(resp)
+
+	// success using MSI configuration
+	s.configureResolverWithMSI()
+}
+
+func (s *MSIResolverSuite) TestGetPluginInfo() {
+	resp, err := s.resolver.GetPluginInfo(context.Background(), &plugin.GetPluginInfoRequest{})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.GetPluginInfoResponse{})
+}
+
+func (s *MSIResolverSuite) configureResolverWithTenant() {
+	resp, err := s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `tenants = {
+			TENANT = {
+				subscription_id = "SUBSCRIPTION"
+				app_id = "APPID"
+				app_secret = "APPSECRET"
+			}
+		}`})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.ConfigureResponse{})
+}
+
+func (s *MSIResolverSuite) configureResolverWithMSI() {
+	resp, err := s.resolver.Configure(context.Background(), &plugin.ConfigureRequest{
+		Configuration: `use_msi = true`,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(resp, &plugin.ConfigureResponse{})
+}
+
+func (s *MSIResolverSuite) assertResolveSuccess(selectorValueSets ...[]string) {
+	var selectorValues []string
+	for _, values := range selectorValueSets {
+		for _, value := range values {
+			selectorValues = append(selectorValues, value)
+		}
+	}
+	sort.Strings(selectorValues)
+
+	selectors := &common.Selectors{}
+	for _, selectorValue := range selectorValues {
+		selectors.Entries = append(selectors.Entries, &common.Selector{
+			Type:  "azure_msi",
+			Value: selectorValue,
+		})
+	}
+
+	expected := &noderesolver.ResolveResponse{
+		Map: map[string]*common.Selectors{
+			azureAgentID: selectors,
+		},
+	}
+
+	actual, err := s.doResolve(azureAgentID)
+	s.Require().NoError(err)
+	s.Require().Equal(expected, actual)
+}
+
+func (s *MSIResolverSuite) assertResolveFailure(spiffeID, containsErr string) {
+	resp, err := s.doResolve(spiffeID)
+	s.requireErrorContains(err, containsErr)
+	s.Require().Nil(resp)
+}
+
+func (s *MSIResolverSuite) doResolve(spiffeID string) (*noderesolver.ResolveResponse, error) {
+	return s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{
+		BaseSpiffeIdList: []string{spiffeID},
+	})
+}
+
+func (s *MSIResolverSuite) requireErrorContains(err error, contains string) {
+	s.Require().Error(err)
+	s.Require().Contains(err.Error(), contains)
+}
+
+func (s *MSIResolverSuite) addVirtualMachine() {
+	s.setVirtualMachine(&compute.VirtualMachine{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			NetworkProfile: &compute.NetworkProfile{
+				NetworkInterfaces: &[]compute.NetworkInterfaceReference{
+					{ID: &niResourceID},
+				},
+			},
+		},
+	})
+}
+
+func (s *MSIResolverSuite) setVirtualMachine(vm *compute.VirtualMachine) {
+	s.api.SetVirtualMachineResourceID("PRINCIPAL", vmResourceID)
+	s.api.SetVirtualMachine("RESOURCEGROUP", "VIRTUALMACHINE", vm)
+}
+
+func (s *MSIResolverSuite) setNetworkInterface(ni *network.Interface) {
+	s.api.SetNetworkInterface("RESOURCEGROUP", "NETWORKINTERFACE", ni)
+}
+
+type fakeAPIClient struct {
+	t testing.TB
+
+	vmResourceIDs     map[string]string
+	virtualMachines   map[string]*compute.VirtualMachine
+	networkInterfaces map[string]*network.Interface
+}
+
+func newFakeAPIClient(t testing.TB) *fakeAPIClient {
+	return &fakeAPIClient{
+		t:                 t,
+		vmResourceIDs:     make(map[string]string),
+		virtualMachines:   make(map[string]*compute.VirtualMachine),
+		networkInterfaces: make(map[string]*network.Interface),
+	}
+}
+
+func (c *fakeAPIClient) SubscriptionID() string {
+	return "SUBSCRIPTION"
+}
+
+func (c *fakeAPIClient) SetVirtualMachineResourceID(principalID, resourceID string) {
+	c.vmResourceIDs[principalID] = resourceID
+}
+
+func (c *fakeAPIClient) GetVirtualMachineResourceID(ctx context.Context, principalID string) (string, error) {
+	id := c.vmResourceIDs[principalID]
+	if id == "" {
+		return "", errors.New("not found")
+	}
+	return id, nil
+}
+
+func (c *fakeAPIClient) SetVirtualMachine(resourceGroup string, name string, vm *compute.VirtualMachine) {
+	c.virtualMachines[resourceGroupName(resourceGroup, name)] = vm
+}
+
+func (c *fakeAPIClient) GetVirtualMachine(ctx context.Context, resourceGroup string, name string) (*compute.VirtualMachine, error) {
+	vm := c.virtualMachines[resourceGroupName(resourceGroup, name)]
+	if vm == nil {
+		return nil, errors.New("not found")
+	}
+	return vm, nil
+}
+
+func (c *fakeAPIClient) SetNetworkInterface(resourceGroup string, name string, ni *network.Interface) {
+	c.networkInterfaces[resourceGroupName(resourceGroup, name)] = ni
+}
+
+func (c *fakeAPIClient) GetNetworkInterface(ctx context.Context, resourceGroup string, name string) (*network.Interface, error) {
+	ni := c.networkInterfaces[resourceGroupName(resourceGroup, name)]
+	if ni == nil {
+		return nil, errors.New("not found")
+	}
+	return ni, nil
+}


### PR DESCRIPTION
Plugin that resolves agent SPIFFE ID's that were attested via the Azure MSI node attestor.

Selectors are returned for the following information:
1. Subscription ID
2. Virtual Machine Name
3. Network Security Group
4. Virtual Network
5. Virtual Network Subnet


Signed-off-by: Andrew Harding <azdagron@gmail.com>