### PR TITLE
sql datastore cleanup

### DIFF
--- a/pkg/server/plugin/datastore/sql/postgres.go
+++ b/pkg/server/plugin/datastore/sql/postgres.go
@@ -10,7 +10,7 @@ type postgres struct{}
 func (p postgres) connect(connectionString string) (*gorm.DB, error) {
 	db, err := gorm.Open("postgres", connectionString)
 	if err != nil {
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 	return db, nil
 

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"fmt"
-	"net/url"
 	"sync"
 	"time"
 
@@ -13,11 +11,13 @@ import (
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/satori/go.uuid"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/selector"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/common"
 	spi "github.com/spiffe/spire/proto/common/plugin"
 	"github.com/spiffe/spire/proto/server/datastore"
+	"github.com/zeebo/errs"
 )
 
 var (
@@ -28,101 +28,535 @@ var (
 		Author:      "",
 		Company:     "",
 	}
+
+	sqlError = errs.Class("datastore-sql")
 )
 
 type configuration struct {
 	DatabaseType     string `hcl:"database_type" json:"database_type"`
 	ConnectionString string `hcl:"connection_string" json:"connection_string"`
+
+	// Undocumented flags
+	LogSQL bool `hcl:"log_sql" json:"log_sql"`
+}
+
+type sqlDB struct {
+	databaseType     string
+	connectionString string
+	*gorm.DB
+
+	// this lock is only required for synchronized writes with "sqlite3". see
+	// the withTx() implementation for details.
+	opMu sync.Mutex
 }
 
 type sqlPlugin struct {
-	db *gorm.DB
+	mu sync.Mutex
+	db *sqlDB
+}
 
-	DatabaseType     string
-	ConnectionString string
+func newPlugin() *sqlPlugin {
+	return &sqlPlugin{}
+}
 
-	mutex *sync.Mutex
+// New creates a new sql plugin struct. Configure must be called
+// in order to start the db.
+func New() datastore.Plugin {
+	return newPlugin()
 }
 
 // CreateBundle stores the given bundle
-func (ds *sqlPlugin) CreateBundle(ctx context.Context, req *datastore.Bundle) (*datastore.Bundle, error) {
-	model, err := ds.bundleToModel(req)
+func (ds *sqlPlugin) CreateBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = createBundle(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// UpdateBundle updates an existing bundle with the given CAs. Overwrites any
+// existing certificates.
+func (ds *sqlPlugin) UpdateBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = updateBundle(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// AppendBundle adds the specified CA certificates to an existing bundle. If no bundle exists for the
+// specified trust domain, create one. Returns the entirety.
+func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = appendBundle(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
+func (ds *sqlPlugin) DeleteBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = deleteBundle(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// FetchBundle returns the bundle matching the specified Trust Domain.
+func (ds *sqlPlugin) FetchBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchBundle(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// ListBundles can be used to fetch all existing bundles.
+func (ds *sqlPlugin) ListBundles(ctx context.Context, req *common.Empty) (resp *datastore.Bundles, err error) {
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listBundles(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
+	req *datastore.CreateAttestedNodeEntryRequest) (resp *datastore.CreateAttestedNodeEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = createAttestedNodeEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
+	req *datastore.FetchAttestedNodeEntryRequest) (resp *datastore.FetchAttestedNodeEntryResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchAttestedNodeEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) FetchStaleNodeEntries(ctx context.Context,
+	req *datastore.FetchStaleNodeEntriesRequest) (resp *datastore.FetchStaleNodeEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchStaleNodeEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
+	req *datastore.UpdateAttestedNodeEntryRequest) (resp *datastore.UpdateAttestedNodeEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = updateAttestedNodeEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) DeleteAttestedNodeEntry(ctx context.Context,
+	req *datastore.DeleteAttestedNodeEntryRequest) (resp *datastore.DeleteAttestedNodeEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = deleteAttestedNodeEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
+	req *datastore.CreateNodeResolverMapEntryRequest) (resp *datastore.CreateNodeResolverMapEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = createNodeResolverMapEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) FetchNodeResolverMapEntry(ctx context.Context,
+	req *datastore.FetchNodeResolverMapEntryRequest) (resp *datastore.FetchNodeResolverMapEntryResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchNodeResolverMapEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) DeleteNodeResolverMapEntry(ctx context.Context,
+	req *datastore.DeleteNodeResolverMapEntryRequest) (resp *datastore.DeleteNodeResolverMapEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = deleteNodeResolverMapEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (sqlPlugin) RectifyNodeResolverMapEntries(ctx context.Context,
+	req *datastore.RectifyNodeResolverMapEntriesRequest) (*datastore.RectifyNodeResolverMapEntriesResponse, error) {
+	return &datastore.RectifyNodeResolverMapEntriesResponse{}, errors.New("Not Implemented")
+}
+
+func (ds *sqlPlugin) CreateRegistrationEntry(ctx context.Context,
+	req *datastore.CreateRegistrationEntryRequest) (resp *datastore.CreateRegistrationEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = createRegistrationEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) FetchRegistrationEntry(ctx context.Context,
+	req *datastore.FetchRegistrationEntryRequest) (resp *datastore.FetchRegistrationEntryResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchRegistrationEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) FetchRegistrationEntries(ctx context.Context,
+	req *common.Empty) (resp *datastore.FetchRegistrationEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchRegistrationEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds sqlPlugin) UpdateRegistrationEntry(ctx context.Context,
+	req *datastore.UpdateRegistrationEntryRequest) (resp *datastore.UpdateRegistrationEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = updateRegistrationEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) DeleteRegistrationEntry(ctx context.Context,
+	req *datastore.DeleteRegistrationEntryRequest) (resp *datastore.DeleteRegistrationEntryResponse, err error) {
+
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = deleteRegistrationEntry(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) ListParentIDEntries(ctx context.Context,
+	req *datastore.ListParentIDEntriesRequest) (resp *datastore.ListParentIDEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listParentIDEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) ListSelectorEntries(ctx context.Context,
+	req *datastore.ListSelectorEntriesRequest) (resp *datastore.ListSelectorEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listSelectorEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) ListMatchingEntries(ctx context.Context,
+	req *datastore.ListSelectorEntriesRequest) (resp *datastore.ListSelectorEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listMatchingEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) ListSpiffeEntries(ctx context.Context,
+	req *datastore.ListSpiffeEntriesRequest) (resp *datastore.ListSpiffeEntriesResponse, err error) {
+
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listSpiffeEntries(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// RegisterToken takes a Token message and stores it
+func (ds *sqlPlugin) RegisterToken(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = registerToken(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// FetchToken takes a Token message and returns one, populating the fields
+// we have knowledge of
+func (ds *sqlPlugin) FetchToken(ctx context.Context, req *datastore.JoinToken) (resp *datastore.JoinToken, err error) {
+	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = fetchToken(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) DeleteToken(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = deleteToken(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// PruneTokens takes a Token message, and deletes all tokens which have expired
+// before the date in the message
+func (ds *sqlPlugin) PruneTokens(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = pruneTokens(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (ds *sqlPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	// Parse HCL config payload into config struct
+	config := &configuration{}
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, err
+	}
+
+	if config.DatabaseType == "" {
+		return nil, errors.New("database_type must be set")
+	}
+
+	if config.ConnectionString == "" {
+		return nil, errors.New("connection_string must be set")
+	}
+
+	ds.mu.Lock()
+	defer ds.mu.Unlock()
+
+	if ds.db == nil ||
+		config.ConnectionString != ds.db.connectionString ||
+		config.DatabaseType != ds.db.databaseType {
+
+		db, err := openDB(config.DatabaseType, config.ConnectionString)
+		if err != nil {
+			return nil, err
+		}
+
+		if ds.db != nil {
+			ds.db.Close()
+		}
+
+		ds.db = &sqlDB{
+			DB:               db,
+			databaseType:     config.DatabaseType,
+			connectionString: config.ConnectionString,
+		}
+	}
+
+	ds.db.LogMode(config.LogSQL)
+
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (sqlPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &pluginInfo, nil
+}
+
+func (ds *sqlPlugin) withWriteTx(ctx context.Context, op func(tx *gorm.DB) error) error {
+	return ds.withTx(ctx, op, false)
+}
+
+func (ds *sqlPlugin) withReadTx(ctx context.Context, op func(tx *gorm.DB) error) error {
+	return ds.withTx(ctx, op, true)
+}
+
+func (ds *sqlPlugin) withTx(ctx context.Context, op func(tx *gorm.DB) error, readOnly bool) error {
+	ds.mu.Lock()
+	db := ds.db
+	ds.mu.Unlock()
+
+	if db.databaseType == "sqlite3" && !readOnly {
+		// sqlite3 can only have one writer at a time. since we're in WAL mode,
+		// there can be concurrent reads and writes, so no lock is necessary
+		// over the read operations.
+		db.opMu.Lock()
+		defer db.opMu.Unlock()
+	}
+
+	// TODO: as soon as GORM supports it, attach the context
+	tx := db.Begin()
+	if err := tx.Error; err != nil {
+		return sqlError.Wrap(err)
+	}
+
+	if err := op(tx); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	if readOnly {
+		// rolling back makes sure that functions that are invoked with
+		// withReadTx, and then do writes, will not pass unit tests, since the
+		// writes won't be committed.
+		return sqlError.Wrap(tx.Rollback().Error)
+	}
+	return sqlError.Wrap(tx.Commit().Error)
+}
+
+func openDB(databaseType, connectionString string) (*gorm.DB, error) {
+	var db *gorm.DB
+	var err error
+
+	switch databaseType {
+	case "sqlite3":
+		db, err = sqlite{}.connect(connectionString)
+	case "postgres":
+		db, err = postgres{}.connect(connectionString)
+	default:
+		return nil, sqlError.New("unsupported database_type: %v", databaseType)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	result := ds.db.Create(model)
-	if result.Error != nil {
-		return nil, result.Error
+	if err := migrateDB(db); err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func createBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
+	model, err := bundleToModel(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Create(model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	return req, nil
 }
 
-// UpdateBundle updates an existing bundle with the given CAs. Overwrites any
-// existing certificates.
-func (ds *sqlPlugin) UpdateBundle(ctx context.Context, req *datastore.Bundle) (*datastore.Bundle, error) {
-	newModel, err := ds.bundleToModel(req)
+func updateBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
+	newModel, err := bundleToModel(req)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := ds.db.Begin()
-
 	// Fetch the model to get its ID
 	model := &Bundle{}
-	result := tx.Find(model, "trust_domain = ?", newModel.TrustDomain)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Find(model, "trust_domain = ?", newModel.TrustDomain).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Delete existing CA certs - the provided list takes precedence
-	result = tx.Where("bundle_id = ?", model.ID).Delete(CACert{})
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Where("bundle_id = ?", model.ID).Delete(CACert{}).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Set the new values
 	model.CACerts = newModel.CACerts
-	result = tx.Save(model)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Save(model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	return req, tx.Commit().Error
+	return req, nil
 }
 
-// AppendBundle adds the specified CA certificates to an existing bundle. If no bundle exists for the
-// specified trust domain, create one. Returns the entirety.
-func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.Bundle) (*datastore.Bundle, error) {
-	newModel, err := ds.bundleToModel(req)
+func appendBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
+	newModel, err := bundleToModel(req)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := ds.db.Begin()
-
 	// First, fetch the existing model
 	model := &Bundle{}
 	result := tx.Find(model, "trust_domain = ?", newModel.TrustDomain)
-
 	if result.RecordNotFound() {
-		tx.Rollback()
-		return ds.CreateBundle(ctx, req)
+		return createBundle(tx, req)
 	} else if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+		return nil, sqlError.Wrap(result.Error)
 	}
 
 	// Get the existing certificates so we can include them in the response
 	var caCerts []CACert
-	result = tx.Model(model).Related(&caCerts)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Model(model).Related(&caCerts).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 	model.CACerts = caCerts
 
@@ -132,108 +566,83 @@ func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.Bundle) (*
 		}
 	}
 
-	result = tx.Save(model)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Save(model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	resp, err := ds.modelToBundle(model)
+	resp, err := modelToBundle(model)
 	if err != nil {
-		tx.Rollback()
 		return nil, err
 	}
 
-	return resp, tx.Commit().Error
+	return resp, nil
 }
 
-// DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
-func (ds *sqlPlugin) DeleteBundle(ctx context.Context, req *datastore.Bundle) (*datastore.Bundle, error) {
+func deleteBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
 	// We don't care if cert data was sent - remove it now to prevent
 	// further processing.
 	req.CaCerts = []byte{}
 
-	model, err := ds.bundleToModel(req)
+	model, err := bundleToModel(req)
 	if err != nil {
 		return nil, err
 	}
 
-	tx := ds.db.Begin()
-
-	result := tx.Find(model, "trust_domain = ?", model.TrustDomain)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Find(model, "trust_domain = ?", model.TrustDomain).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Fetch related CA certs for response before we delete them
 	var caCerts []CACert
-	result = tx.Model(model).Related(&caCerts)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Model(model).Related(&caCerts).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 	model.CACerts = caCerts
 
-	result = tx.Where("bundle_id = ?", model.ID).Delete(CACert{})
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Where("bundle_id = ?", model.ID).Delete(CACert{}).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	result = tx.Delete(model)
-	if result.Error != nil {
-		tx.Rollback()
-		return nil, result.Error
+	if err := tx.Delete(model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	resp, err := ds.modelToBundle(model)
+	resp, err := modelToBundle(model)
 	if err != nil {
-		tx.Rollback()
 		return nil, err
 	}
 
-	return resp, tx.Commit().Error
+	return resp, nil
 }
 
 // FetchBundle returns the bundle matching the specified Trust Domain.
-func (ds *sqlPlugin) FetchBundle(ctx context.Context, req *datastore.Bundle) (*datastore.Bundle, error) {
-	model, err := ds.bundleToModel(req)
+func fetchBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
+	model, err := bundleToModel(req)
 	if err != nil {
 		return nil, err
 	}
 
-	result := ds.db.Find(model, "trust_domain = ?", model.TrustDomain)
-	if result.Error != nil {
-		return nil, result.Error
+	if err := tx.Find(model, "trust_domain = ?", model.TrustDomain).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	var caCerts []CACert
-	result = ds.db.Model(model).Related(&caCerts)
-	if result.Error != nil {
-		return nil, result.Error
+	if err := tx.Model(model).Related(&model.CACerts).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
-	model.CACerts = caCerts
 
-	return ds.modelToBundle(model)
+	return modelToBundle(model)
 }
 
 // ListBundles can be used to fetch all existing bundles.
-func (ds *sqlPlugin) ListBundles(ctx context.Context, req *common.Empty) (*datastore.Bundles, error) {
-	// Get a consistent view
-	tx := ds.db.Begin()
-	defer tx.Rollback()
-
+func listBundles(tx *gorm.DB, req *common.Empty) (*datastore.Bundles, error) {
 	var bundles []Bundle
-	result := tx.Find(&bundles)
-	if result.Error != nil {
-		return nil, result.Error
+	if err := tx.Find(&bundles).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	var caCerts []CACert
-	result = tx.Find(&caCerts)
-	if result.Error != nil {
-		return nil, result.Error
+	if err := tx.Find(&caCerts).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Index CA Certs by Bundle ID so we can reconstruct them more easily
@@ -257,7 +666,7 @@ func (ds *sqlPlugin) ListBundles(ctx context.Context, req *common.Empty) (*datas
 			model.CACerts = []CACert{}
 		}
 
-		bundle, err := ds.modelToBundle(&model)
+		bundle, err := modelToBundle(&model)
 		if err != nil {
 			return nil, err
 		}
@@ -268,20 +677,15 @@ func (ds *sqlPlugin) ListBundles(ctx context.Context, req *common.Empty) (*datas
 	return resp, nil
 }
 
-func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
-	req *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func createAttestedNodeEntry(tx *gorm.DB, req *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
 	entry := req.AttestedNodeEntry
 	if entry == nil {
-		return nil, errors.New("invalid request: missing attested node")
+		return nil, sqlError.New("invalid request: missing attested node")
 	}
 
 	expiresAt, err := time.Parse(datastore.TimeFormat, entry.CertExpirationDate)
 	if err != nil {
-		return nil, errors.New("invalid request: missing expiration")
+		return nil, sqlError.New("invalid request: missing expiration")
 	}
 
 	model := AttestedNodeEntry{
@@ -291,8 +695,8 @@ func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
 		ExpiresAt:    expiresAt,
 	}
 
-	if err := ds.db.Create(&model).Error; err != nil {
-		return nil, err
+	if err := tx.Create(&model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	return &datastore.CreateAttestedNodeEntryResponse{
@@ -305,19 +709,14 @@ func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
 	}, nil
 }
 
-func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
-	req *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func fetchAttestedNodeEntry(tx *gorm.DB, req *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
 	var model AttestedNodeEntry
-	err := ds.db.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error
+	err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
 		return &datastore.FetchAttestedNodeEntryResponse{}, nil
 	case err != nil:
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 	return &datastore.FetchAttestedNodeEntryResponse{
 		AttestedNodeEntry: &datastore.AttestedNodeEntry{
@@ -329,15 +728,10 @@ func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
 	}, nil
 }
 
-func (ds *sqlPlugin) FetchStaleNodeEntries(ctx context.Context,
-	req *datastore.FetchStaleNodeEntriesRequest) (*datastore.FetchStaleNodeEntriesResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func fetchStaleNodeEntries(tx *gorm.DB, req *datastore.FetchStaleNodeEntriesRequest) (*datastore.FetchStaleNodeEntriesResponse, error) {
 	var models []AttestedNodeEntry
-	if err := ds.db.Find(&models, "expires_at < ?", time.Now()).Error; err != nil {
-		return nil, err
+	if err := tx.Find(&models, "expires_at < ?", time.Now()).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	resp := &datastore.FetchStaleNodeEntriesResponse{
@@ -355,24 +749,15 @@ func (ds *sqlPlugin) FetchStaleNodeEntries(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
-	req *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
-	var model AttestedNodeEntry
-
+func updateAttestedNodeEntry(tx *gorm.DB, req *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
 	expiresAt, err := time.Parse(datastore.TimeFormat, req.CertExpirationDate)
 	if err != nil {
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
-	db := ds.db.Begin()
-
-	if err := db.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
-		db.Rollback()
-		return nil, err
+	var model AttestedNodeEntry
+	if err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	updates := AttestedNodeEntry{
@@ -380,9 +765,8 @@ func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
 		ExpiresAt:    expiresAt,
 	}
 
-	if err := db.Model(&model).Updates(updates).Error; err != nil {
-		db.Rollback()
-		return nil, err
+	if err := tx.Model(&model).Updates(updates).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	return &datastore.UpdateAttestedNodeEntryResponse{
@@ -392,27 +776,17 @@ func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
 			CertSerialNumber:    model.SerialNumber,
 			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
 		},
-	}, db.Commit().Error
+	}, nil
 }
 
-func (ds *sqlPlugin) DeleteAttestedNodeEntry(ctx context.Context,
-	req *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
-	db := ds.db.Begin()
-
+func deleteAttestedNodeEntry(tx *gorm.DB, req *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
 	var model AttestedNodeEntry
-
-	if err := db.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
-		db.Rollback()
-		return nil, err
+	if err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	if err := db.Delete(&model).Error; err != nil {
-		db.Rollback()
-		return nil, err
+	if err := tx.Delete(&model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	return &datastore.DeleteAttestedNodeEntryResponse{
@@ -422,23 +796,18 @@ func (ds *sqlPlugin) DeleteAttestedNodeEntry(ctx context.Context,
 			CertSerialNumber:    model.SerialNumber,
 			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
 		},
-	}, db.Commit().Error
+	}, nil
 }
 
-func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
-	req *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func createNodeResolverMapEntry(tx *gorm.DB, req *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
 	entry := req.NodeResolverMapEntry
 	if entry == nil {
-		return nil, errors.New("Invalid Request: no map entry")
+		return nil, sqlError.New("invalid request: no map entry")
 	}
 
 	selector := entry.Selector
 	if selector == nil {
-		return nil, errors.New("Invalid Request: no selector")
+		return nil, sqlError.New("invalid request: no selector")
 	}
 
 	model := NodeResolverMapEntry{
@@ -447,8 +816,8 @@ func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
 		Value:    selector.Value,
 	}
 
-	if err := ds.db.Create(&model).Error; err != nil {
-		return nil, err
+	if err := tx.Create(&model).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	return &datastore.CreateNodeResolverMapEntryResponse{
@@ -462,16 +831,10 @@ func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
 	}, nil
 }
 
-func (ds *sqlPlugin) FetchNodeResolverMapEntry(ctx context.Context,
-	req *datastore.FetchNodeResolverMapEntryRequest) (*datastore.FetchNodeResolverMapEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func fetchNodeResolverMapEntry(tx *gorm.DB, req *datastore.FetchNodeResolverMapEntryRequest) (*datastore.FetchNodeResolverMapEntryResponse, error) {
 	var models []NodeResolverMapEntry
-
-	if err := ds.db.Find(&models, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
-		return nil, err
+	if err := tx.Find(&models, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	resp := &datastore.FetchNodeResolverMapEntryResponse{
@@ -490,21 +853,13 @@ func (ds *sqlPlugin) FetchNodeResolverMapEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) DeleteNodeResolverMapEntry(ctx context.Context,
-	req *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
+func deleteNodeResolverMapEntry(tx *gorm.DB, req *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
 	entry := req.NodeResolverMapEntry
 	if entry == nil {
-		return nil, errors.New("Invalid Request: no map entry")
+		return nil, sqlError.New("invalid request: no map entry")
 	}
 
-	tx := ds.db.Begin()
-
 	// if no selector is given, delete all entries with the given spiffe id
-
 	scope := tx.Where("spiffe_id = ?", entry.BaseSpiffeId)
 
 	if selector := entry.Selector; selector != nil {
@@ -515,13 +870,11 @@ func (ds *sqlPlugin) DeleteNodeResolverMapEntry(ctx context.Context,
 	var models []NodeResolverMapEntry
 
 	if err := scope.Find(&models).Error; err != nil {
-		tx.Rollback()
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
 	if err := scope.Delete(&NodeResolverMapEntry{}).Error; err != nil {
-		tx.Rollback()
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
 	resp := &datastore.DeleteNodeResolverMapEntryResponse{
@@ -538,84 +891,70 @@ func (ds *sqlPlugin) DeleteNodeResolverMapEntry(ctx context.Context,
 		})
 	}
 
-	return resp, tx.Commit().Error
+	return resp, nil
 }
 
-func (sqlPlugin) RectifyNodeResolverMapEntries(ctx context.Context,
-	req *datastore.RectifyNodeResolverMapEntriesRequest) (*datastore.RectifyNodeResolverMapEntriesResponse, error) {
-	return &datastore.RectifyNodeResolverMapEntriesResponse{}, errors.New("Not Implemented")
-}
-
-func (ds *sqlPlugin) CreateRegistrationEntry(ctx context.Context,
-	request *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+func createRegistrationEntry(tx *gorm.DB,
+	req *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
 
 	// TODO: Validations should be done in the ProtoBuf level [https://github.com/spiffe/spire/issues/44]
-	if request.RegisteredEntry == nil {
-		return nil, errors.New("Invalid request: missing registered entry")
+	if req.RegisteredEntry == nil {
+		return nil, sqlError.New("invalid request: missing registered entry")
 	}
 
-	err := ds.validateRegistrationEntry(request.RegisteredEntry)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid registration entry: %v", err)
-	}
-
-	entryID, err := uuid.NewV4()
-	if err != nil {
-		return nil, fmt.Errorf("could not generate entry id: %v", err)
-	}
-
-	newRegisteredEntry := RegisteredEntry{
-		EntryID:  entryID.String(),
-		SpiffeID: request.RegisteredEntry.SpiffeId,
-		ParentID: request.RegisteredEntry.ParentId,
-		TTL:      request.RegisteredEntry.Ttl,
-		// TODO: Add support to Federated Bundles [https://github.com/spiffe/spire/issues/42]
-	}
-
-	tx := ds.db.Begin()
-	if err := tx.Create(&newRegisteredEntry).Error; err != nil {
-		tx.Rollback()
+	if err := validateRegistrationEntry(req.RegisteredEntry); err != nil {
 		return nil, err
 	}
 
-	for _, registeredSelector := range request.RegisteredEntry.Selectors {
+	entryID, err := newRegistrationEntryID()
+	if err != nil {
+		return nil, err
+	}
+
+	newRegisteredEntry := RegisteredEntry{
+		EntryID:  entryID,
+		SpiffeID: req.RegisteredEntry.SpiffeId,
+		ParentID: req.RegisteredEntry.ParentId,
+		TTL:      req.RegisteredEntry.Ttl,
+		// TODO: Add support to Federated Bundles [https://github.com/spiffe/spire/issues/42]
+	}
+
+	if err := tx.Create(&newRegisteredEntry).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
+	for _, registeredSelector := range req.RegisteredEntry.Selectors {
 		newSelector := Selector{
 			RegisteredEntryID: newRegisteredEntry.ID,
 			Type:              registeredSelector.Type,
 			Value:             registeredSelector.Value}
 
 		if err := tx.Create(&newSelector).Error; err != nil {
-			tx.Rollback()
-			return nil, err
+			return nil, sqlError.Wrap(err)
 		}
 	}
 
 	return &datastore.CreateRegistrationEntryResponse{
 		RegisteredEntryId: newRegisteredEntry.EntryID,
-	}, tx.Commit().Error
+	}, nil
 }
 
-func (ds *sqlPlugin) FetchRegistrationEntry(ctx context.Context,
-	request *datastore.FetchRegistrationEntryRequest) (*datastore.FetchRegistrationEntryResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+func fetchRegistrationEntry(tx *gorm.DB,
+	req *datastore.FetchRegistrationEntryRequest) (*datastore.FetchRegistrationEntryResponse, error) {
 
 	var fetchedRegisteredEntry RegisteredEntry
-	err := ds.db.Find(&fetchedRegisteredEntry, "entry_id = ?", request.RegisteredEntryId).Error
-
+	err := tx.Find(&fetchedRegisteredEntry, "entry_id = ?", req.RegisteredEntryId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
 		return &datastore.FetchRegistrationEntryResponse{}, nil
 	case err != nil:
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
 	var fetchedSelectors []*Selector
-	ds.db.Model(&fetchedRegisteredEntry).Related(&fetchedSelectors)
+	if err := tx.Model(&fetchedRegisteredEntry).Related(&fetchedSelectors).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
 
 	selectors := make([]*common.Selector, 0, len(fetchedSelectors))
 
@@ -636,17 +975,17 @@ func (ds *sqlPlugin) FetchRegistrationEntry(ctx context.Context,
 	}, nil
 }
 
-func (ds *sqlPlugin) FetchRegistrationEntries(ctx context.Context,
-	request *common.Empty) (*datastore.FetchRegistrationEntriesResponse, error) {
+func fetchRegistrationEntries(tx *gorm.DB,
+	req *common.Empty) (*datastore.FetchRegistrationEntriesResponse, error) {
 
 	var entries []RegisteredEntry
-	if err := ds.db.Find(&entries).Error; err != nil {
-		return nil, err
+	if err := tx.Find(&entries).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	var sel []Selector
-	if err := ds.db.Find(&sel).Error; err != nil {
-		return nil, err
+	if err := tx.Find(&sel).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Organize the selectors for easier access
@@ -662,50 +1001,43 @@ func (ds *sqlPlugin) FetchRegistrationEntries(ctx context.Context,
 		}
 	}
 
-	resEntries, err := ds.convertEntries(entries)
+	resEntries, err := modelsToEntries(tx, entries)
 	if err != nil {
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
-	res := &datastore.FetchRegistrationEntriesResponse{
+	return &datastore.FetchRegistrationEntriesResponse{
 		RegisteredEntries: &common.RegistrationEntries{
 			Entries: resEntries,
 		},
-	}
-
-	return res, nil
+	}, nil
 }
 
-func (ds sqlPlugin) UpdateRegistrationEntry(ctx context.Context,
-	request *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
+func updateRegistrationEntry(tx *gorm.DB,
+	req *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
 
-	if request.RegisteredEntry == nil {
-		return nil, errors.New("No registration entry provided")
+	if req.RegisteredEntry == nil {
+		return nil, sqlError.New("no registration entry provided")
 	}
 
-	err := ds.validateRegistrationEntry(request.RegisteredEntry)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid registration entry: %v", err)
+	if err := validateRegistrationEntry(req.RegisteredEntry); err != nil {
+		return nil, err
 	}
-
-	tx := ds.db.Begin()
 
 	// Get the existing entry
 	// TODO: Refactor message type to take EntryID directly from the entry - see #449
 	entry := RegisteredEntry{}
-	if err = tx.Find(&entry, "entry_id = ?", request.RegisteredEntryId).Error; err != nil {
-		tx.Rollback()
-		return nil, err
+	if err := tx.Find(&entry, "entry_id = ?", req.RegisteredEntryId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	// Delete existing selectors - we will write new ones
-	if err = tx.Exec("DELETE FROM selectors WHERE registered_entry_id = ?", entry.ID).Error; err != nil {
-		tx.Rollback()
-		return nil, err
+	if err := tx.Exec("DELETE FROM selectors WHERE registered_entry_id = ?", entry.ID).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
 	selectors := []Selector{}
-	for _, s := range request.RegisteredEntry.Selectors {
+	for _, s := range req.RegisteredEntry.Selectors {
 		selector := Selector{
 			Type:  s.Type,
 			Value: s.Value,
@@ -714,96 +1046,81 @@ func (ds sqlPlugin) UpdateRegistrationEntry(ctx context.Context,
 		selectors = append(selectors, selector)
 	}
 
-	entry.SpiffeID = request.RegisteredEntry.SpiffeId
-	entry.ParentID = request.RegisteredEntry.ParentId
-	entry.TTL = request.RegisteredEntry.Ttl
+	entry.SpiffeID = req.RegisteredEntry.SpiffeId
+	entry.ParentID = req.RegisteredEntry.ParentId
+	entry.TTL = req.RegisteredEntry.Ttl
 	entry.Selectors = selectors
-	if err = tx.Save(&entry).Error; err != nil {
-		tx.Rollback()
-		return nil, err
+	if err := tx.Save(&entry).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	if err = tx.Commit().Error; err != nil {
-		tx.Rollback()
-		return nil, err
-	}
-
-	request.RegisteredEntry.EntryId = entry.EntryID
-	return &datastore.UpdateRegistrationEntryResponse{RegisteredEntry: request.RegisteredEntry}, nil
+	req.RegisteredEntry.EntryId = entry.EntryID
+	return &datastore.UpdateRegistrationEntryResponse{
+		RegisteredEntry: req.RegisteredEntry,
+	}, nil
 }
 
-func (ds *sqlPlugin) DeleteRegistrationEntry(ctx context.Context,
-	request *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
+func deleteRegistrationEntry(tx *gorm.DB,
+	req *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
 
 	entry := RegisteredEntry{}
-	if err := ds.db.Find(&entry, "entry_id = ?", request.RegisteredEntryId).Error; err != nil {
-		return &datastore.DeleteRegistrationEntryResponse{}, err
+	if err := tx.Find(&entry, "entry_id = ?", req.RegisteredEntryId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	if err := ds.db.Delete(&entry).Error; err != nil {
-		return &datastore.DeleteRegistrationEntryResponse{}, err
+	if err := tx.Delete(&entry).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	respEntry, err := ds.convertEntries([]RegisteredEntry{entry})
+	respEntry, err := modelToEntry(tx, entry)
 	if err != nil {
-		return &datastore.DeleteRegistrationEntryResponse{}, err
+		return nil, err
 	}
 
-	resp := &datastore.DeleteRegistrationEntryResponse{
-		RegisteredEntry: respEntry[0],
-	}
-	return resp, nil
+	return &datastore.DeleteRegistrationEntryResponse{
+		RegisteredEntry: respEntry,
+	}, nil
 }
 
-func (ds *sqlPlugin) ListParentIDEntries(ctx context.Context,
-	request *datastore.ListParentIDEntriesRequest) (response *datastore.ListParentIDEntriesResponse, err error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+func listParentIDEntries(tx *gorm.DB,
+	req *datastore.ListParentIDEntriesRequest) (*datastore.ListParentIDEntriesResponse, error) {
 
 	var fetchedRegisteredEntries []RegisteredEntry
-	err = ds.db.Find(&fetchedRegisteredEntries, "parent_id = ?", request.ParentId).Error
-
+	err := tx.Find(&fetchedRegisteredEntries, "parent_id = ?", req.ParentId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
 		return &datastore.ListParentIDEntriesResponse{}, nil
 	case err != nil:
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
-	regEntryList, err := ds.convertEntries(fetchedRegisteredEntries)
+	regEntryList, err := modelsToEntries(tx, fetchedRegisteredEntries)
 	if err != nil {
 		return nil, err
 	}
 	return &datastore.ListParentIDEntriesResponse{RegisteredEntryList: regEntryList}, nil
 }
 
-func (ds *sqlPlugin) ListSelectorEntries(ctx context.Context,
-	request *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
+func listSelectorEntries(tx *gorm.DB,
+	req *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
 
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
-	entries, err := ds.listMatchingEntries(request.Selectors)
+	entries, err := listEntriesWithExactSelectorMatch(tx, req.Selectors)
 	if err != nil {
-		return &datastore.ListSelectorEntriesResponse{}, err
+		return nil, err
 	}
 
 	util.SortRegistrationEntries(entries)
 	return &datastore.ListSelectorEntriesResponse{RegisteredEntryList: entries}, nil
 }
 
-func (ds *sqlPlugin) ListMatchingEntries(ctx context.Context,
-	request *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
+func listMatchingEntries(tx *gorm.DB,
+	req *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
 
 	resp := &datastore.ListSelectorEntriesResponse{}
-	for combination := range selector.NewSetFromRaw(request.Selectors).Power() {
-		entries, err := ds.listMatchingEntries(combination.Raw())
+	for combination := range selector.NewSetFromRaw(req.Selectors).Power() {
+		entries, err := listEntriesWithExactSelectorMatch(tx, combination.Raw())
 		if err != nil {
-			return &datastore.ListSelectorEntriesResponse{}, err
+			return nil, err
 		}
 		resp.RegisteredEntryList = append(resp.RegisteredEntryList, entries...)
 	}
@@ -812,31 +1129,27 @@ func (ds *sqlPlugin) ListMatchingEntries(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) ListSpiffeEntries(ctx context.Context,
-	request *datastore.ListSpiffeEntriesRequest) (*datastore.ListSpiffeEntriesResponse, error) {
+func listSpiffeEntries(tx *gorm.DB,
+	req *datastore.ListSpiffeEntriesRequest) (*datastore.ListSpiffeEntriesResponse, error) {
 
 	var entries []RegisteredEntry
-	err := ds.db.Find(&entries, "spiffe_id = ?", request.SpiffeId).Error
-	if err != nil {
-		return &datastore.ListSpiffeEntriesResponse{}, err
+	if err := tx.Find(&entries, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	respEntries, err := ds.convertEntries(entries)
+	respEntries, err := modelsToEntries(tx, entries)
 	if err != nil {
-		return &datastore.ListSpiffeEntriesResponse{}, err
+		return nil, err
 	}
 
-	resp := &datastore.ListSpiffeEntriesResponse{
+	return &datastore.ListSpiffeEntriesResponse{
 		RegisteredEntryList: respEntries,
-	}
-	return resp, nil
+	}, nil
 }
 
-// RegisterToken takes a Token message and stores it
-func (ds *sqlPlugin) RegisterToken(ctx context.Context, req *datastore.JoinToken) (*common.Empty, error) {
-	resp := new(common.Empty)
+func registerToken(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
 	if req.Token == "" || req.Expiry == 0 {
-		return resp, errors.New("token and expiry are required")
+		return nil, errors.New("token and expiry are required")
 	}
 
 	t := JoinToken{
@@ -844,97 +1157,88 @@ func (ds *sqlPlugin) RegisterToken(ctx context.Context, req *datastore.JoinToken
 		Expiry: req.Expiry,
 	}
 
-	return resp, ds.db.Create(&t).Error
+	if err := tx.Create(&t).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
+	return &common.Empty{}, nil
 }
 
-// FetchToken takes a Token message and returns one, populating the fields
-// we have knowledge of
-func (ds *sqlPlugin) FetchToken(ctx context.Context, req *datastore.JoinToken) (*datastore.JoinToken, error) {
+func fetchToken(tx *gorm.DB, req *datastore.JoinToken) (*datastore.JoinToken, error) {
 	var t JoinToken
-
-	err := ds.db.Find(&t, "token = ?", req.Token).Error
+	err := tx.Find(&t, "token = ?", req.Token).Error
 	if err == gorm.ErrRecordNotFound {
 		return &datastore.JoinToken{}, nil
+	} else if err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	resp := &datastore.JoinToken{
+	return &datastore.JoinToken{
 		Token:  t.Token,
 		Expiry: t.Expiry,
-	}
-	return resp, err
+	}, nil
 }
 
-func (ds *sqlPlugin) DeleteToken(ctx context.Context, req *datastore.JoinToken) (*common.Empty, error) {
+func deleteToken(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
 	var t JoinToken
-
-	err := ds.db.Find(&t, "token = ?", req.Token).Error
-	if err != nil {
-		return &common.Empty{}, err
+	if err := tx.Find(&t, "token = ?", req.Token).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	return &common.Empty{}, ds.db.Delete(&t).Error
+	if err := tx.Delete(&t).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
+	return &common.Empty{}, nil
 }
 
-// PruneTokens takes a Token message, and deletes all tokens which have expired
-// before the date in the message
-func (ds *sqlPlugin) PruneTokens(ctx context.Context, req *datastore.JoinToken) (*common.Empty, error) {
-	var staleTokens []JoinToken
-	resp := new(common.Empty)
-
-	err := ds.db.Where("expiry <= ?", req.Expiry).Find(&staleTokens).Error
-	if err != nil {
-		return resp, err
+func pruneTokens(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
+	if err := tx.Where("expiry <= ?", req.Expiry).Delete(&JoinToken{}).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
 
-	for _, t := range staleTokens {
-		err := ds.db.Delete(&t).Error
-		if err != nil {
-			return resp, err
-		}
-	}
-
-	return resp, nil
+	return &common.Empty{}, nil
 }
 
-func (ds *sqlPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	resp := &spi.ConfigureResponse{}
-
-	// Parse HCL config payload into config struct
-	config := &configuration{}
-	hclTree, err := hcl.Parse(req.Configuration)
+// modelToBundle converts the given bundle model to a Protobuf bundle message. It will also
+// include any embedded CACert models.
+func modelToBundle(model *Bundle) (*datastore.Bundle, error) {
+	id, err := idutil.ParseSpiffeID(model.TrustDomain, idutil.AllowAnyTrustDomain())
 	if err != nil {
-		resp.ErrorList = []string{err.Error()}
-		return resp, err
-	}
-	err = hcl.DecodeObject(&config, hclTree)
-	if err != nil {
-		resp.ErrorList = []string{err.Error()}
-		return resp, err
+		return nil, sqlError.Wrap(err)
 	}
 
-	if config.DatabaseType == "" {
-		return resp, errors.New("database_type must be set")
+	caCerts := []byte{}
+	for _, c := range model.CACerts {
+		caCerts = append(caCerts, c.Cert...)
 	}
 
-	if config.ConnectionString == "" {
-		return resp, errors.New("connection_string must be set")
+	pb := &datastore.Bundle{
+		TrustDomain: id.String(),
+		CaCerts:     caCerts,
 	}
 
-	if config.ConnectionString != ds.ConnectionString {
-		ds.DatabaseType = config.DatabaseType
-		ds.ConnectionString = config.ConnectionString
-		return resp, ds.restart()
-	}
-
-	return resp, nil
+	return pb, nil
 }
 
-func (sqlPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &pluginInfo, nil
+func validateRegistrationEntry(entry *common.RegistrationEntry) error {
+	if entry.Selectors == nil || len(entry.Selectors) == 0 {
+		return sqlError.New("invalid registration entry: missing selector list")
+	}
+
+	if len(entry.SpiffeId) == 0 {
+		return sqlError.New("invalid registration entry: missing SPIFFE ID")
+	}
+
+	if entry.Ttl < 0 {
+		return sqlError.New("invalid registration entry: TTL is not set")
+	}
+
+	return nil
 }
 
-// listMatchingEntries finds registered entries containing exactly the specified selectors.
-func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*common.RegistrationEntry, error) {
+// listEntriesWithExactSelectorMatch finds registered entries containing exactly the specified selectors.
+func listEntriesWithExactSelectorMatch(tx *gorm.DB, selectors []*common.Selector) ([]*common.RegistrationEntry, error) {
 	if len(selectors) < 1 {
 		return nil, nil
 	}
@@ -943,9 +1247,8 @@ func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*commo
 	refCount := make(map[uint]int)
 	for _, s := range selectors {
 		var results []Selector
-		err := ds.db.Find(&results, "type = ? AND value = ?", s.Type, s.Value).Error
-		if err != nil {
-			return nil, err
+		if err := tx.Find(&results, "type = ? AND value = ?", s.Type, s.Value).Error; err != nil {
+			return nil, sqlError.Wrap(err)
 		}
 
 		for _, r := range results {
@@ -969,9 +1272,8 @@ func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*commo
 	var resp []RegisteredEntry
 	for _, id := range entryIDs {
 		var result RegisteredEntry
-		err := ds.db.Find(&result, "id = ?", id).Error
-		if err != nil {
-			return nil, err
+		if err := tx.Find(&result, "id = ?", id).Error; err != nil {
+			return nil, sqlError.Wrap(err)
 		}
 
 		resp = append(resp, result)
@@ -979,7 +1281,7 @@ func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*commo
 
 	// Weed out entries that have more selectors than requested, since only
 	// EXACT matches should be returned.
-	convertedEntries, err := ds.convertEntriesNoSort(resp)
+	convertedEntries, err := modelsToUnsortedEntries(tx, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -995,15 +1297,15 @@ func (ds *sqlPlugin) listMatchingEntries(selectors []*common.Selector) ([]*commo
 
 // bundleToModel converts the given Protobuf bundle message to a database model. It
 // performs validation, and fully parses certificates to form CACert embedded models.
-func (ds *sqlPlugin) bundleToModel(pb *datastore.Bundle) (*Bundle, error) {
-	id, err := ds.validateTrustDomain(pb.TrustDomain)
+func bundleToModel(pb *datastore.Bundle) (*Bundle, error) {
+	id, err := idutil.ParseSpiffeID(pb.TrustDomain, idutil.AllowAnyTrustDomain())
 	if err != nil {
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
 
 	certs, err := x509.ParseCertificates(pb.CaCerts)
 	if err != nil {
-		return nil, errors.New("could not parse CA certificates")
+		return nil, sqlError.New("could not parse CA certificates")
 	}
 
 	// Translate CACerts, if any
@@ -1025,67 +1327,8 @@ func (ds *sqlPlugin) bundleToModel(pb *datastore.Bundle) (*Bundle, error) {
 	return bundle, nil
 }
 
-// modelToBundle converts the given bundle model to a Protobuf bundle message. It will also
-// include any embedded CACert models.
-func (ds *sqlPlugin) modelToBundle(model *Bundle) (*datastore.Bundle, error) {
-	id, err := ds.validateTrustDomain(model.TrustDomain)
-	if err != nil {
-		return nil, err
-	}
-
-	caCerts := []byte{}
-	for _, c := range model.CACerts {
-		caCerts = append(caCerts, c.Cert...)
-	}
-
-	pb := &datastore.Bundle{
-		TrustDomain: id.String(),
-		CaCerts:     caCerts,
-	}
-
-	return pb, nil
-}
-
-func (ds *sqlPlugin) validateRegistrationEntry(entry *common.RegistrationEntry) error {
-	if entry.Selectors == nil || len(entry.Selectors) == 0 {
-		return errors.New("missing selector list")
-	}
-
-	if len(entry.SpiffeId) == 0 {
-		return errors.New("missing SPIFFE ID")
-	}
-
-	if entry.Ttl < 0 {
-		return errors.New("TTL is not set")
-	}
-
-	return nil
-}
-
-// validateTrustDomain converts the given string to a URL, and ensures that it is a correctly
-// formatted SPIFFE trust domain. String is taken as the argument here since neither Protobuf nor
-// GORM natively support the url.URL type.
-//
-// A valid trust domain has the SPIFFE scheme, a non-zero host component, and no path
-func (ds *sqlPlugin) validateTrustDomain(in string) (*url.URL, error) {
-	if in == "" {
-		return nil, errors.New("trust domain is required")
-	}
-
-	id, err := url.Parse(in)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse trust domain %v: %v", in, err)
-	}
-
-	if id.Scheme != "spiffe" || id.Host == "" || (id.Path != "" && id.Path != "/") {
-		return nil, fmt.Errorf("%v is not a valid SPIFFE trust domain", id.String())
-	}
-
-	return id, nil
-}
-
-func (ds *sqlPlugin) convertEntries(fetchedRegisteredEntries []RegisteredEntry) (responseEntries []*common.RegistrationEntry, err error) {
-	entries, err := ds.convertEntriesNoSort(fetchedRegisteredEntries)
+func modelsToEntries(tx *gorm.DB, fetchedRegisteredEntries []RegisteredEntry) (responseEntries []*common.RegistrationEntry, err error) {
+	entries, err := modelsToUnsortedEntries(tx, fetchedRegisteredEntries)
 	if err != nil {
 		return nil, err
 	}
@@ -1093,71 +1336,42 @@ func (ds *sqlPlugin) convertEntries(fetchedRegisteredEntries []RegisteredEntry) 
 	return entries, nil
 }
 
-func (ds *sqlPlugin) convertEntriesNoSort(fetchedRegisteredEntries []RegisteredEntry) (responseEntries []*common.RegistrationEntry, err error) {
+func modelsToUnsortedEntries(tx *gorm.DB, fetchedRegisteredEntries []RegisteredEntry) (responseEntries []*common.RegistrationEntry, err error) {
 	for _, regEntry := range fetchedRegisteredEntries {
-		var selectors []*common.Selector
-		var fetchedSelectors []*Selector
-		if err = ds.db.Model(&regEntry).Related(&fetchedSelectors).Error; err != nil {
+		responseEntry, err := modelToEntry(tx, regEntry)
+		if err != nil {
 			return nil, err
 		}
-
-		for _, selector := range fetchedSelectors {
-			selectors = append(selectors, &common.Selector{
-				Type:  selector.Type,
-				Value: selector.Value})
-		}
-		responseEntries = append(responseEntries, &common.RegistrationEntry{
-			EntryId:   regEntry.EntryID,
-			Selectors: selectors,
-			SpiffeId:  regEntry.SpiffeID,
-			ParentId:  regEntry.ParentID,
-			Ttl:       regEntry.TTL,
-		})
+		responseEntries = append(responseEntries, responseEntry)
 	}
 	return responseEntries, nil
 }
 
-// restart will close and re-open the gorm database.
-func (ds *sqlPlugin) restart() error {
-	ds.mutex.Lock()
-	defer ds.mutex.Unlock()
-
-	var db *gorm.DB
-	var err error
-
-	switch ds.DatabaseType {
-	case "sqlite3":
-		db, err = sqlite{}.connect(ds.ConnectionString)
-	case "postgres":
-		db, err = postgres{}.connect(ds.ConnectionString)
-	default:
-		return fmt.Errorf("unsupported database_type: %v", ds.DatabaseType)
+func modelToEntry(tx *gorm.DB, model RegisteredEntry) (*common.RegistrationEntry, error) {
+	var selectors []*common.Selector
+	var fetchedSelectors []*Selector
+	if err := tx.Model(&model).Related(&fetchedSelectors).Error; err != nil {
+		return nil, sqlError.Wrap(err)
 	}
+
+	for _, selector := range fetchedSelectors {
+		selectors = append(selectors, &common.Selector{
+			Type:  selector.Type,
+			Value: selector.Value})
+	}
+	return &common.RegistrationEntry{
+		EntryId:   model.EntryID,
+		Selectors: selectors,
+		SpiffeId:  model.SpiffeID,
+		ParentId:  model.ParentID,
+		Ttl:       model.TTL,
+	}, nil
+}
+
+func newRegistrationEntryID() (string, error) {
+	id, err := uuid.NewV4()
 	if err != nil {
-		return err
+		return "", sqlError.New("unable to generate registration entry id: %v", err)
 	}
-
-	if err := migrateDB(db); err != nil {
-		db.Close()
-		return err
-	}
-
-	if ds.db != nil {
-		ds.db.Close()
-	}
-
-	ds.db = db
-	return nil
-}
-
-func newPlugin() *sqlPlugin {
-	return &sqlPlugin{
-		mutex: new(sync.Mutex),
-	}
-}
-
-// New creates a new sql plugin struct. Configure must be called
-// in order to start the db.
-func New() datastore.Plugin {
-	return newPlugin()
+	return id.String(), nil
 }

--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -10,9 +10,16 @@ type sqlite struct{}
 func (s sqlite) connect(connectionString string) (*gorm.DB, error) {
 	db, err := gorm.Open("sqlite3", connectionString)
 	if err != nil {
-		return nil, err
+		return nil, sqlError.Wrap(err)
 	}
-	db.Exec("PRAGMA foreign_keys = ON")
+	if err := db.Exec("PRAGMA journal_mode = WAL").Error; err != nil {
+		db.Close()
+		return nil, sqlError.Wrap(err)
+	}
+	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+		db.Close()
+		return nil, sqlError.Wrap(err)
+	}
 
 	return db, nil
 }


### PR DESCRIPTION
- consistent use of transactions.
- opens sqlite3 databases in WAL mode to improve concurrency performance
- enforces a lock over write operations for sqlite3.
- improved error handling.
- error wrapping for improved diagnostics.
- fixed Configure() to be safe in the presence of concurrent callers and
to not overwrite the current database unless the new one opened
successfully.
- converts tests to test suite
- has tests test against database on disk in order to properly exercise
behavior (in-memory databases have journaling differences)