### PR TITLE
use SHA256 instead of XOR to combine x509pop nonces

### DIFF
--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
@@ -272,9 +273,8 @@ func combineNonces(challenge, response []byte) ([]byte, error) {
 	if len(response) != nonceLen {
 		return nil, errors.New("invalid response nonce")
 	}
-	combined := make([]byte, nonceLen)
-	for i := range combined {
-		combined[i] = challenge[i] ^ response[i]
-	}
-	return combined, nil
+	h := sha256.New()
+	h.Write(challenge)
+	h.Write(response)
+	return h.Sum(nil), nil
 }


### PR DESCRIPTION
XOR allows for a malicious agent to fake key possession by finding an
existing set of plaintext + signature generated by the key and choosing
a nonce that will produce the plaintext when XOR'd with the server
nonce.

Swapping to SHA256 prevents the attacker from choosing a nonce that
hashes to the plaintext.

Many thanks to @enricoschiattarella for pointing this out.