### PR TITLE
datastore api refactor

### DIFF
--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -271,11 +271,12 @@ func (m *ManagerTestSuite) TestPrune() {
 }
 
 func (m *ManagerTestSuite) requireBundle(expectedCerts ...*x509.Certificate) {
-	bundle, err := m.datastore.FetchBundle(ctx, &datastore.Bundle{
+	resp, err := m.datastore.FetchBundle(ctx, &datastore.FetchBundleRequest{
 		TrustDomain: m.m.c.TrustDomain.String(),
 	})
 	m.Require().NoError(err)
-	actualCerts, err := x509.ParseCertificates(bundle.CaCerts)
+	m.Require().NotNil(resp.Bundle)
+	actualCerts, err := x509.ParseCertificates(resp.Bundle.CaCerts)
 	m.Require().NoError(err)
 	m.Require().Equal(len(expectedCerts), len(actualCerts))
 	for i := range actualCerts {

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -471,7 +471,9 @@ func (h *Handler) updateNodeSelectors(ctx context.Context,
 	}
 
 	var selectors []*common.Selector
-	selectors = append(selectors, response.Map[baseSpiffeID].Entries...)
+	if resolved := response.Map[baseSpiffeID]; resolved != nil {
+		selectors = append(selectors, resolved.Entries...)
+	}
 	selectors = append(selectors, attestResponse.Selectors...)
 
 	dataStore := h.c.Catalog.DataStores()[0]

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -384,10 +384,12 @@ func (h *Handler) attestToken(ctx context.Context,
 		return nil, errors.New("invalid join token")
 	}
 
-	// Don't fail if we can't delete
-	_, _ = ds.DeleteJoinToken(ctx, &datastore.DeleteJoinTokenRequest{
+	_, err := ds.DeleteJoinToken(ctx, &datastore.DeleteJoinTokenRequest{
 		Token: tokenValue,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	if time.Unix(t.Expiry, 0).Before(h.hooks.now()) {
 		return nil, errors.New("join token expired")

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -53,14 +54,14 @@ func (h *Handler) CreateEntry(
 	}
 
 	createResponse, err := ds.CreateRegistrationEntry(ctx,
-		&datastore.CreateRegistrationEntryRequest{RegisteredEntry: request},
+		&datastore.CreateRegistrationEntryRequest{Entry: request},
 	)
 	if err != nil {
 		h.Log.Error(err)
 		return response, errors.New("Error trying to create entry")
 	}
 
-	return &registration.RegistrationEntryID{Id: createResponse.RegisteredEntryId}, nil
+	return &registration.RegistrationEntryID{Id: createResponse.EntryId}, nil
 }
 
 func (h *Handler) DeleteEntry(
@@ -69,14 +70,14 @@ func (h *Handler) DeleteEntry(
 
 	ds := h.getDataStore()
 	req := &datastore.DeleteRegistrationEntryRequest{
-		RegisteredEntryId: request.Id,
+		EntryId: request.Id,
 	}
 	resp, err := ds.DeleteRegistrationEntry(ctx, req)
 	if err != nil {
 		return &common.RegistrationEntry{}, err
 	}
 
-	response = resp.RegisteredEntry
+	response = resp.Entry
 	return response, nil
 }
 
@@ -87,13 +88,13 @@ func (h *Handler) FetchEntry(
 
 	ds := h.getDataStore()
 	fetchResponse, err := ds.FetchRegistrationEntry(ctx,
-		&datastore.FetchRegistrationEntryRequest{RegisteredEntryId: request.Id},
+		&datastore.FetchRegistrationEntryRequest{EntryId: request.Id},
 	)
 	if err != nil {
 		h.Log.Error(err)
 		return response, errors.New("Error trying to fetch entry")
 	}
-	return fetchResponse.RegisteredEntry, nil
+	return fetchResponse.Entry, nil
 }
 
 func (h *Handler) FetchEntries(
@@ -101,12 +102,14 @@ func (h *Handler) FetchEntries(
 	response *common.RegistrationEntries, err error) {
 
 	ds := h.getDataStore()
-	fetchResponse, err := ds.FetchRegistrationEntries(ctx, &common.Empty{})
+	fetchResponse, err := ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
 	if err != nil {
 		h.Log.Error(err)
 		return response, errors.New("Error trying to fetch entries")
 	}
-	return fetchResponse.RegisteredEntries, nil
+	return &common.RegistrationEntries{
+		Entries: fetchResponse.Entries,
+	}, nil
 }
 
 //TODO
@@ -122,16 +125,19 @@ func (h *Handler) ListByParentID(
 	response *common.RegistrationEntries, err error) {
 
 	ds := h.getDataStore()
-	listResponse, err := ds.ListParentIDEntries(ctx,
-		&datastore.ListParentIDEntriesRequest{ParentId: request.Id},
-	)
+	listResponse, err := ds.ListRegistrationEntries(ctx,
+		&datastore.ListRegistrationEntriesRequest{
+			ByParentId: &wrappers.StringValue{
+				Value: request.Id,
+			},
+		})
 	if err != nil {
 		h.Log.Error(err)
 		return response, errors.New("Error trying to list entries by parent ID")
 	}
 
 	return &common.RegistrationEntries{
-		Entries: listResponse.RegisteredEntryList,
+		Entries: listResponse.Entries,
 	}, nil
 }
 
@@ -140,18 +146,19 @@ func (h *Handler) ListBySelector(
 	response *common.RegistrationEntries, err error) {
 
 	ds := h.getDataStore()
-	req := &datastore.ListSelectorEntriesRequest{
-		Selectors: []*common.Selector{request},
+	req := &datastore.ListRegistrationEntriesRequest{
+		BySelectors: &datastore.BySelectors{
+			Selectors: []*common.Selector{request},
+		},
 	}
-	resp, err := ds.ListSelectorEntries(ctx, req)
+	resp, err := ds.ListRegistrationEntries(ctx, req)
 	if err != nil {
 		return &common.RegistrationEntries{}, err
 	}
 
-	response = &common.RegistrationEntries{
-		Entries: resp.RegisteredEntryList,
-	}
-	return response, nil
+	return &common.RegistrationEntries{
+		Entries: resp.Entries,
+	}, nil
 }
 
 func (h *Handler) ListBySpiffeID(
@@ -159,18 +166,19 @@ func (h *Handler) ListBySpiffeID(
 	response *common.RegistrationEntries, err error) {
 
 	ds := h.getDataStore()
-	req := &datastore.ListSpiffeEntriesRequest{
-		SpiffeId: request.Id,
+	req := &datastore.ListRegistrationEntriesRequest{
+		BySpiffeId: &wrappers.StringValue{
+			Value: request.Id,
+		},
 	}
-	resp, err := ds.ListSpiffeEntries(ctx, req)
+	resp, err := ds.ListRegistrationEntries(ctx, req)
 	if err != nil {
 		return &common.RegistrationEntries{}, err
 	}
 
-	response = &common.RegistrationEntries{
-		Entries: resp.RegisteredEntryList,
-	}
-	return response, nil
+	return &common.RegistrationEntries{
+		Entries: resp.Entries,
+	}, nil
 }
 
 func (h *Handler) CreateFederatedBundle(
@@ -186,9 +194,11 @@ func (h *Handler) CreateFederatedBundle(
 	}
 
 	ds := h.getDataStore()
-	if _, err := ds.CreateBundle(ctx, &datastore.Bundle{
-		TrustDomain: request.SpiffeId,
-		CaCerts:     request.CaCerts,
+	if _, err := ds.CreateBundle(ctx, &datastore.CreateBundleRequest{
+		Bundle: &datastore.Bundle{
+			TrustDomain: request.SpiffeId,
+			CaCerts:     request.CaCerts,
+		},
 	}); err != nil {
 		return nil, err
 	}
@@ -209,27 +219,30 @@ func (h *Handler) FetchFederatedBundle(
 	}
 
 	ds := h.getDataStore()
-	bundle, err := ds.FetchBundle(ctx, &datastore.Bundle{
+	resp, err := ds.FetchBundle(ctx, &datastore.FetchBundleRequest{
 		TrustDomain: request.Id,
 	})
 	if err != nil {
 		return nil, err
 	}
+	if resp.Bundle == nil {
+		return nil, errors.New("no bundle in response")
+	}
 
 	return &registration.FederatedBundle{
-		SpiffeId: bundle.TrustDomain,
-		CaCerts:  bundle.CaCerts,
+		SpiffeId: resp.Bundle.TrustDomain,
+		CaCerts:  resp.Bundle.CaCerts,
 	}, nil
 }
 
 func (h *Handler) ListFederatedBundles(request *common.Empty, stream registration.Registration_ListFederatedBundlesServer) (err error) {
 	ds := h.getDataStore()
-	bundles, err := ds.ListBundles(stream.Context(), &common.Empty{})
+	resp, err := ds.ListBundles(stream.Context(), &datastore.ListBundlesRequest{})
 	if err != nil {
 		return err
 	}
 
-	for _, bundle := range bundles.Bundles {
+	for _, bundle := range resp.Bundles {
 		if bundle.TrustDomain == h.TrustDomain.String() {
 			continue
 		}
@@ -257,9 +270,11 @@ func (h *Handler) UpdateFederatedBundle(
 	}
 
 	ds := h.getDataStore()
-	if _, err := ds.UpdateBundle(ctx, &datastore.Bundle{
-		TrustDomain: request.SpiffeId,
-		CaCerts:     request.CaCerts,
+	if _, err := ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
+		Bundle: &datastore.Bundle{
+			TrustDomain: request.SpiffeId,
+			CaCerts:     request.CaCerts,
+		},
 	}); err != nil {
 		return nil, err
 	}
@@ -280,7 +295,7 @@ func (h *Handler) DeleteFederatedBundle(
 	}
 
 	ds := h.getDataStore()
-	if _, err := ds.DeleteBundle(ctx, &datastore.Bundle{
+	if _, err := ds.DeleteBundle(ctx, &datastore.DeleteBundleRequest{
 		TrustDomain: request.Id,
 	}); err != nil {
 		return nil, err
@@ -309,12 +324,13 @@ func (h *Handler) CreateJoinToken(
 
 	ds := h.getDataStore()
 	expiry := time.Now().Unix() + int64(request.Ttl)
-	req := &datastore.JoinToken{
-		Token:  request.Token,
-		Expiry: expiry,
-	}
 
-	_, err := ds.RegisterToken(ctx, req)
+	_, err := ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
+		JoinToken: &datastore.JoinToken{
+			Token:  request.Token,
+			Expiry: expiry,
+		},
+	})
 	if err != nil {
 		h.Log.Error(err)
 		return nil, errors.New("Error trying to register your token")
@@ -328,26 +344,32 @@ func (h *Handler) FetchBundle(
 	ctx context.Context, request *common.Empty) (
 	response *registration.Bundle, err error) {
 	ds := h.getDataStore()
-	req := &datastore.Bundle{
+	resp, err := ds.FetchBundle(ctx, &datastore.FetchBundleRequest{
 		TrustDomain: h.TrustDomain.String(),
-	}
-	b, err := ds.FetchBundle(ctx, req)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get bundle from datastore: %v", err)
 	}
+	if resp.Bundle == nil {
+		return nil, errors.New("response has no bundle")
+	}
 
-	return &registration.Bundle{CaCerts: b.CaCerts}, nil
+	return &registration.Bundle{CaCerts: resp.Bundle.CaCerts}, nil
 }
 
 func (h *Handler) isEntryUnique(ctx context.Context, ds datastore.DataStore, entry *common.RegistrationEntry) (bool, error) {
 	// First we get all the entries that matches the entry's spiffe id.
-	req := &datastore.ListSpiffeEntriesRequest{SpiffeId: entry.SpiffeId}
-	res, err := ds.ListSpiffeEntries(ctx, req)
+	req := &datastore.ListRegistrationEntriesRequest{
+		BySpiffeId: &wrappers.StringValue{
+			Value: entry.SpiffeId,
+		},
+	}
+	res, err := ds.ListRegistrationEntries(ctx, req)
 	if err != nil {
 		return false, err
 	}
 
-	for _, re := range res.RegisteredEntryList {
+	for _, re := range res.Entries {
 		// If an existing entry matches the new entry's parent id also, we must check its
 		// selectors...
 		if re.ParentId == entry.ParentId {

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -61,7 +61,7 @@ func (h *Handler) CreateEntry(
 		return response, errors.New("Error trying to create entry")
 	}
 
-	return &registration.RegistrationEntryID{Id: createResponse.EntryId}, nil
+	return &registration.RegistrationEntryID{Id: createResponse.Entry.EntryId}, nil
 }
 
 func (h *Handler) DeleteEntry(

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -641,20 +641,22 @@ func TestFetchBundle(t *testing.T) {
 func noExpectations(*handlerTestSuite) {}
 
 func createEntryExpectations(suite *handlerTestSuite) {
-	newRegEntry := testutil.GetRegistrationEntries("good.json")[0]
+	entryIn := testutil.GetRegistrationEntries("good.json")[0]
 
 	suite.mockDataStore.EXPECT().
-		ListRegistrationEntries(gomock.Any(), &datastore.ListRegistrationEntriesRequest{BySpiffeId: &wrappers.StringValue{Value: newRegEntry.SpiffeId}}).
+		ListRegistrationEntries(gomock.Any(), &datastore.ListRegistrationEntriesRequest{BySpiffeId: &wrappers.StringValue{Value: entryIn.SpiffeId}}).
 		Return(&datastore.ListRegistrationEntriesResponse{
 			Entries: []*common.RegistrationEntry{},
 		}, nil)
 
 	createRequest := &datastore.CreateRegistrationEntryRequest{
-		Entry: newRegEntry,
+		Entry: entryIn,
 	}
 
+	entryOut := *entryIn
+	entryOut.EntryId = "abcdefgh"
 	createResponse := &datastore.CreateRegistrationEntryResponse{
-		EntryId: "abcdefgh",
+		Entry: &entryOut,
 	}
 
 	suite.mockDataStore.EXPECT().

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/proto/api/registration"
 	"github.com/spiffe/spire/proto/common"
@@ -96,12 +97,12 @@ func (s *HandlerSuite) TestCreateFederatedBundle() {
 		s.Require().Equal(&common.Empty{}, response)
 
 		// assert that the bundle was created in the datastore
-		bundle, err := s.ds.FetchBundle(context.Background(), &datastore.Bundle{
+		resp, err := s.ds.FetchBundle(context.Background(), &datastore.FetchBundleRequest{
 			TrustDomain: testCase.Id,
 		})
 		s.Require().NoError(err)
-		s.Require().Equal(bundle.TrustDomain, testCase.Id)
-		s.Require().Equal(string(bundle.CaCerts), testCase.CaCerts)
+		s.Require().Equal(resp.Bundle.TrustDomain, testCase.Id)
+		s.Require().Equal(string(resp.Bundle.CaCerts), testCase.CaCerts)
 	}
 }
 
@@ -197,12 +198,12 @@ func (s *HandlerSuite) TestUpdateFederatedBundle() {
 		s.Require().Equal(&common.Empty{}, response)
 
 		// assert that the bundle was created in the datastore
-		bundle, err := s.ds.FetchBundle(context.Background(), &datastore.Bundle{
+		resp, err := s.ds.FetchBundle(context.Background(), &datastore.FetchBundleRequest{
 			TrustDomain: testCase.Id,
 		})
 		s.Require().NoError(err)
-		s.Require().Equal(bundle.TrustDomain, testCase.Id)
-		s.Require().Equal(string(bundle.CaCerts), testCase.CaCerts)
+		s.Require().Equal(resp.Bundle.TrustDomain, testCase.Id)
+		s.Require().Equal(string(resp.Bundle.CaCerts), testCase.CaCerts)
 	}
 }
 
@@ -236,16 +237,18 @@ func (s *HandlerSuite) TestDeleteFederatedBundle() {
 		s.Require().Equal(&common.Empty{}, response)
 
 		// assert that the bundle was deleted
-		bundle, err := s.ds.FetchBundle(context.Background(), &datastore.Bundle{
+		resp, err := s.ds.FetchBundle(context.Background(), &datastore.FetchBundleRequest{
 			TrustDomain: testCase.Id,
 		})
 		s.Require().EqualError(err, "no such bundle")
-		s.Require().Nil(bundle)
+		s.Require().Nil(resp)
 	}
 }
 
 func (s *HandlerSuite) createBundle(bundle *datastore.Bundle) {
-	_, err := s.ds.CreateBundle(context.Background(), bundle)
+	_, err := s.ds.CreateBundle(context.Background(), &datastore.CreateBundleRequest{
+		Bundle: bundle,
+	})
 	s.Require().NoError(err)
 }
 
@@ -581,8 +584,8 @@ func TestCreateJoinTokenWithoutToken(t *testing.T) {
 
 	//expectations
 	suite.mockDataStore.EXPECT().
-		RegisterToken(gomock.Any(), gomock.Any()).
-		Return(&common.Empty{}, nil)
+		CreateJoinToken(gomock.Any(), gomock.Any()).
+		Return(&datastore.CreateJoinTokenResponse{}, nil)
 
 	//exercise
 	response, err := suite.handler.CreateJoinToken(nil, request)
@@ -641,17 +644,17 @@ func createEntryExpectations(suite *handlerTestSuite) {
 	newRegEntry := testutil.GetRegistrationEntries("good.json")[0]
 
 	suite.mockDataStore.EXPECT().
-		ListSpiffeEntries(gomock.Any(), &datastore.ListSpiffeEntriesRequest{SpiffeId: newRegEntry.SpiffeId}).
-		Return(&datastore.ListSpiffeEntriesResponse{
-			RegisteredEntryList: []*common.RegistrationEntry{},
+		ListRegistrationEntries(gomock.Any(), &datastore.ListRegistrationEntriesRequest{BySpiffeId: &wrappers.StringValue{Value: newRegEntry.SpiffeId}}).
+		Return(&datastore.ListRegistrationEntriesResponse{
+			Entries: []*common.RegistrationEntry{},
 		}, nil)
 
 	createRequest := &datastore.CreateRegistrationEntryRequest{
-		RegisteredEntry: newRegEntry,
+		Entry: newRegEntry,
 	}
 
 	createResponse := &datastore.CreateRegistrationEntryResponse{
-		RegisteredEntryId: "abcdefgh",
+		EntryId: "abcdefgh",
 	}
 
 	suite.mockDataStore.EXPECT().
@@ -661,9 +664,9 @@ func createEntryExpectations(suite *handlerTestSuite) {
 
 func createEntryErrorExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		ListSpiffeEntries(gomock.Any(), gomock.Any()).
-		Return(&datastore.ListSpiffeEntriesResponse{
-			RegisteredEntryList: []*common.RegistrationEntry{},
+		ListRegistrationEntries(gomock.Any(), gomock.Any()).
+		Return(&datastore.ListRegistrationEntriesResponse{
+			Entries: []*common.RegistrationEntry{},
 		}, nil)
 
 	suite.mockDataStore.EXPECT().
@@ -675,18 +678,22 @@ func createEntryNonUniqueExpectations(suite *handlerTestSuite) {
 	newRegEntry := testutil.GetRegistrationEntries("good.json")[0]
 
 	suite.mockDataStore.EXPECT().
-		ListSpiffeEntries(gomock.Any(), &datastore.ListSpiffeEntriesRequest{SpiffeId: newRegEntry.SpiffeId}).
-		Return(&datastore.ListSpiffeEntriesResponse{
-			RegisteredEntryList: []*common.RegistrationEntry{newRegEntry},
+		ListRegistrationEntries(gomock.Any(), &datastore.ListRegistrationEntriesRequest{
+			BySpiffeId: &wrappers.StringValue{
+				Value: newRegEntry.SpiffeId,
+			},
+		}).
+		Return(&datastore.ListRegistrationEntriesResponse{
+			Entries: []*common.RegistrationEntry{newRegEntry},
 		}, nil)
 }
 
 func fetchEntryExpectations(suite *handlerTestSuite) {
 	fetchRequest := &datastore.FetchRegistrationEntryRequest{
-		RegisteredEntryId: "abcdefgh",
+		EntryId: "abcdefgh",
 	}
 	fetchResponse := &datastore.FetchRegistrationEntryResponse{
-		RegisteredEntry: testutil.GetRegistrationEntries("good.json")[0],
+		Entry: testutil.GetRegistrationEntries("good.json")[0],
 	}
 	suite.mockDataStore.EXPECT().
 		FetchRegistrationEntry(gomock.Any(), fetchRequest).
@@ -694,13 +701,11 @@ func fetchEntryExpectations(suite *handlerTestSuite) {
 }
 
 func fetchEntriesExpectations(suite *handlerTestSuite) {
-	fetchResponse := &datastore.FetchRegistrationEntriesResponse{
-		RegisteredEntries: &common.RegistrationEntries{
-			Entries: testutil.GetRegistrationEntries("good.json"),
-		},
+	fetchResponse := &datastore.ListRegistrationEntriesResponse{
+		Entries: testutil.GetRegistrationEntries("good.json"),
 	}
 	suite.mockDataStore.EXPECT().
-		FetchRegistrationEntries(gomock.Any(), &common.Empty{}).
+		ListRegistrationEntries(gomock.Any(), &datastore.ListRegistrationEntriesRequest{}).
 		Return(fetchResponse, nil)
 }
 
@@ -712,7 +717,7 @@ func fetchEntryErrorExpectations(suite *handlerTestSuite) {
 
 func deleteEntryExpectations(suite *handlerTestSuite) {
 	resp := &datastore.DeleteRegistrationEntryResponse{
-		RegisteredEntry: testutil.GetRegistrationEntries("good.json")[0],
+		Entry: testutil.GetRegistrationEntries("good.json")[0],
 	}
 
 	suite.mockDataStore.EXPECT().
@@ -721,73 +726,81 @@ func deleteEntryExpectations(suite *handlerTestSuite) {
 }
 
 func listByParentIDExpectations(suite *handlerTestSuite) {
-	listRequest := &datastore.ListParentIDEntriesRequest{ParentId: "spiffe://example.org/spire/agent/join_token/TokenBlog"}
-	listResponse := &datastore.ListParentIDEntriesResponse{
-		RegisteredEntryList: testutil.GetRegistrationEntries("good.json"),
+	listRequest := &datastore.ListRegistrationEntriesRequest{
+		ByParentId: &wrappers.StringValue{
+			Value: "spiffe://example.org/spire/agent/join_token/TokenBlog",
+		},
+	}
+	listResponse := &datastore.ListRegistrationEntriesResponse{
+		Entries: testutil.GetRegistrationEntries("good.json"),
 	}
 	suite.mockDataStore.EXPECT().
-		ListParentIDEntries(gomock.Any(), listRequest).
+		ListRegistrationEntries(gomock.Any(), listRequest).
 		Return(listResponse, nil)
 }
 
 func listByParentIDErrorExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		ListParentIDEntries(gomock.Any(), gomock.Any()).
+		ListRegistrationEntries(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("foo"))
 }
 
 func listBySelectorExpectations(suite *handlerTestSuite) {
-	req := &datastore.ListSelectorEntriesRequest{
-		Selectors: []*common.Selector{
-			{Type: "unix", Value: "uid:1111"},
+	req := &datastore.ListRegistrationEntriesRequest{
+		BySelectors: &datastore.BySelectors{
+			Selectors: []*common.Selector{{Type: "unix", Value: "uid:1111"}},
 		},
 	}
-	resp := &datastore.ListSelectorEntriesResponse{
-		RegisteredEntryList: testutil.GetRegistrationEntries("good.json"),
+	resp := &datastore.ListRegistrationEntriesResponse{
+		Entries: testutil.GetRegistrationEntries("good.json"),
 	}
 
 	suite.mockDataStore.EXPECT().
-		ListSelectorEntries(gomock.Any(), req).
+		ListRegistrationEntries(gomock.Any(), req).
 		Return(resp, nil)
 }
 
 func listBySpiffeIDExpectations(suite *handlerTestSuite) {
-	req := &datastore.ListSpiffeEntriesRequest{
-		SpiffeId: "spiffe://example.org/Blog",
+	req := &datastore.ListRegistrationEntriesRequest{
+		BySpiffeId: &wrappers.StringValue{
+			Value: "spiffe://example.org/Blog",
+		},
 	}
 
-	resp := &datastore.ListSpiffeEntriesResponse{
-		RegisteredEntryList: testutil.GetRegistrationEntries("good.json")[0:1],
+	resp := &datastore.ListRegistrationEntriesResponse{
+		Entries: testutil.GetRegistrationEntries("good.json")[0:1],
 	}
 
 	suite.mockDataStore.EXPECT().
-		ListSpiffeEntries(gomock.Any(), req).
+		ListRegistrationEntries(gomock.Any(), req).
 		Return(resp, nil)
 }
 
 func createJoinTokenExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		RegisterToken(gomock.Any(), gomock.Any()).
-		Return(&common.Empty{}, nil)
+		CreateJoinToken(gomock.Any(), gomock.Any()).
+		Return(&datastore.CreateJoinTokenResponse{}, nil)
 }
 
 func createJoinTokenErrorExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		RegisterToken(gomock.Any(), gomock.Any()).
+		CreateJoinToken(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("foo"))
 }
 
 func createFetchBundleExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		FetchBundle(gomock.Any(), &datastore.Bundle{
+		FetchBundle(gomock.Any(), &datastore.FetchBundleRequest{
 			TrustDomain: "spiffe://example.org",
 		}).
-		Return(&datastore.Bundle{CaCerts: []byte{1, 2, 3}}, nil)
+		Return(&datastore.FetchBundleResponse{
+			Bundle: &datastore.Bundle{CaCerts: []byte{1, 2, 3}},
+		}, nil)
 }
 
 func createFetchBundleErrorExpectations(suite *handlerTestSuite) {
 	suite.mockDataStore.EXPECT().
-		FetchBundle(gomock.Any(), &datastore.Bundle{
+		FetchBundle(gomock.Any(), &datastore.FetchBundleRequest{
 			TrustDomain: "spiffe://example.org",
 		}).
 		Return(nil, errors.New("bundle not found"))

--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -69,8 +69,8 @@ func initDB(db *gorm.DB) (err error) {
 		return sqlError.Wrap(err)
 	}
 
-	if err := tx.AutoMigrate(&Bundle{}, &CACert{}, &AttestedNodeEntry{},
-		&NodeResolverMapEntry{}, &RegisteredEntry{}, &JoinToken{},
+	if err := tx.AutoMigrate(&Bundle{}, &CACert{}, &AttestedNode{},
+		&NodeSelector{}, &RegisteredEntry{}, &JoinToken{},
 		&Selector{}, &Migration{}).Error; err != nil {
 		tx.Rollback()
 		return sqlError.Wrap(err)

--- a/pkg/server/plugin/datastore/sql/models.go
+++ b/pkg/server/plugin/datastore/sql/models.go
@@ -27,7 +27,7 @@ type Bundle struct {
 	CACerts     []CACert
 }
 
-type AttestedNodeEntry struct {
+type AttestedNode struct {
 	Model
 
 	SpiffeID     string `gorm:"unique_index"`
@@ -36,12 +36,20 @@ type AttestedNodeEntry struct {
 	ExpiresAt    time.Time
 }
 
-type NodeResolverMapEntry struct {
+func (AttestedNode) TableName() string {
+	return "attested_node_entries"
+}
+
+type NodeSelector struct {
 	Model
 
 	SpiffeID string `gorm:"unique_index:idx_node_resolver_map"`
 	Type     string `gorm:"unique_index:idx_node_resolver_map"`
 	Value    string `gorm:"unique_index:idx_node_resolver_map"`
+}
+
+func (NodeSelector) TableName() string {
+	return "node_resolver_map_entries"
 }
 
 type RegisteredEntry struct {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -66,7 +66,7 @@ func New() datastore.Plugin {
 }
 
 // CreateBundle stores the given bundle
-func (ds *sqlPlugin) CreateBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+func (ds *sqlPlugin) CreateBundle(ctx context.Context, req *datastore.CreateBundleRequest) (resp *datastore.CreateBundleResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createBundle(tx, req)
 		return err
@@ -78,7 +78,7 @@ func (ds *sqlPlugin) CreateBundle(ctx context.Context, req *datastore.Bundle) (r
 
 // UpdateBundle updates an existing bundle with the given CAs. Overwrites any
 // existing certificates.
-func (ds *sqlPlugin) UpdateBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+func (ds *sqlPlugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (resp *datastore.UpdateBundleResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = updateBundle(tx, req)
 		return err
@@ -90,7 +90,7 @@ func (ds *sqlPlugin) UpdateBundle(ctx context.Context, req *datastore.Bundle) (r
 
 // AppendBundle adds the specified CA certificates to an existing bundle. If no bundle exists for the
 // specified trust domain, create one. Returns the entirety.
-func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (resp *datastore.AppendBundleResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = appendBundle(tx, req)
 		return err
@@ -101,7 +101,7 @@ func (ds *sqlPlugin) AppendBundle(ctx context.Context, req *datastore.Bundle) (r
 }
 
 // DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
-func (ds *sqlPlugin) DeleteBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+func (ds *sqlPlugin) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleRequest) (resp *datastore.DeleteBundleResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = deleteBundle(tx, req)
 		return err
@@ -112,7 +112,7 @@ func (ds *sqlPlugin) DeleteBundle(ctx context.Context, req *datastore.Bundle) (r
 }
 
 // FetchBundle returns the bundle matching the specified Trust Domain.
-func (ds *sqlPlugin) FetchBundle(ctx context.Context, req *datastore.Bundle) (resp *datastore.Bundle, err error) {
+func (ds *sqlPlugin) FetchBundle(ctx context.Context, req *datastore.FetchBundleRequest) (resp *datastore.FetchBundleResponse, err error) {
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = fetchBundle(tx, req)
 		return err
@@ -123,7 +123,7 @@ func (ds *sqlPlugin) FetchBundle(ctx context.Context, req *datastore.Bundle) (re
 }
 
 // ListBundles can be used to fetch all existing bundles.
-func (ds *sqlPlugin) ListBundles(ctx context.Context, req *common.Empty) (resp *datastore.Bundles, err error) {
+func (ds *sqlPlugin) ListBundles(ctx context.Context, req *datastore.ListBundlesRequest) (resp *datastore.ListBundlesResponse, err error) {
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listBundles(tx, req)
 		return err
@@ -157,11 +157,11 @@ func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) FetchStaleNodeEntries(ctx context.Context,
-	req *datastore.FetchStaleNodeEntriesRequest) (resp *datastore.FetchStaleNodeEntriesResponse, err error) {
+func (ds *sqlPlugin) ListAttestedNodeEntries(ctx context.Context,
+	req *datastore.ListAttestedNodeEntriesRequest) (resp *datastore.ListAttestedNodeEntriesResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = fetchStaleNodeEntries(tx, req)
+		resp, err = listAttestedNodeEntries(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -205,11 +205,11 @@ func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) FetchNodeResolverMapEntry(ctx context.Context,
-	req *datastore.FetchNodeResolverMapEntryRequest) (resp *datastore.FetchNodeResolverMapEntryResponse, err error) {
+func (ds *sqlPlugin) ListNodeResolverMapEntries(ctx context.Context,
+	req *datastore.ListNodeResolverMapEntriesRequest) (resp *datastore.ListNodeResolverMapEntriesResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = fetchNodeResolverMapEntry(tx, req)
+		resp, err = listNodeResolverMapEntries(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -258,11 +258,11 @@ func (ds *sqlPlugin) FetchRegistrationEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) FetchRegistrationEntries(ctx context.Context,
-	req *common.Empty) (resp *datastore.FetchRegistrationEntriesResponse, err error) {
+func (ds *sqlPlugin) ListRegistrationEntries(ctx context.Context,
+	req *datastore.ListRegistrationEntriesRequest) (resp *datastore.ListRegistrationEntriesResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = fetchRegistrationEntries(tx, req)
+		resp, err = listRegistrationEntries(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -294,58 +294,10 @@ func (ds *sqlPlugin) DeleteRegistrationEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) ListParentIDEntries(ctx context.Context,
-	req *datastore.ListParentIDEntriesRequest) (resp *datastore.ListParentIDEntriesResponse, err error) {
-
-	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listParentIDEntries(tx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (ds *sqlPlugin) ListSelectorEntries(ctx context.Context,
-	req *datastore.ListSelectorEntriesRequest) (resp *datastore.ListSelectorEntriesResponse, err error) {
-
-	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listSelectorEntries(tx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (ds *sqlPlugin) ListMatchingEntries(ctx context.Context,
-	req *datastore.ListSelectorEntriesRequest) (resp *datastore.ListSelectorEntriesResponse, err error) {
-
-	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listMatchingEntries(tx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (ds *sqlPlugin) ListSpiffeEntries(ctx context.Context,
-	req *datastore.ListSpiffeEntriesRequest) (resp *datastore.ListSpiffeEntriesResponse, err error) {
-
-	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listSpiffeEntries(tx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-// RegisterToken takes a Token message and stores it
-func (ds *sqlPlugin) RegisterToken(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+// CreateJoinToken takes a Token message and stores it
+func (ds *sqlPlugin) CreateJoinToken(ctx context.Context, req *datastore.CreateJoinTokenRequest) (resp *datastore.CreateJoinTokenResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = registerToken(tx, req)
+		resp, err = createJoinToken(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -353,11 +305,11 @@ func (ds *sqlPlugin) RegisterToken(ctx context.Context, req *datastore.JoinToken
 	return resp, nil
 }
 
-// FetchToken takes a Token message and returns one, populating the fields
+// FetchJoinToken takes a Token message and returns one, populating the fields
 // we have knowledge of
-func (ds *sqlPlugin) FetchToken(ctx context.Context, req *datastore.JoinToken) (resp *datastore.JoinToken, err error) {
+func (ds *sqlPlugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTokenRequest) (resp *datastore.FetchJoinTokenResponse, err error) {
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = fetchToken(tx, req)
+		resp, err = fetchJoinToken(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -365,9 +317,9 @@ func (ds *sqlPlugin) FetchToken(ctx context.Context, req *datastore.JoinToken) (
 	return resp, nil
 }
 
-func (ds *sqlPlugin) DeleteToken(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+func (ds *sqlPlugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (resp *datastore.DeleteJoinTokenResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = deleteToken(tx, req)
+		resp, err = deleteJoinToken(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -375,11 +327,11 @@ func (ds *sqlPlugin) DeleteToken(ctx context.Context, req *datastore.JoinToken) 
 	return resp, nil
 }
 
-// PruneTokens takes a Token message, and deletes all tokens which have expired
+// PruneJoinTokens takes a Token message, and deletes all tokens which have expired
 // before the date in the message
-func (ds *sqlPlugin) PruneTokens(ctx context.Context, req *datastore.JoinToken) (resp *common.Empty, err error) {
+func (ds *sqlPlugin) PruneJoinTokens(ctx context.Context, req *datastore.PruneJoinTokensRequest) (resp *datastore.PruneJoinTokensResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = pruneTokens(tx, req)
+		resp, err = pruneJoinTokens(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -456,6 +408,7 @@ func (ds *sqlPlugin) withTx(ctx context.Context, op func(tx *gorm.DB) error, rea
 	}
 
 	// TODO: as soon as GORM supports it, attach the context
+	// https://github.com/jinzhu/gorm/issues/1231
 	tx := db.Begin()
 	if err := tx.Error; err != nil {
 		return sqlError.Wrap(err)
@@ -499,8 +452,8 @@ func openDB(databaseType, connectionString string) (*gorm.DB, error) {
 	return db, nil
 }
 
-func createBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
-	model, err := bundleToModel(req)
+func createBundle(tx *gorm.DB, req *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {
+	model, err := bundleToModel(req.Bundle)
 	if err != nil {
 		return nil, err
 	}
@@ -509,11 +462,13 @@ func createBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error)
 		return nil, sqlError.Wrap(err)
 	}
 
-	return req, nil
+	return &datastore.CreateBundleResponse{
+		Bundle: req.Bundle,
+	}, nil
 }
 
-func updateBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
-	newModel, err := bundleToModel(req)
+func updateBundle(tx *gorm.DB, req *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
+	newModel, err := bundleToModel(req.Bundle)
 	if err != nil {
 		return nil, err
 	}
@@ -535,11 +490,13 @@ func updateBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error)
 		return nil, sqlError.Wrap(err)
 	}
 
-	return req, nil
+	return &datastore.UpdateBundleResponse{
+		Bundle: req.Bundle,
+	}, nil
 }
 
-func appendBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
-	newModel, err := bundleToModel(req)
+func appendBundle(tx *gorm.DB, req *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
+	newModel, err := bundleToModel(req.Bundle)
 	if err != nil {
 		return nil, err
 	}
@@ -548,7 +505,13 @@ func appendBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error)
 	model := &Bundle{}
 	result := tx.Find(model, "trust_domain = ?", newModel.TrustDomain)
 	if result.RecordNotFound() {
-		return createBundle(tx, req)
+		resp, err := createBundle(tx, &datastore.CreateBundleRequest{Bundle: req.Bundle})
+		if err != nil {
+			return nil, err
+		}
+		return &datastore.AppendBundleResponse{
+			Bundle: resp.Bundle,
+		}, nil
 	} else if result.Error != nil {
 		return nil, sqlError.Wrap(result.Error)
 	}
@@ -570,25 +533,19 @@ func appendBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error)
 		return nil, sqlError.Wrap(err)
 	}
 
-	resp, err := modelToBundle(model)
+	bundle, err := modelToBundle(model)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp, nil
+	return &datastore.AppendBundleResponse{
+		Bundle: bundle,
+	}, nil
 }
 
-func deleteBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
-	// We don't care if cert data was sent - remove it now to prevent
-	// further processing.
-	req.CaCerts = []byte{}
-
-	model, err := bundleToModel(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := tx.Find(model, "trust_domain = ?", model.TrustDomain).Error; err != nil {
+func deleteBundle(tx *gorm.DB, req *datastore.DeleteBundleRequest) (*datastore.DeleteBundleResponse, error) {
+	model := new(Bundle)
+	if err := tx.Find(model, "trust_domain = ?", req.TrustDomain).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
@@ -607,22 +564,20 @@ func deleteBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error)
 		return nil, sqlError.Wrap(err)
 	}
 
-	resp, err := modelToBundle(model)
+	bundle, err := modelToBundle(model)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp, nil
+	return &datastore.DeleteBundleResponse{
+		Bundle: bundle,
+	}, nil
 }
 
 // FetchBundle returns the bundle matching the specified Trust Domain.
-func fetchBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) {
-	model, err := bundleToModel(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := tx.Find(model, "trust_domain = ?", model.TrustDomain).Error; err != nil {
+func fetchBundle(tx *gorm.DB, req *datastore.FetchBundleRequest) (*datastore.FetchBundleResponse, error) {
+	model := new(Bundle)
+	if err := tx.Find(model, "trust_domain = ?", req.TrustDomain).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
@@ -630,11 +585,18 @@ func fetchBundle(tx *gorm.DB, req *datastore.Bundle) (*datastore.Bundle, error) 
 		return nil, sqlError.Wrap(err)
 	}
 
-	return modelToBundle(model)
+	bundle, err := modelToBundle(model)
+	if err != nil {
+		return nil, err
+	}
+
+	return &datastore.FetchBundleResponse{
+		Bundle: bundle,
+	}, nil
 }
 
 // ListBundles can be used to fetch all existing bundles.
-func listBundles(tx *gorm.DB, req *common.Empty) (*datastore.Bundles, error) {
+func listBundles(tx *gorm.DB, req *datastore.ListBundlesRequest) (*datastore.ListBundlesResponse, error) {
 	var bundles []Bundle
 	if err := tx.Find(&bundles).Error; err != nil {
 		return nil, sqlError.Wrap(err)
@@ -657,7 +619,7 @@ func listBundles(tx *gorm.DB, req *common.Empty) (*datastore.Bundles, error) {
 		}
 	}
 
-	resp := &datastore.Bundles{}
+	resp := &datastore.ListBundlesResponse{}
 	for _, model := range bundles {
 		certs, ok := caMap[model.ID]
 		if ok {
@@ -678,21 +640,16 @@ func listBundles(tx *gorm.DB, req *common.Empty) (*datastore.Bundles, error) {
 }
 
 func createAttestedNodeEntry(tx *gorm.DB, req *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
-	entry := req.AttestedNodeEntry
+	entry := req.Entry
 	if entry == nil {
 		return nil, sqlError.New("invalid request: missing attested node")
 	}
 
-	expiresAt, err := time.Parse(datastore.TimeFormat, entry.CertExpirationDate)
-	if err != nil {
-		return nil, sqlError.New("invalid request: missing expiration")
-	}
-
 	model := AttestedNodeEntry{
-		SpiffeID:     entry.BaseSpiffeId,
+		SpiffeID:     entry.SpiffeId,
 		DataType:     entry.AttestationDataType,
 		SerialNumber: entry.CertSerialNumber,
-		ExpiresAt:    expiresAt,
+		ExpiresAt:    time.Unix(entry.CertNotAfter, 0),
 	}
 
 	if err := tx.Create(&model).Error; err != nil {
@@ -700,18 +657,13 @@ func createAttestedNodeEntry(tx *gorm.DB, req *datastore.CreateAttestedNodeEntry
 	}
 
 	return &datastore.CreateAttestedNodeEntryResponse{
-		AttestedNodeEntry: &datastore.AttestedNodeEntry{
-			BaseSpiffeId:        model.SpiffeID,
-			AttestationDataType: model.DataType,
-			CertSerialNumber:    model.SerialNumber,
-			CertExpirationDate:  expiresAt.Format(datastore.TimeFormat),
-		},
+		Entry: modelToAttestedNodeEntry(model),
 	}, nil
 }
 
 func fetchAttestedNodeEntry(tx *gorm.DB, req *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
 	var model AttestedNodeEntry
-	err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error
+	err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
 		return &datastore.FetchAttestedNodeEntryResponse{}, nil
@@ -719,50 +671,39 @@ func fetchAttestedNodeEntry(tx *gorm.DB, req *datastore.FetchAttestedNodeEntryRe
 		return nil, sqlError.Wrap(err)
 	}
 	return &datastore.FetchAttestedNodeEntryResponse{
-		AttestedNodeEntry: &datastore.AttestedNodeEntry{
-			BaseSpiffeId:        model.SpiffeID,
-			AttestationDataType: model.DataType,
-			CertSerialNumber:    model.SerialNumber,
-			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
-		},
+		Entry: modelToAttestedNodeEntry(model),
 	}, nil
 }
 
-func fetchStaleNodeEntries(tx *gorm.DB, req *datastore.FetchStaleNodeEntriesRequest) (*datastore.FetchStaleNodeEntriesResponse, error) {
+func listAttestedNodeEntries(tx *gorm.DB, req *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
+	if req.ByExpiresBefore != nil {
+		tx = tx.Where("expires_at < ?", time.Unix(req.ByExpiresBefore.Value, 0))
+	}
+
 	var models []AttestedNodeEntry
-	if err := tx.Find(&models, "expires_at < ?", time.Now()).Error; err != nil {
+	if err := tx.Find(&models).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	resp := &datastore.FetchStaleNodeEntriesResponse{
-		AttestedNodeEntryList: make([]*datastore.AttestedNodeEntry, 0, len(models)),
+	resp := &datastore.ListAttestedNodeEntriesResponse{
+		Entries: make([]*datastore.AttestedNodeEntry, 0, len(models)),
 	}
 
 	for _, model := range models {
-		resp.AttestedNodeEntryList = append(resp.AttestedNodeEntryList, &datastore.AttestedNodeEntry{
-			BaseSpiffeId:        model.SpiffeID,
-			AttestationDataType: model.DataType,
-			CertSerialNumber:    model.SerialNumber,
-			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
-		})
+		resp.Entries = append(resp.Entries, modelToAttestedNodeEntry(model))
 	}
 	return resp, nil
 }
 
 func updateAttestedNodeEntry(tx *gorm.DB, req *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
-	expiresAt, err := time.Parse(datastore.TimeFormat, req.CertExpirationDate)
-	if err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
 	var model AttestedNodeEntry
-	if err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+	if err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
 	updates := AttestedNodeEntry{
 		SerialNumber: req.CertSerialNumber,
-		ExpiresAt:    expiresAt,
+		ExpiresAt:    time.Unix(req.CertNotAfter, 0),
 	}
 
 	if err := tx.Model(&model).Updates(updates).Error; err != nil {
@@ -770,18 +711,13 @@ func updateAttestedNodeEntry(tx *gorm.DB, req *datastore.UpdateAttestedNodeEntry
 	}
 
 	return &datastore.UpdateAttestedNodeEntryResponse{
-		AttestedNodeEntry: &datastore.AttestedNodeEntry{
-			BaseSpiffeId:        model.SpiffeID,
-			AttestationDataType: model.DataType,
-			CertSerialNumber:    model.SerialNumber,
-			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
-		},
+		Entry: modelToAttestedNodeEntry(model),
 	}, nil
 }
 
 func deleteAttestedNodeEntry(tx *gorm.DB, req *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
 	var model AttestedNodeEntry
-	if err := tx.Find(&model, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+	if err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
@@ -790,17 +726,12 @@ func deleteAttestedNodeEntry(tx *gorm.DB, req *datastore.DeleteAttestedNodeEntry
 	}
 
 	return &datastore.DeleteAttestedNodeEntryResponse{
-		AttestedNodeEntry: &datastore.AttestedNodeEntry{
-			BaseSpiffeId:        model.SpiffeID,
-			AttestationDataType: model.DataType,
-			CertSerialNumber:    model.SerialNumber,
-			CertExpirationDate:  model.ExpiresAt.Format(datastore.TimeFormat),
-		},
+		Entry: modelToAttestedNodeEntry(model),
 	}, nil
 }
 
 func createNodeResolverMapEntry(tx *gorm.DB, req *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
-	entry := req.NodeResolverMapEntry
+	entry := req.Entry
 	if entry == nil {
 		return nil, sqlError.New("invalid request: no map entry")
 	}
@@ -811,7 +742,7 @@ func createNodeResolverMapEntry(tx *gorm.DB, req *datastore.CreateNodeResolverMa
 	}
 
 	model := NodeResolverMapEntry{
-		SpiffeID: entry.BaseSpiffeId,
+		SpiffeID: entry.SpiffeId,
 		Type:     selector.Type,
 		Value:    selector.Value,
 	}
@@ -821,46 +752,34 @@ func createNodeResolverMapEntry(tx *gorm.DB, req *datastore.CreateNodeResolverMa
 	}
 
 	return &datastore.CreateNodeResolverMapEntryResponse{
-		NodeResolverMapEntry: &datastore.NodeResolverMapEntry{
-			BaseSpiffeId: model.SpiffeID,
-			Selector: &common.Selector{
-				Type:  model.Type,
-				Value: model.Value,
-			},
-		},
+		Entry: modelToNodeResolverMapEntry(model),
 	}, nil
 }
 
-func fetchNodeResolverMapEntry(tx *gorm.DB, req *datastore.FetchNodeResolverMapEntryRequest) (*datastore.FetchNodeResolverMapEntryResponse, error) {
+func listNodeResolverMapEntries(tx *gorm.DB, req *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
 	var models []NodeResolverMapEntry
-	if err := tx.Find(&models, "spiffe_id = ?", req.BaseSpiffeId).Error; err != nil {
+	if err := tx.Find(&models, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	resp := &datastore.FetchNodeResolverMapEntryResponse{
-		NodeResolverMapEntryList: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
+	resp := &datastore.ListNodeResolverMapEntriesResponse{
+		Entries: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
 	}
 
 	for _, model := range models {
-		resp.NodeResolverMapEntryList = append(resp.NodeResolverMapEntryList, &datastore.NodeResolverMapEntry{
-			BaseSpiffeId: model.SpiffeID,
-			Selector: &common.Selector{
-				Type:  model.Type,
-				Value: model.Value,
-			},
-		})
+		resp.Entries = append(resp.Entries, modelToNodeResolverMapEntry(model))
 	}
 	return resp, nil
 }
 
 func deleteNodeResolverMapEntry(tx *gorm.DB, req *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
-	entry := req.NodeResolverMapEntry
+	entry := req.Entry
 	if entry == nil {
 		return nil, sqlError.New("invalid request: no map entry")
 	}
 
 	// if no selector is given, delete all entries with the given spiffe id
-	scope := tx.Where("spiffe_id = ?", entry.BaseSpiffeId)
+	scope := tx.Where("spiffe_id = ?", entry.SpiffeId)
 
 	if selector := entry.Selector; selector != nil {
 		scope = scope.Where("type  = ?", selector.Type)
@@ -878,17 +797,11 @@ func deleteNodeResolverMapEntry(tx *gorm.DB, req *datastore.DeleteNodeResolverMa
 	}
 
 	resp := &datastore.DeleteNodeResolverMapEntryResponse{
-		NodeResolverMapEntryList: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
+		Entries: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
 	}
 
 	for _, model := range models {
-		resp.NodeResolverMapEntryList = append(resp.NodeResolverMapEntryList, &datastore.NodeResolverMapEntry{
-			BaseSpiffeId: model.SpiffeID,
-			Selector: &common.Selector{
-				Type:  model.Type,
-				Value: model.Value,
-			},
-		})
+		resp.Entries = append(resp.Entries, modelToNodeResolverMapEntry(model))
 	}
 
 	return resp, nil
@@ -898,11 +811,11 @@ func createRegistrationEntry(tx *gorm.DB,
 	req *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
 
 	// TODO: Validations should be done in the ProtoBuf level [https://github.com/spiffe/spire/issues/44]
-	if req.RegisteredEntry == nil {
+	if req.Entry == nil {
 		return nil, sqlError.New("invalid request: missing registered entry")
 	}
 
-	if err := validateRegistrationEntry(req.RegisteredEntry); err != nil {
+	if err := validateRegistrationEntry(req.Entry); err != nil {
 		return nil, err
 	}
 
@@ -913,9 +826,9 @@ func createRegistrationEntry(tx *gorm.DB,
 
 	newRegisteredEntry := RegisteredEntry{
 		EntryID:  entryID,
-		SpiffeID: req.RegisteredEntry.SpiffeId,
-		ParentID: req.RegisteredEntry.ParentId,
-		TTL:      req.RegisteredEntry.Ttl,
+		SpiffeID: req.Entry.SpiffeId,
+		ParentID: req.Entry.ParentId,
+		TTL:      req.Entry.Ttl,
 		// TODO: Add support to Federated Bundles [https://github.com/spiffe/spire/issues/42]
 	}
 
@@ -923,7 +836,7 @@ func createRegistrationEntry(tx *gorm.DB,
 		return nil, sqlError.Wrap(err)
 	}
 
-	for _, registeredSelector := range req.RegisteredEntry.Selectors {
+	for _, registeredSelector := range req.Entry.Selectors {
 		newSelector := Selector{
 			RegisteredEntryID: newRegisteredEntry.ID,
 			Type:              registeredSelector.Type,
@@ -935,7 +848,7 @@ func createRegistrationEntry(tx *gorm.DB,
 	}
 
 	return &datastore.CreateRegistrationEntryResponse{
-		RegisteredEntryId: newRegisteredEntry.EntryID,
+		EntryId: newRegisteredEntry.EntryID,
 	}, nil
 }
 
@@ -943,7 +856,7 @@ func fetchRegistrationEntry(tx *gorm.DB,
 	req *datastore.FetchRegistrationEntryRequest) (*datastore.FetchRegistrationEntryResponse, error) {
 
 	var fetchedRegisteredEntry RegisteredEntry
-	err := tx.Find(&fetchedRegisteredEntry, "entry_id = ?", req.RegisteredEntryId).Error
+	err := tx.Find(&fetchedRegisteredEntry, "entry_id = ?", req.EntryId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
 		return &datastore.FetchRegistrationEntryResponse{}, nil
@@ -965,7 +878,7 @@ func fetchRegistrationEntry(tx *gorm.DB,
 	}
 
 	return &datastore.FetchRegistrationEntryResponse{
-		RegisteredEntry: &common.RegistrationEntry{
+		Entry: &common.RegistrationEntry{
 			EntryId:   fetchedRegisteredEntry.EntryID,
 			Selectors: selectors,
 			SpiffeId:  fetchedRegisteredEntry.SpiffeID,
@@ -975,59 +888,127 @@ func fetchRegistrationEntry(tx *gorm.DB,
 	}, nil
 }
 
-func fetchRegistrationEntries(tx *gorm.DB,
-	req *common.Empty) (*datastore.FetchRegistrationEntriesResponse, error) {
+func listRegistrationEntries(tx *gorm.DB,
+	req *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {
 
-	var entries []RegisteredEntry
-	if err := tx.Find(&entries).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	var sel []Selector
-	if err := tx.Find(&sel).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	// Organize the selectors for easier access
-	selectors := map[uint][]Selector{}
-	for _, s := range sel {
-		selectors[s.RegisteredEntryID] = append(selectors[s.RegisteredEntryID], s)
-	}
-
-	// Populate registration entries with their related selectors
-	for _, entry := range entries {
-		if s, ok := selectors[entry.ID]; ok {
-			entry.Selectors = s
+	// list of selector sets to match against
+	var selectorsList [][]*common.Selector
+	if req.BySelectors != nil && len(req.BySelectors.Selectors) > 0 {
+		selectorSet := selector.NewSetFromRaw(req.BySelectors.Selectors)
+		if req.BySelectors.AllowAnyCombination {
+			// find entries matching any combination of the filter set
+			for combination := range selectorSet.Power() {
+				selectorsList = append(selectorsList, combination.Raw())
+			}
+		} else {
+			// find entries matching EXACTLY the filter set
+			selectorsList = append(selectorsList, selectorSet.Raw())
 		}
 	}
 
-	resEntries, err := modelsToEntries(tx, entries)
+	// filter registration entries
+	entryTx := tx
+	if req.ByParentId != nil {
+		entryTx = entryTx.Where("parent_id = ?", req.ByParentId.Value)
+	}
+	if req.BySpiffeId != nil {
+		entryTx = entryTx.Where("spiffe_id = ?", req.BySpiffeId.Value)
+	}
+
+	if len(selectorsList) == 0 {
+		// no selectors to filter against.
+		var entries []RegisteredEntry
+		if err := entryTx.Find(&entries).Error; err != nil {
+			return nil, sqlError.Wrap(err)
+		}
+
+		respEntries, err := modelsToEntries(tx, entries)
+		if err != nil {
+			return nil, sqlError.Wrap(err)
+		}
+
+		return &datastore.ListRegistrationEntriesResponse{
+			Entries: respEntries,
+		}, nil
+	}
+
+	modelsSet := make(map[uint]RegisteredEntry)
+	for _, selectors := range selectorsList {
+		refCount := make(map[uint]int)
+		for _, s := range selectors {
+			var results []Selector
+			if err := tx.Find(&results, "type = ? AND value = ?", s.Type, s.Value).Error; err != nil {
+				return nil, sqlError.Wrap(err)
+			}
+
+			for _, r := range results {
+				if count, ok := refCount[r.RegisteredEntryID]; ok {
+					refCount[r.RegisteredEntryID] = count + 1
+				} else {
+					refCount[r.RegisteredEntryID] = 1
+				}
+			}
+		}
+
+		// exclude entry ids that don't have an exect number of selectors
+		entryIDs := make([]uint, 0, len(refCount))
+		for id, count := range refCount {
+			if count == len(selectors) {
+				entryIDs = append(entryIDs, id)
+			}
+		}
+		if len(entryIDs) == 0 {
+			continue
+		}
+
+		// fetch the entries in the id set, filtered by any parent/spiffe id filters
+		// applied globally
+		var models []RegisteredEntry
+		if err := entryTx.Where(entryIDs).Find(&models).Error; err != nil {
+			return nil, sqlError.Wrap(err)
+		}
+
+		for _, model := range models {
+			var count int
+			if err := tx.Model(&Selector{}).Where("registered_entry_id = ?", model.ID).Count(&count).Error; err != nil {
+				return nil, sqlError.Wrap(err)
+			}
+			if count == len(selectors) {
+				modelsSet[model.ID] = model
+			}
+		}
+	}
+
+	models := make([]RegisteredEntry, 0, len(modelsSet))
+	for _, model := range modelsSet {
+		models = append(models, model)
+	}
+
+	entries, err := modelsToEntries(tx, models)
 	if err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.FetchRegistrationEntriesResponse{
-		RegisteredEntries: &common.RegistrationEntries{
-			Entries: resEntries,
-		},
+	return &datastore.ListRegistrationEntriesResponse{
+		Entries: entries,
 	}, nil
 }
 
 func updateRegistrationEntry(tx *gorm.DB,
 	req *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
 
-	if req.RegisteredEntry == nil {
+	if req.Entry == nil {
 		return nil, sqlError.New("no registration entry provided")
 	}
 
-	if err := validateRegistrationEntry(req.RegisteredEntry); err != nil {
+	if err := validateRegistrationEntry(req.Entry); err != nil {
 		return nil, err
 	}
 
 	// Get the existing entry
 	// TODO: Refactor message type to take EntryID directly from the entry - see #449
 	entry := RegisteredEntry{}
-	if err := tx.Find(&entry, "entry_id = ?", req.RegisteredEntryId).Error; err != nil {
+	if err := tx.Find(&entry, "entry_id = ?", req.Entry.EntryId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
@@ -1037,7 +1018,7 @@ func updateRegistrationEntry(tx *gorm.DB,
 	}
 
 	selectors := []Selector{}
-	for _, s := range req.RegisteredEntry.Selectors {
+	for _, s := range req.Entry.Selectors {
 		selector := Selector{
 			Type:  s.Type,
 			Value: s.Value,
@@ -1046,17 +1027,17 @@ func updateRegistrationEntry(tx *gorm.DB,
 		selectors = append(selectors, selector)
 	}
 
-	entry.SpiffeID = req.RegisteredEntry.SpiffeId
-	entry.ParentID = req.RegisteredEntry.ParentId
-	entry.TTL = req.RegisteredEntry.Ttl
+	entry.SpiffeID = req.Entry.SpiffeId
+	entry.ParentID = req.Entry.ParentId
+	entry.TTL = req.Entry.Ttl
 	entry.Selectors = selectors
 	if err := tx.Save(&entry).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	req.RegisteredEntry.EntryId = entry.EntryID
+	req.Entry.EntryId = entry.EntryID
 	return &datastore.UpdateRegistrationEntryResponse{
-		RegisteredEntry: req.RegisteredEntry,
+		Entry: req.Entry,
 	}, nil
 }
 
@@ -1064,7 +1045,7 @@ func deleteRegistrationEntry(tx *gorm.DB,
 	req *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
 
 	entry := RegisteredEntry{}
-	if err := tx.Find(&entry, "entry_id = ?", req.RegisteredEntryId).Error; err != nil {
+	if err := tx.Find(&entry, "entry_id = ?", req.EntryId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
@@ -1078,126 +1059,64 @@ func deleteRegistrationEntry(tx *gorm.DB,
 	}
 
 	return &datastore.DeleteRegistrationEntryResponse{
-		RegisteredEntry: respEntry,
+		Entry: respEntry,
 	}, nil
 }
 
-func listParentIDEntries(tx *gorm.DB,
-	req *datastore.ListParentIDEntriesRequest) (*datastore.ListParentIDEntriesResponse, error) {
-
-	var fetchedRegisteredEntries []RegisteredEntry
-	err := tx.Find(&fetchedRegisteredEntries, "parent_id = ?", req.ParentId).Error
-	switch {
-	case err == gorm.ErrRecordNotFound:
-		return &datastore.ListParentIDEntriesResponse{}, nil
-	case err != nil:
-		return nil, sqlError.Wrap(err)
-	}
-
-	regEntryList, err := modelsToEntries(tx, fetchedRegisteredEntries)
-	if err != nil {
-		return nil, err
-	}
-	return &datastore.ListParentIDEntriesResponse{RegisteredEntryList: regEntryList}, nil
-}
-
-func listSelectorEntries(tx *gorm.DB,
-	req *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-
-	entries, err := listEntriesWithExactSelectorMatch(tx, req.Selectors)
-	if err != nil {
-		return nil, err
-	}
-
-	util.SortRegistrationEntries(entries)
-	return &datastore.ListSelectorEntriesResponse{RegisteredEntryList: entries}, nil
-}
-
-func listMatchingEntries(tx *gorm.DB,
-	req *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-
-	resp := &datastore.ListSelectorEntriesResponse{}
-	for combination := range selector.NewSetFromRaw(req.Selectors).Power() {
-		entries, err := listEntriesWithExactSelectorMatch(tx, combination.Raw())
-		if err != nil {
-			return nil, err
-		}
-		resp.RegisteredEntryList = append(resp.RegisteredEntryList, entries...)
-	}
-
-	util.SortRegistrationEntries(resp.RegisteredEntryList)
-	return resp, nil
-}
-
-func listSpiffeEntries(tx *gorm.DB,
-	req *datastore.ListSpiffeEntriesRequest) (*datastore.ListSpiffeEntriesResponse, error) {
-
-	var entries []RegisteredEntry
-	if err := tx.Find(&entries, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	respEntries, err := modelsToEntries(tx, entries)
-	if err != nil {
-		return nil, err
-	}
-
-	return &datastore.ListSpiffeEntriesResponse{
-		RegisteredEntryList: respEntries,
-	}, nil
-}
-
-func registerToken(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
-	if req.Token == "" || req.Expiry == 0 {
+func createJoinToken(tx *gorm.DB, req *datastore.CreateJoinTokenRequest) (*datastore.CreateJoinTokenResponse, error) {
+	if req.JoinToken == nil || req.JoinToken.Token == "" || req.JoinToken.Expiry == 0 {
 		return nil, errors.New("token and expiry are required")
 	}
 
 	t := JoinToken{
-		Token:  req.Token,
-		Expiry: req.Expiry,
+		Token:  req.JoinToken.Token,
+		Expiry: req.JoinToken.Expiry,
 	}
 
 	if err := tx.Create(&t).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &common.Empty{}, nil
+	return &datastore.CreateJoinTokenResponse{
+		JoinToken: req.JoinToken,
+	}, nil
 }
 
-func fetchToken(tx *gorm.DB, req *datastore.JoinToken) (*datastore.JoinToken, error) {
-	var t JoinToken
-	err := tx.Find(&t, "token = ?", req.Token).Error
+func fetchJoinToken(tx *gorm.DB, req *datastore.FetchJoinTokenRequest) (*datastore.FetchJoinTokenResponse, error) {
+	var model JoinToken
+	err := tx.Find(&model, "token = ?", req.Token).Error
 	if err == gorm.ErrRecordNotFound {
-		return &datastore.JoinToken{}, nil
+		return &datastore.FetchJoinTokenResponse{}, nil
 	} else if err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.JoinToken{
-		Token:  t.Token,
-		Expiry: t.Expiry,
+	return &datastore.FetchJoinTokenResponse{
+		JoinToken: modelToJoinToken(model),
 	}, nil
 }
 
-func deleteToken(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
-	var t JoinToken
-	if err := tx.Find(&t, "token = ?", req.Token).Error; err != nil {
+func deleteJoinToken(tx *gorm.DB, req *datastore.DeleteJoinTokenRequest) (*datastore.DeleteJoinTokenResponse, error) {
+	var model JoinToken
+	if err := tx.Find(&model, "token = ?", req.Token).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	if err := tx.Delete(&t).Error; err != nil {
+	if err := tx.Delete(&model).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &common.Empty{}, nil
+	return &datastore.DeleteJoinTokenResponse{
+		JoinToken: modelToJoinToken(model),
+	}, nil
 }
 
-func pruneTokens(tx *gorm.DB, req *datastore.JoinToken) (*common.Empty, error) {
-	if err := tx.Where("expiry <= ?", req.Expiry).Delete(&JoinToken{}).Error; err != nil {
+func pruneJoinTokens(tx *gorm.DB, req *datastore.PruneJoinTokensRequest) (*datastore.PruneJoinTokensResponse, error) {
+	if err := tx.Where("expiry <= ?", req.ExpiresBefore).Delete(&JoinToken{}).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &common.Empty{}, nil
+	return &datastore.PruneJoinTokensResponse{}, nil
 }
 
 // modelToBundle converts the given bundle model to a Protobuf bundle message. It will also
@@ -1237,67 +1156,12 @@ func validateRegistrationEntry(entry *common.RegistrationEntry) error {
 	return nil
 }
 
-// listEntriesWithExactSelectorMatch finds registered entries containing exactly the specified selectors.
-func listEntriesWithExactSelectorMatch(tx *gorm.DB, selectors []*common.Selector) ([]*common.RegistrationEntry, error) {
-	if len(selectors) < 1 {
-		return nil, nil
-	}
-
-	// Count references to each entry ID
-	refCount := make(map[uint]int)
-	for _, s := range selectors {
-		var results []Selector
-		if err := tx.Find(&results, "type = ? AND value = ?", s.Type, s.Value).Error; err != nil {
-			return nil, sqlError.Wrap(err)
-		}
-
-		for _, r := range results {
-			if count, ok := refCount[r.RegisteredEntryID]; ok {
-				refCount[r.RegisteredEntryID] = count + 1
-			} else {
-				refCount[r.RegisteredEntryID] = 1
-			}
-		}
-	}
-
-	// Weed out entries that don't have every selector
-	var entryIDs []uint
-	for id, count := range refCount {
-		if count == len(selectors) {
-			entryIDs = append(entryIDs, id)
-		}
-	}
-
-	// Fetch the distilled entries.
-	var resp []RegisteredEntry
-	for _, id := range entryIDs {
-		var result RegisteredEntry
-		if err := tx.Find(&result, "id = ?", id).Error; err != nil {
-			return nil, sqlError.Wrap(err)
-		}
-
-		resp = append(resp, result)
-	}
-
-	// Weed out entries that have more selectors than requested, since only
-	// EXACT matches should be returned.
-	convertedEntries, err := modelsToUnsortedEntries(tx, resp)
-	if err != nil {
-		return nil, err
-	}
-	var entries []*common.RegistrationEntry
-	for _, entry := range convertedEntries {
-		if len(entry.Selectors) == len(selectors) {
-			entries = append(entries, entry)
-		}
-	}
-
-	return entries, nil
-}
-
 // bundleToModel converts the given Protobuf bundle message to a database model. It
 // performs validation, and fully parses certificates to form CACert embedded models.
 func bundleToModel(pb *datastore.Bundle) (*Bundle, error) {
+	if pb == nil {
+		return nil, sqlError.New("missing bundle in request")
+	}
 	id, err := idutil.ParseSpiffeID(pb.TrustDomain, idutil.AllowAnyTrustDomain())
 	if err != nil {
 		return nil, sqlError.Wrap(err)
@@ -1319,12 +1183,10 @@ func bundleToModel(pb *datastore.Bundle) (*Bundle, error) {
 		caCerts = append(caCerts, cert)
 	}
 
-	bundle := &Bundle{
+	return &Bundle{
 		TrustDomain: id.String(),
 		CACerts:     caCerts,
-	}
-
-	return bundle, nil
+	}, nil
 }
 
 func modelsToEntries(tx *gorm.DB, fetchedRegisteredEntries []RegisteredEntry) (responseEntries []*common.RegistrationEntry, err error) {
@@ -1374,4 +1236,30 @@ func newRegistrationEntryID() (string, error) {
 		return "", sqlError.New("unable to generate registration entry id: %v", err)
 	}
 	return id.String(), nil
+}
+
+func modelToAttestedNodeEntry(model AttestedNodeEntry) *datastore.AttestedNodeEntry {
+	return &datastore.AttestedNodeEntry{
+		SpiffeId:            model.SpiffeID,
+		AttestationDataType: model.DataType,
+		CertSerialNumber:    model.SerialNumber,
+		CertNotAfter:        model.ExpiresAt.Unix(),
+	}
+}
+
+func modelToNodeResolverMapEntry(model NodeResolverMapEntry) *datastore.NodeResolverMapEntry {
+	return &datastore.NodeResolverMapEntry{
+		SpiffeId: model.SpiffeID,
+		Selector: &common.Selector{
+			Type:  model.Type,
+			Value: model.Value,
+		},
+	}
+}
+
+func modelToJoinToken(model JoinToken) *datastore.JoinToken {
+	return &datastore.JoinToken{
+		Token:  model.Token,
+		Expiry: model.Expiry,
+	}
 }

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -854,6 +855,8 @@ func listRegistrationEntries(tx *gorm.DB,
 			}
 		case datastore.BySelectors_MATCH_EXACT:
 			selectorsList = append(selectorsList, selectorSet.Raw())
+		default:
+			return nil, fmt.Errorf("unhandled match behavior %q", req.BySelectors.Match)
 		}
 	}
 

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -133,11 +133,11 @@ func (ds *sqlPlugin) ListBundles(ctx context.Context, req *datastore.ListBundles
 	return resp, nil
 }
 
-func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
-	req *datastore.CreateAttestedNodeEntryRequest) (resp *datastore.CreateAttestedNodeEntryResponse, err error) {
+func (ds *sqlPlugin) CreateAttestedNode(ctx context.Context,
+	req *datastore.CreateAttestedNodeRequest) (resp *datastore.CreateAttestedNodeResponse, err error) {
 
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = createAttestedNodeEntry(tx, req)
+		resp, err = createAttestedNode(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -145,11 +145,11 @@ func (ds *sqlPlugin) CreateAttestedNodeEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
-	req *datastore.FetchAttestedNodeEntryRequest) (resp *datastore.FetchAttestedNodeEntryResponse, err error) {
+func (ds *sqlPlugin) FetchAttestedNode(ctx context.Context,
+	req *datastore.FetchAttestedNodeRequest) (resp *datastore.FetchAttestedNodeResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = fetchAttestedNodeEntry(tx, req)
+		resp, err = fetchAttestedNode(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -157,11 +157,11 @@ func (ds *sqlPlugin) FetchAttestedNodeEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) ListAttestedNodeEntries(ctx context.Context,
-	req *datastore.ListAttestedNodeEntriesRequest) (resp *datastore.ListAttestedNodeEntriesResponse, err error) {
+func (ds *sqlPlugin) ListAttestedNodes(ctx context.Context,
+	req *datastore.ListAttestedNodesRequest) (resp *datastore.ListAttestedNodesResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listAttestedNodeEntries(tx, req)
+		resp, err = listAttestedNodes(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -169,11 +169,11 @@ func (ds *sqlPlugin) ListAttestedNodeEntries(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
-	req *datastore.UpdateAttestedNodeEntryRequest) (resp *datastore.UpdateAttestedNodeEntryResponse, err error) {
+func (ds *sqlPlugin) UpdateAttestedNode(ctx context.Context,
+	req *datastore.UpdateAttestedNodeRequest) (resp *datastore.UpdateAttestedNodeResponse, err error) {
 
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = updateAttestedNodeEntry(tx, req)
+		resp, err = updateAttestedNode(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -181,11 +181,11 @@ func (ds *sqlPlugin) UpdateAttestedNodeEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) DeleteAttestedNodeEntry(ctx context.Context,
-	req *datastore.DeleteAttestedNodeEntryRequest) (resp *datastore.DeleteAttestedNodeEntryResponse, err error) {
+func (ds *sqlPlugin) DeleteAttestedNode(ctx context.Context,
+	req *datastore.DeleteAttestedNodeRequest) (resp *datastore.DeleteAttestedNodeResponse, err error) {
 
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = deleteAttestedNodeEntry(tx, req)
+		resp, err = deleteAttestedNode(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -193,11 +193,9 @@ func (ds *sqlPlugin) DeleteAttestedNodeEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
-	req *datastore.CreateNodeResolverMapEntryRequest) (resp *datastore.CreateNodeResolverMapEntryResponse, err error) {
-
+func (ds *sqlPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (resp *datastore.SetNodeSelectorsResponse, err error) {
 	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = createNodeResolverMapEntry(tx, req)
+		resp, err = setNodeSelectors(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
@@ -205,33 +203,16 @@ func (ds *sqlPlugin) CreateNodeResolverMapEntry(ctx context.Context,
 	return resp, nil
 }
 
-func (ds *sqlPlugin) ListNodeResolverMapEntries(ctx context.Context,
-	req *datastore.ListNodeResolverMapEntriesRequest) (resp *datastore.ListNodeResolverMapEntriesResponse, err error) {
+func (ds *sqlPlugin) GetNodeSelectors(ctx context.Context,
+	req *datastore.GetNodeSelectorsRequest) (resp *datastore.GetNodeSelectorsResponse, err error) {
 
 	if err := ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = listNodeResolverMapEntries(tx, req)
+		resp, err = getNodeSelectors(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
 	}
 	return resp, nil
-}
-
-func (ds *sqlPlugin) DeleteNodeResolverMapEntry(ctx context.Context,
-	req *datastore.DeleteNodeResolverMapEntryRequest) (resp *datastore.DeleteNodeResolverMapEntryResponse, err error) {
-
-	if err := ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = deleteNodeResolverMapEntry(tx, req)
-		return err
-	}); err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (sqlPlugin) RectifyNodeResolverMapEntries(ctx context.Context,
-	req *datastore.RectifyNodeResolverMapEntriesRequest) (*datastore.RectifyNodeResolverMapEntriesResponse, error) {
-	return &datastore.RectifyNodeResolverMapEntriesResponse{}, errors.New("Not Implemented")
 }
 
 func (ds *sqlPlugin) CreateRegistrationEntry(ctx context.Context,
@@ -639,69 +620,69 @@ func listBundles(tx *gorm.DB, req *datastore.ListBundlesRequest) (*datastore.Lis
 	return resp, nil
 }
 
-func createAttestedNodeEntry(tx *gorm.DB, req *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
-	entry := req.Entry
-	if entry == nil {
+func createAttestedNode(tx *gorm.DB, req *datastore.CreateAttestedNodeRequest) (*datastore.CreateAttestedNodeResponse, error) {
+	node := req.Node
+	if node == nil {
 		return nil, sqlError.New("invalid request: missing attested node")
 	}
 
-	model := AttestedNodeEntry{
-		SpiffeID:     entry.SpiffeId,
-		DataType:     entry.AttestationDataType,
-		SerialNumber: entry.CertSerialNumber,
-		ExpiresAt:    time.Unix(entry.CertNotAfter, 0),
+	model := AttestedNode{
+		SpiffeID:     node.SpiffeId,
+		DataType:     node.AttestationDataType,
+		SerialNumber: node.CertSerialNumber,
+		ExpiresAt:    time.Unix(node.CertNotAfter, 0),
 	}
 
 	if err := tx.Create(&model).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.CreateAttestedNodeEntryResponse{
-		Entry: modelToAttestedNodeEntry(model),
+	return &datastore.CreateAttestedNodeResponse{
+		Node: modelToAttestedNode(model),
 	}, nil
 }
 
-func fetchAttestedNodeEntry(tx *gorm.DB, req *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
-	var model AttestedNodeEntry
+func fetchAttestedNode(tx *gorm.DB, req *datastore.FetchAttestedNodeRequest) (*datastore.FetchAttestedNodeResponse, error) {
+	var model AttestedNode
 	err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error
 	switch {
 	case err == gorm.ErrRecordNotFound:
-		return &datastore.FetchAttestedNodeEntryResponse{}, nil
+		return &datastore.FetchAttestedNodeResponse{}, nil
 	case err != nil:
 		return nil, sqlError.Wrap(err)
 	}
-	return &datastore.FetchAttestedNodeEntryResponse{
-		Entry: modelToAttestedNodeEntry(model),
+	return &datastore.FetchAttestedNodeResponse{
+		Node: modelToAttestedNode(model),
 	}, nil
 }
 
-func listAttestedNodeEntries(tx *gorm.DB, req *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
+func listAttestedNodes(tx *gorm.DB, req *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
 	if req.ByExpiresBefore != nil {
 		tx = tx.Where("expires_at < ?", time.Unix(req.ByExpiresBefore.Value, 0))
 	}
 
-	var models []AttestedNodeEntry
+	var models []AttestedNode
 	if err := tx.Find(&models).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	resp := &datastore.ListAttestedNodeEntriesResponse{
-		Entries: make([]*datastore.AttestedNodeEntry, 0, len(models)),
+	resp := &datastore.ListAttestedNodesResponse{
+		Nodes: make([]*datastore.AttestedNode, 0, len(models)),
 	}
 
 	for _, model := range models {
-		resp.Entries = append(resp.Entries, modelToAttestedNodeEntry(model))
+		resp.Nodes = append(resp.Nodes, modelToAttestedNode(model))
 	}
 	return resp, nil
 }
 
-func updateAttestedNodeEntry(tx *gorm.DB, req *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
-	var model AttestedNodeEntry
+func updateAttestedNode(tx *gorm.DB, req *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+	var model AttestedNode
 	if err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	updates := AttestedNodeEntry{
+	updates := AttestedNode{
 		SerialNumber: req.CertSerialNumber,
 		ExpiresAt:    time.Unix(req.CertNotAfter, 0),
 	}
@@ -710,13 +691,13 @@ func updateAttestedNodeEntry(tx *gorm.DB, req *datastore.UpdateAttestedNodeEntry
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.UpdateAttestedNodeEntryResponse{
-		Entry: modelToAttestedNodeEntry(model),
+	return &datastore.UpdateAttestedNodeResponse{
+		Node: modelToAttestedNode(model),
 	}, nil
 }
 
-func deleteAttestedNodeEntry(tx *gorm.DB, req *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
-	var model AttestedNodeEntry
+func deleteAttestedNode(tx *gorm.DB, req *datastore.DeleteAttestedNodeRequest) (*datastore.DeleteAttestedNodeResponse, error) {
+	var model AttestedNode
 	if err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
@@ -725,86 +706,52 @@ func deleteAttestedNodeEntry(tx *gorm.DB, req *datastore.DeleteAttestedNodeEntry
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.DeleteAttestedNodeEntryResponse{
-		Entry: modelToAttestedNodeEntry(model),
+	return &datastore.DeleteAttestedNodeResponse{
+		Node: modelToAttestedNode(model),
 	}, nil
 }
 
-func createNodeResolverMapEntry(tx *gorm.DB, req *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
-	entry := req.Entry
-	if entry == nil {
-		return nil, sqlError.New("invalid request: no map entry")
+func setNodeSelectors(tx *gorm.DB, req *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
+	if req.Selectors == nil {
+		return nil, errors.New("invalid request: missing selectors")
 	}
-
-	selector := entry.Selector
-	if selector == nil {
-		return nil, sqlError.New("invalid request: no selector")
-	}
-
-	model := NodeResolverMapEntry{
-		SpiffeID: entry.SpiffeId,
-		Type:     selector.Type,
-		Value:    selector.Value,
-	}
-
-	if err := tx.Create(&model).Error; err != nil {
+	if err := tx.Delete(NodeSelector{}, "spiffe_id = ?", req.Selectors.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.CreateNodeResolverMapEntryResponse{
-		Entry: modelToNodeResolverMapEntry(model),
+	for _, selector := range req.Selectors.Selectors {
+		model := &NodeSelector{
+			SpiffeID: req.Selectors.SpiffeId,
+			Type:     selector.Type,
+			Value:    selector.Value,
+		}
+		if err := tx.Create(model).Error; err != nil {
+			return nil, sqlError.Wrap(err)
+		}
+	}
+
+	return &datastore.SetNodeSelectorsResponse{}, nil
+}
+
+func getNodeSelectors(tx *gorm.DB, req *datastore.GetNodeSelectorsRequest) (*datastore.GetNodeSelectorsResponse, error) {
+	var models []NodeSelector
+	if err := tx.Where("spiffe_id = ?", req.SpiffeId).Find(&models).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
+	var selectors []*common.Selector
+	for _, selector := range models {
+		selectors = append(selectors, &common.Selector{
+			Type:  selector.Type,
+			Value: selector.Value,
+		})
+	}
+	return &datastore.GetNodeSelectorsResponse{
+		Selectors: &datastore.NodeSelectors{
+			SpiffeId:  req.SpiffeId,
+			Selectors: selectors,
+		},
 	}, nil
-}
-
-func listNodeResolverMapEntries(tx *gorm.DB, req *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
-	var models []NodeResolverMapEntry
-	if err := tx.Find(&models, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	resp := &datastore.ListNodeResolverMapEntriesResponse{
-		Entries: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
-	}
-
-	for _, model := range models {
-		resp.Entries = append(resp.Entries, modelToNodeResolverMapEntry(model))
-	}
-	return resp, nil
-}
-
-func deleteNodeResolverMapEntry(tx *gorm.DB, req *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
-	entry := req.Entry
-	if entry == nil {
-		return nil, sqlError.New("invalid request: no map entry")
-	}
-
-	// if no selector is given, delete all entries with the given spiffe id
-	scope := tx.Where("spiffe_id = ?", entry.SpiffeId)
-
-	if selector := entry.Selector; selector != nil {
-		scope = scope.Where("type  = ?", selector.Type)
-		scope = scope.Where("value = ?", selector.Value)
-	}
-
-	var models []NodeResolverMapEntry
-
-	if err := scope.Find(&models).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	if err := scope.Delete(&NodeResolverMapEntry{}).Error; err != nil {
-		return nil, sqlError.Wrap(err)
-	}
-
-	resp := &datastore.DeleteNodeResolverMapEntryResponse{
-		Entries: make([]*datastore.NodeResolverMapEntry, 0, len(models)),
-	}
-
-	for _, model := range models {
-		resp.Entries = append(resp.Entries, modelToNodeResolverMapEntry(model))
-	}
-
-	return resp, nil
 }
 
 func createRegistrationEntry(tx *gorm.DB,
@@ -847,8 +794,13 @@ func createRegistrationEntry(tx *gorm.DB,
 		}
 	}
 
+	entry, err := modelToEntry(tx, newRegisteredEntry)
+	if err != nil {
+		return nil, err
+	}
+
 	return &datastore.CreateRegistrationEntryResponse{
-		EntryId: newRegisteredEntry.EntryID,
+		Entry: entry,
 	}, nil
 }
 
@@ -895,13 +847,12 @@ func listRegistrationEntries(tx *gorm.DB,
 	var selectorsList [][]*common.Selector
 	if req.BySelectors != nil && len(req.BySelectors.Selectors) > 0 {
 		selectorSet := selector.NewSetFromRaw(req.BySelectors.Selectors)
-		if req.BySelectors.AllowAnyCombination {
-			// find entries matching any combination of the filter set
+		switch req.BySelectors.Match {
+		case datastore.BySelectors_MATCH_SUBSET:
 			for combination := range selectorSet.Power() {
 				selectorsList = append(selectorsList, combination.Raw())
 			}
-		} else {
-			// find entries matching EXACTLY the filter set
+		case datastore.BySelectors_MATCH_EXACT:
 			selectorsList = append(selectorsList, selectorSet.Raw())
 		}
 	}
@@ -942,11 +893,7 @@ func listRegistrationEntries(tx *gorm.DB,
 			}
 
 			for _, r := range results {
-				if count, ok := refCount[r.RegisteredEntryID]; ok {
-					refCount[r.RegisteredEntryID] = count + 1
-				} else {
-					refCount[r.RegisteredEntryID] = 1
-				}
+				refCount[r.RegisteredEntryID]++
 			}
 		}
 
@@ -1238,22 +1185,12 @@ func newRegistrationEntryID() (string, error) {
 	return id.String(), nil
 }
 
-func modelToAttestedNodeEntry(model AttestedNodeEntry) *datastore.AttestedNodeEntry {
-	return &datastore.AttestedNodeEntry{
+func modelToAttestedNode(model AttestedNode) *datastore.AttestedNode {
+	return &datastore.AttestedNode{
 		SpiffeId:            model.SpiffeID,
 		AttestationDataType: model.DataType,
 		CertSerialNumber:    model.SerialNumber,
 		CertNotAfter:        model.ExpiresAt.Unix(),
-	}
-}
-
-func modelToNodeResolverMapEntry(model NodeResolverMapEntry) *datastore.NodeResolverMapEntry {
-	return &datastore.NodeResolverMapEntry{
-		SpiffeId: model.SpiffeID,
-		Selector: &common.Selector{
-			Type:  model.Type,
-			Value: model.Value,
-		},
 	}
 }
 

--- a/pkg/server/util/regentryutil/fetch_test.go
+++ b/pkg/server/util/regentryutil/fetch_test.go
@@ -23,16 +23,17 @@ func TestFetchRegistrationEntries(t *testing.T) {
 			Entry: entry,
 		})
 		assert.NoError(err)
-		entry.EntryId = resp.EntryId
-		return entry
+		return resp.Entry
 	}
 
-	createNodeResolverMapEntry := func(entry *datastore.NodeResolverMapEntry) *datastore.NodeResolverMapEntry {
-		resp, err := dataStore.CreateNodeResolverMapEntry(ctx, &datastore.CreateNodeResolverMapEntryRequest{
-			Entry: entry,
+	setNodeSelectors := func(spiffeID string, selectors ...*common.Selector) {
+		_, err := dataStore.SetNodeSelectors(ctx, &datastore.SetNodeSelectorsRequest{
+			Selectors: &datastore.NodeSelectors{
+				SpiffeId:  spiffeID,
+				Selectors: selectors,
+			},
 		})
 		assert.NoError(err)
-		return resp.Entry
 	}
 
 	rootID := "spiffe://example.org/root"
@@ -79,14 +80,7 @@ func TestFetchRegistrationEntries(t *testing.T) {
 		SpiffeId: fiveID,
 	})
 
-	createNodeResolverMapEntry(&datastore.NodeResolverMapEntry{
-		SpiffeId: twoID,
-		Selector: a1,
-	})
-	createNodeResolverMapEntry(&datastore.NodeResolverMapEntry{
-		SpiffeId: twoID,
-		Selector: b2,
-	})
+	setNodeSelectors(twoID, a1, b2)
 
 	actual, err := FetchRegistrationEntries(ctx, dataStore, rootID)
 	assert.NoError(err)

--- a/pkg/server/util/regentryutil/fetch_test.go
+++ b/pkg/server/util/regentryutil/fetch_test.go
@@ -20,19 +20,19 @@ func TestFetchRegistrationEntries(t *testing.T) {
 
 	createRegistrationEntry := func(entry *datastore.RegistrationEntry) *datastore.RegistrationEntry {
 		resp, err := dataStore.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{
-			RegisteredEntry: entry,
+			Entry: entry,
 		})
 		assert.NoError(err)
-		entry.EntryId = resp.RegisteredEntryId
+		entry.EntryId = resp.EntryId
 		return entry
 	}
 
 	createNodeResolverMapEntry := func(entry *datastore.NodeResolverMapEntry) *datastore.NodeResolverMapEntry {
 		resp, err := dataStore.CreateNodeResolverMapEntry(ctx, &datastore.CreateNodeResolverMapEntryRequest{
-			NodeResolverMapEntry: entry,
+			Entry: entry,
 		})
 		assert.NoError(err)
-		return resp.NodeResolverMapEntry
+		return resp.Entry
 	}
 
 	rootID := "spiffe://example.org/root"
@@ -80,12 +80,12 @@ func TestFetchRegistrationEntries(t *testing.T) {
 	})
 
 	createNodeResolverMapEntry(&datastore.NodeResolverMapEntry{
-		BaseSpiffeId: twoID,
-		Selector:     a1,
+		SpiffeId: twoID,
+		Selector: a1,
 	})
 	createNodeResolverMapEntry(&datastore.NodeResolverMapEntry{
-		BaseSpiffeId: twoID,
-		Selector:     b2,
+		SpiffeId: twoID,
+		Selector: b2,
 	})
 
 	actual, err := FetchRegistrationEntries(ctx, dataStore, rootID)

--- a/proto/server/datastore/README_pb.md
+++ b/proto/server/datastore/README_pb.md
@@ -3,6 +3,21 @@
 
 ## Table of Contents
 
+- [wrappers.proto](#wrappers.proto)
+    - [BoolValue](#google.protobuf.BoolValue)
+    - [BytesValue](#google.protobuf.BytesValue)
+    - [DoubleValue](#google.protobuf.DoubleValue)
+    - [FloatValue](#google.protobuf.FloatValue)
+    - [Int32Value](#google.protobuf.Int32Value)
+    - [Int64Value](#google.protobuf.Int64Value)
+    - [StringValue](#google.protobuf.StringValue)
+    - [UInt32Value](#google.protobuf.UInt32Value)
+    - [UInt64Value](#google.protobuf.UInt64Value)
+  
+  
+  
+  
+
 - [plugin.proto](#plugin.proto)
     - [ConfigureRequest](#spire.common.plugin.ConfigureRequest)
     - [ConfigureResponse](#spire.common.plugin.ConfigureResponse)
@@ -26,42 +41,57 @@
   
 
 - [datastore.proto](#datastore.proto)
+    - [AppendBundleRequest](#spire.server.datastore.AppendBundleRequest)
+    - [AppendBundleResponse](#spire.server.datastore.AppendBundleResponse)
     - [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry)
     - [Bundle](#spire.server.datastore.Bundle)
-    - [Bundles](#spire.server.datastore.Bundles)
+    - [BySelectors](#spire.server.datastore.BySelectors)
     - [CreateAttestedNodeEntryRequest](#spire.server.datastore.CreateAttestedNodeEntryRequest)
     - [CreateAttestedNodeEntryResponse](#spire.server.datastore.CreateAttestedNodeEntryResponse)
+    - [CreateBundleRequest](#spire.server.datastore.CreateBundleRequest)
+    - [CreateBundleResponse](#spire.server.datastore.CreateBundleResponse)
+    - [CreateJoinTokenRequest](#spire.server.datastore.CreateJoinTokenRequest)
+    - [CreateJoinTokenResponse](#spire.server.datastore.CreateJoinTokenResponse)
     - [CreateNodeResolverMapEntryRequest](#spire.server.datastore.CreateNodeResolverMapEntryRequest)
     - [CreateNodeResolverMapEntryResponse](#spire.server.datastore.CreateNodeResolverMapEntryResponse)
     - [CreateRegistrationEntryRequest](#spire.server.datastore.CreateRegistrationEntryRequest)
     - [CreateRegistrationEntryResponse](#spire.server.datastore.CreateRegistrationEntryResponse)
     - [DeleteAttestedNodeEntryRequest](#spire.server.datastore.DeleteAttestedNodeEntryRequest)
     - [DeleteAttestedNodeEntryResponse](#spire.server.datastore.DeleteAttestedNodeEntryResponse)
+    - [DeleteBundleRequest](#spire.server.datastore.DeleteBundleRequest)
+    - [DeleteBundleResponse](#spire.server.datastore.DeleteBundleResponse)
+    - [DeleteJoinTokenRequest](#spire.server.datastore.DeleteJoinTokenRequest)
+    - [DeleteJoinTokenResponse](#spire.server.datastore.DeleteJoinTokenResponse)
     - [DeleteNodeResolverMapEntryRequest](#spire.server.datastore.DeleteNodeResolverMapEntryRequest)
     - [DeleteNodeResolverMapEntryResponse](#spire.server.datastore.DeleteNodeResolverMapEntryResponse)
     - [DeleteRegistrationEntryRequest](#spire.server.datastore.DeleteRegistrationEntryRequest)
     - [DeleteRegistrationEntryResponse](#spire.server.datastore.DeleteRegistrationEntryResponse)
     - [FetchAttestedNodeEntryRequest](#spire.server.datastore.FetchAttestedNodeEntryRequest)
     - [FetchAttestedNodeEntryResponse](#spire.server.datastore.FetchAttestedNodeEntryResponse)
-    - [FetchNodeResolverMapEntryRequest](#spire.server.datastore.FetchNodeResolverMapEntryRequest)
-    - [FetchNodeResolverMapEntryResponse](#spire.server.datastore.FetchNodeResolverMapEntryResponse)
-    - [FetchRegistrationEntriesResponse](#spire.server.datastore.FetchRegistrationEntriesResponse)
+    - [FetchBundleRequest](#spire.server.datastore.FetchBundleRequest)
+    - [FetchBundleResponse](#spire.server.datastore.FetchBundleResponse)
+    - [FetchJoinTokenRequest](#spire.server.datastore.FetchJoinTokenRequest)
+    - [FetchJoinTokenResponse](#spire.server.datastore.FetchJoinTokenResponse)
     - [FetchRegistrationEntryRequest](#spire.server.datastore.FetchRegistrationEntryRequest)
     - [FetchRegistrationEntryResponse](#spire.server.datastore.FetchRegistrationEntryResponse)
-    - [FetchStaleNodeEntriesRequest](#spire.server.datastore.FetchStaleNodeEntriesRequest)
-    - [FetchStaleNodeEntriesResponse](#spire.server.datastore.FetchStaleNodeEntriesResponse)
     - [JoinToken](#spire.server.datastore.JoinToken)
-    - [ListParentIDEntriesRequest](#spire.server.datastore.ListParentIDEntriesRequest)
-    - [ListParentIDEntriesResponse](#spire.server.datastore.ListParentIDEntriesResponse)
-    - [ListSelectorEntriesRequest](#spire.server.datastore.ListSelectorEntriesRequest)
-    - [ListSelectorEntriesResponse](#spire.server.datastore.ListSelectorEntriesResponse)
-    - [ListSpiffeEntriesRequest](#spire.server.datastore.ListSpiffeEntriesRequest)
-    - [ListSpiffeEntriesResponse](#spire.server.datastore.ListSpiffeEntriesResponse)
+    - [ListAttestedNodeEntriesRequest](#spire.server.datastore.ListAttestedNodeEntriesRequest)
+    - [ListAttestedNodeEntriesResponse](#spire.server.datastore.ListAttestedNodeEntriesResponse)
+    - [ListBundlesRequest](#spire.server.datastore.ListBundlesRequest)
+    - [ListBundlesResponse](#spire.server.datastore.ListBundlesResponse)
+    - [ListNodeResolverMapEntriesRequest](#spire.server.datastore.ListNodeResolverMapEntriesRequest)
+    - [ListNodeResolverMapEntriesResponse](#spire.server.datastore.ListNodeResolverMapEntriesResponse)
+    - [ListRegistrationEntriesRequest](#spire.server.datastore.ListRegistrationEntriesRequest)
+    - [ListRegistrationEntriesResponse](#spire.server.datastore.ListRegistrationEntriesResponse)
     - [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry)
+    - [PruneJoinTokensRequest](#spire.server.datastore.PruneJoinTokensRequest)
+    - [PruneJoinTokensResponse](#spire.server.datastore.PruneJoinTokensResponse)
     - [RectifyNodeResolverMapEntriesRequest](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest)
     - [RectifyNodeResolverMapEntriesResponse](#spire.server.datastore.RectifyNodeResolverMapEntriesResponse)
     - [UpdateAttestedNodeEntryRequest](#spire.server.datastore.UpdateAttestedNodeEntryRequest)
     - [UpdateAttestedNodeEntryResponse](#spire.server.datastore.UpdateAttestedNodeEntryResponse)
+    - [UpdateBundleRequest](#spire.server.datastore.UpdateBundleRequest)
+    - [UpdateBundleResponse](#spire.server.datastore.UpdateBundleResponse)
     - [UpdateRegistrationEntryRequest](#spire.server.datastore.UpdateRegistrationEntryRequest)
     - [UpdateRegistrationEntryResponse](#spire.server.datastore.UpdateRegistrationEntryResponse)
   
@@ -71,6 +101,175 @@
   
 
 - [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="wrappers.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## wrappers.proto
+
+
+
+<a name="google.protobuf.BoolValue"/>
+
+### BoolValue
+Wrapper message for `bool`.
+
+The JSON representation for `BoolValue` is JSON `true` and `false`.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [bool](#bool) |  | The bool value. |
+
+
+
+
+
+
+<a name="google.protobuf.BytesValue"/>
+
+### BytesValue
+Wrapper message for `bytes`.
+
+The JSON representation for `BytesValue` is JSON string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [bytes](#bytes) |  | The bytes value. |
+
+
+
+
+
+
+<a name="google.protobuf.DoubleValue"/>
+
+### DoubleValue
+Wrapper message for `double`.
+
+The JSON representation for `DoubleValue` is JSON number.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [double](#double) |  | The double value. |
+
+
+
+
+
+
+<a name="google.protobuf.FloatValue"/>
+
+### FloatValue
+Wrapper message for `float`.
+
+The JSON representation for `FloatValue` is JSON number.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [float](#float) |  | The float value. |
+
+
+
+
+
+
+<a name="google.protobuf.Int32Value"/>
+
+### Int32Value
+Wrapper message for `int32`.
+
+The JSON representation for `Int32Value` is JSON number.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [int32](#int32) |  | The int32 value. |
+
+
+
+
+
+
+<a name="google.protobuf.Int64Value"/>
+
+### Int64Value
+Wrapper message for `int64`.
+
+The JSON representation for `Int64Value` is JSON string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [int64](#int64) |  | The int64 value. |
+
+
+
+
+
+
+<a name="google.protobuf.StringValue"/>
+
+### StringValue
+Wrapper message for `string`.
+
+The JSON representation for `StringValue` is JSON string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [string](#string) |  | The string value. |
+
+
+
+
+
+
+<a name="google.protobuf.UInt32Value"/>
+
+### UInt32Value
+Wrapper message for `uint32`.
+
+The JSON representation for `UInt32Value` is JSON number.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [uint32](#uint32) |  | The uint32 value. |
+
+
+
+
+
+
+<a name="google.protobuf.UInt64Value"/>
+
+### UInt64Value
+Wrapper message for `uint64`.
+
+The JSON representation for `UInt64Value` is JSON string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| value | [uint64](#uint64) |  | The uint64 value. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
 
 
 
@@ -271,20 +470,48 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.AttestedNodeEntry"/>
+<a name="spire.server.datastore.AppendBundleRequest"/>
 
-### AttestedNodeEntry
-Represents a single entry in AttestedNodes and stores the node&#39;s
-SPIFFE ID, the type of attestation it performed, as well as the serial
-number and expiration date of its node SVID.
+### AppendBundleRequest
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  | Spiffe ID |
-| attestationDataType | [string](#string) |  | Attestation type |
-| certSerialNumber | [string](#string) |  | Serial number |
-| certExpirationDate | [string](#string) |  | Expiration date |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.AppendBundleResponse"/>
+
+### AppendBundleResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.AttestedNodeEntry"/>
+
+### AttestedNodeEntry
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  | Node SPIFFE ID |
+| attestation_data_type | [string](#string) |  | Attestation data type |
+| cert_serial_number | [string](#string) |  | Node certificate serial number |
+| cert_not_after | [int64](#int64) |  | Node certificate not_after (seconds since unix epoch) |
 
 
 
@@ -294,22 +521,514 @@ number and expiration date of its node SVID.
 <a name="spire.server.datastore.Bundle"/>
 
 ### Bundle
-Represents the trust bundle of a foreign trust domain
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| trust_domain | [string](#string) |  | SPIFFE ID of the foreign trust domain |
-| ca_certs | [bytes](#bytes) |  | CA Certificates ASN.1 DER encoded |
+| trust_domain | [string](#string) |  | Trust domain SPIFFE ID |
+| ca_certs | [bytes](#bytes) |  | CA Certificates (ASN.1 DER encoded) |
 
 
 
 
 
 
-<a name="spire.server.datastore.Bundles"/>
+<a name="spire.server.datastore.BySelectors"/>
 
-### Bundles
+### BySelectors
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| selectors | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) | repeated |  |
+| allow_any_combination | [bool](#bool) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateAttestedNodeEntryRequest"/>
+
+### CreateAttestedNodeEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateAttestedNodeEntryResponse"/>
+
+### CreateAttestedNodeEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateBundleRequest"/>
+
+### CreateBundleRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateBundleResponse"/>
+
+### CreateBundleResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateJoinTokenRequest"/>
+
+### CreateJoinTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| join_token | [JoinToken](#spire.server.datastore.JoinToken) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateJoinTokenResponse"/>
+
+### CreateJoinTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| join_token | [JoinToken](#spire.server.datastore.JoinToken) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateNodeResolverMapEntryRequest"/>
+
+### CreateNodeResolverMapEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateNodeResolverMapEntryResponse"/>
+
+### CreateNodeResolverMapEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateRegistrationEntryRequest"/>
+
+### CreateRegistrationEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateRegistrationEntryResponse"/>
+
+### CreateRegistrationEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteAttestedNodeEntryRequest"/>
+
+### DeleteAttestedNodeEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteAttestedNodeEntryResponse"/>
+
+### DeleteAttestedNodeEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteBundleRequest"/>
+
+### DeleteBundleRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| trust_domain | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteBundleResponse"/>
+
+### DeleteBundleResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteJoinTokenRequest"/>
+
+### DeleteJoinTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteJoinTokenResponse"/>
+
+### DeleteJoinTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| join_token | [JoinToken](#spire.server.datastore.JoinToken) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteNodeResolverMapEntryRequest"/>
+
+### DeleteNodeResolverMapEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteNodeResolverMapEntryResponse"/>
+
+### DeleteNodeResolverMapEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteRegistrationEntryRequest"/>
+
+### DeleteRegistrationEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.DeleteRegistrationEntryResponse"/>
+
+### DeleteRegistrationEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchAttestedNodeEntryRequest"/>
+
+### FetchAttestedNodeEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchAttestedNodeEntryResponse"/>
+
+### FetchAttestedNodeEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchBundleRequest"/>
+
+### FetchBundleRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| trust_domain | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchBundleResponse"/>
+
+### FetchBundleResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchJoinTokenRequest"/>
+
+### FetchJoinTokenRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchJoinTokenResponse"/>
+
+### FetchJoinTokenResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| join_token | [JoinToken](#spire.server.datastore.JoinToken) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchRegistrationEntryRequest"/>
+
+### FetchRegistrationEntryRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.FetchRegistrationEntryResponse"/>
+
+### FetchRegistrationEntryResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.JoinToken"/>
+
+### JoinToken
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| token | [string](#string) |  | Token value |
+| expiry | [int64](#int64) |  | Expiration in seconds since unix epoch |
+
+
+
+
+
+
+<a name="spire.server.datastore.ListAttestedNodeEntriesRequest"/>
+
+### ListAttestedNodeEntriesRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| by_expires_before | [.google.protobuf.Int64Value](#spire.server.datastore..google.protobuf.Int64Value) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.ListAttestedNodeEntriesResponse"/>
+
+### ListAttestedNodeEntriesResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| entries | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) | repeated |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.ListBundlesRequest"/>
+
+### ListBundlesRequest
+
+
+
+
+
+
+
+<a name="spire.server.datastore.ListBundlesResponse"/>
+
+### ListBundlesResponse
 
 
 
@@ -322,416 +1041,62 @@ Represents the trust bundle of a foreign trust domain
 
 
 
-<a name="spire.server.datastore.CreateAttestedNodeEntryRequest"/>
+<a name="spire.server.datastore.ListNodeResolverMapEntriesRequest"/>
 
-### CreateAttestedNodeEntryRequest
-Represents an Attested Node entry to create
+### ListNodeResolverMapEntriesRequest
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| attestedNodeEntry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  | Attested node entry |
+| spiffe_id | [string](#string) |  |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.CreateAttestedNodeEntryResponse"/>
+<a name="spire.server.datastore.ListNodeResolverMapEntriesResponse"/>
 
-### CreateAttestedNodeEntryResponse
-Represents the created Attested Node entry
+### ListNodeResolverMapEntriesResponse
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| attestedNodeEntry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  | Attested node entry |
+| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.CreateNodeResolverMapEntryRequest"/>
+<a name="spire.server.datastore.ListRegistrationEntriesRequest"/>
 
-### CreateNodeResolverMapEntryRequest
-Represents a Node resolver map entry to create
+### ListRegistrationEntriesRequest
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  | Node resolver map entry |
+| by_parent_id | [.google.protobuf.StringValue](#spire.server.datastore..google.protobuf.StringValue) |  |  |
+| by_selectors | [BySelectors](#spire.server.datastore.BySelectors) |  |  |
+| by_spiffe_id | [.google.protobuf.StringValue](#spire.server.datastore..google.protobuf.StringValue) |  |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.CreateNodeResolverMapEntryResponse"/>
+<a name="spire.server.datastore.ListRegistrationEntriesResponse"/>
 
-### CreateNodeResolverMapEntryResponse
-Represents the created Node resolver map entry
+### ListRegistrationEntriesResponse
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  | Node resolver map entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.CreateRegistrationEntryRequest"/>
-
-### CreateRegistrationEntryRequest
-Represents a Registration entry to create
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  | Registration entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.CreateRegistrationEntryResponse"/>
-
-### CreateRegistrationEntryResponse
-Represents the created Registration entry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryId | [string](#string) |  | Registration entry ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteAttestedNodeEntryRequest"/>
-
-### DeleteAttestedNodeEntryRequest
-Represents the Spiffe ID of the Attested node entry to delete
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  | SPIFFE ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteAttestedNodeEntryResponse"/>
-
-### DeleteAttestedNodeEntryResponse
-Represents the deleted Attested node entry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| attestedNodeEntry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteNodeResolverMapEntryRequest"/>
-
-### DeleteNodeResolverMapEntryRequest
-Represents a Node resolver map entry to delete
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  | Node resolver map entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteNodeResolverMapEntryResponse"/>
-
-### DeleteNodeResolverMapEntryResponse
-Represents a list of Node resolver map entries
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntryList | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated | List of Node resolver map entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteRegistrationEntryRequest"/>
-
-### DeleteRegistrationEntryRequest
-Represents a Registration entry ID to delete
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryId | [string](#string) |  | Registration entry ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteRegistrationEntryResponse"/>
-
-### DeleteRegistrationEntryResponse
-Represents the deleted Registration entry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  | Registration entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchAttestedNodeEntryRequest"/>
-
-### FetchAttestedNodeEntryRequest
-Represents the Spiffe ID of the node entry to retrieve
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  | SPIFFE ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchAttestedNodeEntryResponse"/>
-
-### FetchAttestedNodeEntryResponse
-Represents an Attested Node entry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| attestedNodeEntry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  | Attested node entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchNodeResolverMapEntryRequest"/>
-
-### FetchNodeResolverMapEntryRequest
-Represents a Spiffe ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  | SPIFFE ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchNodeResolverMapEntryResponse"/>
-
-### FetchNodeResolverMapEntryResponse
-Represents a list of Node resolver map entries for the specified Spiffe ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntryList | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated | List of Node resolver map entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchRegistrationEntriesResponse"/>
-
-### FetchRegistrationEntriesResponse
-Represents a list of Registration entries
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntries | [.spire.common.RegistrationEntries](#spire.server.datastore..spire.common.RegistrationEntries) |  | Registration entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchRegistrationEntryRequest"/>
-
-### FetchRegistrationEntryRequest
-Represents a Registration entry ID to fetch
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryId | [string](#string) |  | Registration entry ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchRegistrationEntryResponse"/>
-
-### FetchRegistrationEntryResponse
-Represents a Registration entry
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  | Registration entry |
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchStaleNodeEntriesRequest"/>
-
-### FetchStaleNodeEntriesRequest
-Empty Request
-
-
-
-
-
-
-<a name="spire.server.datastore.FetchStaleNodeEntriesResponse"/>
-
-### FetchStaleNodeEntriesResponse
-Represents dead nodes for which the base SVID has expired
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| attestedNodeEntryList | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) | repeated | List of attested node entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.JoinToken"/>
-
-### JoinToken
-Represents a join token and associated metadata, if known
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| token | [string](#string) |  |  |
-| expiry | [int64](#int64) |  | Expiration date, represented in UNIX time |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListParentIDEntriesRequest"/>
-
-### ListParentIDEntriesRequest
-Represents a Parent ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| parentId | [string](#string) |  | Parent ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListParentIDEntriesResponse"/>
-
-### ListParentIDEntriesResponse
-Represents a list of Registered entries with the specified Parent ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryList | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) | repeated | List of Registration entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListSelectorEntriesRequest"/>
-
-### ListSelectorEntriesRequest
-Represents a selector
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| selectors | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) | repeated | Selector |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListSelectorEntriesResponse"/>
-
-### ListSelectorEntriesResponse
-Represents a list of Registered entries with the specified selector
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryList | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) | repeated | List of Registration entries |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListSpiffeEntriesRequest"/>
-
-### ListSpiffeEntriesRequest
-Represents a Spiffe ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| spiffeId | [string](#string) |  | SPIFFE ID |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListSpiffeEntriesResponse"/>
-
-### ListSpiffeEntriesResponse
-Represents a list of Registered entries with the specified Spiffe ID
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| registeredEntryList | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) | repeated | List of Registration entries |
+| entries | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) | repeated |  |
 
 
 
@@ -741,14 +1106,38 @@ Represents a list of Registered entries with the specified Spiffe ID
 <a name="spire.server.datastore.NodeResolverMapEntry"/>
 
 ### NodeResolverMapEntry
-Represents a single entry in NodeResolverMap and maps node properties
-to logical attributes (i.e. an AWS instance to its ASG).
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  |  |
-| selector | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) |  |  |
+| spiffe_id | [string](#string) |  | Node SPIFFE ID |
+| selector | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) |  | Node selector |
+
+
+
+
+
+
+<a name="spire.server.datastore.PruneJoinTokensRequest"/>
+
+### PruneJoinTokensRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| expires_before | [int64](#int64) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.PruneJoinTokensResponse"/>
+
+### PruneJoinTokensResponse
+
 
 
 
@@ -758,12 +1147,12 @@ to logical attributes (i.e. an AWS instance to its ASG).
 <a name="spire.server.datastore.RectifyNodeResolverMapEntriesRequest"/>
 
 ### RectifyNodeResolverMapEntriesRequest
-Represents a list of Node resolver map entries
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntryList | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated | List of Node resolver map entries |
+| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
 
 
 
@@ -773,12 +1162,12 @@ Represents a list of Node resolver map entries
 <a name="spire.server.datastore.RectifyNodeResolverMapEntriesResponse"/>
 
 ### RectifyNodeResolverMapEntriesResponse
-Represents a list of Node resolver map entries
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| nodeResolverMapEntryList | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated | List of Node resolver map entries |
+| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
 
 
 
@@ -788,14 +1177,14 @@ Represents a list of Node resolver map entries
 <a name="spire.server.datastore.UpdateAttestedNodeEntryRequest"/>
 
 ### UpdateAttestedNodeEntryRequest
-Represents Attested node entry fields to update
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| baseSpiffeId | [string](#string) |  | SPIFFE ID |
-| certSerialNumber | [string](#string) |  | Serial number |
-| certExpirationDate | [string](#string) |  | Expiration date |
+| spiffe_id | [string](#string) |  |  |
+| cert_serial_number | [string](#string) |  |  |
+| cert_not_after | [int64](#int64) |  |  |
 
 
 
@@ -805,12 +1194,42 @@ Represents Attested node entry fields to update
 <a name="spire.server.datastore.UpdateAttestedNodeEntryResponse"/>
 
 ### UpdateAttestedNodeEntryResponse
-Represents the updated Attested node entry
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| attestedNodeEntry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  | Attested node entry |
+| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.UpdateBundleRequest"/>
+
+### UpdateBundleRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.UpdateBundleResponse"/>
+
+### UpdateBundleResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| bundle | [Bundle](#spire.server.datastore.Bundle) |  |  |
 
 
 
@@ -820,13 +1239,12 @@ Represents the updated Attested node entry
 <a name="spire.server.datastore.UpdateRegistrationEntryRequest"/>
 
 ### UpdateRegistrationEntryRequest
-Represents a Registration entry to update
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| registeredEntryId | [string](#string) |  | Registration entry ID |
-| registeredEntry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  | Registration entry |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
 
 
 
@@ -836,12 +1254,12 @@ Represents a Registration entry to update
 <a name="spire.server.datastore.UpdateRegistrationEntryResponse"/>
 
 ### UpdateRegistrationEntryResponse
-Represents the updated Registration entry
+
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| registeredEntry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  | Registration entry |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
 
 
 
@@ -861,34 +1279,30 @@ Represents the updated Registration entry
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| CreateBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Creates a Bundle |
-| UpdateBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Updates the specified Bundle, overwriting existing certs |
-| AppendBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Appends the provided certs onto an existing bundle, creating a new bundle if one doesn&#39;t exist |
-| DeleteBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Deletes the specified Bundle |
-| FetchBundle | [Bundle](#spire.server.datastore.Bundle) | [Bundle](#spire.server.datastore.Bundle) | Returns the specified Bundle |
-| ListBundles | [spire.common.Empty](#spire.common.Empty) | [Bundles](#spire.common.Empty) | List all Bundles |
-| CreateAttestedNodeEntry | [CreateAttestedNodeEntryRequest](#spire.server.datastore.CreateAttestedNodeEntryRequest) | [CreateAttestedNodeEntryResponse](#spire.server.datastore.CreateAttestedNodeEntryRequest) | Creates an Attested Node Entry |
-| FetchAttestedNodeEntry | [FetchAttestedNodeEntryRequest](#spire.server.datastore.FetchAttestedNodeEntryRequest) | [FetchAttestedNodeEntryResponse](#spire.server.datastore.FetchAttestedNodeEntryRequest) | Retrieves the Attested Node Entry |
-| FetchStaleNodeEntries | [FetchStaleNodeEntriesRequest](#spire.server.datastore.FetchStaleNodeEntriesRequest) | [FetchStaleNodeEntriesResponse](#spire.server.datastore.FetchStaleNodeEntriesRequest) | Retrieves dead nodes for which the base SVID has expired |
-| UpdateAttestedNodeEntry | [UpdateAttestedNodeEntryRequest](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | [UpdateAttestedNodeEntryResponse](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | Updates the Attested Node Entry |
-| DeleteAttestedNodeEntry | [DeleteAttestedNodeEntryRequest](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | [DeleteAttestedNodeEntryResponse](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | Deletes the Attested Node Entry |
-| CreateNodeResolverMapEntry | [CreateNodeResolverMapEntryRequest](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | [CreateNodeResolverMapEntryResponse](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | Creates a Node resolver map Entry |
-| FetchNodeResolverMapEntry | [FetchNodeResolverMapEntryRequest](#spire.server.datastore.FetchNodeResolverMapEntryRequest) | [FetchNodeResolverMapEntryResponse](#spire.server.datastore.FetchNodeResolverMapEntryRequest) | Retrieves all Node Resolver Map Entry for the specific base SPIFFEID |
-| DeleteNodeResolverMapEntry | [DeleteNodeResolverMapEntryRequest](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | [DeleteNodeResolverMapEntryResponse](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | Deletes all Node Resolver Map Entry for the specific base SPIFFEID |
-| RectifyNodeResolverMapEntries | [RectifyNodeResolverMapEntriesRequest](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | [RectifyNodeResolverMapEntriesResponse](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | Used for rectifying updated node resolutions |
-| CreateRegistrationEntry | [CreateRegistrationEntryRequest](#spire.server.datastore.CreateRegistrationEntryRequest) | [CreateRegistrationEntryResponse](#spire.server.datastore.CreateRegistrationEntryRequest) | Creates a Registered Entry |
-| FetchRegistrationEntry | [FetchRegistrationEntryRequest](#spire.server.datastore.FetchRegistrationEntryRequest) | [FetchRegistrationEntryResponse](#spire.server.datastore.FetchRegistrationEntryRequest) | Retrieve a specific registered entry |
-| FetchRegistrationEntries | [spire.common.Empty](#spire.common.Empty) | [FetchRegistrationEntriesResponse](#spire.common.Empty) | Retrieve all registration entries |
-| UpdateRegistrationEntry | [UpdateRegistrationEntryRequest](#spire.server.datastore.UpdateRegistrationEntryRequest) | [UpdateRegistrationEntryResponse](#spire.server.datastore.UpdateRegistrationEntryRequest) | Updates a specific registered entry |
-| DeleteRegistrationEntry | [DeleteRegistrationEntryRequest](#spire.server.datastore.DeleteRegistrationEntryRequest) | [DeleteRegistrationEntryResponse](#spire.server.datastore.DeleteRegistrationEntryRequest) | Deletes a specific registered entry |
-| ListParentIDEntries | [ListParentIDEntriesRequest](#spire.server.datastore.ListParentIDEntriesRequest) | [ListParentIDEntriesResponse](#spire.server.datastore.ListParentIDEntriesRequest) | Retrieves all the registered entry with the same ParentID |
-| ListSelectorEntries | [ListSelectorEntriesRequest](#spire.server.datastore.ListSelectorEntriesRequest) | [ListSelectorEntriesResponse](#spire.server.datastore.ListSelectorEntriesRequest) | Retrieves all the registered entry matching exactly the compound Selector |
-| ListMatchingEntries | [ListSelectorEntriesRequest](#spire.server.datastore.ListSelectorEntriesRequest) | [ListSelectorEntriesResponse](#spire.server.datastore.ListSelectorEntriesRequest) | Retrieves registered entries containing all of the specified selectors |
-| ListSpiffeEntries | [ListSpiffeEntriesRequest](#spire.server.datastore.ListSpiffeEntriesRequest) | [ListSpiffeEntriesResponse](#spire.server.datastore.ListSpiffeEntriesRequest) | Retrieves all the registered entry with the same SpiffeId |
-| RegisterToken | [JoinToken](#spire.server.datastore.JoinToken) | [spire.common.Empty](#spire.server.datastore.JoinToken) | Register a new join token |
-| FetchToken | [JoinToken](#spire.server.datastore.JoinToken) | [JoinToken](#spire.server.datastore.JoinToken) | Fetch a token record |
-| DeleteToken | [JoinToken](#spire.server.datastore.JoinToken) | [spire.common.Empty](#spire.server.datastore.JoinToken) | Delete the referenced token |
-| PruneTokens | [JoinToken](#spire.server.datastore.JoinToken) | [spire.common.Empty](#spire.server.datastore.JoinToken) | Delete all tokens with expiry less than the one specified |
+| CreateBundle | [CreateBundleRequest](#spire.server.datastore.CreateBundleRequest) | [CreateBundleResponse](#spire.server.datastore.CreateBundleRequest) | Creates a bundle |
+| FetchBundle | [FetchBundleRequest](#spire.server.datastore.FetchBundleRequest) | [FetchBundleResponse](#spire.server.datastore.FetchBundleRequest) | Fetches a specific bundle |
+| ListBundles | [ListBundlesRequest](#spire.server.datastore.ListBundlesRequest) | [ListBundlesResponse](#spire.server.datastore.ListBundlesRequest) | Lists bundles (optionally filtered) |
+| UpdateBundle | [UpdateBundleRequest](#spire.server.datastore.UpdateBundleRequest) | [UpdateBundleResponse](#spire.server.datastore.UpdateBundleRequest) | Updates a specific bundle, overwriting existing certs |
+| AppendBundle | [AppendBundleRequest](#spire.server.datastore.AppendBundleRequest) | [AppendBundleResponse](#spire.server.datastore.AppendBundleRequest) | Appends the provided certs onto an existing bundle, creating a new bundle if one doesn&#39;t exist |
+| DeleteBundle | [DeleteBundleRequest](#spire.server.datastore.DeleteBundleRequest) | [DeleteBundleResponse](#spire.server.datastore.DeleteBundleRequest) | Deletes a specific bundle |
+| CreateAttestedNodeEntry | [CreateAttestedNodeEntryRequest](#spire.server.datastore.CreateAttestedNodeEntryRequest) | [CreateAttestedNodeEntryResponse](#spire.server.datastore.CreateAttestedNodeEntryRequest) | Creates an attested node entry |
+| FetchAttestedNodeEntry | [FetchAttestedNodeEntryRequest](#spire.server.datastore.FetchAttestedNodeEntryRequest) | [FetchAttestedNodeEntryResponse](#spire.server.datastore.FetchAttestedNodeEntryRequest) | Fetches a specific attested node entry |
+| ListAttestedNodeEntries | [ListAttestedNodeEntriesRequest](#spire.server.datastore.ListAttestedNodeEntriesRequest) | [ListAttestedNodeEntriesResponse](#spire.server.datastore.ListAttestedNodeEntriesRequest) | Lists attested node entries (optionally filtered) |
+| UpdateAttestedNodeEntry | [UpdateAttestedNodeEntryRequest](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | [UpdateAttestedNodeEntryResponse](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | Updates a specific attested node entry |
+| DeleteAttestedNodeEntry | [DeleteAttestedNodeEntryRequest](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | [DeleteAttestedNodeEntryResponse](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | Deletes a specific attested node entry |
+| CreateNodeResolverMapEntry | [CreateNodeResolverMapEntryRequest](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | [CreateNodeResolverMapEntryResponse](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | Creates a node resolver map entry |
+| ListNodeResolverMapEntries | [ListNodeResolverMapEntriesRequest](#spire.server.datastore.ListNodeResolverMapEntriesRequest) | [ListNodeResolverMapEntriesResponse](#spire.server.datastore.ListNodeResolverMapEntriesRequest) | Lists node resolver map entries for a specified SPIFFE ID |
+| DeleteNodeResolverMapEntry | [DeleteNodeResolverMapEntryRequest](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | [DeleteNodeResolverMapEntryResponse](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | Deletes a specific node resolver map entry |
+| RectifyNodeResolverMapEntries | [RectifyNodeResolverMapEntriesRequest](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | [RectifyNodeResolverMapEntriesResponse](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | Sets the list of node resolver map entries for the specified SPIFFE ID |
+| CreateRegistrationEntry | [CreateRegistrationEntryRequest](#spire.server.datastore.CreateRegistrationEntryRequest) | [CreateRegistrationEntryResponse](#spire.server.datastore.CreateRegistrationEntryRequest) | Creates a registration entry |
+| FetchRegistrationEntry | [FetchRegistrationEntryRequest](#spire.server.datastore.FetchRegistrationEntryRequest) | [FetchRegistrationEntryResponse](#spire.server.datastore.FetchRegistrationEntryRequest) | Fetches a specific registration entry |
+| ListRegistrationEntries | [ListRegistrationEntriesRequest](#spire.server.datastore.ListRegistrationEntriesRequest) | [ListRegistrationEntriesResponse](#spire.server.datastore.ListRegistrationEntriesRequest) | Lists registration entries (optionally filtered) |
+| UpdateRegistrationEntry | [UpdateRegistrationEntryRequest](#spire.server.datastore.UpdateRegistrationEntryRequest) | [UpdateRegistrationEntryResponse](#spire.server.datastore.UpdateRegistrationEntryRequest) | Updates a specific registration entry |
+| DeleteRegistrationEntry | [DeleteRegistrationEntryRequest](#spire.server.datastore.DeleteRegistrationEntryRequest) | [DeleteRegistrationEntryResponse](#spire.server.datastore.DeleteRegistrationEntryRequest) | Deletes a specific registration entry |
+| CreateJoinToken | [CreateJoinTokenRequest](#spire.server.datastore.CreateJoinTokenRequest) | [CreateJoinTokenResponse](#spire.server.datastore.CreateJoinTokenRequest) | Creates a join token |
+| FetchJoinToken | [FetchJoinTokenRequest](#spire.server.datastore.FetchJoinTokenRequest) | [FetchJoinTokenResponse](#spire.server.datastore.FetchJoinTokenRequest) | Fetches a specific join token |
+| DeleteJoinToken | [DeleteJoinTokenRequest](#spire.server.datastore.DeleteJoinTokenRequest) | [DeleteJoinTokenResponse](#spire.server.datastore.DeleteJoinTokenRequest) | Delete a specific join token |
+| PruneJoinTokens | [PruneJoinTokensRequest](#spire.server.datastore.PruneJoinTokensRequest) | [PruneJoinTokensResponse](#spire.server.datastore.PruneJoinTokensRequest) | Prunes all join tokens that expire before the specified timestamp |
 | Configure | [spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureRequest) | Applies the plugin configuration |
 | GetPluginInfo | [spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoRequest) | Returns the version and related metadata of the installed plugin |
 

--- a/proto/server/datastore/README_pb.md
+++ b/proto/server/datastore/README_pb.md
@@ -43,58 +43,55 @@
 - [datastore.proto](#datastore.proto)
     - [AppendBundleRequest](#spire.server.datastore.AppendBundleRequest)
     - [AppendBundleResponse](#spire.server.datastore.AppendBundleResponse)
-    - [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry)
+    - [AttestedNode](#spire.server.datastore.AttestedNode)
     - [Bundle](#spire.server.datastore.Bundle)
     - [BySelectors](#spire.server.datastore.BySelectors)
-    - [CreateAttestedNodeEntryRequest](#spire.server.datastore.CreateAttestedNodeEntryRequest)
-    - [CreateAttestedNodeEntryResponse](#spire.server.datastore.CreateAttestedNodeEntryResponse)
+    - [CreateAttestedNodeRequest](#spire.server.datastore.CreateAttestedNodeRequest)
+    - [CreateAttestedNodeResponse](#spire.server.datastore.CreateAttestedNodeResponse)
     - [CreateBundleRequest](#spire.server.datastore.CreateBundleRequest)
     - [CreateBundleResponse](#spire.server.datastore.CreateBundleResponse)
     - [CreateJoinTokenRequest](#spire.server.datastore.CreateJoinTokenRequest)
     - [CreateJoinTokenResponse](#spire.server.datastore.CreateJoinTokenResponse)
-    - [CreateNodeResolverMapEntryRequest](#spire.server.datastore.CreateNodeResolverMapEntryRequest)
-    - [CreateNodeResolverMapEntryResponse](#spire.server.datastore.CreateNodeResolverMapEntryResponse)
     - [CreateRegistrationEntryRequest](#spire.server.datastore.CreateRegistrationEntryRequest)
     - [CreateRegistrationEntryResponse](#spire.server.datastore.CreateRegistrationEntryResponse)
-    - [DeleteAttestedNodeEntryRequest](#spire.server.datastore.DeleteAttestedNodeEntryRequest)
-    - [DeleteAttestedNodeEntryResponse](#spire.server.datastore.DeleteAttestedNodeEntryResponse)
+    - [DeleteAttestedNodeRequest](#spire.server.datastore.DeleteAttestedNodeRequest)
+    - [DeleteAttestedNodeResponse](#spire.server.datastore.DeleteAttestedNodeResponse)
     - [DeleteBundleRequest](#spire.server.datastore.DeleteBundleRequest)
     - [DeleteBundleResponse](#spire.server.datastore.DeleteBundleResponse)
     - [DeleteJoinTokenRequest](#spire.server.datastore.DeleteJoinTokenRequest)
     - [DeleteJoinTokenResponse](#spire.server.datastore.DeleteJoinTokenResponse)
-    - [DeleteNodeResolverMapEntryRequest](#spire.server.datastore.DeleteNodeResolverMapEntryRequest)
-    - [DeleteNodeResolverMapEntryResponse](#spire.server.datastore.DeleteNodeResolverMapEntryResponse)
     - [DeleteRegistrationEntryRequest](#spire.server.datastore.DeleteRegistrationEntryRequest)
     - [DeleteRegistrationEntryResponse](#spire.server.datastore.DeleteRegistrationEntryResponse)
-    - [FetchAttestedNodeEntryRequest](#spire.server.datastore.FetchAttestedNodeEntryRequest)
-    - [FetchAttestedNodeEntryResponse](#spire.server.datastore.FetchAttestedNodeEntryResponse)
+    - [FetchAttestedNodeRequest](#spire.server.datastore.FetchAttestedNodeRequest)
+    - [FetchAttestedNodeResponse](#spire.server.datastore.FetchAttestedNodeResponse)
     - [FetchBundleRequest](#spire.server.datastore.FetchBundleRequest)
     - [FetchBundleResponse](#spire.server.datastore.FetchBundleResponse)
     - [FetchJoinTokenRequest](#spire.server.datastore.FetchJoinTokenRequest)
     - [FetchJoinTokenResponse](#spire.server.datastore.FetchJoinTokenResponse)
     - [FetchRegistrationEntryRequest](#spire.server.datastore.FetchRegistrationEntryRequest)
     - [FetchRegistrationEntryResponse](#spire.server.datastore.FetchRegistrationEntryResponse)
+    - [GetNodeSelectorsRequest](#spire.server.datastore.GetNodeSelectorsRequest)
+    - [GetNodeSelectorsResponse](#spire.server.datastore.GetNodeSelectorsResponse)
     - [JoinToken](#spire.server.datastore.JoinToken)
-    - [ListAttestedNodeEntriesRequest](#spire.server.datastore.ListAttestedNodeEntriesRequest)
-    - [ListAttestedNodeEntriesResponse](#spire.server.datastore.ListAttestedNodeEntriesResponse)
+    - [ListAttestedNodesRequest](#spire.server.datastore.ListAttestedNodesRequest)
+    - [ListAttestedNodesResponse](#spire.server.datastore.ListAttestedNodesResponse)
     - [ListBundlesRequest](#spire.server.datastore.ListBundlesRequest)
     - [ListBundlesResponse](#spire.server.datastore.ListBundlesResponse)
-    - [ListNodeResolverMapEntriesRequest](#spire.server.datastore.ListNodeResolverMapEntriesRequest)
-    - [ListNodeResolverMapEntriesResponse](#spire.server.datastore.ListNodeResolverMapEntriesResponse)
     - [ListRegistrationEntriesRequest](#spire.server.datastore.ListRegistrationEntriesRequest)
     - [ListRegistrationEntriesResponse](#spire.server.datastore.ListRegistrationEntriesResponse)
-    - [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry)
+    - [NodeSelectors](#spire.server.datastore.NodeSelectors)
     - [PruneJoinTokensRequest](#spire.server.datastore.PruneJoinTokensRequest)
     - [PruneJoinTokensResponse](#spire.server.datastore.PruneJoinTokensResponse)
-    - [RectifyNodeResolverMapEntriesRequest](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest)
-    - [RectifyNodeResolverMapEntriesResponse](#spire.server.datastore.RectifyNodeResolverMapEntriesResponse)
-    - [UpdateAttestedNodeEntryRequest](#spire.server.datastore.UpdateAttestedNodeEntryRequest)
-    - [UpdateAttestedNodeEntryResponse](#spire.server.datastore.UpdateAttestedNodeEntryResponse)
+    - [SetNodeSelectorsRequest](#spire.server.datastore.SetNodeSelectorsRequest)
+    - [SetNodeSelectorsResponse](#spire.server.datastore.SetNodeSelectorsResponse)
+    - [UpdateAttestedNodeRequest](#spire.server.datastore.UpdateAttestedNodeRequest)
+    - [UpdateAttestedNodeResponse](#spire.server.datastore.UpdateAttestedNodeResponse)
     - [UpdateBundleRequest](#spire.server.datastore.UpdateBundleRequest)
     - [UpdateBundleResponse](#spire.server.datastore.UpdateBundleResponse)
     - [UpdateRegistrationEntryRequest](#spire.server.datastore.UpdateRegistrationEntryRequest)
     - [UpdateRegistrationEntryResponse](#spire.server.datastore.UpdateRegistrationEntryResponse)
   
+    - [BySelectors.MatchBehavior](#spire.server.datastore.BySelectors.MatchBehavior)
   
   
     - [DataStore](#spire.server.datastore.DataStore)
@@ -500,9 +497,9 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.AttestedNodeEntry"/>
+<a name="spire.server.datastore.AttestedNode"/>
 
-### AttestedNodeEntry
+### AttestedNode
 
 
 
@@ -543,37 +540,37 @@ Represents a type with a list of Selector.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | selectors | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) | repeated |  |
-| allow_any_combination | [bool](#bool) |  |  |
+| match | [BySelectors.MatchBehavior](#spire.server.datastore.BySelectors.MatchBehavior) |  |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.CreateAttestedNodeEntryRequest"/>
+<a name="spire.server.datastore.CreateAttestedNodeRequest"/>
 
-### CreateAttestedNodeEntryRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.CreateAttestedNodeEntryResponse"/>
-
-### CreateAttestedNodeEntryResponse
+### CreateAttestedNodeRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+| node | [AttestedNode](#spire.server.datastore.AttestedNode) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.CreateAttestedNodeResponse"/>
+
+### CreateAttestedNodeResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| node | [AttestedNode](#spire.server.datastore.AttestedNode) |  |  |
 
 
 
@@ -640,36 +637,6 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.CreateNodeResolverMapEntryRequest"/>
-
-### CreateNodeResolverMapEntryRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.CreateNodeResolverMapEntryResponse"/>
-
-### CreateNodeResolverMapEntryResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
-
-
-
-
-
-
 <a name="spire.server.datastore.CreateRegistrationEntryRequest"/>
 
 ### CreateRegistrationEntryRequest
@@ -693,16 +660,16 @@ Represents a type with a list of Selector.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry_id | [string](#string) |  |  |
+| entry | [.spire.common.RegistrationEntry](#spire.server.datastore..spire.common.RegistrationEntry) |  |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.DeleteAttestedNodeEntryRequest"/>
+<a name="spire.server.datastore.DeleteAttestedNodeRequest"/>
 
-### DeleteAttestedNodeEntryRequest
+### DeleteAttestedNodeRequest
 
 
 
@@ -715,15 +682,15 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.DeleteAttestedNodeEntryResponse"/>
+<a name="spire.server.datastore.DeleteAttestedNodeResponse"/>
 
-### DeleteAttestedNodeEntryResponse
+### DeleteAttestedNodeResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+| node | [AttestedNode](#spire.server.datastore.AttestedNode) |  |  |
 
 
 
@@ -790,36 +757,6 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.DeleteNodeResolverMapEntryRequest"/>
-
-### DeleteNodeResolverMapEntryRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entry | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) |  |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.DeleteNodeResolverMapEntryResponse"/>
-
-### DeleteNodeResolverMapEntryResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
-
-
-
-
-
-
 <a name="spire.server.datastore.DeleteRegistrationEntryRequest"/>
 
 ### DeleteRegistrationEntryRequest
@@ -850,9 +787,9 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.FetchAttestedNodeEntryRequest"/>
+<a name="spire.server.datastore.FetchAttestedNodeRequest"/>
 
-### FetchAttestedNodeEntryRequest
+### FetchAttestedNodeRequest
 
 
 
@@ -865,15 +802,15 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.FetchAttestedNodeEntryResponse"/>
+<a name="spire.server.datastore.FetchAttestedNodeResponse"/>
 
-### FetchAttestedNodeEntryResponse
+### FetchAttestedNodeResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+| node | [AttestedNode](#spire.server.datastore.AttestedNode) |  |  |
 
 
 
@@ -970,6 +907,36 @@ Represents a type with a list of Selector.
 
 
 
+<a name="spire.server.datastore.GetNodeSelectorsRequest"/>
+
+### GetNodeSelectorsRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| spiffe_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.server.datastore.GetNodeSelectorsResponse"/>
+
+### GetNodeSelectorsResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| selectors | [NodeSelectors](#spire.server.datastore.NodeSelectors) |  |  |
+
+
+
+
+
+
 <a name="spire.server.datastore.JoinToken"/>
 
 ### JoinToken
@@ -986,9 +953,9 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.ListAttestedNodeEntriesRequest"/>
+<a name="spire.server.datastore.ListAttestedNodesRequest"/>
 
-### ListAttestedNodeEntriesRequest
+### ListAttestedNodesRequest
 
 
 
@@ -1001,15 +968,15 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.ListAttestedNodeEntriesResponse"/>
+<a name="spire.server.datastore.ListAttestedNodesResponse"/>
 
-### ListAttestedNodeEntriesResponse
+### ListAttestedNodesResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entries | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) | repeated |  |
+| nodes | [AttestedNode](#spire.server.datastore.AttestedNode) | repeated |  |
 
 
 
@@ -1035,36 +1002,6 @@ Represents a type with a list of Selector.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | bundles | [Bundle](#spire.server.datastore.Bundle) | repeated |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListNodeResolverMapEntriesRequest"/>
-
-### ListNodeResolverMapEntriesRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| spiffe_id | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.ListNodeResolverMapEntriesResponse"/>
-
-### ListNodeResolverMapEntriesResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
 
 
 
@@ -1103,16 +1040,16 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.NodeResolverMapEntry"/>
+<a name="spire.server.datastore.NodeSelectors"/>
 
-### NodeResolverMapEntry
+### NodeSelectors
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | spiffe_id | [string](#string) |  | Node SPIFFE ID |
-| selector | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) |  | Node selector |
+| selectors | [.spire.common.Selector](#spire.server.datastore..spire.common.Selector) | repeated | Node selectors |
 
 
 
@@ -1144,39 +1081,34 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.RectifyNodeResolverMapEntriesRequest"/>
+<a name="spire.server.datastore.SetNodeSelectorsRequest"/>
 
-### RectifyNodeResolverMapEntriesRequest
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
-
-
-
-
-
-
-<a name="spire.server.datastore.RectifyNodeResolverMapEntriesResponse"/>
-
-### RectifyNodeResolverMapEntriesResponse
+### SetNodeSelectorsRequest
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entries | [NodeResolverMapEntry](#spire.server.datastore.NodeResolverMapEntry) | repeated |  |
+| selectors | [NodeSelectors](#spire.server.datastore.NodeSelectors) |  |  |
 
 
 
 
 
 
-<a name="spire.server.datastore.UpdateAttestedNodeEntryRequest"/>
+<a name="spire.server.datastore.SetNodeSelectorsResponse"/>
 
-### UpdateAttestedNodeEntryRequest
+### SetNodeSelectorsResponse
+
+
+
+
+
+
+
+<a name="spire.server.datastore.UpdateAttestedNodeRequest"/>
+
+### UpdateAttestedNodeRequest
 
 
 
@@ -1191,15 +1123,15 @@ Represents a type with a list of Selector.
 
 
 
-<a name="spire.server.datastore.UpdateAttestedNodeEntryResponse"/>
+<a name="spire.server.datastore.UpdateAttestedNodeResponse"/>
 
-### UpdateAttestedNodeEntryResponse
+### UpdateAttestedNodeResponse
 
 
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| entry | [AttestedNodeEntry](#spire.server.datastore.AttestedNodeEntry) |  |  |
+| node | [AttestedNode](#spire.server.datastore.AttestedNode) |  |  |
 
 
 
@@ -1267,6 +1199,18 @@ Represents a type with a list of Selector.
 
  
 
+
+<a name="spire.server.datastore.BySelectors.MatchBehavior"/>
+
+### BySelectors.MatchBehavior
+
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MATCH_EXACT | 0 |  |
+| MATCH_SUBSET | 1 |  |
+
+
  
 
  
@@ -1285,15 +1229,13 @@ Represents a type with a list of Selector.
 | UpdateBundle | [UpdateBundleRequest](#spire.server.datastore.UpdateBundleRequest) | [UpdateBundleResponse](#spire.server.datastore.UpdateBundleRequest) | Updates a specific bundle, overwriting existing certs |
 | AppendBundle | [AppendBundleRequest](#spire.server.datastore.AppendBundleRequest) | [AppendBundleResponse](#spire.server.datastore.AppendBundleRequest) | Appends the provided certs onto an existing bundle, creating a new bundle if one doesn&#39;t exist |
 | DeleteBundle | [DeleteBundleRequest](#spire.server.datastore.DeleteBundleRequest) | [DeleteBundleResponse](#spire.server.datastore.DeleteBundleRequest) | Deletes a specific bundle |
-| CreateAttestedNodeEntry | [CreateAttestedNodeEntryRequest](#spire.server.datastore.CreateAttestedNodeEntryRequest) | [CreateAttestedNodeEntryResponse](#spire.server.datastore.CreateAttestedNodeEntryRequest) | Creates an attested node entry |
-| FetchAttestedNodeEntry | [FetchAttestedNodeEntryRequest](#spire.server.datastore.FetchAttestedNodeEntryRequest) | [FetchAttestedNodeEntryResponse](#spire.server.datastore.FetchAttestedNodeEntryRequest) | Fetches a specific attested node entry |
-| ListAttestedNodeEntries | [ListAttestedNodeEntriesRequest](#spire.server.datastore.ListAttestedNodeEntriesRequest) | [ListAttestedNodeEntriesResponse](#spire.server.datastore.ListAttestedNodeEntriesRequest) | Lists attested node entries (optionally filtered) |
-| UpdateAttestedNodeEntry | [UpdateAttestedNodeEntryRequest](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | [UpdateAttestedNodeEntryResponse](#spire.server.datastore.UpdateAttestedNodeEntryRequest) | Updates a specific attested node entry |
-| DeleteAttestedNodeEntry | [DeleteAttestedNodeEntryRequest](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | [DeleteAttestedNodeEntryResponse](#spire.server.datastore.DeleteAttestedNodeEntryRequest) | Deletes a specific attested node entry |
-| CreateNodeResolverMapEntry | [CreateNodeResolverMapEntryRequest](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | [CreateNodeResolverMapEntryResponse](#spire.server.datastore.CreateNodeResolverMapEntryRequest) | Creates a node resolver map entry |
-| ListNodeResolverMapEntries | [ListNodeResolverMapEntriesRequest](#spire.server.datastore.ListNodeResolverMapEntriesRequest) | [ListNodeResolverMapEntriesResponse](#spire.server.datastore.ListNodeResolverMapEntriesRequest) | Lists node resolver map entries for a specified SPIFFE ID |
-| DeleteNodeResolverMapEntry | [DeleteNodeResolverMapEntryRequest](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | [DeleteNodeResolverMapEntryResponse](#spire.server.datastore.DeleteNodeResolverMapEntryRequest) | Deletes a specific node resolver map entry |
-| RectifyNodeResolverMapEntries | [RectifyNodeResolverMapEntriesRequest](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | [RectifyNodeResolverMapEntriesResponse](#spire.server.datastore.RectifyNodeResolverMapEntriesRequest) | Sets the list of node resolver map entries for the specified SPIFFE ID |
+| CreateAttestedNode | [CreateAttestedNodeRequest](#spire.server.datastore.CreateAttestedNodeRequest) | [CreateAttestedNodeResponse](#spire.server.datastore.CreateAttestedNodeRequest) | Creates an attested node |
+| FetchAttestedNode | [FetchAttestedNodeRequest](#spire.server.datastore.FetchAttestedNodeRequest) | [FetchAttestedNodeResponse](#spire.server.datastore.FetchAttestedNodeRequest) | Fetches a specific attested node |
+| ListAttestedNodes | [ListAttestedNodesRequest](#spire.server.datastore.ListAttestedNodesRequest) | [ListAttestedNodesResponse](#spire.server.datastore.ListAttestedNodesRequest) | Lists attested nodes (optionally filtered) |
+| UpdateAttestedNode | [UpdateAttestedNodeRequest](#spire.server.datastore.UpdateAttestedNodeRequest) | [UpdateAttestedNodeResponse](#spire.server.datastore.UpdateAttestedNodeRequest) | Updates a specific attested node |
+| DeleteAttestedNode | [DeleteAttestedNodeRequest](#spire.server.datastore.DeleteAttestedNodeRequest) | [DeleteAttestedNodeResponse](#spire.server.datastore.DeleteAttestedNodeRequest) | Deletes a specific attested node |
+| SetNodeSelectors | [SetNodeSelectorsRequest](#spire.server.datastore.SetNodeSelectorsRequest) | [SetNodeSelectorsResponse](#spire.server.datastore.SetNodeSelectorsRequest) | Sets the set of selectors for a specific node id |
+| GetNodeSelectors | [GetNodeSelectorsRequest](#spire.server.datastore.GetNodeSelectorsRequest) | [GetNodeSelectorsResponse](#spire.server.datastore.GetNodeSelectorsRequest) | Gets the set of node selectors for a specific node id |
 | CreateRegistrationEntry | [CreateRegistrationEntryRequest](#spire.server.datastore.CreateRegistrationEntryRequest) | [CreateRegistrationEntryResponse](#spire.server.datastore.CreateRegistrationEntryRequest) | Creates a registration entry |
 | FetchRegistrationEntry | [FetchRegistrationEntryRequest](#spire.server.datastore.FetchRegistrationEntryRequest) | [FetchRegistrationEntryResponse](#spire.server.datastore.FetchRegistrationEntryRequest) | Fetches a specific registration entry |
 | ListRegistrationEntries | [ListRegistrationEntriesRequest](#spire.server.datastore.ListRegistrationEntriesRequest) | [ListRegistrationEntriesResponse](#spire.server.datastore.ListRegistrationEntriesRequest) | Lists registration entries (optionally filtered) |

--- a/proto/server/datastore/datastore.go
+++ b/proto/server/datastore/datastore.go
@@ -6,73 +6,64 @@ import (
 
 	"github.com/golang/protobuf/ptypes/empty"
 	go_plugin "github.com/hashicorp/go-plugin"
-	"github.com/spiffe/spire/proto/common"
 	"github.com/spiffe/spire/proto/common/plugin"
 	"google.golang.org/grpc"
 )
 
 // DataStore is the interface used by all non-catalog components.
 type DataStore interface {
-	CreateBundle(context.Context, *Bundle) (*Bundle, error)
-	UpdateBundle(context.Context, *Bundle) (*Bundle, error)
-	AppendBundle(context.Context, *Bundle) (*Bundle, error)
-	DeleteBundle(context.Context, *Bundle) (*Bundle, error)
-	FetchBundle(context.Context, *Bundle) (*Bundle, error)
-	ListBundles(context.Context, *common.Empty) (*Bundles, error)
+	CreateBundle(context.Context, *CreateBundleRequest) (*CreateBundleResponse, error)
+	FetchBundle(context.Context, *FetchBundleRequest) (*FetchBundleResponse, error)
+	ListBundles(context.Context, *ListBundlesRequest) (*ListBundlesResponse, error)
+	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
+	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
+	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
 	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
 	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	FetchStaleNodeEntries(context.Context, *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error)
+	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
 	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
 	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
 	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	FetchNodeResolverMapEntry(context.Context, *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error)
+	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
 	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
 	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
 	FetchRegistrationEntry(context.Context, *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error)
-	FetchRegistrationEntries(context.Context, *common.Empty) (*FetchRegistrationEntriesResponse, error)
+	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
 	UpdateRegistrationEntry(context.Context, *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error)
 	DeleteRegistrationEntry(context.Context, *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error)
-	ListParentIDEntries(context.Context, *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error)
-	ListSelectorEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	ListMatchingEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	ListSpiffeEntries(context.Context, *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error)
-	RegisterToken(context.Context, *JoinToken) (*common.Empty, error)
-	FetchToken(context.Context, *JoinToken) (*JoinToken, error)
-	DeleteToken(context.Context, *JoinToken) (*common.Empty, error)
-	PruneTokens(context.Context, *JoinToken) (*common.Empty, error)
+	CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error)
+	FetchJoinToken(context.Context, *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error)
+	DeleteJoinToken(context.Context, *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error)
+	PruneJoinTokens(context.Context, *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error)
 }
 
 // Plugin is the interface implemented by plugin implementations
 type Plugin interface {
-	CreateBundle(context.Context, *Bundle) (*Bundle, error)
-	UpdateBundle(context.Context, *Bundle) (*Bundle, error)
-	AppendBundle(context.Context, *Bundle) (*Bundle, error)
-	DeleteBundle(context.Context, *Bundle) (*Bundle, error)
-	FetchBundle(context.Context, *Bundle) (*Bundle, error)
-	ListBundles(context.Context, *common.Empty) (*Bundles, error)
+	CreateBundle(context.Context, *CreateBundleRequest) (*CreateBundleResponse, error)
+	FetchBundle(context.Context, *FetchBundleRequest) (*FetchBundleResponse, error)
+	ListBundles(context.Context, *ListBundlesRequest) (*ListBundlesResponse, error)
+	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
+	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
+	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
 	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
 	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	FetchStaleNodeEntries(context.Context, *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error)
+	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
 	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
 	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
 	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	FetchNodeResolverMapEntry(context.Context, *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error)
+	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
 	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
 	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
 	FetchRegistrationEntry(context.Context, *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error)
-	FetchRegistrationEntries(context.Context, *common.Empty) (*FetchRegistrationEntriesResponse, error)
+	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
 	UpdateRegistrationEntry(context.Context, *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error)
 	DeleteRegistrationEntry(context.Context, *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error)
-	ListParentIDEntries(context.Context, *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error)
-	ListSelectorEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	ListMatchingEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	ListSpiffeEntries(context.Context, *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error)
-	RegisterToken(context.Context, *JoinToken) (*common.Empty, error)
-	FetchToken(context.Context, *JoinToken) (*JoinToken, error)
-	DeleteToken(context.Context, *JoinToken) (*common.Empty, error)
-	PruneTokens(context.Context, *JoinToken) (*common.Empty, error)
+	CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error)
+	FetchJoinToken(context.Context, *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error)
+	DeleteJoinToken(context.Context, *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error)
+	PruneJoinTokens(context.Context, *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error)
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
 }
@@ -89,7 +80,7 @@ func NewBuiltIn(plugin Plugin) *BuiltIn {
 	}
 }
 
-func (b BuiltIn) CreateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (b BuiltIn) CreateBundle(ctx context.Context, req *CreateBundleRequest) (*CreateBundleResponse, error) {
 	resp, err := b.plugin.CreateBundle(ctx, req)
 	if err != nil {
 		return nil, err
@@ -97,31 +88,7 @@ func (b BuiltIn) CreateBundle(ctx context.Context, req *Bundle) (*Bundle, error)
 	return resp, nil
 }
 
-func (b BuiltIn) UpdateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	resp, err := b.plugin.UpdateBundle(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) AppendBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	resp, err := b.plugin.AppendBundle(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) DeleteBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	resp, err := b.plugin.DeleteBundle(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) FetchBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (b BuiltIn) FetchBundle(ctx context.Context, req *FetchBundleRequest) (*FetchBundleResponse, error) {
 	resp, err := b.plugin.FetchBundle(ctx, req)
 	if err != nil {
 		return nil, err
@@ -129,8 +96,32 @@ func (b BuiltIn) FetchBundle(ctx context.Context, req *Bundle) (*Bundle, error) 
 	return resp, nil
 }
 
-func (b BuiltIn) ListBundles(ctx context.Context, req *common.Empty) (*Bundles, error) {
+func (b BuiltIn) ListBundles(ctx context.Context, req *ListBundlesRequest) (*ListBundlesResponse, error) {
 	resp, err := b.plugin.ListBundles(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (b BuiltIn) UpdateBundle(ctx context.Context, req *UpdateBundleRequest) (*UpdateBundleResponse, error) {
+	resp, err := b.plugin.UpdateBundle(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (b BuiltIn) AppendBundle(ctx context.Context, req *AppendBundleRequest) (*AppendBundleResponse, error) {
+	resp, err := b.plugin.AppendBundle(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (b BuiltIn) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*DeleteBundleResponse, error) {
+	resp, err := b.plugin.DeleteBundle(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +144,8 @@ func (b BuiltIn) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedN
 	return resp, nil
 }
 
-func (b BuiltIn) FetchStaleNodeEntries(ctx context.Context, req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
-	resp, err := b.plugin.FetchStaleNodeEntries(ctx, req)
+func (b BuiltIn) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
+	resp, err := b.plugin.ListAttestedNodeEntries(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +176,8 @@ func (b BuiltIn) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNode
 	return resp, nil
 }
 
-func (b BuiltIn) FetchNodeResolverMapEntry(ctx context.Context, req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
-	resp, err := b.plugin.FetchNodeResolverMapEntry(ctx, req)
+func (b BuiltIn) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
+	resp, err := b.plugin.ListNodeResolverMapEntries(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -225,8 +216,8 @@ func (b BuiltIn) FetchRegistrationEntry(ctx context.Context, req *FetchRegistrat
 	return resp, nil
 }
 
-func (b BuiltIn) FetchRegistrationEntries(ctx context.Context, req *common.Empty) (*FetchRegistrationEntriesResponse, error) {
-	resp, err := b.plugin.FetchRegistrationEntries(ctx, req)
+func (b BuiltIn) ListRegistrationEntries(ctx context.Context, req *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error) {
+	resp, err := b.plugin.ListRegistrationEntries(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -249,64 +240,32 @@ func (b BuiltIn) DeleteRegistrationEntry(ctx context.Context, req *DeleteRegistr
 	return resp, nil
 }
 
-func (b BuiltIn) ListParentIDEntries(ctx context.Context, req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
-	resp, err := b.plugin.ListParentIDEntries(ctx, req)
+func (b BuiltIn) CreateJoinToken(ctx context.Context, req *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error) {
+	resp, err := b.plugin.CreateJoinToken(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) ListSelectorEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	resp, err := b.plugin.ListSelectorEntries(ctx, req)
+func (b BuiltIn) FetchJoinToken(ctx context.Context, req *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error) {
+	resp, err := b.plugin.FetchJoinToken(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) ListMatchingEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	resp, err := b.plugin.ListMatchingEntries(ctx, req)
+func (b BuiltIn) DeleteJoinToken(ctx context.Context, req *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error) {
+	resp, err := b.plugin.DeleteJoinToken(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) ListSpiffeEntries(ctx context.Context, req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
-	resp, err := b.plugin.ListSpiffeEntries(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) RegisterToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	resp, err := b.plugin.RegisterToken(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) FetchToken(ctx context.Context, req *JoinToken) (*JoinToken, error) {
-	resp, err := b.plugin.FetchToken(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) DeleteToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	resp, err := b.plugin.DeleteToken(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) PruneTokens(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	resp, err := b.plugin.PruneTokens(ctx, req)
+func (b BuiltIn) PruneJoinTokens(ctx context.Context, req *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error) {
+	resp, err := b.plugin.PruneJoinTokens(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -360,23 +319,23 @@ type GRPCServer struct {
 	Plugin Plugin
 }
 
-func (s *GRPCServer) CreateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (s *GRPCServer) CreateBundle(ctx context.Context, req *CreateBundleRequest) (*CreateBundleResponse, error) {
 	return s.Plugin.CreateBundle(ctx, req)
 }
-func (s *GRPCServer) UpdateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return s.Plugin.UpdateBundle(ctx, req)
-}
-func (s *GRPCServer) AppendBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return s.Plugin.AppendBundle(ctx, req)
-}
-func (s *GRPCServer) DeleteBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return s.Plugin.DeleteBundle(ctx, req)
-}
-func (s *GRPCServer) FetchBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (s *GRPCServer) FetchBundle(ctx context.Context, req *FetchBundleRequest) (*FetchBundleResponse, error) {
 	return s.Plugin.FetchBundle(ctx, req)
 }
-func (s *GRPCServer) ListBundles(ctx context.Context, req *common.Empty) (*Bundles, error) {
+func (s *GRPCServer) ListBundles(ctx context.Context, req *ListBundlesRequest) (*ListBundlesResponse, error) {
 	return s.Plugin.ListBundles(ctx, req)
+}
+func (s *GRPCServer) UpdateBundle(ctx context.Context, req *UpdateBundleRequest) (*UpdateBundleResponse, error) {
+	return s.Plugin.UpdateBundle(ctx, req)
+}
+func (s *GRPCServer) AppendBundle(ctx context.Context, req *AppendBundleRequest) (*AppendBundleResponse, error) {
+	return s.Plugin.AppendBundle(ctx, req)
+}
+func (s *GRPCServer) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*DeleteBundleResponse, error) {
+	return s.Plugin.DeleteBundle(ctx, req)
 }
 func (s *GRPCServer) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
 	return s.Plugin.CreateAttestedNodeEntry(ctx, req)
@@ -384,8 +343,8 @@ func (s *GRPCServer) CreateAttestedNodeEntry(ctx context.Context, req *CreateAtt
 func (s *GRPCServer) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
 	return s.Plugin.FetchAttestedNodeEntry(ctx, req)
 }
-func (s *GRPCServer) FetchStaleNodeEntries(ctx context.Context, req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
-	return s.Plugin.FetchStaleNodeEntries(ctx, req)
+func (s *GRPCServer) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
+	return s.Plugin.ListAttestedNodeEntries(ctx, req)
 }
 func (s *GRPCServer) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
 	return s.Plugin.UpdateAttestedNodeEntry(ctx, req)
@@ -396,8 +355,8 @@ func (s *GRPCServer) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAtt
 func (s *GRPCServer) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
 	return s.Plugin.CreateNodeResolverMapEntry(ctx, req)
 }
-func (s *GRPCServer) FetchNodeResolverMapEntry(ctx context.Context, req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
-	return s.Plugin.FetchNodeResolverMapEntry(ctx, req)
+func (s *GRPCServer) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
+	return s.Plugin.ListNodeResolverMapEntries(ctx, req)
 }
 func (s *GRPCServer) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
 	return s.Plugin.DeleteNodeResolverMapEntry(ctx, req)
@@ -411,8 +370,8 @@ func (s *GRPCServer) CreateRegistrationEntry(ctx context.Context, req *CreateReg
 func (s *GRPCServer) FetchRegistrationEntry(ctx context.Context, req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
 	return s.Plugin.FetchRegistrationEntry(ctx, req)
 }
-func (s *GRPCServer) FetchRegistrationEntries(ctx context.Context, req *common.Empty) (*FetchRegistrationEntriesResponse, error) {
-	return s.Plugin.FetchRegistrationEntries(ctx, req)
+func (s *GRPCServer) ListRegistrationEntries(ctx context.Context, req *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error) {
+	return s.Plugin.ListRegistrationEntries(ctx, req)
 }
 func (s *GRPCServer) UpdateRegistrationEntry(ctx context.Context, req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
 	return s.Plugin.UpdateRegistrationEntry(ctx, req)
@@ -420,29 +379,17 @@ func (s *GRPCServer) UpdateRegistrationEntry(ctx context.Context, req *UpdateReg
 func (s *GRPCServer) DeleteRegistrationEntry(ctx context.Context, req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
 	return s.Plugin.DeleteRegistrationEntry(ctx, req)
 }
-func (s *GRPCServer) ListParentIDEntries(ctx context.Context, req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
-	return s.Plugin.ListParentIDEntries(ctx, req)
+func (s *GRPCServer) CreateJoinToken(ctx context.Context, req *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error) {
+	return s.Plugin.CreateJoinToken(ctx, req)
 }
-func (s *GRPCServer) ListSelectorEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	return s.Plugin.ListSelectorEntries(ctx, req)
+func (s *GRPCServer) FetchJoinToken(ctx context.Context, req *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error) {
+	return s.Plugin.FetchJoinToken(ctx, req)
 }
-func (s *GRPCServer) ListMatchingEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	return s.Plugin.ListMatchingEntries(ctx, req)
+func (s *GRPCServer) DeleteJoinToken(ctx context.Context, req *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error) {
+	return s.Plugin.DeleteJoinToken(ctx, req)
 }
-func (s *GRPCServer) ListSpiffeEntries(ctx context.Context, req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
-	return s.Plugin.ListSpiffeEntries(ctx, req)
-}
-func (s *GRPCServer) RegisterToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return s.Plugin.RegisterToken(ctx, req)
-}
-func (s *GRPCServer) FetchToken(ctx context.Context, req *JoinToken) (*JoinToken, error) {
-	return s.Plugin.FetchToken(ctx, req)
-}
-func (s *GRPCServer) DeleteToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return s.Plugin.DeleteToken(ctx, req)
-}
-func (s *GRPCServer) PruneTokens(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return s.Plugin.PruneTokens(ctx, req)
+func (s *GRPCServer) PruneJoinTokens(ctx context.Context, req *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error) {
+	return s.Plugin.PruneJoinTokens(ctx, req)
 }
 func (s *GRPCServer) Configure(ctx context.Context, req *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error) {
 	return s.Plugin.Configure(ctx, req)
@@ -455,23 +402,23 @@ type GRPCClient struct {
 	client DataStoreClient
 }
 
-func (c *GRPCClient) CreateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (c *GRPCClient) CreateBundle(ctx context.Context, req *CreateBundleRequest) (*CreateBundleResponse, error) {
 	return c.client.CreateBundle(ctx, req)
 }
-func (c *GRPCClient) UpdateBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return c.client.UpdateBundle(ctx, req)
-}
-func (c *GRPCClient) AppendBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return c.client.AppendBundle(ctx, req)
-}
-func (c *GRPCClient) DeleteBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
-	return c.client.DeleteBundle(ctx, req)
-}
-func (c *GRPCClient) FetchBundle(ctx context.Context, req *Bundle) (*Bundle, error) {
+func (c *GRPCClient) FetchBundle(ctx context.Context, req *FetchBundleRequest) (*FetchBundleResponse, error) {
 	return c.client.FetchBundle(ctx, req)
 }
-func (c *GRPCClient) ListBundles(ctx context.Context, req *common.Empty) (*Bundles, error) {
+func (c *GRPCClient) ListBundles(ctx context.Context, req *ListBundlesRequest) (*ListBundlesResponse, error) {
 	return c.client.ListBundles(ctx, req)
+}
+func (c *GRPCClient) UpdateBundle(ctx context.Context, req *UpdateBundleRequest) (*UpdateBundleResponse, error) {
+	return c.client.UpdateBundle(ctx, req)
+}
+func (c *GRPCClient) AppendBundle(ctx context.Context, req *AppendBundleRequest) (*AppendBundleResponse, error) {
+	return c.client.AppendBundle(ctx, req)
+}
+func (c *GRPCClient) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*DeleteBundleResponse, error) {
+	return c.client.DeleteBundle(ctx, req)
 }
 func (c *GRPCClient) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
 	return c.client.CreateAttestedNodeEntry(ctx, req)
@@ -479,8 +426,8 @@ func (c *GRPCClient) CreateAttestedNodeEntry(ctx context.Context, req *CreateAtt
 func (c *GRPCClient) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
 	return c.client.FetchAttestedNodeEntry(ctx, req)
 }
-func (c *GRPCClient) FetchStaleNodeEntries(ctx context.Context, req *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error) {
-	return c.client.FetchStaleNodeEntries(ctx, req)
+func (c *GRPCClient) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
+	return c.client.ListAttestedNodeEntries(ctx, req)
 }
 func (c *GRPCClient) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
 	return c.client.UpdateAttestedNodeEntry(ctx, req)
@@ -491,8 +438,8 @@ func (c *GRPCClient) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAtt
 func (c *GRPCClient) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
 	return c.client.CreateNodeResolverMapEntry(ctx, req)
 }
-func (c *GRPCClient) FetchNodeResolverMapEntry(ctx context.Context, req *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error) {
-	return c.client.FetchNodeResolverMapEntry(ctx, req)
+func (c *GRPCClient) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
+	return c.client.ListNodeResolverMapEntries(ctx, req)
 }
 func (c *GRPCClient) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
 	return c.client.DeleteNodeResolverMapEntry(ctx, req)
@@ -506,8 +453,8 @@ func (c *GRPCClient) CreateRegistrationEntry(ctx context.Context, req *CreateReg
 func (c *GRPCClient) FetchRegistrationEntry(ctx context.Context, req *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error) {
 	return c.client.FetchRegistrationEntry(ctx, req)
 }
-func (c *GRPCClient) FetchRegistrationEntries(ctx context.Context, req *common.Empty) (*FetchRegistrationEntriesResponse, error) {
-	return c.client.FetchRegistrationEntries(ctx, req)
+func (c *GRPCClient) ListRegistrationEntries(ctx context.Context, req *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error) {
+	return c.client.ListRegistrationEntries(ctx, req)
 }
 func (c *GRPCClient) UpdateRegistrationEntry(ctx context.Context, req *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error) {
 	return c.client.UpdateRegistrationEntry(ctx, req)
@@ -515,29 +462,17 @@ func (c *GRPCClient) UpdateRegistrationEntry(ctx context.Context, req *UpdateReg
 func (c *GRPCClient) DeleteRegistrationEntry(ctx context.Context, req *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error) {
 	return c.client.DeleteRegistrationEntry(ctx, req)
 }
-func (c *GRPCClient) ListParentIDEntries(ctx context.Context, req *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error) {
-	return c.client.ListParentIDEntries(ctx, req)
+func (c *GRPCClient) CreateJoinToken(ctx context.Context, req *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error) {
+	return c.client.CreateJoinToken(ctx, req)
 }
-func (c *GRPCClient) ListSelectorEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	return c.client.ListSelectorEntries(ctx, req)
+func (c *GRPCClient) FetchJoinToken(ctx context.Context, req *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error) {
+	return c.client.FetchJoinToken(ctx, req)
 }
-func (c *GRPCClient) ListMatchingEntries(ctx context.Context, req *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error) {
-	return c.client.ListMatchingEntries(ctx, req)
+func (c *GRPCClient) DeleteJoinToken(ctx context.Context, req *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error) {
+	return c.client.DeleteJoinToken(ctx, req)
 }
-func (c *GRPCClient) ListSpiffeEntries(ctx context.Context, req *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error) {
-	return c.client.ListSpiffeEntries(ctx, req)
-}
-func (c *GRPCClient) RegisterToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return c.client.RegisterToken(ctx, req)
-}
-func (c *GRPCClient) FetchToken(ctx context.Context, req *JoinToken) (*JoinToken, error) {
-	return c.client.FetchToken(ctx, req)
-}
-func (c *GRPCClient) DeleteToken(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return c.client.DeleteToken(ctx, req)
-}
-func (c *GRPCClient) PruneTokens(ctx context.Context, req *JoinToken) (*common.Empty, error) {
-	return c.client.PruneTokens(ctx, req)
+func (c *GRPCClient) PruneJoinTokens(ctx context.Context, req *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error) {
+	return c.client.PruneJoinTokens(ctx, req)
 }
 func (c *GRPCClient) Configure(ctx context.Context, req *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error) {
 	return c.client.Configure(ctx, req)

--- a/proto/server/datastore/datastore.go
+++ b/proto/server/datastore/datastore.go
@@ -18,15 +18,13 @@ type DataStore interface {
 	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
 	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
 	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
-	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
-	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
-	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
-	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
-	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
-	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
-	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
+	CreateAttestedNode(context.Context, *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error)
+	FetchAttestedNode(context.Context, *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error)
+	ListAttestedNodes(context.Context, *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error)
+	UpdateAttestedNode(context.Context, *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error)
+	DeleteAttestedNode(context.Context, *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error)
+	SetNodeSelectors(context.Context, *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error)
+	GetNodeSelectors(context.Context, *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error)
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
 	FetchRegistrationEntry(context.Context, *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error)
 	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
@@ -46,15 +44,13 @@ type Plugin interface {
 	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
 	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
 	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
-	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
-	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
-	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
-	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
-	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
-	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
-	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
+	CreateAttestedNode(context.Context, *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error)
+	FetchAttestedNode(context.Context, *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error)
+	ListAttestedNodes(context.Context, *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error)
+	UpdateAttestedNode(context.Context, *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error)
+	DeleteAttestedNode(context.Context, *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error)
+	SetNodeSelectors(context.Context, *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error)
+	GetNodeSelectors(context.Context, *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error)
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
 	FetchRegistrationEntry(context.Context, *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error)
 	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
@@ -128,72 +124,56 @@ func (b BuiltIn) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*D
 	return resp, nil
 }
 
-func (b BuiltIn) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
-	resp, err := b.plugin.CreateAttestedNodeEntry(ctx, req)
+func (b BuiltIn) CreateAttestedNode(ctx context.Context, req *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error) {
+	resp, err := b.plugin.CreateAttestedNode(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
-	resp, err := b.plugin.FetchAttestedNodeEntry(ctx, req)
+func (b BuiltIn) FetchAttestedNode(ctx context.Context, req *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error) {
+	resp, err := b.plugin.FetchAttestedNode(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
-	resp, err := b.plugin.ListAttestedNodeEntries(ctx, req)
+func (b BuiltIn) ListAttestedNodes(ctx context.Context, req *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error) {
+	resp, err := b.plugin.ListAttestedNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
-	resp, err := b.plugin.UpdateAttestedNodeEntry(ctx, req)
+func (b BuiltIn) UpdateAttestedNode(ctx context.Context, req *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error) {
+	resp, err := b.plugin.UpdateAttestedNode(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
-	resp, err := b.plugin.DeleteAttestedNodeEntry(ctx, req)
+func (b BuiltIn) DeleteAttestedNode(ctx context.Context, req *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error) {
+	resp, err := b.plugin.DeleteAttestedNode(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
-	resp, err := b.plugin.CreateNodeResolverMapEntry(ctx, req)
+func (b BuiltIn) SetNodeSelectors(ctx context.Context, req *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error) {
+	resp, err := b.plugin.SetNodeSelectors(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 	return resp, nil
 }
 
-func (b BuiltIn) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
-	resp, err := b.plugin.ListNodeResolverMapEntries(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
-	resp, err := b.plugin.DeleteNodeResolverMapEntry(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (b BuiltIn) RectifyNodeResolverMapEntries(ctx context.Context, req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
-	resp, err := b.plugin.RectifyNodeResolverMapEntries(ctx, req)
+func (b BuiltIn) GetNodeSelectors(ctx context.Context, req *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error) {
+	resp, err := b.plugin.GetNodeSelectors(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -337,32 +317,26 @@ func (s *GRPCServer) AppendBundle(ctx context.Context, req *AppendBundleRequest)
 func (s *GRPCServer) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*DeleteBundleResponse, error) {
 	return s.Plugin.DeleteBundle(ctx, req)
 }
-func (s *GRPCServer) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
-	return s.Plugin.CreateAttestedNodeEntry(ctx, req)
+func (s *GRPCServer) CreateAttestedNode(ctx context.Context, req *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error) {
+	return s.Plugin.CreateAttestedNode(ctx, req)
 }
-func (s *GRPCServer) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
-	return s.Plugin.FetchAttestedNodeEntry(ctx, req)
+func (s *GRPCServer) FetchAttestedNode(ctx context.Context, req *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error) {
+	return s.Plugin.FetchAttestedNode(ctx, req)
 }
-func (s *GRPCServer) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
-	return s.Plugin.ListAttestedNodeEntries(ctx, req)
+func (s *GRPCServer) ListAttestedNodes(ctx context.Context, req *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error) {
+	return s.Plugin.ListAttestedNodes(ctx, req)
 }
-func (s *GRPCServer) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
-	return s.Plugin.UpdateAttestedNodeEntry(ctx, req)
+func (s *GRPCServer) UpdateAttestedNode(ctx context.Context, req *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error) {
+	return s.Plugin.UpdateAttestedNode(ctx, req)
 }
-func (s *GRPCServer) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
-	return s.Plugin.DeleteAttestedNodeEntry(ctx, req)
+func (s *GRPCServer) DeleteAttestedNode(ctx context.Context, req *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error) {
+	return s.Plugin.DeleteAttestedNode(ctx, req)
 }
-func (s *GRPCServer) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
-	return s.Plugin.CreateNodeResolverMapEntry(ctx, req)
+func (s *GRPCServer) SetNodeSelectors(ctx context.Context, req *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error) {
+	return s.Plugin.SetNodeSelectors(ctx, req)
 }
-func (s *GRPCServer) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
-	return s.Plugin.ListNodeResolverMapEntries(ctx, req)
-}
-func (s *GRPCServer) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
-	return s.Plugin.DeleteNodeResolverMapEntry(ctx, req)
-}
-func (s *GRPCServer) RectifyNodeResolverMapEntries(ctx context.Context, req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
-	return s.Plugin.RectifyNodeResolverMapEntries(ctx, req)
+func (s *GRPCServer) GetNodeSelectors(ctx context.Context, req *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error) {
+	return s.Plugin.GetNodeSelectors(ctx, req)
 }
 func (s *GRPCServer) CreateRegistrationEntry(ctx context.Context, req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
 	return s.Plugin.CreateRegistrationEntry(ctx, req)
@@ -420,32 +394,26 @@ func (c *GRPCClient) AppendBundle(ctx context.Context, req *AppendBundleRequest)
 func (c *GRPCClient) DeleteBundle(ctx context.Context, req *DeleteBundleRequest) (*DeleteBundleResponse, error) {
 	return c.client.DeleteBundle(ctx, req)
 }
-func (c *GRPCClient) CreateAttestedNodeEntry(ctx context.Context, req *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error) {
-	return c.client.CreateAttestedNodeEntry(ctx, req)
+func (c *GRPCClient) CreateAttestedNode(ctx context.Context, req *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error) {
+	return c.client.CreateAttestedNode(ctx, req)
 }
-func (c *GRPCClient) FetchAttestedNodeEntry(ctx context.Context, req *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error) {
-	return c.client.FetchAttestedNodeEntry(ctx, req)
+func (c *GRPCClient) FetchAttestedNode(ctx context.Context, req *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error) {
+	return c.client.FetchAttestedNode(ctx, req)
 }
-func (c *GRPCClient) ListAttestedNodeEntries(ctx context.Context, req *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error) {
-	return c.client.ListAttestedNodeEntries(ctx, req)
+func (c *GRPCClient) ListAttestedNodes(ctx context.Context, req *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error) {
+	return c.client.ListAttestedNodes(ctx, req)
 }
-func (c *GRPCClient) UpdateAttestedNodeEntry(ctx context.Context, req *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error) {
-	return c.client.UpdateAttestedNodeEntry(ctx, req)
+func (c *GRPCClient) UpdateAttestedNode(ctx context.Context, req *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error) {
+	return c.client.UpdateAttestedNode(ctx, req)
 }
-func (c *GRPCClient) DeleteAttestedNodeEntry(ctx context.Context, req *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error) {
-	return c.client.DeleteAttestedNodeEntry(ctx, req)
+func (c *GRPCClient) DeleteAttestedNode(ctx context.Context, req *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error) {
+	return c.client.DeleteAttestedNode(ctx, req)
 }
-func (c *GRPCClient) CreateNodeResolverMapEntry(ctx context.Context, req *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error) {
-	return c.client.CreateNodeResolverMapEntry(ctx, req)
+func (c *GRPCClient) SetNodeSelectors(ctx context.Context, req *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error) {
+	return c.client.SetNodeSelectors(ctx, req)
 }
-func (c *GRPCClient) ListNodeResolverMapEntries(ctx context.Context, req *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error) {
-	return c.client.ListNodeResolverMapEntries(ctx, req)
-}
-func (c *GRPCClient) DeleteNodeResolverMapEntry(ctx context.Context, req *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error) {
-	return c.client.DeleteNodeResolverMapEntry(ctx, req)
-}
-func (c *GRPCClient) RectifyNodeResolverMapEntries(ctx context.Context, req *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error) {
-	return c.client.RectifyNodeResolverMapEntries(ctx, req)
+func (c *GRPCClient) GetNodeSelectors(ctx context.Context, req *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error) {
+	return c.client.GetNodeSelectors(ctx, req)
 }
 func (c *GRPCClient) CreateRegistrationEntry(ctx context.Context, req *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error) {
 	return c.client.CreateRegistrationEntry(ctx, req)

--- a/proto/server/datastore/datastore.pb.go
+++ b/proto/server/datastore/datastore.pb.go
@@ -83,6 +83,29 @@ type RegistrationEntry = common.RegistrationEntry
 // RegistrationEntries from public import github.com/spiffe/spire/proto/common/common.proto
 type RegistrationEntries = common.RegistrationEntries
 
+type BySelectors_MatchBehavior int32
+
+const (
+	BySelectors_MATCH_EXACT  BySelectors_MatchBehavior = 0
+	BySelectors_MATCH_SUBSET BySelectors_MatchBehavior = 1
+)
+
+var BySelectors_MatchBehavior_name = map[int32]string{
+	0: "MATCH_EXACT",
+	1: "MATCH_SUBSET",
+}
+var BySelectors_MatchBehavior_value = map[string]int32{
+	"MATCH_EXACT":  0,
+	"MATCH_SUBSET": 1,
+}
+
+func (x BySelectors_MatchBehavior) String() string {
+	return proto.EnumName(BySelectors_MatchBehavior_name, int32(x))
+}
+func (BySelectors_MatchBehavior) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{33, 0}
+}
+
 type Bundle struct {
 	// Trust domain SPIFFE ID
 	TrustDomain string `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain" json:"trust_domain,omitempty"`
@@ -97,7 +120,7 @@ func (m *Bundle) Reset()         { *m = Bundle{} }
 func (m *Bundle) String() string { return proto.CompactTextString(m) }
 func (*Bundle) ProtoMessage()    {}
 func (*Bundle) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{0}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{0}
 }
 func (m *Bundle) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Bundle.Unmarshal(m, b)
@@ -142,7 +165,7 @@ func (m *CreateBundleRequest) Reset()         { *m = CreateBundleRequest{} }
 func (m *CreateBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateBundleRequest) ProtoMessage()    {}
 func (*CreateBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{1}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{1}
 }
 func (m *CreateBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateBundleRequest.Unmarshal(m, b)
@@ -180,7 +203,7 @@ func (m *CreateBundleResponse) Reset()         { *m = CreateBundleResponse{} }
 func (m *CreateBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateBundleResponse) ProtoMessage()    {}
 func (*CreateBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{2}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{2}
 }
 func (m *CreateBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateBundleResponse.Unmarshal(m, b)
@@ -218,7 +241,7 @@ func (m *FetchBundleRequest) Reset()         { *m = FetchBundleRequest{} }
 func (m *FetchBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchBundleRequest) ProtoMessage()    {}
 func (*FetchBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{3}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{3}
 }
 func (m *FetchBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchBundleRequest.Unmarshal(m, b)
@@ -256,7 +279,7 @@ func (m *FetchBundleResponse) Reset()         { *m = FetchBundleResponse{} }
 func (m *FetchBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchBundleResponse) ProtoMessage()    {}
 func (*FetchBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{4}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{4}
 }
 func (m *FetchBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchBundleResponse.Unmarshal(m, b)
@@ -293,7 +316,7 @@ func (m *ListBundlesRequest) Reset()         { *m = ListBundlesRequest{} }
 func (m *ListBundlesRequest) String() string { return proto.CompactTextString(m) }
 func (*ListBundlesRequest) ProtoMessage()    {}
 func (*ListBundlesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{5}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{5}
 }
 func (m *ListBundlesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListBundlesRequest.Unmarshal(m, b)
@@ -324,7 +347,7 @@ func (m *ListBundlesResponse) Reset()         { *m = ListBundlesResponse{} }
 func (m *ListBundlesResponse) String() string { return proto.CompactTextString(m) }
 func (*ListBundlesResponse) ProtoMessage()    {}
 func (*ListBundlesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{6}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{6}
 }
 func (m *ListBundlesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListBundlesResponse.Unmarshal(m, b)
@@ -362,7 +385,7 @@ func (m *UpdateBundleRequest) Reset()         { *m = UpdateBundleRequest{} }
 func (m *UpdateBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdateBundleRequest) ProtoMessage()    {}
 func (*UpdateBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{7}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{7}
 }
 func (m *UpdateBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateBundleRequest.Unmarshal(m, b)
@@ -400,7 +423,7 @@ func (m *UpdateBundleResponse) Reset()         { *m = UpdateBundleResponse{} }
 func (m *UpdateBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateBundleResponse) ProtoMessage()    {}
 func (*UpdateBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{8}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{8}
 }
 func (m *UpdateBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateBundleResponse.Unmarshal(m, b)
@@ -438,7 +461,7 @@ func (m *AppendBundleRequest) Reset()         { *m = AppendBundleRequest{} }
 func (m *AppendBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*AppendBundleRequest) ProtoMessage()    {}
 func (*AppendBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{9}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{9}
 }
 func (m *AppendBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AppendBundleRequest.Unmarshal(m, b)
@@ -476,7 +499,7 @@ func (m *AppendBundleResponse) Reset()         { *m = AppendBundleResponse{} }
 func (m *AppendBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*AppendBundleResponse) ProtoMessage()    {}
 func (*AppendBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{10}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{10}
 }
 func (m *AppendBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AppendBundleResponse.Unmarshal(m, b)
@@ -514,7 +537,7 @@ func (m *DeleteBundleRequest) Reset()         { *m = DeleteBundleRequest{} }
 func (m *DeleteBundleRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteBundleRequest) ProtoMessage()    {}
 func (*DeleteBundleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{11}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{11}
 }
 func (m *DeleteBundleRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteBundleRequest.Unmarshal(m, b)
@@ -552,7 +575,7 @@ func (m *DeleteBundleResponse) Reset()         { *m = DeleteBundleResponse{} }
 func (m *DeleteBundleResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteBundleResponse) ProtoMessage()    {}
 func (*DeleteBundleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{12}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{12}
 }
 func (m *DeleteBundleResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteBundleResponse.Unmarshal(m, b)
@@ -579,359 +602,199 @@ func (m *DeleteBundleResponse) GetBundle() *Bundle {
 	return nil
 }
 
-type NodeResolverMapEntry struct {
+type NodeSelectors struct {
 	// Node SPIFFE ID
 	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
-	// Node selector
-	Selector             *common.Selector `protobuf:"bytes,2,opt,name=selector" json:"selector,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
-	XXX_unrecognized     []byte           `json:"-"`
-	XXX_sizecache        int32            `json:"-"`
+	// Node selectors
+	Selectors            []*common.Selector `protobuf:"bytes,2,rep,name=selectors" json:"selectors,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
 }
 
-func (m *NodeResolverMapEntry) Reset()         { *m = NodeResolverMapEntry{} }
-func (m *NodeResolverMapEntry) String() string { return proto.CompactTextString(m) }
-func (*NodeResolverMapEntry) ProtoMessage()    {}
-func (*NodeResolverMapEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{13}
+func (m *NodeSelectors) Reset()         { *m = NodeSelectors{} }
+func (m *NodeSelectors) String() string { return proto.CompactTextString(m) }
+func (*NodeSelectors) ProtoMessage()    {}
+func (*NodeSelectors) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{13}
 }
-func (m *NodeResolverMapEntry) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_NodeResolverMapEntry.Unmarshal(m, b)
+func (m *NodeSelectors) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_NodeSelectors.Unmarshal(m, b)
 }
-func (m *NodeResolverMapEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_NodeResolverMapEntry.Marshal(b, m, deterministic)
+func (m *NodeSelectors) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_NodeSelectors.Marshal(b, m, deterministic)
 }
-func (dst *NodeResolverMapEntry) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_NodeResolverMapEntry.Merge(dst, src)
+func (dst *NodeSelectors) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NodeSelectors.Merge(dst, src)
 }
-func (m *NodeResolverMapEntry) XXX_Size() int {
-	return xxx_messageInfo_NodeResolverMapEntry.Size(m)
+func (m *NodeSelectors) XXX_Size() int {
+	return xxx_messageInfo_NodeSelectors.Size(m)
 }
-func (m *NodeResolverMapEntry) XXX_DiscardUnknown() {
-	xxx_messageInfo_NodeResolverMapEntry.DiscardUnknown(m)
+func (m *NodeSelectors) XXX_DiscardUnknown() {
+	xxx_messageInfo_NodeSelectors.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_NodeResolverMapEntry proto.InternalMessageInfo
+var xxx_messageInfo_NodeSelectors proto.InternalMessageInfo
 
-func (m *NodeResolverMapEntry) GetSpiffeId() string {
+func (m *NodeSelectors) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-func (m *NodeResolverMapEntry) GetSelector() *common.Selector {
+func (m *NodeSelectors) GetSelectors() []*common.Selector {
 	if m != nil {
-		return m.Selector
+		return m.Selectors
 	}
 	return nil
 }
 
-type CreateNodeResolverMapEntryRequest struct {
-	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
+type SetNodeSelectorsRequest struct {
+	Selectors            *NodeSelectors `protobuf:"bytes,1,opt,name=selectors" json:"selectors,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *CreateNodeResolverMapEntryRequest) Reset()         { *m = CreateNodeResolverMapEntryRequest{} }
-func (m *CreateNodeResolverMapEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateNodeResolverMapEntryRequest) ProtoMessage()    {}
-func (*CreateNodeResolverMapEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{14}
+func (m *SetNodeSelectorsRequest) Reset()         { *m = SetNodeSelectorsRequest{} }
+func (m *SetNodeSelectorsRequest) String() string { return proto.CompactTextString(m) }
+func (*SetNodeSelectorsRequest) ProtoMessage()    {}
+func (*SetNodeSelectorsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{14}
 }
-func (m *CreateNodeResolverMapEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateNodeResolverMapEntryRequest.Unmarshal(m, b)
+func (m *SetNodeSelectorsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetNodeSelectorsRequest.Unmarshal(m, b)
 }
-func (m *CreateNodeResolverMapEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateNodeResolverMapEntryRequest.Marshal(b, m, deterministic)
+func (m *SetNodeSelectorsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetNodeSelectorsRequest.Marshal(b, m, deterministic)
 }
-func (dst *CreateNodeResolverMapEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateNodeResolverMapEntryRequest.Merge(dst, src)
+func (dst *SetNodeSelectorsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetNodeSelectorsRequest.Merge(dst, src)
 }
-func (m *CreateNodeResolverMapEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateNodeResolverMapEntryRequest.Size(m)
+func (m *SetNodeSelectorsRequest) XXX_Size() int {
+	return xxx_messageInfo_SetNodeSelectorsRequest.Size(m)
 }
-func (m *CreateNodeResolverMapEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateNodeResolverMapEntryRequest.DiscardUnknown(m)
+func (m *SetNodeSelectorsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetNodeSelectorsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CreateNodeResolverMapEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_SetNodeSelectorsRequest proto.InternalMessageInfo
 
-func (m *CreateNodeResolverMapEntryRequest) GetEntry() *NodeResolverMapEntry {
+func (m *SetNodeSelectorsRequest) GetSelectors() *NodeSelectors {
 	if m != nil {
-		return m.Entry
+		return m.Selectors
 	}
 	return nil
 }
 
-type CreateNodeResolverMapEntryResponse struct {
-	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
+type SetNodeSelectorsResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CreateNodeResolverMapEntryResponse) Reset()         { *m = CreateNodeResolverMapEntryResponse{} }
-func (m *CreateNodeResolverMapEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*CreateNodeResolverMapEntryResponse) ProtoMessage()    {}
-func (*CreateNodeResolverMapEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{15}
+func (m *SetNodeSelectorsResponse) Reset()         { *m = SetNodeSelectorsResponse{} }
+func (m *SetNodeSelectorsResponse) String() string { return proto.CompactTextString(m) }
+func (*SetNodeSelectorsResponse) ProtoMessage()    {}
+func (*SetNodeSelectorsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{15}
 }
-func (m *CreateNodeResolverMapEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateNodeResolverMapEntryResponse.Unmarshal(m, b)
+func (m *SetNodeSelectorsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetNodeSelectorsResponse.Unmarshal(m, b)
 }
-func (m *CreateNodeResolverMapEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateNodeResolverMapEntryResponse.Marshal(b, m, deterministic)
+func (m *SetNodeSelectorsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetNodeSelectorsResponse.Marshal(b, m, deterministic)
 }
-func (dst *CreateNodeResolverMapEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateNodeResolverMapEntryResponse.Merge(dst, src)
+func (dst *SetNodeSelectorsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetNodeSelectorsResponse.Merge(dst, src)
 }
-func (m *CreateNodeResolverMapEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_CreateNodeResolverMapEntryResponse.Size(m)
+func (m *SetNodeSelectorsResponse) XXX_Size() int {
+	return xxx_messageInfo_SetNodeSelectorsResponse.Size(m)
 }
-func (m *CreateNodeResolverMapEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateNodeResolverMapEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateNodeResolverMapEntryResponse proto.InternalMessageInfo
-
-func (m *CreateNodeResolverMapEntryResponse) GetEntry() *NodeResolverMapEntry {
-	if m != nil {
-		return m.Entry
-	}
-	return nil
+func (m *SetNodeSelectorsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetNodeSelectorsResponse.DiscardUnknown(m)
 }
 
-type ListNodeResolverMapEntriesRequest struct {
+var xxx_messageInfo_SetNodeSelectorsResponse proto.InternalMessageInfo
+
+type GetNodeSelectorsRequest struct {
 	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ListNodeResolverMapEntriesRequest) Reset()         { *m = ListNodeResolverMapEntriesRequest{} }
-func (m *ListNodeResolverMapEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListNodeResolverMapEntriesRequest) ProtoMessage()    {}
-func (*ListNodeResolverMapEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{16}
+func (m *GetNodeSelectorsRequest) Reset()         { *m = GetNodeSelectorsRequest{} }
+func (m *GetNodeSelectorsRequest) String() string { return proto.CompactTextString(m) }
+func (*GetNodeSelectorsRequest) ProtoMessage()    {}
+func (*GetNodeSelectorsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{16}
 }
-func (m *ListNodeResolverMapEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Unmarshal(m, b)
+func (m *GetNodeSelectorsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetNodeSelectorsRequest.Unmarshal(m, b)
 }
-func (m *ListNodeResolverMapEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Marshal(b, m, deterministic)
+func (m *GetNodeSelectorsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetNodeSelectorsRequest.Marshal(b, m, deterministic)
 }
-func (dst *ListNodeResolverMapEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListNodeResolverMapEntriesRequest.Merge(dst, src)
+func (dst *GetNodeSelectorsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetNodeSelectorsRequest.Merge(dst, src)
 }
-func (m *ListNodeResolverMapEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Size(m)
+func (m *GetNodeSelectorsRequest) XXX_Size() int {
+	return xxx_messageInfo_GetNodeSelectorsRequest.Size(m)
 }
-func (m *ListNodeResolverMapEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListNodeResolverMapEntriesRequest.DiscardUnknown(m)
+func (m *GetNodeSelectorsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetNodeSelectorsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListNodeResolverMapEntriesRequest proto.InternalMessageInfo
+var xxx_messageInfo_GetNodeSelectorsRequest proto.InternalMessageInfo
 
-func (m *ListNodeResolverMapEntriesRequest) GetSpiffeId() string {
+func (m *GetNodeSelectorsRequest) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-type ListNodeResolverMapEntriesResponse struct {
-	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
-	XXX_unrecognized     []byte                  `json:"-"`
-	XXX_sizecache        int32                   `json:"-"`
+type GetNodeSelectorsResponse struct {
+	Selectors            *NodeSelectors `protobuf:"bytes,1,opt,name=selectors" json:"selectors,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *ListNodeResolverMapEntriesResponse) Reset()         { *m = ListNodeResolverMapEntriesResponse{} }
-func (m *ListNodeResolverMapEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*ListNodeResolverMapEntriesResponse) ProtoMessage()    {}
-func (*ListNodeResolverMapEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{17}
+func (m *GetNodeSelectorsResponse) Reset()         { *m = GetNodeSelectorsResponse{} }
+func (m *GetNodeSelectorsResponse) String() string { return proto.CompactTextString(m) }
+func (*GetNodeSelectorsResponse) ProtoMessage()    {}
+func (*GetNodeSelectorsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{17}
 }
-func (m *ListNodeResolverMapEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Unmarshal(m, b)
+func (m *GetNodeSelectorsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetNodeSelectorsResponse.Unmarshal(m, b)
 }
-func (m *ListNodeResolverMapEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Marshal(b, m, deterministic)
+func (m *GetNodeSelectorsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetNodeSelectorsResponse.Marshal(b, m, deterministic)
 }
-func (dst *ListNodeResolverMapEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListNodeResolverMapEntriesResponse.Merge(dst, src)
+func (dst *GetNodeSelectorsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetNodeSelectorsResponse.Merge(dst, src)
 }
-func (m *ListNodeResolverMapEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Size(m)
+func (m *GetNodeSelectorsResponse) XXX_Size() int {
+	return xxx_messageInfo_GetNodeSelectorsResponse.Size(m)
 }
-func (m *ListNodeResolverMapEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListNodeResolverMapEntriesResponse.DiscardUnknown(m)
+func (m *GetNodeSelectorsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetNodeSelectorsResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListNodeResolverMapEntriesResponse proto.InternalMessageInfo
+var xxx_messageInfo_GetNodeSelectorsResponse proto.InternalMessageInfo
 
-func (m *ListNodeResolverMapEntriesResponse) GetEntries() []*NodeResolverMapEntry {
+func (m *GetNodeSelectorsResponse) GetSelectors() *NodeSelectors {
 	if m != nil {
-		return m.Entries
+		return m.Selectors
 	}
 	return nil
 }
 
-type DeleteNodeResolverMapEntryRequest struct {
-	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
-	XXX_unrecognized     []byte                `json:"-"`
-	XXX_sizecache        int32                 `json:"-"`
-}
-
-func (m *DeleteNodeResolverMapEntryRequest) Reset()         { *m = DeleteNodeResolverMapEntryRequest{} }
-func (m *DeleteNodeResolverMapEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*DeleteNodeResolverMapEntryRequest) ProtoMessage()    {}
-func (*DeleteNodeResolverMapEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{18}
-}
-func (m *DeleteNodeResolverMapEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryRequest.Unmarshal(m, b)
-}
-func (m *DeleteNodeResolverMapEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryRequest.Marshal(b, m, deterministic)
-}
-func (dst *DeleteNodeResolverMapEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteNodeResolverMapEntryRequest.Merge(dst, src)
-}
-func (m *DeleteNodeResolverMapEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryRequest.Size(m)
-}
-func (m *DeleteNodeResolverMapEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteNodeResolverMapEntryRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteNodeResolverMapEntryRequest proto.InternalMessageInfo
-
-func (m *DeleteNodeResolverMapEntryRequest) GetEntry() *NodeResolverMapEntry {
-	if m != nil {
-		return m.Entry
-	}
-	return nil
-}
-
-type DeleteNodeResolverMapEntryResponse struct {
-	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
-	XXX_unrecognized     []byte                  `json:"-"`
-	XXX_sizecache        int32                   `json:"-"`
-}
-
-func (m *DeleteNodeResolverMapEntryResponse) Reset()         { *m = DeleteNodeResolverMapEntryResponse{} }
-func (m *DeleteNodeResolverMapEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*DeleteNodeResolverMapEntryResponse) ProtoMessage()    {}
-func (*DeleteNodeResolverMapEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{19}
-}
-func (m *DeleteNodeResolverMapEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryResponse.Unmarshal(m, b)
-}
-func (m *DeleteNodeResolverMapEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryResponse.Marshal(b, m, deterministic)
-}
-func (dst *DeleteNodeResolverMapEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteNodeResolverMapEntryResponse.Merge(dst, src)
-}
-func (m *DeleteNodeResolverMapEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_DeleteNodeResolverMapEntryResponse.Size(m)
-}
-func (m *DeleteNodeResolverMapEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteNodeResolverMapEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteNodeResolverMapEntryResponse proto.InternalMessageInfo
-
-func (m *DeleteNodeResolverMapEntryResponse) GetEntries() []*NodeResolverMapEntry {
-	if m != nil {
-		return m.Entries
-	}
-	return nil
-}
-
-type RectifyNodeResolverMapEntriesRequest struct {
-	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
-	XXX_unrecognized     []byte                  `json:"-"`
-	XXX_sizecache        int32                   `json:"-"`
-}
-
-func (m *RectifyNodeResolverMapEntriesRequest) Reset()         { *m = RectifyNodeResolverMapEntriesRequest{} }
-func (m *RectifyNodeResolverMapEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*RectifyNodeResolverMapEntriesRequest) ProtoMessage()    {}
-func (*RectifyNodeResolverMapEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{20}
-}
-func (m *RectifyNodeResolverMapEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.Unmarshal(m, b)
-}
-func (m *RectifyNodeResolverMapEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.Marshal(b, m, deterministic)
-}
-func (dst *RectifyNodeResolverMapEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.Merge(dst, src)
-}
-func (m *RectifyNodeResolverMapEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.Size(m)
-}
-func (m *RectifyNodeResolverMapEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_RectifyNodeResolverMapEntriesRequest proto.InternalMessageInfo
-
-func (m *RectifyNodeResolverMapEntriesRequest) GetEntries() []*NodeResolverMapEntry {
-	if m != nil {
-		return m.Entries
-	}
-	return nil
-}
-
-type RectifyNodeResolverMapEntriesResponse struct {
-	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
-	XXX_unrecognized     []byte                  `json:"-"`
-	XXX_sizecache        int32                   `json:"-"`
-}
-
-func (m *RectifyNodeResolverMapEntriesResponse) Reset()         { *m = RectifyNodeResolverMapEntriesResponse{} }
-func (m *RectifyNodeResolverMapEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*RectifyNodeResolverMapEntriesResponse) ProtoMessage()    {}
-func (*RectifyNodeResolverMapEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{21}
-}
-func (m *RectifyNodeResolverMapEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.Unmarshal(m, b)
-}
-func (m *RectifyNodeResolverMapEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.Marshal(b, m, deterministic)
-}
-func (dst *RectifyNodeResolverMapEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.Merge(dst, src)
-}
-func (m *RectifyNodeResolverMapEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.Size(m)
-}
-func (m *RectifyNodeResolverMapEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_RectifyNodeResolverMapEntriesResponse proto.InternalMessageInfo
-
-func (m *RectifyNodeResolverMapEntriesResponse) GetEntries() []*NodeResolverMapEntry {
-	if m != nil {
-		return m.Entries
-	}
-	return nil
-}
-
-type AttestedNodeEntry struct {
+type AttestedNode struct {
 	// Node SPIFFE ID
 	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	// Attestation data type
@@ -945,287 +808,287 @@ type AttestedNodeEntry struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *AttestedNodeEntry) Reset()         { *m = AttestedNodeEntry{} }
-func (m *AttestedNodeEntry) String() string { return proto.CompactTextString(m) }
-func (*AttestedNodeEntry) ProtoMessage()    {}
-func (*AttestedNodeEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{22}
+func (m *AttestedNode) Reset()         { *m = AttestedNode{} }
+func (m *AttestedNode) String() string { return proto.CompactTextString(m) }
+func (*AttestedNode) ProtoMessage()    {}
+func (*AttestedNode) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{18}
 }
-func (m *AttestedNodeEntry) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_AttestedNodeEntry.Unmarshal(m, b)
+func (m *AttestedNode) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_AttestedNode.Unmarshal(m, b)
 }
-func (m *AttestedNodeEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_AttestedNodeEntry.Marshal(b, m, deterministic)
+func (m *AttestedNode) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_AttestedNode.Marshal(b, m, deterministic)
 }
-func (dst *AttestedNodeEntry) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AttestedNodeEntry.Merge(dst, src)
+func (dst *AttestedNode) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AttestedNode.Merge(dst, src)
 }
-func (m *AttestedNodeEntry) XXX_Size() int {
-	return xxx_messageInfo_AttestedNodeEntry.Size(m)
+func (m *AttestedNode) XXX_Size() int {
+	return xxx_messageInfo_AttestedNode.Size(m)
 }
-func (m *AttestedNodeEntry) XXX_DiscardUnknown() {
-	xxx_messageInfo_AttestedNodeEntry.DiscardUnknown(m)
+func (m *AttestedNode) XXX_DiscardUnknown() {
+	xxx_messageInfo_AttestedNode.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_AttestedNodeEntry proto.InternalMessageInfo
+var xxx_messageInfo_AttestedNode proto.InternalMessageInfo
 
-func (m *AttestedNodeEntry) GetSpiffeId() string {
+func (m *AttestedNode) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-func (m *AttestedNodeEntry) GetAttestationDataType() string {
+func (m *AttestedNode) GetAttestationDataType() string {
 	if m != nil {
 		return m.AttestationDataType
 	}
 	return ""
 }
 
-func (m *AttestedNodeEntry) GetCertSerialNumber() string {
+func (m *AttestedNode) GetCertSerialNumber() string {
 	if m != nil {
 		return m.CertSerialNumber
 	}
 	return ""
 }
 
-func (m *AttestedNodeEntry) GetCertNotAfter() int64 {
+func (m *AttestedNode) GetCertNotAfter() int64 {
 	if m != nil {
 		return m.CertNotAfter
 	}
 	return 0
 }
 
-type CreateAttestedNodeEntryRequest struct {
-	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+type CreateAttestedNodeRequest struct {
+	Node                 *AttestedNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *CreateAttestedNodeEntryRequest) Reset()         { *m = CreateAttestedNodeEntryRequest{} }
-func (m *CreateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*CreateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{23}
+func (m *CreateAttestedNodeRequest) Reset()         { *m = CreateAttestedNodeRequest{} }
+func (m *CreateAttestedNodeRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateAttestedNodeRequest) ProtoMessage()    {}
+func (*CreateAttestedNodeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{19}
 }
-func (m *CreateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Unmarshal(m, b)
+func (m *CreateAttestedNodeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateAttestedNodeRequest.Unmarshal(m, b)
 }
-func (m *CreateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+func (m *CreateAttestedNodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateAttestedNodeRequest.Marshal(b, m, deterministic)
 }
-func (dst *CreateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateAttestedNodeEntryRequest.Merge(dst, src)
+func (dst *CreateAttestedNodeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateAttestedNodeRequest.Merge(dst, src)
 }
-func (m *CreateAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Size(m)
+func (m *CreateAttestedNodeRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateAttestedNodeRequest.Size(m)
 }
-func (m *CreateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateAttestedNodeEntryRequest.DiscardUnknown(m)
+func (m *CreateAttestedNodeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateAttestedNodeRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CreateAttestedNodeEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_CreateAttestedNodeRequest proto.InternalMessageInfo
 
-func (m *CreateAttestedNodeEntryRequest) GetEntry() *AttestedNodeEntry {
+func (m *CreateAttestedNodeRequest) GetNode() *AttestedNode {
 	if m != nil {
-		return m.Entry
+		return m.Node
 	}
 	return nil
 }
 
-type CreateAttestedNodeEntryResponse struct {
-	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+type CreateAttestedNodeResponse struct {
+	Node                 *AttestedNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *CreateAttestedNodeEntryResponse) Reset()         { *m = CreateAttestedNodeEntryResponse{} }
-func (m *CreateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*CreateAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*CreateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{24}
+func (m *CreateAttestedNodeResponse) Reset()         { *m = CreateAttestedNodeResponse{} }
+func (m *CreateAttestedNodeResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateAttestedNodeResponse) ProtoMessage()    {}
+func (*CreateAttestedNodeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{20}
 }
-func (m *CreateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Unmarshal(m, b)
+func (m *CreateAttestedNodeResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateAttestedNodeResponse.Unmarshal(m, b)
 }
-func (m *CreateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+func (m *CreateAttestedNodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateAttestedNodeResponse.Marshal(b, m, deterministic)
 }
-func (dst *CreateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateAttestedNodeEntryResponse.Merge(dst, src)
+func (dst *CreateAttestedNodeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateAttestedNodeResponse.Merge(dst, src)
 }
-func (m *CreateAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Size(m)
+func (m *CreateAttestedNodeResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateAttestedNodeResponse.Size(m)
 }
-func (m *CreateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateAttestedNodeEntryResponse.DiscardUnknown(m)
+func (m *CreateAttestedNodeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateAttestedNodeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CreateAttestedNodeEntryResponse proto.InternalMessageInfo
+var xxx_messageInfo_CreateAttestedNodeResponse proto.InternalMessageInfo
 
-func (m *CreateAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+func (m *CreateAttestedNodeResponse) GetNode() *AttestedNode {
 	if m != nil {
-		return m.Entry
+		return m.Node
 	}
 	return nil
 }
 
-type FetchAttestedNodeEntryRequest struct {
+type FetchAttestedNodeRequest struct {
 	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *FetchAttestedNodeEntryRequest) Reset()         { *m = FetchAttestedNodeEntryRequest{} }
-func (m *FetchAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*FetchAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{25}
+func (m *FetchAttestedNodeRequest) Reset()         { *m = FetchAttestedNodeRequest{} }
+func (m *FetchAttestedNodeRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchAttestedNodeRequest) ProtoMessage()    {}
+func (*FetchAttestedNodeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{21}
 }
-func (m *FetchAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Unmarshal(m, b)
+func (m *FetchAttestedNodeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchAttestedNodeRequest.Unmarshal(m, b)
 }
-func (m *FetchAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+func (m *FetchAttestedNodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchAttestedNodeRequest.Marshal(b, m, deterministic)
 }
-func (dst *FetchAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchAttestedNodeEntryRequest.Merge(dst, src)
+func (dst *FetchAttestedNodeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchAttestedNodeRequest.Merge(dst, src)
 }
-func (m *FetchAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Size(m)
+func (m *FetchAttestedNodeRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchAttestedNodeRequest.Size(m)
 }
-func (m *FetchAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchAttestedNodeEntryRequest.DiscardUnknown(m)
+func (m *FetchAttestedNodeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchAttestedNodeRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FetchAttestedNodeEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_FetchAttestedNodeRequest proto.InternalMessageInfo
 
-func (m *FetchAttestedNodeEntryRequest) GetSpiffeId() string {
+func (m *FetchAttestedNodeRequest) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-type FetchAttestedNodeEntryResponse struct {
-	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+type FetchAttestedNodeResponse struct {
+	Node                 *AttestedNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *FetchAttestedNodeEntryResponse) Reset()         { *m = FetchAttestedNodeEntryResponse{} }
-func (m *FetchAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*FetchAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{26}
+func (m *FetchAttestedNodeResponse) Reset()         { *m = FetchAttestedNodeResponse{} }
+func (m *FetchAttestedNodeResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchAttestedNodeResponse) ProtoMessage()    {}
+func (*FetchAttestedNodeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{22}
 }
-func (m *FetchAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Unmarshal(m, b)
+func (m *FetchAttestedNodeResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchAttestedNodeResponse.Unmarshal(m, b)
 }
-func (m *FetchAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+func (m *FetchAttestedNodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchAttestedNodeResponse.Marshal(b, m, deterministic)
 }
-func (dst *FetchAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchAttestedNodeEntryResponse.Merge(dst, src)
+func (dst *FetchAttestedNodeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchAttestedNodeResponse.Merge(dst, src)
 }
-func (m *FetchAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Size(m)
+func (m *FetchAttestedNodeResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchAttestedNodeResponse.Size(m)
 }
-func (m *FetchAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchAttestedNodeEntryResponse.DiscardUnknown(m)
+func (m *FetchAttestedNodeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchAttestedNodeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FetchAttestedNodeEntryResponse proto.InternalMessageInfo
+var xxx_messageInfo_FetchAttestedNodeResponse proto.InternalMessageInfo
 
-func (m *FetchAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+func (m *FetchAttestedNodeResponse) GetNode() *AttestedNode {
 	if m != nil {
-		return m.Entry
+		return m.Node
 	}
 	return nil
 }
 
-type ListAttestedNodeEntriesRequest struct {
+type ListAttestedNodesRequest struct {
 	ByExpiresBefore      *wrappers.Int64Value `protobuf:"bytes,1,opt,name=by_expires_before,json=byExpiresBefore" json:"by_expires_before,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
 	XXX_unrecognized     []byte               `json:"-"`
 	XXX_sizecache        int32                `json:"-"`
 }
 
-func (m *ListAttestedNodeEntriesRequest) Reset()         { *m = ListAttestedNodeEntriesRequest{} }
-func (m *ListAttestedNodeEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListAttestedNodeEntriesRequest) ProtoMessage()    {}
-func (*ListAttestedNodeEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{27}
+func (m *ListAttestedNodesRequest) Reset()         { *m = ListAttestedNodesRequest{} }
+func (m *ListAttestedNodesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListAttestedNodesRequest) ProtoMessage()    {}
+func (*ListAttestedNodesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{23}
 }
-func (m *ListAttestedNodeEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Unmarshal(m, b)
+func (m *ListAttestedNodesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListAttestedNodesRequest.Unmarshal(m, b)
 }
-func (m *ListAttestedNodeEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Marshal(b, m, deterministic)
+func (m *ListAttestedNodesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListAttestedNodesRequest.Marshal(b, m, deterministic)
 }
-func (dst *ListAttestedNodeEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListAttestedNodeEntriesRequest.Merge(dst, src)
+func (dst *ListAttestedNodesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListAttestedNodesRequest.Merge(dst, src)
 }
-func (m *ListAttestedNodeEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Size(m)
+func (m *ListAttestedNodesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListAttestedNodesRequest.Size(m)
 }
-func (m *ListAttestedNodeEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListAttestedNodeEntriesRequest.DiscardUnknown(m)
+func (m *ListAttestedNodesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListAttestedNodesRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListAttestedNodeEntriesRequest proto.InternalMessageInfo
+var xxx_messageInfo_ListAttestedNodesRequest proto.InternalMessageInfo
 
-func (m *ListAttestedNodeEntriesRequest) GetByExpiresBefore() *wrappers.Int64Value {
+func (m *ListAttestedNodesRequest) GetByExpiresBefore() *wrappers.Int64Value {
 	if m != nil {
 		return m.ByExpiresBefore
 	}
 	return nil
 }
 
-type ListAttestedNodeEntriesResponse struct {
-	Entries              []*AttestedNodeEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
-	XXX_unrecognized     []byte               `json:"-"`
-	XXX_sizecache        int32                `json:"-"`
+type ListAttestedNodesResponse struct {
+	Nodes                []*AttestedNode `protobuf:"bytes,1,rep,name=nodes" json:"nodes,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
 }
 
-func (m *ListAttestedNodeEntriesResponse) Reset()         { *m = ListAttestedNodeEntriesResponse{} }
-func (m *ListAttestedNodeEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*ListAttestedNodeEntriesResponse) ProtoMessage()    {}
-func (*ListAttestedNodeEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{28}
+func (m *ListAttestedNodesResponse) Reset()         { *m = ListAttestedNodesResponse{} }
+func (m *ListAttestedNodesResponse) String() string { return proto.CompactTextString(m) }
+func (*ListAttestedNodesResponse) ProtoMessage()    {}
+func (*ListAttestedNodesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{24}
 }
-func (m *ListAttestedNodeEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Unmarshal(m, b)
+func (m *ListAttestedNodesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListAttestedNodesResponse.Unmarshal(m, b)
 }
-func (m *ListAttestedNodeEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Marshal(b, m, deterministic)
+func (m *ListAttestedNodesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListAttestedNodesResponse.Marshal(b, m, deterministic)
 }
-func (dst *ListAttestedNodeEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListAttestedNodeEntriesResponse.Merge(dst, src)
+func (dst *ListAttestedNodesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListAttestedNodesResponse.Merge(dst, src)
 }
-func (m *ListAttestedNodeEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Size(m)
+func (m *ListAttestedNodesResponse) XXX_Size() int {
+	return xxx_messageInfo_ListAttestedNodesResponse.Size(m)
 }
-func (m *ListAttestedNodeEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListAttestedNodeEntriesResponse.DiscardUnknown(m)
+func (m *ListAttestedNodesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListAttestedNodesResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ListAttestedNodeEntriesResponse proto.InternalMessageInfo
+var xxx_messageInfo_ListAttestedNodesResponse proto.InternalMessageInfo
 
-func (m *ListAttestedNodeEntriesResponse) GetEntries() []*AttestedNodeEntry {
+func (m *ListAttestedNodesResponse) GetNodes() []*AttestedNode {
 	if m != nil {
-		return m.Entries
+		return m.Nodes
 	}
 	return nil
 }
 
-type UpdateAttestedNodeEntryRequest struct {
+type UpdateAttestedNodeRequest struct {
 	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	CertSerialNumber     string   `protobuf:"bytes,2,opt,name=cert_serial_number,json=certSerialNumber" json:"cert_serial_number,omitempty"`
 	CertNotAfter         int64    `protobuf:"varint,3,opt,name=cert_not_after,json=certNotAfter" json:"cert_not_after,omitempty"`
@@ -1234,161 +1097,161 @@ type UpdateAttestedNodeEntryRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *UpdateAttestedNodeEntryRequest) Reset()         { *m = UpdateAttestedNodeEntryRequest{} }
-func (m *UpdateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*UpdateAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*UpdateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{29}
+func (m *UpdateAttestedNodeRequest) Reset()         { *m = UpdateAttestedNodeRequest{} }
+func (m *UpdateAttestedNodeRequest) String() string { return proto.CompactTextString(m) }
+func (*UpdateAttestedNodeRequest) ProtoMessage()    {}
+func (*UpdateAttestedNodeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{25}
 }
-func (m *UpdateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Unmarshal(m, b)
+func (m *UpdateAttestedNodeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateAttestedNodeRequest.Unmarshal(m, b)
 }
-func (m *UpdateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+func (m *UpdateAttestedNodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateAttestedNodeRequest.Marshal(b, m, deterministic)
 }
-func (dst *UpdateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateAttestedNodeEntryRequest.Merge(dst, src)
+func (dst *UpdateAttestedNodeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateAttestedNodeRequest.Merge(dst, src)
 }
-func (m *UpdateAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Size(m)
+func (m *UpdateAttestedNodeRequest) XXX_Size() int {
+	return xxx_messageInfo_UpdateAttestedNodeRequest.Size(m)
 }
-func (m *UpdateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateAttestedNodeEntryRequest.DiscardUnknown(m)
+func (m *UpdateAttestedNodeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateAttestedNodeRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_UpdateAttestedNodeEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_UpdateAttestedNodeRequest proto.InternalMessageInfo
 
-func (m *UpdateAttestedNodeEntryRequest) GetSpiffeId() string {
+func (m *UpdateAttestedNodeRequest) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-func (m *UpdateAttestedNodeEntryRequest) GetCertSerialNumber() string {
+func (m *UpdateAttestedNodeRequest) GetCertSerialNumber() string {
 	if m != nil {
 		return m.CertSerialNumber
 	}
 	return ""
 }
 
-func (m *UpdateAttestedNodeEntryRequest) GetCertNotAfter() int64 {
+func (m *UpdateAttestedNodeRequest) GetCertNotAfter() int64 {
 	if m != nil {
 		return m.CertNotAfter
 	}
 	return 0
 }
 
-type UpdateAttestedNodeEntryResponse struct {
-	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+type UpdateAttestedNodeResponse struct {
+	Node                 *AttestedNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *UpdateAttestedNodeEntryResponse) Reset()         { *m = UpdateAttestedNodeEntryResponse{} }
-func (m *UpdateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*UpdateAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*UpdateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{30}
+func (m *UpdateAttestedNodeResponse) Reset()         { *m = UpdateAttestedNodeResponse{} }
+func (m *UpdateAttestedNodeResponse) String() string { return proto.CompactTextString(m) }
+func (*UpdateAttestedNodeResponse) ProtoMessage()    {}
+func (*UpdateAttestedNodeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{26}
 }
-func (m *UpdateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Unmarshal(m, b)
+func (m *UpdateAttestedNodeResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateAttestedNodeResponse.Unmarshal(m, b)
 }
-func (m *UpdateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+func (m *UpdateAttestedNodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateAttestedNodeResponse.Marshal(b, m, deterministic)
 }
-func (dst *UpdateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateAttestedNodeEntryResponse.Merge(dst, src)
+func (dst *UpdateAttestedNodeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateAttestedNodeResponse.Merge(dst, src)
 }
-func (m *UpdateAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Size(m)
+func (m *UpdateAttestedNodeResponse) XXX_Size() int {
+	return xxx_messageInfo_UpdateAttestedNodeResponse.Size(m)
 }
-func (m *UpdateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateAttestedNodeEntryResponse.DiscardUnknown(m)
+func (m *UpdateAttestedNodeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateAttestedNodeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_UpdateAttestedNodeEntryResponse proto.InternalMessageInfo
+var xxx_messageInfo_UpdateAttestedNodeResponse proto.InternalMessageInfo
 
-func (m *UpdateAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+func (m *UpdateAttestedNodeResponse) GetNode() *AttestedNode {
 	if m != nil {
-		return m.Entry
+		return m.Node
 	}
 	return nil
 }
 
-type DeleteAttestedNodeEntryRequest struct {
+type DeleteAttestedNodeRequest struct {
 	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *DeleteAttestedNodeEntryRequest) Reset()         { *m = DeleteAttestedNodeEntryRequest{} }
-func (m *DeleteAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*DeleteAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*DeleteAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{31}
+func (m *DeleteAttestedNodeRequest) Reset()         { *m = DeleteAttestedNodeRequest{} }
+func (m *DeleteAttestedNodeRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteAttestedNodeRequest) ProtoMessage()    {}
+func (*DeleteAttestedNodeRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{27}
 }
-func (m *DeleteAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Unmarshal(m, b)
+func (m *DeleteAttestedNodeRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteAttestedNodeRequest.Unmarshal(m, b)
 }
-func (m *DeleteAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+func (m *DeleteAttestedNodeRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteAttestedNodeRequest.Marshal(b, m, deterministic)
 }
-func (dst *DeleteAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteAttestedNodeEntryRequest.Merge(dst, src)
+func (dst *DeleteAttestedNodeRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteAttestedNodeRequest.Merge(dst, src)
 }
-func (m *DeleteAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Size(m)
+func (m *DeleteAttestedNodeRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteAttestedNodeRequest.Size(m)
 }
-func (m *DeleteAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteAttestedNodeEntryRequest.DiscardUnknown(m)
+func (m *DeleteAttestedNodeRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteAttestedNodeRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_DeleteAttestedNodeEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_DeleteAttestedNodeRequest proto.InternalMessageInfo
 
-func (m *DeleteAttestedNodeEntryRequest) GetSpiffeId() string {
+func (m *DeleteAttestedNodeRequest) GetSpiffeId() string {
 	if m != nil {
 		return m.SpiffeId
 	}
 	return ""
 }
 
-type DeleteAttestedNodeEntryResponse struct {
-	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+type DeleteAttestedNodeResponse struct {
+	Node                 *AttestedNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *DeleteAttestedNodeEntryResponse) Reset()         { *m = DeleteAttestedNodeEntryResponse{} }
-func (m *DeleteAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*DeleteAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*DeleteAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{32}
+func (m *DeleteAttestedNodeResponse) Reset()         { *m = DeleteAttestedNodeResponse{} }
+func (m *DeleteAttestedNodeResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteAttestedNodeResponse) ProtoMessage()    {}
+func (*DeleteAttestedNodeResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{28}
 }
-func (m *DeleteAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Unmarshal(m, b)
+func (m *DeleteAttestedNodeResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteAttestedNodeResponse.Unmarshal(m, b)
 }
-func (m *DeleteAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+func (m *DeleteAttestedNodeResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteAttestedNodeResponse.Marshal(b, m, deterministic)
 }
-func (dst *DeleteAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteAttestedNodeEntryResponse.Merge(dst, src)
+func (dst *DeleteAttestedNodeResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteAttestedNodeResponse.Merge(dst, src)
 }
-func (m *DeleteAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Size(m)
+func (m *DeleteAttestedNodeResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteAttestedNodeResponse.Size(m)
 }
-func (m *DeleteAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteAttestedNodeEntryResponse.DiscardUnknown(m)
+func (m *DeleteAttestedNodeResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteAttestedNodeResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_DeleteAttestedNodeEntryResponse proto.InternalMessageInfo
+var xxx_messageInfo_DeleteAttestedNodeResponse proto.InternalMessageInfo
 
-func (m *DeleteAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+func (m *DeleteAttestedNodeResponse) GetNode() *AttestedNode {
 	if m != nil {
-		return m.Entry
+		return m.Node
 	}
 	return nil
 }
@@ -1404,7 +1267,7 @@ func (m *CreateRegistrationEntryRequest) Reset()         { *m = CreateRegistrati
 func (m *CreateRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateRegistrationEntryRequest) ProtoMessage()    {}
 func (*CreateRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{33}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{29}
 }
 func (m *CreateRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateRegistrationEntryRequest.Unmarshal(m, b)
@@ -1432,17 +1295,17 @@ func (m *CreateRegistrationEntryRequest) GetEntry() *common.RegistrationEntry {
 }
 
 type CreateRegistrationEntryResponse struct {
-	EntryId              string   `protobuf:"bytes,1,opt,name=entry_id,json=entryId" json:"entry_id,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
+	XXX_unrecognized     []byte                    `json:"-"`
+	XXX_sizecache        int32                     `json:"-"`
 }
 
 func (m *CreateRegistrationEntryResponse) Reset()         { *m = CreateRegistrationEntryResponse{} }
 func (m *CreateRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateRegistrationEntryResponse) ProtoMessage()    {}
 func (*CreateRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{34}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{30}
 }
 func (m *CreateRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateRegistrationEntryResponse.Unmarshal(m, b)
@@ -1462,11 +1325,11 @@ func (m *CreateRegistrationEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateRegistrationEntryResponse proto.InternalMessageInfo
 
-func (m *CreateRegistrationEntryResponse) GetEntryId() string {
+func (m *CreateRegistrationEntryResponse) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.EntryId
+		return m.Entry
 	}
-	return ""
+	return nil
 }
 
 type FetchRegistrationEntryRequest struct {
@@ -1480,7 +1343,7 @@ func (m *FetchRegistrationEntryRequest) Reset()         { *m = FetchRegistration
 func (m *FetchRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchRegistrationEntryRequest) ProtoMessage()    {}
 func (*FetchRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{35}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{31}
 }
 func (m *FetchRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchRegistrationEntryRequest.Unmarshal(m, b)
@@ -1518,7 +1381,7 @@ func (m *FetchRegistrationEntryResponse) Reset()         { *m = FetchRegistratio
 func (m *FetchRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchRegistrationEntryResponse) ProtoMessage()    {}
 func (*FetchRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{36}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{32}
 }
 func (m *FetchRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchRegistrationEntryResponse.Unmarshal(m, b)
@@ -1546,18 +1409,18 @@ func (m *FetchRegistrationEntryResponse) GetEntry() *common.RegistrationEntry {
 }
 
 type BySelectors struct {
-	Selectors            []*common.Selector `protobuf:"bytes,1,rep,name=selectors" json:"selectors,omitempty"`
-	AllowAnyCombination  bool               `protobuf:"varint,2,opt,name=allow_any_combination,json=allowAnyCombination" json:"allow_any_combination,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
+	Selectors            []*common.Selector        `protobuf:"bytes,1,rep,name=selectors" json:"selectors,omitempty"`
+	Match                BySelectors_MatchBehavior `protobuf:"varint,2,opt,name=match,enum=spire.server.datastore.BySelectors_MatchBehavior" json:"match,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
+	XXX_unrecognized     []byte                    `json:"-"`
+	XXX_sizecache        int32                     `json:"-"`
 }
 
 func (m *BySelectors) Reset()         { *m = BySelectors{} }
 func (m *BySelectors) String() string { return proto.CompactTextString(m) }
 func (*BySelectors) ProtoMessage()    {}
 func (*BySelectors) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{37}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{33}
 }
 func (m *BySelectors) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BySelectors.Unmarshal(m, b)
@@ -1584,11 +1447,11 @@ func (m *BySelectors) GetSelectors() []*common.Selector {
 	return nil
 }
 
-func (m *BySelectors) GetAllowAnyCombination() bool {
+func (m *BySelectors) GetMatch() BySelectors_MatchBehavior {
 	if m != nil {
-		return m.AllowAnyCombination
+		return m.Match
 	}
-	return false
+	return BySelectors_MATCH_EXACT
 }
 
 type ListRegistrationEntriesRequest struct {
@@ -1604,7 +1467,7 @@ func (m *ListRegistrationEntriesRequest) Reset()         { *m = ListRegistration
 func (m *ListRegistrationEntriesRequest) String() string { return proto.CompactTextString(m) }
 func (*ListRegistrationEntriesRequest) ProtoMessage()    {}
 func (*ListRegistrationEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{38}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{34}
 }
 func (m *ListRegistrationEntriesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListRegistrationEntriesRequest.Unmarshal(m, b)
@@ -1656,7 +1519,7 @@ func (m *ListRegistrationEntriesResponse) Reset()         { *m = ListRegistratio
 func (m *ListRegistrationEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*ListRegistrationEntriesResponse) ProtoMessage()    {}
 func (*ListRegistrationEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{39}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{35}
 }
 func (m *ListRegistrationEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ListRegistrationEntriesResponse.Unmarshal(m, b)
@@ -1694,7 +1557,7 @@ func (m *UpdateRegistrationEntryRequest) Reset()         { *m = UpdateRegistrati
 func (m *UpdateRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdateRegistrationEntryRequest) ProtoMessage()    {}
 func (*UpdateRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{40}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{36}
 }
 func (m *UpdateRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateRegistrationEntryRequest.Unmarshal(m, b)
@@ -1732,7 +1595,7 @@ func (m *UpdateRegistrationEntryResponse) Reset()         { *m = UpdateRegistrat
 func (m *UpdateRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateRegistrationEntryResponse) ProtoMessage()    {}
 func (*UpdateRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{41}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{37}
 }
 func (m *UpdateRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateRegistrationEntryResponse.Unmarshal(m, b)
@@ -1770,7 +1633,7 @@ func (m *DeleteRegistrationEntryRequest) Reset()         { *m = DeleteRegistrati
 func (m *DeleteRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRegistrationEntryRequest) ProtoMessage()    {}
 func (*DeleteRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{42}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{38}
 }
 func (m *DeleteRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteRegistrationEntryRequest.Unmarshal(m, b)
@@ -1808,7 +1671,7 @@ func (m *DeleteRegistrationEntryResponse) Reset()         { *m = DeleteRegistrat
 func (m *DeleteRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRegistrationEntryResponse) ProtoMessage()    {}
 func (*DeleteRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{43}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{39}
 }
 func (m *DeleteRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteRegistrationEntryResponse.Unmarshal(m, b)
@@ -1849,7 +1712,7 @@ func (m *JoinToken) Reset()         { *m = JoinToken{} }
 func (m *JoinToken) String() string { return proto.CompactTextString(m) }
 func (*JoinToken) ProtoMessage()    {}
 func (*JoinToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{44}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{40}
 }
 func (m *JoinToken) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JoinToken.Unmarshal(m, b)
@@ -1894,7 +1757,7 @@ func (m *CreateJoinTokenRequest) Reset()         { *m = CreateJoinTokenRequest{}
 func (m *CreateJoinTokenRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateJoinTokenRequest) ProtoMessage()    {}
 func (*CreateJoinTokenRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{45}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{41}
 }
 func (m *CreateJoinTokenRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateJoinTokenRequest.Unmarshal(m, b)
@@ -1932,7 +1795,7 @@ func (m *CreateJoinTokenResponse) Reset()         { *m = CreateJoinTokenResponse
 func (m *CreateJoinTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateJoinTokenResponse) ProtoMessage()    {}
 func (*CreateJoinTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{46}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{42}
 }
 func (m *CreateJoinTokenResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateJoinTokenResponse.Unmarshal(m, b)
@@ -1970,7 +1833,7 @@ func (m *FetchJoinTokenRequest) Reset()         { *m = FetchJoinTokenRequest{} }
 func (m *FetchJoinTokenRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchJoinTokenRequest) ProtoMessage()    {}
 func (*FetchJoinTokenRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{47}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{43}
 }
 func (m *FetchJoinTokenRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchJoinTokenRequest.Unmarshal(m, b)
@@ -2008,7 +1871,7 @@ func (m *FetchJoinTokenResponse) Reset()         { *m = FetchJoinTokenResponse{}
 func (m *FetchJoinTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchJoinTokenResponse) ProtoMessage()    {}
 func (*FetchJoinTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{48}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{44}
 }
 func (m *FetchJoinTokenResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchJoinTokenResponse.Unmarshal(m, b)
@@ -2046,7 +1909,7 @@ func (m *DeleteJoinTokenRequest) Reset()         { *m = DeleteJoinTokenRequest{}
 func (m *DeleteJoinTokenRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteJoinTokenRequest) ProtoMessage()    {}
 func (*DeleteJoinTokenRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{49}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{45}
 }
 func (m *DeleteJoinTokenRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteJoinTokenRequest.Unmarshal(m, b)
@@ -2084,7 +1947,7 @@ func (m *DeleteJoinTokenResponse) Reset()         { *m = DeleteJoinTokenResponse
 func (m *DeleteJoinTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteJoinTokenResponse) ProtoMessage()    {}
 func (*DeleteJoinTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{50}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{46}
 }
 func (m *DeleteJoinTokenResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteJoinTokenResponse.Unmarshal(m, b)
@@ -2122,7 +1985,7 @@ func (m *PruneJoinTokensRequest) Reset()         { *m = PruneJoinTokensRequest{}
 func (m *PruneJoinTokensRequest) String() string { return proto.CompactTextString(m) }
 func (*PruneJoinTokensRequest) ProtoMessage()    {}
 func (*PruneJoinTokensRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{51}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{47}
 }
 func (m *PruneJoinTokensRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PruneJoinTokensRequest.Unmarshal(m, b)
@@ -2159,7 +2022,7 @@ func (m *PruneJoinTokensResponse) Reset()         { *m = PruneJoinTokensResponse
 func (m *PruneJoinTokensResponse) String() string { return proto.CompactTextString(m) }
 func (*PruneJoinTokensResponse) ProtoMessage()    {}
 func (*PruneJoinTokensResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{52}
+	return fileDescriptor_datastore_5f1f189cc5ca3aad, []int{48}
 }
 func (m *PruneJoinTokensResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_PruneJoinTokensResponse.Unmarshal(m, b)
@@ -2193,26 +2056,22 @@ func init() {
 	proto.RegisterType((*AppendBundleResponse)(nil), "spire.server.datastore.AppendBundleResponse")
 	proto.RegisterType((*DeleteBundleRequest)(nil), "spire.server.datastore.DeleteBundleRequest")
 	proto.RegisterType((*DeleteBundleResponse)(nil), "spire.server.datastore.DeleteBundleResponse")
-	proto.RegisterType((*NodeResolverMapEntry)(nil), "spire.server.datastore.NodeResolverMapEntry")
-	proto.RegisterType((*CreateNodeResolverMapEntryRequest)(nil), "spire.server.datastore.CreateNodeResolverMapEntryRequest")
-	proto.RegisterType((*CreateNodeResolverMapEntryResponse)(nil), "spire.server.datastore.CreateNodeResolverMapEntryResponse")
-	proto.RegisterType((*ListNodeResolverMapEntriesRequest)(nil), "spire.server.datastore.ListNodeResolverMapEntriesRequest")
-	proto.RegisterType((*ListNodeResolverMapEntriesResponse)(nil), "spire.server.datastore.ListNodeResolverMapEntriesResponse")
-	proto.RegisterType((*DeleteNodeResolverMapEntryRequest)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryRequest")
-	proto.RegisterType((*DeleteNodeResolverMapEntryResponse)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryResponse")
-	proto.RegisterType((*RectifyNodeResolverMapEntriesRequest)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesRequest")
-	proto.RegisterType((*RectifyNodeResolverMapEntriesResponse)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesResponse")
-	proto.RegisterType((*AttestedNodeEntry)(nil), "spire.server.datastore.AttestedNodeEntry")
-	proto.RegisterType((*CreateAttestedNodeEntryRequest)(nil), "spire.server.datastore.CreateAttestedNodeEntryRequest")
-	proto.RegisterType((*CreateAttestedNodeEntryResponse)(nil), "spire.server.datastore.CreateAttestedNodeEntryResponse")
-	proto.RegisterType((*FetchAttestedNodeEntryRequest)(nil), "spire.server.datastore.FetchAttestedNodeEntryRequest")
-	proto.RegisterType((*FetchAttestedNodeEntryResponse)(nil), "spire.server.datastore.FetchAttestedNodeEntryResponse")
-	proto.RegisterType((*ListAttestedNodeEntriesRequest)(nil), "spire.server.datastore.ListAttestedNodeEntriesRequest")
-	proto.RegisterType((*ListAttestedNodeEntriesResponse)(nil), "spire.server.datastore.ListAttestedNodeEntriesResponse")
-	proto.RegisterType((*UpdateAttestedNodeEntryRequest)(nil), "spire.server.datastore.UpdateAttestedNodeEntryRequest")
-	proto.RegisterType((*UpdateAttestedNodeEntryResponse)(nil), "spire.server.datastore.UpdateAttestedNodeEntryResponse")
-	proto.RegisterType((*DeleteAttestedNodeEntryRequest)(nil), "spire.server.datastore.DeleteAttestedNodeEntryRequest")
-	proto.RegisterType((*DeleteAttestedNodeEntryResponse)(nil), "spire.server.datastore.DeleteAttestedNodeEntryResponse")
+	proto.RegisterType((*NodeSelectors)(nil), "spire.server.datastore.NodeSelectors")
+	proto.RegisterType((*SetNodeSelectorsRequest)(nil), "spire.server.datastore.SetNodeSelectorsRequest")
+	proto.RegisterType((*SetNodeSelectorsResponse)(nil), "spire.server.datastore.SetNodeSelectorsResponse")
+	proto.RegisterType((*GetNodeSelectorsRequest)(nil), "spire.server.datastore.GetNodeSelectorsRequest")
+	proto.RegisterType((*GetNodeSelectorsResponse)(nil), "spire.server.datastore.GetNodeSelectorsResponse")
+	proto.RegisterType((*AttestedNode)(nil), "spire.server.datastore.AttestedNode")
+	proto.RegisterType((*CreateAttestedNodeRequest)(nil), "spire.server.datastore.CreateAttestedNodeRequest")
+	proto.RegisterType((*CreateAttestedNodeResponse)(nil), "spire.server.datastore.CreateAttestedNodeResponse")
+	proto.RegisterType((*FetchAttestedNodeRequest)(nil), "spire.server.datastore.FetchAttestedNodeRequest")
+	proto.RegisterType((*FetchAttestedNodeResponse)(nil), "spire.server.datastore.FetchAttestedNodeResponse")
+	proto.RegisterType((*ListAttestedNodesRequest)(nil), "spire.server.datastore.ListAttestedNodesRequest")
+	proto.RegisterType((*ListAttestedNodesResponse)(nil), "spire.server.datastore.ListAttestedNodesResponse")
+	proto.RegisterType((*UpdateAttestedNodeRequest)(nil), "spire.server.datastore.UpdateAttestedNodeRequest")
+	proto.RegisterType((*UpdateAttestedNodeResponse)(nil), "spire.server.datastore.UpdateAttestedNodeResponse")
+	proto.RegisterType((*DeleteAttestedNodeRequest)(nil), "spire.server.datastore.DeleteAttestedNodeRequest")
+	proto.RegisterType((*DeleteAttestedNodeResponse)(nil), "spire.server.datastore.DeleteAttestedNodeResponse")
 	proto.RegisterType((*CreateRegistrationEntryRequest)(nil), "spire.server.datastore.CreateRegistrationEntryRequest")
 	proto.RegisterType((*CreateRegistrationEntryResponse)(nil), "spire.server.datastore.CreateRegistrationEntryResponse")
 	proto.RegisterType((*FetchRegistrationEntryRequest)(nil), "spire.server.datastore.FetchRegistrationEntryRequest")
@@ -2233,6 +2092,7 @@ func init() {
 	proto.RegisterType((*DeleteJoinTokenResponse)(nil), "spire.server.datastore.DeleteJoinTokenResponse")
 	proto.RegisterType((*PruneJoinTokensRequest)(nil), "spire.server.datastore.PruneJoinTokensRequest")
 	proto.RegisterType((*PruneJoinTokensResponse)(nil), "spire.server.datastore.PruneJoinTokensResponse")
+	proto.RegisterEnum("spire.server.datastore.BySelectors_MatchBehavior", BySelectors_MatchBehavior_name, BySelectors_MatchBehavior_value)
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -2258,24 +2118,20 @@ type DataStoreClient interface {
 	AppendBundle(ctx context.Context, in *AppendBundleRequest, opts ...grpc.CallOption) (*AppendBundleResponse, error)
 	// Deletes a specific bundle
 	DeleteBundle(ctx context.Context, in *DeleteBundleRequest, opts ...grpc.CallOption) (*DeleteBundleResponse, error)
-	// Creates an attested node entry
-	CreateAttestedNodeEntry(ctx context.Context, in *CreateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*CreateAttestedNodeEntryResponse, error)
-	// Fetches a specific attested node entry
-	FetchAttestedNodeEntry(ctx context.Context, in *FetchAttestedNodeEntryRequest, opts ...grpc.CallOption) (*FetchAttestedNodeEntryResponse, error)
-	// Lists attested node entries (optionally filtered)
-	ListAttestedNodeEntries(ctx context.Context, in *ListAttestedNodeEntriesRequest, opts ...grpc.CallOption) (*ListAttestedNodeEntriesResponse, error)
-	// Updates a specific attested node entry
-	UpdateAttestedNodeEntry(ctx context.Context, in *UpdateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*UpdateAttestedNodeEntryResponse, error)
-	// Deletes a specific attested node entry
-	DeleteAttestedNodeEntry(ctx context.Context, in *DeleteAttestedNodeEntryRequest, opts ...grpc.CallOption) (*DeleteAttestedNodeEntryResponse, error)
-	// Creates a node resolver map entry
-	CreateNodeResolverMapEntry(ctx context.Context, in *CreateNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*CreateNodeResolverMapEntryResponse, error)
-	// Lists node resolver map entries for a specified SPIFFE ID
-	ListNodeResolverMapEntries(ctx context.Context, in *ListNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*ListNodeResolverMapEntriesResponse, error)
-	// Deletes a specific node resolver map entry
-	DeleteNodeResolverMapEntry(ctx context.Context, in *DeleteNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*DeleteNodeResolverMapEntryResponse, error)
-	// Sets the list of node resolver map entries for the specified SPIFFE ID
-	RectifyNodeResolverMapEntries(ctx context.Context, in *RectifyNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*RectifyNodeResolverMapEntriesResponse, error)
+	// Creates an attested node
+	CreateAttestedNode(ctx context.Context, in *CreateAttestedNodeRequest, opts ...grpc.CallOption) (*CreateAttestedNodeResponse, error)
+	// Fetches a specific attested node
+	FetchAttestedNode(ctx context.Context, in *FetchAttestedNodeRequest, opts ...grpc.CallOption) (*FetchAttestedNodeResponse, error)
+	// Lists attested nodes (optionally filtered)
+	ListAttestedNodes(ctx context.Context, in *ListAttestedNodesRequest, opts ...grpc.CallOption) (*ListAttestedNodesResponse, error)
+	// Updates a specific attested node
+	UpdateAttestedNode(ctx context.Context, in *UpdateAttestedNodeRequest, opts ...grpc.CallOption) (*UpdateAttestedNodeResponse, error)
+	// Deletes a specific attested node
+	DeleteAttestedNode(ctx context.Context, in *DeleteAttestedNodeRequest, opts ...grpc.CallOption) (*DeleteAttestedNodeResponse, error)
+	// Sets the set of selectors for a specific node id
+	SetNodeSelectors(ctx context.Context, in *SetNodeSelectorsRequest, opts ...grpc.CallOption) (*SetNodeSelectorsResponse, error)
+	// Gets the set of node selectors for a specific node id
+	GetNodeSelectors(ctx context.Context, in *GetNodeSelectorsRequest, opts ...grpc.CallOption) (*GetNodeSelectorsResponse, error)
 	// Creates a registration entry
 	CreateRegistrationEntry(ctx context.Context, in *CreateRegistrationEntryRequest, opts ...grpc.CallOption) (*CreateRegistrationEntryResponse, error)
 	// Fetches a specific registration entry
@@ -2362,81 +2218,63 @@ func (c *dataStoreClient) DeleteBundle(ctx context.Context, in *DeleteBundleRequ
 	return out, nil
 }
 
-func (c *dataStoreClient) CreateAttestedNodeEntry(ctx context.Context, in *CreateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*CreateAttestedNodeEntryResponse, error) {
-	out := new(CreateAttestedNodeEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/CreateAttestedNodeEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) CreateAttestedNode(ctx context.Context, in *CreateAttestedNodeRequest, opts ...grpc.CallOption) (*CreateAttestedNodeResponse, error) {
+	out := new(CreateAttestedNodeResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/CreateAttestedNode", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) FetchAttestedNodeEntry(ctx context.Context, in *FetchAttestedNodeEntryRequest, opts ...grpc.CallOption) (*FetchAttestedNodeEntryResponse, error) {
-	out := new(FetchAttestedNodeEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchAttestedNodeEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) FetchAttestedNode(ctx context.Context, in *FetchAttestedNodeRequest, opts ...grpc.CallOption) (*FetchAttestedNodeResponse, error) {
+	out := new(FetchAttestedNodeResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchAttestedNode", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) ListAttestedNodeEntries(ctx context.Context, in *ListAttestedNodeEntriesRequest, opts ...grpc.CallOption) (*ListAttestedNodeEntriesResponse, error) {
-	out := new(ListAttestedNodeEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListAttestedNodeEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) ListAttestedNodes(ctx context.Context, in *ListAttestedNodesRequest, opts ...grpc.CallOption) (*ListAttestedNodesResponse, error) {
+	out := new(ListAttestedNodesResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListAttestedNodes", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) UpdateAttestedNodeEntry(ctx context.Context, in *UpdateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*UpdateAttestedNodeEntryResponse, error) {
-	out := new(UpdateAttestedNodeEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/UpdateAttestedNodeEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) UpdateAttestedNode(ctx context.Context, in *UpdateAttestedNodeRequest, opts ...grpc.CallOption) (*UpdateAttestedNodeResponse, error) {
+	out := new(UpdateAttestedNodeResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/UpdateAttestedNode", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) DeleteAttestedNodeEntry(ctx context.Context, in *DeleteAttestedNodeEntryRequest, opts ...grpc.CallOption) (*DeleteAttestedNodeEntryResponse, error) {
-	out := new(DeleteAttestedNodeEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteAttestedNodeEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) DeleteAttestedNode(ctx context.Context, in *DeleteAttestedNodeRequest, opts ...grpc.CallOption) (*DeleteAttestedNodeResponse, error) {
+	out := new(DeleteAttestedNodeResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteAttestedNode", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) CreateNodeResolverMapEntry(ctx context.Context, in *CreateNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*CreateNodeResolverMapEntryResponse, error) {
-	out := new(CreateNodeResolverMapEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/CreateNodeResolverMapEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) SetNodeSelectors(ctx context.Context, in *SetNodeSelectorsRequest, opts ...grpc.CallOption) (*SetNodeSelectorsResponse, error) {
+	out := new(SetNodeSelectorsResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/SetNodeSelectors", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) ListNodeResolverMapEntries(ctx context.Context, in *ListNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*ListNodeResolverMapEntriesResponse, error) {
-	out := new(ListNodeResolverMapEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListNodeResolverMapEntries", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) DeleteNodeResolverMapEntry(ctx context.Context, in *DeleteNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*DeleteNodeResolverMapEntryResponse, error) {
-	out := new(DeleteNodeResolverMapEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteNodeResolverMapEntry", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) RectifyNodeResolverMapEntries(ctx context.Context, in *RectifyNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*RectifyNodeResolverMapEntriesResponse, error) {
-	out := new(RectifyNodeResolverMapEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/RectifyNodeResolverMapEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) GetNodeSelectors(ctx context.Context, in *GetNodeSelectorsRequest, opts ...grpc.CallOption) (*GetNodeSelectorsResponse, error) {
+	out := new(GetNodeSelectorsResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/GetNodeSelectors", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2557,24 +2395,20 @@ type DataStoreServer interface {
 	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
 	// Deletes a specific bundle
 	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
-	// Creates an attested node entry
-	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
-	// Fetches a specific attested node entry
-	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	// Lists attested node entries (optionally filtered)
-	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
-	// Updates a specific attested node entry
-	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
-	// Deletes a specific attested node entry
-	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
-	// Creates a node resolver map entry
-	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	// Lists node resolver map entries for a specified SPIFFE ID
-	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
-	// Deletes a specific node resolver map entry
-	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
-	// Sets the list of node resolver map entries for the specified SPIFFE ID
-	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
+	// Creates an attested node
+	CreateAttestedNode(context.Context, *CreateAttestedNodeRequest) (*CreateAttestedNodeResponse, error)
+	// Fetches a specific attested node
+	FetchAttestedNode(context.Context, *FetchAttestedNodeRequest) (*FetchAttestedNodeResponse, error)
+	// Lists attested nodes (optionally filtered)
+	ListAttestedNodes(context.Context, *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error)
+	// Updates a specific attested node
+	UpdateAttestedNode(context.Context, *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error)
+	// Deletes a specific attested node
+	DeleteAttestedNode(context.Context, *DeleteAttestedNodeRequest) (*DeleteAttestedNodeResponse, error)
+	// Sets the set of selectors for a specific node id
+	SetNodeSelectors(context.Context, *SetNodeSelectorsRequest) (*SetNodeSelectorsResponse, error)
+	// Gets the set of node selectors for a specific node id
+	GetNodeSelectors(context.Context, *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error)
 	// Creates a registration entry
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
 	// Fetches a specific registration entry
@@ -2711,164 +2545,128 @@ func _DataStore_DeleteBundle_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_CreateAttestedNodeEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateAttestedNodeEntryRequest)
+func _DataStore_CreateAttestedNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateAttestedNodeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).CreateAttestedNodeEntry(ctx, in)
+		return srv.(DataStoreServer).CreateAttestedNode(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/CreateAttestedNodeEntry",
+		FullMethod: "/spire.server.datastore.DataStore/CreateAttestedNode",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).CreateAttestedNodeEntry(ctx, req.(*CreateAttestedNodeEntryRequest))
+		return srv.(DataStoreServer).CreateAttestedNode(ctx, req.(*CreateAttestedNodeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_FetchAttestedNodeEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(FetchAttestedNodeEntryRequest)
+func _DataStore_FetchAttestedNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchAttestedNodeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).FetchAttestedNodeEntry(ctx, in)
+		return srv.(DataStoreServer).FetchAttestedNode(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/FetchAttestedNodeEntry",
+		FullMethod: "/spire.server.datastore.DataStore/FetchAttestedNode",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchAttestedNodeEntry(ctx, req.(*FetchAttestedNodeEntryRequest))
+		return srv.(DataStoreServer).FetchAttestedNode(ctx, req.(*FetchAttestedNodeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListAttestedNodeEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListAttestedNodeEntriesRequest)
+func _DataStore_ListAttestedNodes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAttestedNodesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListAttestedNodeEntries(ctx, in)
+		return srv.(DataStoreServer).ListAttestedNodes(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListAttestedNodeEntries",
+		FullMethod: "/spire.server.datastore.DataStore/ListAttestedNodes",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListAttestedNodeEntries(ctx, req.(*ListAttestedNodeEntriesRequest))
+		return srv.(DataStoreServer).ListAttestedNodes(ctx, req.(*ListAttestedNodesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_UpdateAttestedNodeEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(UpdateAttestedNodeEntryRequest)
+func _DataStore_UpdateAttestedNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateAttestedNodeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).UpdateAttestedNodeEntry(ctx, in)
+		return srv.(DataStoreServer).UpdateAttestedNode(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/UpdateAttestedNodeEntry",
+		FullMethod: "/spire.server.datastore.DataStore/UpdateAttestedNode",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).UpdateAttestedNodeEntry(ctx, req.(*UpdateAttestedNodeEntryRequest))
+		return srv.(DataStoreServer).UpdateAttestedNode(ctx, req.(*UpdateAttestedNodeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_DeleteAttestedNodeEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteAttestedNodeEntryRequest)
+func _DataStore_DeleteAttestedNode_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteAttestedNodeRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).DeleteAttestedNodeEntry(ctx, in)
+		return srv.(DataStoreServer).DeleteAttestedNode(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/DeleteAttestedNodeEntry",
+		FullMethod: "/spire.server.datastore.DataStore/DeleteAttestedNode",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).DeleteAttestedNodeEntry(ctx, req.(*DeleteAttestedNodeEntryRequest))
+		return srv.(DataStoreServer).DeleteAttestedNode(ctx, req.(*DeleteAttestedNodeRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_CreateNodeResolverMapEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateNodeResolverMapEntryRequest)
+func _DataStore_SetNodeSelectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetNodeSelectorsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).CreateNodeResolverMapEntry(ctx, in)
+		return srv.(DataStoreServer).SetNodeSelectors(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/CreateNodeResolverMapEntry",
+		FullMethod: "/spire.server.datastore.DataStore/SetNodeSelectors",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).CreateNodeResolverMapEntry(ctx, req.(*CreateNodeResolverMapEntryRequest))
+		return srv.(DataStoreServer).SetNodeSelectors(ctx, req.(*SetNodeSelectorsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListNodeResolverMapEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListNodeResolverMapEntriesRequest)
+func _DataStore_GetNodeSelectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetNodeSelectorsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListNodeResolverMapEntries(ctx, in)
+		return srv.(DataStoreServer).GetNodeSelectors(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListNodeResolverMapEntries",
+		FullMethod: "/spire.server.datastore.DataStore/GetNodeSelectors",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListNodeResolverMapEntries(ctx, req.(*ListNodeResolverMapEntriesRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_DeleteNodeResolverMapEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(DeleteNodeResolverMapEntryRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).DeleteNodeResolverMapEntry(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/DeleteNodeResolverMapEntry",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).DeleteNodeResolverMapEntry(ctx, req.(*DeleteNodeResolverMapEntryRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_RectifyNodeResolverMapEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RectifyNodeResolverMapEntriesRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).RectifyNodeResolverMapEntries(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/RectifyNodeResolverMapEntries",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).RectifyNodeResolverMapEntries(ctx, req.(*RectifyNodeResolverMapEntriesRequest))
+		return srv.(DataStoreServer).GetNodeSelectors(ctx, req.(*GetNodeSelectorsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3100,40 +2898,32 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_DeleteBundle_Handler,
 		},
 		{
-			MethodName: "CreateAttestedNodeEntry",
-			Handler:    _DataStore_CreateAttestedNodeEntry_Handler,
+			MethodName: "CreateAttestedNode",
+			Handler:    _DataStore_CreateAttestedNode_Handler,
 		},
 		{
-			MethodName: "FetchAttestedNodeEntry",
-			Handler:    _DataStore_FetchAttestedNodeEntry_Handler,
+			MethodName: "FetchAttestedNode",
+			Handler:    _DataStore_FetchAttestedNode_Handler,
 		},
 		{
-			MethodName: "ListAttestedNodeEntries",
-			Handler:    _DataStore_ListAttestedNodeEntries_Handler,
+			MethodName: "ListAttestedNodes",
+			Handler:    _DataStore_ListAttestedNodes_Handler,
 		},
 		{
-			MethodName: "UpdateAttestedNodeEntry",
-			Handler:    _DataStore_UpdateAttestedNodeEntry_Handler,
+			MethodName: "UpdateAttestedNode",
+			Handler:    _DataStore_UpdateAttestedNode_Handler,
 		},
 		{
-			MethodName: "DeleteAttestedNodeEntry",
-			Handler:    _DataStore_DeleteAttestedNodeEntry_Handler,
+			MethodName: "DeleteAttestedNode",
+			Handler:    _DataStore_DeleteAttestedNode_Handler,
 		},
 		{
-			MethodName: "CreateNodeResolverMapEntry",
-			Handler:    _DataStore_CreateNodeResolverMapEntry_Handler,
+			MethodName: "SetNodeSelectors",
+			Handler:    _DataStore_SetNodeSelectors_Handler,
 		},
 		{
-			MethodName: "ListNodeResolverMapEntries",
-			Handler:    _DataStore_ListNodeResolverMapEntries_Handler,
-		},
-		{
-			MethodName: "DeleteNodeResolverMapEntry",
-			Handler:    _DataStore_DeleteNodeResolverMapEntry_Handler,
-		},
-		{
-			MethodName: "RectifyNodeResolverMapEntries",
-			Handler:    _DataStore_RectifyNodeResolverMapEntries_Handler,
+			MethodName: "GetNodeSelectors",
+			Handler:    _DataStore_GetNodeSelectors_Handler,
 		},
 		{
 			MethodName: "CreateRegistrationEntry",
@@ -3184,106 +2974,103 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 	Metadata: "datastore.proto",
 }
 
-func init() { proto.RegisterFile("datastore.proto", fileDescriptor_datastore_e3e0d519b06ed1bf) }
+func init() { proto.RegisterFile("datastore.proto", fileDescriptor_datastore_5f1f189cc5ca3aad) }
 
-var fileDescriptor_datastore_e3e0d519b06ed1bf = []byte{
-	// 1562 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x59, 0xef, 0x72, 0xd3, 0xd6,
-	0x12, 0xbf, 0xc6, 0x97, 0x10, 0xaf, 0x0d, 0xb9, 0x28, 0x21, 0x24, 0xe6, 0xe2, 0x24, 0xba, 0x70,
-	0x87, 0xbf, 0xf6, 0x34, 0x85, 0xf0, 0xa7, 0x50, 0x48, 0x02, 0x61, 0xd2, 0x29, 0x69, 0x46, 0xa1,
-	0x85, 0x81, 0xce, 0x68, 0x24, 0xfb, 0xd8, 0x88, 0x3a, 0x3a, 0xaa, 0x74, 0x0c, 0xd5, 0x13, 0x74,
-	0xa6, 0xdf, 0x3a, 0xfd, 0xda, 0x07, 0xe9, 0x23, 0xf5, 0x05, 0xfa, 0xbd, 0xa3, 0x73, 0x8e, 0x6c,
-	0xcb, 0xd2, 0x4a, 0xb2, 0xa3, 0x7e, 0x8a, 0x7d, 0xce, 0xfe, 0xf9, 0xed, 0x9e, 0xdd, 0xf5, 0xee,
-	0x06, 0x16, 0x3a, 0x06, 0x33, 0x3c, 0x46, 0x5d, 0xd2, 0x74, 0x5c, 0xca, 0xa8, 0xb2, 0xec, 0x39,
-	0x96, 0x4b, 0x9a, 0x1e, 0x71, 0x3f, 0x12, 0xb7, 0x39, 0xbc, 0xad, 0x37, 0x7a, 0x94, 0xf6, 0xfa,
-	0xa4, 0xc5, 0xa9, 0xcc, 0x41, 0xb7, 0xf5, 0xc9, 0x35, 0x1c, 0x87, 0xb8, 0x9e, 0xe0, 0xab, 0xdf,
-	0xef, 0x59, 0xec, 0xfd, 0xc0, 0x6c, 0xb6, 0xe9, 0x71, 0xcb, 0x73, 0xac, 0x6e, 0x97, 0xb4, 0xb8,
-	0x24, 0xc1, 0xd0, 0x6a, 0xd3, 0xe3, 0x63, 0x6a, 0xb7, 0x9c, 0xfe, 0xa0, 0x67, 0x85, 0x7f, 0x24,
-	0xe7, 0x67, 0xb9, 0x38, 0xc5, 0x1f, 0xc1, 0xa2, 0xee, 0xc1, 0xdc, 0xce, 0xc0, 0xee, 0xf4, 0x89,
-	0xb2, 0x01, 0x35, 0xe6, 0x0e, 0x3c, 0xa6, 0x77, 0xe8, 0xb1, 0x61, 0xd9, 0x2b, 0xa5, 0xf5, 0xd2,
-	0xb5, 0x8a, 0x56, 0xe5, 0x67, 0xcf, 0xf8, 0x91, 0xb2, 0x0a, 0xf3, 0x6d, 0x43, 0x6f, 0x13, 0x97,
-	0x79, 0x2b, 0xa7, 0xd6, 0x4b, 0xd7, 0x6a, 0xda, 0x99, 0xb6, 0xb1, 0x1b, 0x7c, 0x55, 0x5f, 0xc2,
-	0xe2, 0xae, 0x4b, 0x0c, 0x46, 0x84, 0x34, 0x8d, 0xfc, 0x38, 0x20, 0x1e, 0x53, 0xb6, 0x60, 0xce,
-	0xe4, 0x07, 0x5c, 0x5c, 0x75, 0xb3, 0xd1, 0x4c, 0x76, 0x4a, 0x53, 0xb2, 0x49, 0x6a, 0xf5, 0x00,
-	0x96, 0xa2, 0xe2, 0x3c, 0x87, 0xda, 0x1e, 0x99, 0x59, 0xde, 0x3d, 0x50, 0xf6, 0x08, 0x6b, 0xbf,
-	0x8f, 0xa2, 0xcb, 0x36, 0x39, 0xb0, 0x2b, 0xc2, 0x78, 0x42, 0x1c, 0x4b, 0xa0, 0x7c, 0x6d, 0x79,
-	0x4c, 0x9c, 0x7a, 0x12, 0x87, 0xfa, 0x0d, 0x2c, 0x46, 0x4e, 0xa5, 0x92, 0xfb, 0x70, 0x46, 0xb0,
-	0x79, 0x2b, 0xa5, 0xf5, 0x72, 0x0e, 0x2d, 0x21, 0x79, 0x80, 0xfa, 0x5b, 0xa7, 0x53, 0xe4, 0x6b,
-	0x44, 0xc5, 0x9d, 0xd0, 0x0b, 0x2f, 0x61, 0x71, 0xdb, 0x71, 0x88, 0xdd, 0x29, 0x0c, 0x5e, 0x54,
-	0xdc, 0x09, 0xe1, 0xdd, 0x87, 0xc5, 0x67, 0xa4, 0x4f, 0x26, 0xbd, 0x97, 0x23, 0x5a, 0x0e, 0x60,
-	0x29, 0xca, 0x79, 0x42, 0x24, 0x3d, 0x58, 0x3a, 0xa0, 0x9d, 0x40, 0x0e, 0xed, 0x7f, 0x24, 0xee,
-	0x4b, 0xc3, 0x79, 0x6e, 0x33, 0xd7, 0x57, 0x2e, 0x41, 0x45, 0xe4, 0xb7, 0x6e, 0x75, 0x24, 0x8e,
-	0x79, 0x71, 0xb0, 0xdf, 0x51, 0x36, 0x61, 0xde, 0x23, 0x7d, 0xd2, 0x66, 0xd4, 0xe5, 0x59, 0x5a,
-	0xdd, 0x5c, 0x96, 0xea, 0x64, 0xe6, 0x1f, 0xc9, 0x5b, 0x6d, 0x48, 0xa7, 0xf6, 0x60, 0x43, 0xe4,
-	0x5b, 0x92, 0xba, 0xd0, 0x01, 0x3b, 0x70, 0x9a, 0x04, 0xdf, 0xa5, 0x11, 0xb7, 0x30, 0x23, 0x12,
-	0x65, 0x08, 0x56, 0xf5, 0x3d, 0xa8, 0x69, 0x8a, 0xa4, 0xbf, 0x8a, 0xd0, 0xf4, 0x14, 0x36, 0x82,
-	0xa4, 0x4a, 0x20, 0xb1, 0x86, 0x99, 0x97, 0xea, 0x48, 0xb5, 0x0f, 0x6a, 0x9a, 0x04, 0x89, 0x75,
-	0x0f, 0xce, 0x10, 0x71, 0x24, 0xb3, 0x74, 0x3a, 0xb4, 0x21, 0x73, 0xf0, 0x04, 0x22, 0x76, 0xfe,
-	0xe9, 0x27, 0xe8, 0x83, 0x9a, 0xa6, 0xa8, 0x60, 0xb3, 0x6c, 0xb8, 0xa2, 0x91, 0x36, 0xb3, 0xba,
-	0x7e, 0xfa, 0x4b, 0x14, 0xa5, 0x8f, 0xc2, 0xd5, 0x0c, 0x7d, 0x05, 0x1b, 0xf8, 0x47, 0x09, 0xce,
-	0x6f, 0x33, 0x46, 0x3c, 0x46, 0x3a, 0x01, 0x65, 0xae, 0x0c, 0xbd, 0x60, 0x70, 0x0e, 0x83, 0x59,
-	0xd4, 0xd6, 0x03, 0x4d, 0x3a, 0xf3, 0x1d, 0xc2, 0xd3, 0xb5, 0xa2, 0x2d, 0x8e, 0x5d, 0x3e, 0x33,
-	0x98, 0xf1, 0xca, 0x77, 0x88, 0x72, 0x0b, 0x94, 0xe0, 0x87, 0x57, 0xf7, 0x88, 0x6b, 0x19, 0x7d,
-	0xdd, 0x1e, 0x1c, 0x9b, 0xc4, 0x5d, 0x29, 0x73, 0x86, 0xff, 0x04, 0x37, 0x47, 0xfc, 0xe2, 0x80,
-	0x9f, 0x2b, 0x57, 0xe0, 0x1c, 0xa7, 0xb6, 0x29, 0xd3, 0x8d, 0x2e, 0x23, 0xee, 0xca, 0xbf, 0xd7,
-	0x4b, 0xd7, 0xca, 0x5a, 0x2d, 0x38, 0x3d, 0xa0, 0x6c, 0x3b, 0x38, 0x53, 0x0d, 0x68, 0x88, 0x64,
-	0x8c, 0xe1, 0x0f, 0x5f, 0xe5, 0x49, 0x34, 0xde, 0xae, 0x63, 0x2e, 0x8a, 0x0b, 0x90, 0xc1, 0x66,
-	0xc2, 0x1a, 0xaa, 0x42, 0x3e, 0xc4, 0x89, 0x75, 0x3c, 0x82, 0xcb, 0xfc, 0x37, 0x1a, 0xb5, 0x22,
-	0x35, 0xcb, 0x0d, 0x68, 0x60, 0xdc, 0x45, 0x01, 0xb4, 0xa0, 0x11, 0x14, 0x92, 0xc9, 0xfb, 0xb1,
-	0xe8, 0x7f, 0x01, 0xe7, 0x4d, 0x5f, 0x27, 0x3f, 0x05, 0x82, 0x3d, 0xdd, 0x24, 0x5d, 0xea, 0x86,
-	0xbf, 0x15, 0x97, 0x9a, 0xa2, 0x5f, 0x6c, 0x86, 0xfd, 0x62, 0x73, 0xdf, 0x66, 0x5b, 0x77, 0xbe,
-	0x33, 0xfa, 0x03, 0xa2, 0x2d, 0x98, 0xfe, 0x73, 0xc1, 0xb4, 0xc3, 0x79, 0xd4, 0x2e, 0xac, 0xa1,
-	0xaa, 0xa4, 0x39, 0xbb, 0x93, 0x81, 0x3f, 0x85, 0x41, 0xc3, 0xa8, 0xff, 0xb5, 0x04, 0x0d, 0xd1,
-	0x13, 0xcc, 0xe4, 0x75, 0x24, 0x9c, 0x4f, 0xe5, 0x0e, 0xe7, 0x72, 0x42, 0x38, 0x9b, 0xb0, 0x86,
-	0x42, 0x2a, 0xea, 0x29, 0x1f, 0x43, 0x43, 0x14, 0xcf, 0xd9, 0x82, 0xcd, 0x84, 0x35, 0x94, 0xbd,
-	0x28, 0x88, 0xaf, 0xc3, 0xac, 0xd6, 0x48, 0xcf, 0xf2, 0x98, 0xcb, 0xeb, 0x48, 0x04, 0xe2, 0xdd,
-	0xa8, 0x8a, 0xb5, 0x68, 0x7b, 0x10, 0x67, 0x1b, 0xe6, 0xd9, 0x1a, 0x2a, 0x58, 0x82, 0x5f, 0x85,
-	0x79, 0x4e, 0x3b, 0xb2, 0x9d, 0x47, 0x8c, 0xbf, 0xdf, 0x51, 0x1f, 0xca, 0x2c, 0x45, 0x51, 0xa5,
-	0xf0, 0xbe, 0x96, 0x39, 0x8a, 0x2b, 0x9e, 0xd1, 0xa4, 0x4f, 0x50, 0xdd, 0xf1, 0xc3, 0x7e, 0xc8,
-	0x53, 0xee, 0x40, 0x25, 0x6c, 0x89, 0xc2, 0xe4, 0xc0, 0x7a, 0xa7, 0x11, 0x21, 0x2f, 0xe7, 0xfd,
-	0x3e, 0xfd, 0xa4, 0x1b, 0xb6, 0xaf, 0xb7, 0xe9, 0xb1, 0x69, 0xd9, 0x5c, 0x13, 0x0f, 0xe7, 0x79,
-	0x6d, 0x91, 0x5f, 0x6e, 0xdb, 0xfe, 0xee, 0xe8, 0x4a, 0xfd, 0xb3, 0x24, 0x6a, 0xc2, 0x24, 0xb2,
-	0xb1, 0x9a, 0xf0, 0x25, 0xd4, 0x4c, 0x5f, 0x77, 0x0c, 0x97, 0xd8, 0x2c, 0xf4, 0x49, 0x75, 0xf3,
-	0xbf, 0xb1, 0x72, 0x70, 0xc4, 0x5c, 0xcb, 0xee, 0x89, 0x7a, 0x00, 0xa6, 0x7f, 0xc8, 0x19, 0xf6,
-	0x3b, 0xca, 0x1e, 0xe7, 0x1f, 0xd9, 0x23, 0x7a, 0xc1, 0xff, 0xa1, 0xad, 0xe7, 0xc8, 0x0f, 0x5a,
-	0xd5, 0x1c, 0x73, 0x8a, 0xc0, 0x31, 0x8a, 0xe9, 0x72, 0x3e, 0x1c, 0x47, 0x61, 0xcc, 0x7f, 0x2f,
-	0x4a, 0x52, 0xa2, 0xa5, 0xf2, 0xf5, 0x1e, 0x4c, 0x96, 0xa4, 0xcc, 0xf7, 0x1b, 0x16, 0xa2, 0xd7,
-	0x61, 0x1d, 0x2a, 0x3a, 0xda, 0xdf, 0x84, 0xd5, 0xa4, 0xf0, 0xa0, 0xfb, 0x22, 0xac, 0x21, 0xb3,
-	0xa4, 0xc2, 0x9b, 0xb0, 0x82, 0x14, 0x0e, 0xeb, 0x01, 0x54, 0xbe, 0xa2, 0x96, 0xfd, 0x8a, 0xfe,
-	0x40, 0x6c, 0x65, 0x09, 0x4e, 0xb3, 0xe0, 0x83, 0x54, 0x2f, 0xbe, 0x28, 0xcb, 0x30, 0xc7, 0x7f,
-	0xa3, 0x7c, 0x1e, 0x4c, 0x65, 0x4d, 0x7e, 0x53, 0xdf, 0xc2, 0xb2, 0xa8, 0x0c, 0x43, 0x01, 0xa1,
-	0x25, 0x4f, 0x01, 0x3e, 0x50, 0xcb, 0xd6, 0x47, 0xc2, 0xaa, 0x9b, 0x1b, 0x58, 0x08, 0x8e, 0xb8,
-	0x2b, 0x1f, 0xc2, 0x8f, 0xea, 0x3b, 0xb8, 0x18, 0x93, 0x2d, 0x0d, 0x3d, 0xb9, 0xf0, 0xdb, 0x70,
-	0x81, 0x17, 0x96, 0x18, 0xee, 0x44, 0xfb, 0x03, 0x3b, 0x27, 0xc9, 0x0b, 0x83, 0xd2, 0x84, 0x65,
-	0xf1, 0xb0, 0x39, 0xb1, 0xbc, 0x83, 0x8b, 0x31, 0xfa, 0xc2, 0xc0, 0x3c, 0x81, 0xe5, 0x43, 0x77,
-	0x60, 0x8f, 0x64, 0x0f, 0xab, 0xd2, 0x55, 0x38, 0x97, 0xd0, 0xa6, 0x94, 0xb5, 0xb3, 0x24, 0xd2,
-	0x87, 0xac, 0xc2, 0xc5, 0x98, 0x00, 0x81, 0x6e, 0xf3, 0xaf, 0x55, 0xa8, 0x04, 0x6d, 0xed, 0x51,
-	0xa0, 0x5e, 0xb1, 0xa0, 0x36, 0xbe, 0xe9, 0x51, 0x6e, 0x62, 0x38, 0x13, 0xd6, 0x4b, 0xf5, 0x5b,
-	0xf9, 0x88, 0xa5, 0x5b, 0xba, 0x50, 0x1d, 0xdb, 0xe5, 0x28, 0x37, 0x30, 0xe6, 0xf8, 0xa6, 0xa8,
-	0x7e, 0x33, 0x17, 0xed, 0x48, 0xcf, 0xd8, 0x3a, 0x07, 0xd7, 0x13, 0xdf, 0x04, 0xe1, 0x7a, 0x92,
-	0xf6, 0x43, 0x16, 0xd4, 0xc6, 0xd7, 0x32, 0xb8, 0xeb, 0x12, 0x76, 0x41, 0xb8, 0xeb, 0x12, 0x37,
-	0x3d, 0x16, 0xd4, 0xc6, 0x57, 0x2c, 0xb8, 0xaa, 0x84, 0xbd, 0x0e, 0xae, 0x2a, 0x71, 0x6b, 0x63,
-	0x41, 0x6d, 0x7c, 0x87, 0x82, 0xab, 0x4a, 0xd8, 0xd1, 0xe0, 0xaa, 0x12, 0xd7, 0x32, 0xbf, 0x94,
-	0xc2, 0xda, 0x12, 0x1f, 0xe0, 0xb6, 0xd2, 0x43, 0x0b, 0x6b, 0xff, 0xea, 0xf7, 0xa6, 0xe6, 0x93,
-	0x60, 0x7e, 0x2e, 0xc9, 0xe2, 0x12, 0xc7, 0x72, 0x37, 0x35, 0xfa, 0x50, 0x28, 0x5b, 0xd3, 0xb2,
-	0x8d, 0xb9, 0x05, 0x19, 0x22, 0x70, 0xb7, 0xa4, 0x0f, 0x38, 0xb8, 0x5b, 0xb2, 0xa6, 0x95, 0x00,
-	0x0c, 0xd2, 0xd5, 0xe3, 0x60, 0xd2, 0x27, 0x13, 0x1c, 0x4c, 0xd6, 0xf8, 0x10, 0x80, 0x41, 0xfa,
-	0x77, 0x1c, 0x4c, 0xfa, 0xbc, 0x80, 0x83, 0xc9, 0x1a, 0x14, 0x7e, 0x2b, 0x41, 0x1d, 0xdf, 0xa5,
-	0x29, 0x0f, 0xd2, 0x03, 0x31, 0x65, 0xcb, 0x54, 0x7f, 0x38, 0x0b, 0xeb, 0x18, 0x2a, 0x7c, 0x6b,
-	0x86, 0xa3, 0xca, 0xdc, 0xd5, 0xe1, 0xa8, 0x72, 0x2c, 0xe9, 0x02, 0x54, 0xf8, 0xd2, 0x0b, 0x47,
-	0x95, 0xb9, 0x91, 0xc3, 0x51, 0xe5, 0xd8, 0xb1, 0xfd, 0x5e, 0x82, 0xcb, 0xa9, 0xcb, 0x2a, 0xe5,
-	0x11, 0x26, 0x3d, 0xcf, 0x4e, 0xad, 0xfe, 0x78, 0x46, 0xee, 0x58, 0x79, 0x8c, 0xf5, 0x8c, 0x59,
-	0xe5, 0x11, 0xeb, 0x6c, 0xb3, 0xca, 0x23, 0xde, 0xd4, 0x0e, 0xcb, 0x63, 0x1c, 0x4b, 0x7a, 0x79,
-	0x44, 0xa1, 0x6c, 0x4d, 0xcb, 0x36, 0x51, 0x1e, 0x13, 0x06, 0x9a, 0xf4, 0xf2, 0x88, 0xcf, 0x7a,
-	0xe9, 0xe5, 0x31, 0x6d, 0x72, 0x1a, 0x95, 0xc7, 0x29, 0xde, 0x28, 0x7d, 0x60, 0xca, 0x2a, 0x8f,
-	0xe9, 0x9e, 0x41, 0x86, 0x93, 0xac, 0xf2, 0x38, 0x3d, 0x98, 0xac, 0x29, 0xc8, 0x85, 0x85, 0x89,
-	0xb9, 0x41, 0x69, 0xa6, 0x07, 0xdf, 0x64, 0xe3, 0x5d, 0x6f, 0xe5, 0xa6, 0x97, 0x3a, 0x29, 0x9c,
-	0x8b, 0xce, 0x07, 0xca, 0xed, 0xd4, 0x20, 0x8b, 0x69, 0x6c, 0xe6, 0x25, 0x1f, 0x19, 0x39, 0x31,
-	0x04, 0xe0, 0x46, 0x26, 0x4f, 0x17, 0xb8, 0x91, 0xd8, 0x74, 0xe1, 0xc2, 0xc2, 0x44, 0x6b, 0x8f,
-	0xeb, 0x4c, 0x1e, 0x22, 0x70, 0x9d, 0xc8, 0xcc, 0xa0, 0xbc, 0x85, 0xca, 0x2e, 0xb5, 0xbb, 0x56,
-	0x6f, 0xe0, 0x12, 0xe5, 0x6a, 0x74, 0xa0, 0x95, 0xff, 0x02, 0x1f, 0xde, 0x87, 0x4a, 0xfe, 0x9f,
-	0x45, 0x36, 0x6c, 0xd7, 0xcf, 0xbe, 0x20, 0xec, 0x90, 0x5f, 0xef, 0xdb, 0x5d, 0xaa, 0x5c, 0x4f,
-	0x64, 0x8c, 0xd0, 0x84, 0x3a, 0x6e, 0xe4, 0x21, 0x15, 0x7a, 0x76, 0xaa, 0x6f, 0x2b, 0x43, 0x43,
-	0x0f, 0xff, 0x75, 0x58, 0x3a, 0x3c, 0x65, 0xce, 0xf1, 0xe5, 0xc9, 0xe7, 0x7f, 0x07, 0x00, 0x00,
-	0xff, 0xff, 0x14, 0xfe, 0x43, 0x8a, 0x3c, 0x20, 0x00, 0x00,
+var fileDescriptor_datastore_5f1f189cc5ca3aad = []byte{
+	// 1519 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x59, 0x7f, 0x53, 0xdb, 0x46,
+	0x13, 0x8e, 0x71, 0x20, 0xf1, 0xda, 0xfc, 0xc8, 0x41, 0x8c, 0xed, 0xbc, 0x2f, 0x10, 0xbd, 0xc9,
+	0x3b, 0x69, 0x7e, 0xd8, 0xc1, 0x4d, 0x08, 0x49, 0x67, 0xda, 0x02, 0x21, 0x2e, 0x9d, 0x42, 0x19,
+	0x1b, 0x48, 0x26, 0xe9, 0x54, 0x23, 0xdb, 0x67, 0xa3, 0xd4, 0x48, 0xaa, 0x74, 0x4e, 0xe3, 0xc9,
+	0x07, 0xe8, 0x4c, 0xa7, 0xdf, 0xa5, 0x7f, 0xf4, 0x0b, 0xf4, 0xe3, 0xf4, 0x63, 0x74, 0x74, 0x27,
+	0x59, 0x92, 0xa5, 0x15, 0x32, 0xa6, 0x7f, 0x61, 0x9d, 0xf6, 0xd9, 0xe7, 0xb9, 0xf5, 0xde, 0xde,
+	0xae, 0x81, 0xf9, 0xb6, 0xc2, 0x14, 0x8b, 0xe9, 0x26, 0x2d, 0x1b, 0xa6, 0xce, 0x74, 0x92, 0xb7,
+	0x0c, 0xd5, 0xa4, 0x65, 0x8b, 0x9a, 0x1f, 0xa8, 0x59, 0x1e, 0xbe, 0x2d, 0xad, 0x74, 0x75, 0xbd,
+	0xdb, 0xa3, 0x15, 0x6e, 0xd5, 0xec, 0x77, 0x2a, 0xbf, 0x98, 0x8a, 0x61, 0x50, 0xd3, 0x12, 0xb8,
+	0xd2, 0x66, 0x57, 0x65, 0xa7, 0xfd, 0x66, 0xb9, 0xa5, 0x9f, 0x55, 0x2c, 0x43, 0xed, 0x74, 0x68,
+	0x85, 0x7b, 0x12, 0x80, 0x4a, 0x4b, 0x3f, 0x3b, 0xd3, 0xb5, 0x8a, 0xd1, 0xeb, 0x77, 0x55, 0xf7,
+	0x8f, 0x83, 0x5c, 0x4f, 0x84, 0x14, 0x7f, 0x04, 0x44, 0x7a, 0x05, 0x33, 0xdb, 0x7d, 0xad, 0xdd,
+	0xa3, 0xe4, 0x36, 0xe4, 0x98, 0xd9, 0xb7, 0x98, 0xdc, 0xd6, 0xcf, 0x14, 0x55, 0x2b, 0xa4, 0xd6,
+	0x52, 0xf7, 0x32, 0xf5, 0x2c, 0x5f, 0x7b, 0xc9, 0x97, 0x48, 0x11, 0xae, 0xb7, 0x14, 0xb9, 0x45,
+	0x4d, 0x66, 0x15, 0xa6, 0xd6, 0x52, 0xf7, 0x72, 0xf5, 0x6b, 0x2d, 0x65, 0xc7, 0x7e, 0x94, 0xf6,
+	0x61, 0x71, 0xc7, 0xa4, 0x0a, 0xa3, 0xc2, 0x5b, 0x9d, 0xfe, 0xdc, 0xa7, 0x16, 0x23, 0x1b, 0x30,
+	0xd3, 0xe4, 0x0b, 0xdc, 0x5d, 0xb6, 0xba, 0x52, 0x8e, 0x0e, 0x4a, 0xd9, 0x81, 0x39, 0xd6, 0xd2,
+	0x01, 0x2c, 0x05, 0xdd, 0x59, 0x86, 0xae, 0x59, 0xf4, 0xc2, 0xfe, 0x9e, 0x01, 0x79, 0x45, 0x59,
+	0xeb, 0x34, 0xa8, 0xee, 0xfc, 0x2d, 0xdb, 0xfb, 0x0a, 0x00, 0x27, 0xd4, 0xb1, 0x04, 0xe4, 0x3b,
+	0xd5, 0x62, 0x62, 0xd5, 0x72, 0x74, 0x48, 0xdf, 0xc3, 0x62, 0x60, 0xd5, 0x21, 0xd9, 0x84, 0x6b,
+	0x02, 0x66, 0x15, 0x52, 0x6b, 0xe9, 0x04, 0x2c, 0xae, 0xb9, 0xad, 0xfa, 0xd8, 0x68, 0x5f, 0xe6,
+	0xb7, 0x11, 0x74, 0x37, 0x61, 0x14, 0xf6, 0x61, 0x71, 0xcb, 0x30, 0xa8, 0xd6, 0xbe, 0x34, 0x79,
+	0x41, 0x77, 0x13, 0xca, 0xdb, 0x84, 0xc5, 0x97, 0xb4, 0x47, 0x47, 0xa3, 0x97, 0x20, 0x5b, 0x0e,
+	0x60, 0x29, 0x88, 0x9c, 0x50, 0x49, 0x13, 0x66, 0x0f, 0xf4, 0x36, 0x6d, 0xd0, 0x1e, 0x6d, 0x31,
+	0xdd, 0xb4, 0xc8, 0x2d, 0xc8, 0x88, 0x83, 0x2d, 0xab, 0x6d, 0x47, 0xc0, 0x75, 0xb1, 0xb0, 0xd7,
+	0x26, 0x4f, 0x20, 0x63, 0xb9, 0x96, 0x85, 0x29, 0x9e, 0x31, 0x79, 0x87, 0xc8, 0x39, 0xf3, 0xae,
+	0xa3, 0xba, 0x67, 0x28, 0xfd, 0x08, 0xcb, 0x0d, 0xca, 0x02, 0x34, 0xee, 0x8e, 0x77, 0xfc, 0x0e,
+	0x85, 0xf2, 0xbb, 0x98, 0xf2, 0xa0, 0x03, 0x9f, 0xff, 0x12, 0x14, 0xc2, 0xfe, 0x45, 0x5c, 0xa4,
+	0x0d, 0x58, 0xae, 0x21, 0xdc, 0x71, 0x3b, 0x95, 0x64, 0x28, 0xd4, 0x10, 0x9f, 0x97, 0x23, 0xfa,
+	0xcf, 0x14, 0xe4, 0xb6, 0x18, 0xa3, 0x16, 0xa3, 0x6d, 0xdb, 0x28, 0x3e, 0xf0, 0x55, 0xb8, 0xa9,
+	0x70, 0x63, 0x85, 0xa9, 0xba, 0x26, 0xdb, 0xfe, 0x65, 0x36, 0x30, 0x28, 0x2f, 0x92, 0x99, 0xfa,
+	0xa2, 0xef, 0xe5, 0x4b, 0x85, 0x29, 0x47, 0x03, 0x83, 0x92, 0x87, 0x40, 0xec, 0x42, 0x2a, 0x5b,
+	0xd4, 0x54, 0x95, 0x9e, 0xac, 0xf5, 0xcf, 0x9a, 0xd4, 0x2c, 0xa4, 0x39, 0x60, 0xc1, 0x7e, 0xd3,
+	0xe0, 0x2f, 0x0e, 0xf8, 0x3a, 0xb9, 0x03, 0x73, 0xdc, 0x5a, 0xd3, 0x99, 0xac, 0x74, 0x18, 0x35,
+	0x0b, 0x57, 0xd7, 0x52, 0xf7, 0xd2, 0xf5, 0x9c, 0xbd, 0x7a, 0xa0, 0xb3, 0x2d, 0x7b, 0x4d, 0x3a,
+	0x86, 0xa2, 0xa8, 0x9a, 0x7e, 0xe9, 0x6e, 0x40, 0x37, 0xe1, 0xaa, 0xa6, 0xb7, 0xdd, 0x0c, 0xbc,
+	0x83, 0x85, 0x24, 0x00, 0xe5, 0x08, 0xe9, 0x04, 0x4a, 0x51, 0x6e, 0x87, 0x55, 0xea, 0xa2, 0x7e,
+	0x9f, 0x41, 0x81, 0xd7, 0xd6, 0x28, 0xb5, 0xb1, 0x5f, 0xff, 0x31, 0x14, 0x23, 0x80, 0x13, 0xeb,
+	0x69, 0x41, 0xc1, 0x2e, 0xc3, 0xfe, 0x37, 0xc3, 0x74, 0xac, 0xc1, 0x8d, 0xe6, 0x40, 0xa6, 0x1f,
+	0x6d, 0x67, 0x96, 0xdc, 0xa4, 0x1d, 0xdd, 0x74, 0x29, 0x6e, 0x95, 0xc5, 0x85, 0x5e, 0x76, 0x2f,
+	0xf4, 0xf2, 0x9e, 0xc6, 0x36, 0x9e, 0x9c, 0x28, 0xbd, 0x3e, 0xad, 0xcf, 0x37, 0x07, 0xbb, 0x02,
+	0xb4, 0xcd, 0x31, 0xd2, 0x6b, 0x28, 0x46, 0x90, 0x38, 0xda, 0x5f, 0xc0, 0xb4, 0xad, 0xc4, 0xad,
+	0xf7, 0xc9, 0xc4, 0x0b, 0x88, 0xf4, 0x7b, 0x0a, 0x8a, 0xa2, 0x4a, 0x8f, 0x1b, 0x4f, 0x24, 0x17,
+	0xa7, 0x12, 0xe7, 0x62, 0x3a, 0x22, 0x17, 0x4f, 0xa0, 0x14, 0xa5, 0x66, 0xe2, 0x2f, 0x69, 0x13,
+	0x8a, 0xa2, 0xc4, 0x8e, 0x9d, 0x35, 0x27, 0x50, 0x8a, 0x42, 0x4e, 0xac, 0xe8, 0x35, 0xac, 0x88,
+	0xe3, 0x51, 0xa7, 0x5d, 0xd5, 0x62, 0x26, 0x3f, 0xe7, 0xbb, 0x1a, 0x33, 0x07, 0xae, 0xac, 0xa7,
+	0x30, 0x4d, 0xed, 0x67, 0xc7, 0xf9, 0x6a, 0xb0, 0x28, 0x87, 0x61, 0xc2, 0x5a, 0x7a, 0x03, 0xab,
+	0xa8, 0x63, 0x47, 0xf5, 0x05, 0x3d, 0xbf, 0x80, 0xff, 0xf2, 0x03, 0x84, 0x2a, 0x2e, 0xc2, 0x75,
+	0x6e, 0xe9, 0xc5, 0xf1, 0x1a, 0x7f, 0xde, 0x6b, 0xdb, 0xdb, 0xc5, 0xb0, 0x93, 0x89, 0xfa, 0x2b,
+	0x05, 0xd9, 0xed, 0x81, 0x77, 0xd7, 0x3d, 0x09, 0x16, 0xf2, 0x64, 0xd7, 0x19, 0xa9, 0xc1, 0xf4,
+	0x99, 0xc2, 0x5a, 0xa7, 0x3c, 0x7d, 0xe7, 0xaa, 0xeb, 0xe8, 0x4d, 0xeb, 0x31, 0x95, 0xf7, 0x6d,
+	0xc0, 0x36, 0x3d, 0x55, 0x3e, 0xa8, 0xba, 0x59, 0x17, 0x78, 0xa9, 0x0a, 0xb3, 0x81, 0x75, 0x32,
+	0x0f, 0xd9, 0xfd, 0xad, 0xa3, 0x9d, 0x6f, 0xe4, 0xdd, 0x37, 0x5b, 0x3b, 0x47, 0x0b, 0x57, 0xc8,
+	0x02, 0xe4, 0xc4, 0x42, 0xe3, 0x78, 0xbb, 0xb1, 0x7b, 0xb4, 0x90, 0x92, 0xfe, 0x4e, 0xc1, 0x8a,
+	0x7d, 0xba, 0x47, 0xf7, 0xa8, 0x7a, 0x85, 0xe4, 0x4b, 0xc8, 0x35, 0x07, 0xb2, 0xa1, 0x98, 0x54,
+	0x63, 0x6e, 0x74, 0xb3, 0xd5, 0xff, 0x84, 0x6a, 0x48, 0x83, 0x99, 0xaa, 0xd6, 0x15, 0x45, 0x04,
+	0x9a, 0x83, 0x43, 0x0e, 0xd8, 0x6b, 0x93, 0x57, 0x1c, 0xef, 0xbf, 0xe7, 0x6d, 0xfc, 0xff, 0x12,
+	0x6c, 0xb3, 0x9e, 0x6d, 0xfa, 0xa2, 0x2b, 0x74, 0x78, 0xa7, 0x25, 0x9d, 0x4c, 0x47, 0xc3, 0x3d,
+	0x4d, 0x3f, 0xc0, 0x2a, 0xba, 0x53, 0x27, 0x0f, 0x9e, 0x03, 0x4f, 0x1a, 0x75, 0x58, 0xcf, 0xce,
+	0xcd, 0x04, 0xd7, 0xde, 0x4e, 0x32, 0x51, 0x3d, 0xfe, 0x85, 0x33, 0x85, 0x3a, 0x9e, 0x2c, 0x7d,
+	0xbf, 0x80, 0x15, 0x51, 0x5e, 0x2e, 0x72, 0xa8, 0xde, 0xc0, 0x2a, 0x0a, 0x9e, 0x4c, 0xd6, 0x73,
+	0xc8, 0x7c, 0xab, 0xab, 0xda, 0x91, 0xfe, 0x13, 0xd5, 0xc8, 0x12, 0x4c, 0x33, 0xfb, 0x83, 0x43,
+	0x2f, 0x1e, 0x48, 0x1e, 0x66, 0xf8, 0xc5, 0x36, 0xe0, 0xc9, 0x94, 0xae, 0x3b, 0x4f, 0xd2, 0x5b,
+	0xc8, 0x8b, 0xfa, 0x33, 0x74, 0xe0, 0xee, 0xe4, 0x6b, 0x80, 0xf7, 0xba, 0xaa, 0xc9, 0x9e, 0xb3,
+	0x6c, 0xf5, 0x36, 0x96, 0x82, 0x1e, 0x3a, 0xf3, 0xde, 0xfd, 0x28, 0xbd, 0x83, 0xe5, 0x90, 0x6f,
+	0x67, 0xa3, 0x93, 0x3b, 0x7f, 0x04, 0x37, 0x79, 0x89, 0x0a, 0xe9, 0x8e, 0xdc, 0xbf, 0xbd, 0xcf,
+	0x51, 0xf3, 0x4b, 0x93, 0x52, 0x86, 0xbc, 0xf8, 0x62, 0x13, 0x6a, 0x79, 0x07, 0xcb, 0x21, 0xfb,
+	0x4b, 0x13, 0xf3, 0x15, 0xe4, 0x0f, 0xcd, 0xbe, 0xe6, 0xf9, 0x1e, 0x56, 0xa5, 0xbb, 0x30, 0x17,
+	0xd1, 0xdb, 0xa4, 0xeb, 0xb3, 0x34, 0xd0, 0xbc, 0x14, 0x61, 0x39, 0xe4, 0x40, 0xa8, 0xab, 0xfe,
+	0x91, 0x87, 0x8c, 0xdd, 0xdc, 0x36, 0x6c, 0x7a, 0xa2, 0x42, 0xce, 0x3f, 0xbf, 0x93, 0x07, 0x98,
+	0xce, 0x88, 0x1f, 0x0d, 0x4a, 0x0f, 0x93, 0x19, 0x3b, 0x61, 0xe9, 0x40, 0xd6, 0x37, 0xa1, 0x93,
+	0xfb, 0x18, 0x38, 0x3c, 0xff, 0x97, 0x1e, 0x24, 0xb2, 0xf5, 0x78, 0x7c, 0x43, 0x3a, 0xce, 0x13,
+	0x9e, 0xef, 0x71, 0x9e, 0xa8, 0xa9, 0x5f, 0x85, 0x9c, 0x7f, 0xd8, 0xc6, 0x43, 0x17, 0x31, 0xe1,
+	0xe3, 0xa1, 0x8b, 0x9c, 0xdf, 0x55, 0xc8, 0xf9, 0x07, 0x67, 0x9c, 0x2a, 0x62, 0x5a, 0xc7, 0xa9,
+	0x22, 0x67, 0x71, 0x15, 0x72, 0xfe, 0xc9, 0x18, 0xa7, 0x8a, 0x98, 0xbc, 0x71, 0xaa, 0xc8, 0x61,
+	0xfb, 0x13, 0x90, 0xf0, 0xb8, 0x42, 0xd6, 0xe3, 0x93, 0x2a, 0xa2, 0x9b, 0x2c, 0x55, 0xc7, 0x81,
+	0x38, 0xe4, 0x1f, 0xe1, 0x46, 0x68, 0x34, 0x21, 0x8f, 0x63, 0xf3, 0x2c, 0x8a, 0x7a, 0x7d, 0x0c,
+	0x84, 0xc7, 0x1c, 0x1a, 0x2c, 0x70, 0x66, 0x6c, 0xd0, 0xc1, 0x99, 0xf1, 0xa9, 0xe5, 0x13, 0x90,
+	0x70, 0xab, 0x8f, 0x07, 0x1c, 0x1d, 0x52, 0xf0, 0x80, 0xc7, 0x4c, 0x12, 0x9f, 0x80, 0x84, 0xbb,
+	0x7a, 0x9c, 0x1c, 0x9d, 0x1d, 0x70, 0xf2, 0x98, 0xa1, 0xa1, 0x0f, 0x0b, 0xa3, 0xbf, 0x6d, 0x90,
+	0x0a, 0xe6, 0x07, 0xf9, 0x95, 0xa5, 0xf4, 0x38, 0x39, 0xc0, 0xa3, 0xad, 0x25, 0xa6, 0xad, 0x8d,
+	0x4b, 0x8b, 0xfe, 0xb2, 0xf2, 0x5b, 0xca, 0xbd, 0xb4, 0x43, 0xdd, 0x06, 0xd9, 0x88, 0x3f, 0x2b,
+	0x58, 0x4f, 0x54, 0x7a, 0x36, 0x36, 0xce, 0x11, 0xf3, 0x6b, 0xca, 0xb9, 0xb5, 0xc3, 0x5a, 0x9e,
+	0xc6, 0x1e, 0x1e, 0x54, 0xca, 0xc6, 0xb8, 0x30, 0x5f, 0x58, 0x90, 0x56, 0x18, 0x0f, 0x4b, 0xfc,
+	0x94, 0x80, 0x87, 0xe5, 0xbc, 0x9e, 0xdb, 0x16, 0x83, 0x34, 0xb8, 0xb8, 0x98, 0xf8, 0x56, 0x1b,
+	0x17, 0x73, 0x5e, 0x27, 0x6d, 0x8b, 0x41, 0xda, 0x5a, 0x5c, 0x4c, 0x7c, 0x13, 0x8d, 0x8b, 0x39,
+	0xaf, 0x7f, 0x36, 0x61, 0x7e, 0xa4, 0xe3, 0x24, 0xe5, 0xf8, 0xe4, 0x1b, 0x6d, 0xd9, 0x4a, 0x95,
+	0xc4, 0xf6, 0x0e, 0xa7, 0x0e, 0x73, 0xc1, 0xce, 0x92, 0x3c, 0x8a, 0x4d, 0xb2, 0x10, 0x63, 0x39,
+	0xa9, 0xb9, 0xb7, 0xc9, 0x91, 0xf6, 0x11, 0xdf, 0x64, 0x74, 0x5f, 0x8a, 0x6f, 0x12, 0xeb, 0x4b,
+	0x4d, 0x98, 0x1f, 0x69, 0x0a, 0x71, 0xce, 0xe8, 0xf6, 0x13, 0xe7, 0x44, 0xba, 0x4d, 0xf2, 0x16,
+	0x32, 0x3b, 0xba, 0xd6, 0x51, 0xbb, 0x7d, 0x93, 0x92, 0xbb, 0xc1, 0x51, 0xc8, 0xf9, 0x97, 0xd8,
+	0xf0, 0xbd, 0x4b, 0xf2, 0xff, 0xf3, 0xcc, 0x86, 0x8d, 0xde, 0x6c, 0x8d, 0xb2, 0x43, 0xfe, 0x7a,
+	0x4f, 0xeb, 0xe8, 0xe4, 0xb3, 0x48, 0x60, 0xc0, 0xc6, 0xe5, 0xb8, 0x9f, 0xc4, 0x54, 0xf0, 0x6c,
+	0x67, 0xdf, 0x66, 0x86, 0x1b, 0x3d, 0xbc, 0x72, 0x98, 0x3a, 0x9c, 0x6a, 0xce, 0xf0, 0xb1, 0xfb,
+	0xf3, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0x09, 0xde, 0xc2, 0x3f, 0x4c, 0x1c, 0x00, 0x00,
 }

--- a/proto/server/datastore/datastore.pb.go
+++ b/proto/server/datastore/datastore.pb.go
@@ -6,6 +6,7 @@ package datastore
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
+import wrappers "github.com/golang/protobuf/ptypes/wrappers"
 import common "github.com/spiffe/spire/proto/common"
 import plugin "github.com/spiffe/spire/proto/common/plugin"
 
@@ -24,6 +25,33 @@ var _ = math.Inf
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+
+// DoubleValue from public import google/protobuf/wrappers.proto
+type DoubleValue = wrappers.DoubleValue
+
+// FloatValue from public import google/protobuf/wrappers.proto
+type FloatValue = wrappers.FloatValue
+
+// Int64Value from public import google/protobuf/wrappers.proto
+type Int64Value = wrappers.Int64Value
+
+// UInt64Value from public import google/protobuf/wrappers.proto
+type UInt64Value = wrappers.UInt64Value
+
+// Int32Value from public import google/protobuf/wrappers.proto
+type Int32Value = wrappers.Int32Value
+
+// UInt32Value from public import google/protobuf/wrappers.proto
+type UInt32Value = wrappers.UInt32Value
+
+// BoolValue from public import google/protobuf/wrappers.proto
+type BoolValue = wrappers.BoolValue
+
+// StringValue from public import google/protobuf/wrappers.proto
+type StringValue = wrappers.StringValue
+
+// BytesValue from public import google/protobuf/wrappers.proto
+type BytesValue = wrappers.BytesValue
 
 // ConfigureRequest from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type ConfigureRequest = plugin.ConfigureRequest
@@ -55,12 +83,10 @@ type RegistrationEntry = common.RegistrationEntry
 // RegistrationEntries from public import github.com/spiffe/spire/proto/common/common.proto
 type RegistrationEntries = common.RegistrationEntries
 
-// Represents the trust bundle of a foreign trust domain
 type Bundle struct {
-	// SPIFFE ID of the foreign trust domain
+	// Trust domain SPIFFE ID
 	TrustDomain string `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain" json:"trust_domain,omitempty"`
-	// CA Certificates
-	// ASN.1 DER encoded
+	// CA Certificates (ASN.1 DER encoded)
 	CaCerts              []byte   `protobuf:"bytes,2,opt,name=ca_certs,json=caCerts,proto3" json:"ca_certs,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -71,7 +97,7 @@ func (m *Bundle) Reset()         { *m = Bundle{} }
 func (m *Bundle) String() string { return proto.CompactTextString(m) }
 func (*Bundle) ProtoMessage()    {}
 func (*Bundle) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{0}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{0}
 }
 func (m *Bundle) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Bundle.Unmarshal(m, b)
@@ -105,48 +131,458 @@ func (m *Bundle) GetCaCerts() []byte {
 	return nil
 }
 
-type Bundles struct {
+type CreateBundleRequest struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *CreateBundleRequest) Reset()         { *m = CreateBundleRequest{} }
+func (m *CreateBundleRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateBundleRequest) ProtoMessage()    {}
+func (*CreateBundleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{1}
+}
+func (m *CreateBundleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateBundleRequest.Unmarshal(m, b)
+}
+func (m *CreateBundleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateBundleRequest.Marshal(b, m, deterministic)
+}
+func (dst *CreateBundleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateBundleRequest.Merge(dst, src)
+}
+func (m *CreateBundleRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateBundleRequest.Size(m)
+}
+func (m *CreateBundleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateBundleRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateBundleRequest proto.InternalMessageInfo
+
+func (m *CreateBundleRequest) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type CreateBundleResponse struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *CreateBundleResponse) Reset()         { *m = CreateBundleResponse{} }
+func (m *CreateBundleResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateBundleResponse) ProtoMessage()    {}
+func (*CreateBundleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{2}
+}
+func (m *CreateBundleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateBundleResponse.Unmarshal(m, b)
+}
+func (m *CreateBundleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateBundleResponse.Marshal(b, m, deterministic)
+}
+func (dst *CreateBundleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateBundleResponse.Merge(dst, src)
+}
+func (m *CreateBundleResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateBundleResponse.Size(m)
+}
+func (m *CreateBundleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateBundleResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateBundleResponse proto.InternalMessageInfo
+
+func (m *CreateBundleResponse) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type FetchBundleRequest struct {
+	TrustDomain          string   `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain" json:"trust_domain,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *FetchBundleRequest) Reset()         { *m = FetchBundleRequest{} }
+func (m *FetchBundleRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchBundleRequest) ProtoMessage()    {}
+func (*FetchBundleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{3}
+}
+func (m *FetchBundleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchBundleRequest.Unmarshal(m, b)
+}
+func (m *FetchBundleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchBundleRequest.Marshal(b, m, deterministic)
+}
+func (dst *FetchBundleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchBundleRequest.Merge(dst, src)
+}
+func (m *FetchBundleRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchBundleRequest.Size(m)
+}
+func (m *FetchBundleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchBundleRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchBundleRequest proto.InternalMessageInfo
+
+func (m *FetchBundleRequest) GetTrustDomain() string {
+	if m != nil {
+		return m.TrustDomain
+	}
+	return ""
+}
+
+type FetchBundleResponse struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *FetchBundleResponse) Reset()         { *m = FetchBundleResponse{} }
+func (m *FetchBundleResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchBundleResponse) ProtoMessage()    {}
+func (*FetchBundleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{4}
+}
+func (m *FetchBundleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchBundleResponse.Unmarshal(m, b)
+}
+func (m *FetchBundleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchBundleResponse.Marshal(b, m, deterministic)
+}
+func (dst *FetchBundleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchBundleResponse.Merge(dst, src)
+}
+func (m *FetchBundleResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchBundleResponse.Size(m)
+}
+func (m *FetchBundleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchBundleResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchBundleResponse proto.InternalMessageInfo
+
+func (m *FetchBundleResponse) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type ListBundlesRequest struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ListBundlesRequest) Reset()         { *m = ListBundlesRequest{} }
+func (m *ListBundlesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListBundlesRequest) ProtoMessage()    {}
+func (*ListBundlesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{5}
+}
+func (m *ListBundlesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListBundlesRequest.Unmarshal(m, b)
+}
+func (m *ListBundlesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListBundlesRequest.Marshal(b, m, deterministic)
+}
+func (dst *ListBundlesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListBundlesRequest.Merge(dst, src)
+}
+func (m *ListBundlesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListBundlesRequest.Size(m)
+}
+func (m *ListBundlesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListBundlesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListBundlesRequest proto.InternalMessageInfo
+
+type ListBundlesResponse struct {
 	Bundles              []*Bundle `protobuf:"bytes,1,rep,name=bundles" json:"bundles,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
 }
 
-func (m *Bundles) Reset()         { *m = Bundles{} }
-func (m *Bundles) String() string { return proto.CompactTextString(m) }
-func (*Bundles) ProtoMessage()    {}
-func (*Bundles) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{1}
+func (m *ListBundlesResponse) Reset()         { *m = ListBundlesResponse{} }
+func (m *ListBundlesResponse) String() string { return proto.CompactTextString(m) }
+func (*ListBundlesResponse) ProtoMessage()    {}
+func (*ListBundlesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{6}
 }
-func (m *Bundles) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Bundles.Unmarshal(m, b)
+func (m *ListBundlesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListBundlesResponse.Unmarshal(m, b)
 }
-func (m *Bundles) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Bundles.Marshal(b, m, deterministic)
+func (m *ListBundlesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListBundlesResponse.Marshal(b, m, deterministic)
 }
-func (dst *Bundles) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Bundles.Merge(dst, src)
+func (dst *ListBundlesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListBundlesResponse.Merge(dst, src)
 }
-func (m *Bundles) XXX_Size() int {
-	return xxx_messageInfo_Bundles.Size(m)
+func (m *ListBundlesResponse) XXX_Size() int {
+	return xxx_messageInfo_ListBundlesResponse.Size(m)
 }
-func (m *Bundles) XXX_DiscardUnknown() {
-	xxx_messageInfo_Bundles.DiscardUnknown(m)
+func (m *ListBundlesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListBundlesResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Bundles proto.InternalMessageInfo
+var xxx_messageInfo_ListBundlesResponse proto.InternalMessageInfo
 
-func (m *Bundles) GetBundles() []*Bundle {
+func (m *ListBundlesResponse) GetBundles() []*Bundle {
 	if m != nil {
 		return m.Bundles
 	}
 	return nil
 }
 
-// Represents a single entry in NodeResolverMap and maps node properties
-// to logical attributes (i.e. an AWS instance to its ASG).
+type UpdateBundleRequest struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *UpdateBundleRequest) Reset()         { *m = UpdateBundleRequest{} }
+func (m *UpdateBundleRequest) String() string { return proto.CompactTextString(m) }
+func (*UpdateBundleRequest) ProtoMessage()    {}
+func (*UpdateBundleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{7}
+}
+func (m *UpdateBundleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateBundleRequest.Unmarshal(m, b)
+}
+func (m *UpdateBundleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateBundleRequest.Marshal(b, m, deterministic)
+}
+func (dst *UpdateBundleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateBundleRequest.Merge(dst, src)
+}
+func (m *UpdateBundleRequest) XXX_Size() int {
+	return xxx_messageInfo_UpdateBundleRequest.Size(m)
+}
+func (m *UpdateBundleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateBundleRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UpdateBundleRequest proto.InternalMessageInfo
+
+func (m *UpdateBundleRequest) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type UpdateBundleResponse struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *UpdateBundleResponse) Reset()         { *m = UpdateBundleResponse{} }
+func (m *UpdateBundleResponse) String() string { return proto.CompactTextString(m) }
+func (*UpdateBundleResponse) ProtoMessage()    {}
+func (*UpdateBundleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{8}
+}
+func (m *UpdateBundleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateBundleResponse.Unmarshal(m, b)
+}
+func (m *UpdateBundleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateBundleResponse.Marshal(b, m, deterministic)
+}
+func (dst *UpdateBundleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateBundleResponse.Merge(dst, src)
+}
+func (m *UpdateBundleResponse) XXX_Size() int {
+	return xxx_messageInfo_UpdateBundleResponse.Size(m)
+}
+func (m *UpdateBundleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateBundleResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UpdateBundleResponse proto.InternalMessageInfo
+
+func (m *UpdateBundleResponse) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type AppendBundleRequest struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *AppendBundleRequest) Reset()         { *m = AppendBundleRequest{} }
+func (m *AppendBundleRequest) String() string { return proto.CompactTextString(m) }
+func (*AppendBundleRequest) ProtoMessage()    {}
+func (*AppendBundleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{9}
+}
+func (m *AppendBundleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_AppendBundleRequest.Unmarshal(m, b)
+}
+func (m *AppendBundleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_AppendBundleRequest.Marshal(b, m, deterministic)
+}
+func (dst *AppendBundleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AppendBundleRequest.Merge(dst, src)
+}
+func (m *AppendBundleRequest) XXX_Size() int {
+	return xxx_messageInfo_AppendBundleRequest.Size(m)
+}
+func (m *AppendBundleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_AppendBundleRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AppendBundleRequest proto.InternalMessageInfo
+
+func (m *AppendBundleRequest) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type AppendBundleResponse struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *AppendBundleResponse) Reset()         { *m = AppendBundleResponse{} }
+func (m *AppendBundleResponse) String() string { return proto.CompactTextString(m) }
+func (*AppendBundleResponse) ProtoMessage()    {}
+func (*AppendBundleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{10}
+}
+func (m *AppendBundleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_AppendBundleResponse.Unmarshal(m, b)
+}
+func (m *AppendBundleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_AppendBundleResponse.Marshal(b, m, deterministic)
+}
+func (dst *AppendBundleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AppendBundleResponse.Merge(dst, src)
+}
+func (m *AppendBundleResponse) XXX_Size() int {
+	return xxx_messageInfo_AppendBundleResponse.Size(m)
+}
+func (m *AppendBundleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_AppendBundleResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AppendBundleResponse proto.InternalMessageInfo
+
+func (m *AppendBundleResponse) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
+type DeleteBundleRequest struct {
+	TrustDomain          string   `protobuf:"bytes,1,opt,name=trust_domain,json=trustDomain" json:"trust_domain,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteBundleRequest) Reset()         { *m = DeleteBundleRequest{} }
+func (m *DeleteBundleRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteBundleRequest) ProtoMessage()    {}
+func (*DeleteBundleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{11}
+}
+func (m *DeleteBundleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteBundleRequest.Unmarshal(m, b)
+}
+func (m *DeleteBundleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteBundleRequest.Marshal(b, m, deterministic)
+}
+func (dst *DeleteBundleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteBundleRequest.Merge(dst, src)
+}
+func (m *DeleteBundleRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteBundleRequest.Size(m)
+}
+func (m *DeleteBundleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteBundleRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteBundleRequest proto.InternalMessageInfo
+
+func (m *DeleteBundleRequest) GetTrustDomain() string {
+	if m != nil {
+		return m.TrustDomain
+	}
+	return ""
+}
+
+type DeleteBundleResponse struct {
+	Bundle               *Bundle  `protobuf:"bytes,1,opt,name=bundle" json:"bundle,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteBundleResponse) Reset()         { *m = DeleteBundleResponse{} }
+func (m *DeleteBundleResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteBundleResponse) ProtoMessage()    {}
+func (*DeleteBundleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{12}
+}
+func (m *DeleteBundleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteBundleResponse.Unmarshal(m, b)
+}
+func (m *DeleteBundleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteBundleResponse.Marshal(b, m, deterministic)
+}
+func (dst *DeleteBundleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteBundleResponse.Merge(dst, src)
+}
+func (m *DeleteBundleResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteBundleResponse.Size(m)
+}
+func (m *DeleteBundleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteBundleResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteBundleResponse proto.InternalMessageInfo
+
+func (m *DeleteBundleResponse) GetBundle() *Bundle {
+	if m != nil {
+		return m.Bundle
+	}
+	return nil
+}
+
 type NodeResolverMapEntry struct {
-	BaseSpiffeId         string           `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
+	// Node SPIFFE ID
+	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	// Node selector
 	Selector             *common.Selector `protobuf:"bytes,2,opt,name=selector" json:"selector,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
@@ -157,7 +593,7 @@ func (m *NodeResolverMapEntry) Reset()         { *m = NodeResolverMapEntry{} }
 func (m *NodeResolverMapEntry) String() string { return proto.CompactTextString(m) }
 func (*NodeResolverMapEntry) ProtoMessage()    {}
 func (*NodeResolverMapEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{2}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{13}
 }
 func (m *NodeResolverMapEntry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_NodeResolverMapEntry.Unmarshal(m, b)
@@ -177,9 +613,9 @@ func (m *NodeResolverMapEntry) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_NodeResolverMapEntry proto.InternalMessageInfo
 
-func (m *NodeResolverMapEntry) GetBaseSpiffeId() string {
+func (m *NodeResolverMapEntry) GetSpiffeId() string {
 	if m != nil {
-		return m.BaseSpiffeId
+		return m.SpiffeId
 	}
 	return ""
 }
@@ -191,487 +627,8 @@ func (m *NodeResolverMapEntry) GetSelector() *common.Selector {
 	return nil
 }
 
-// Represents a single entry in AttestedNodes and stores the node's
-// SPIFFE ID, the type of attestation it performed, as well as the serial
-// number and expiration date of its node SVID.
-type AttestedNodeEntry struct {
-	// Spiffe ID
-	BaseSpiffeId string `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
-	// Attestation type
-	AttestationDataType string `protobuf:"bytes,2,opt,name=attestationDataType" json:"attestationDataType,omitempty"`
-	// Serial number
-	CertSerialNumber string `protobuf:"bytes,3,opt,name=certSerialNumber" json:"certSerialNumber,omitempty"`
-	// Expiration date
-	CertExpirationDate   string   `protobuf:"bytes,4,opt,name=certExpirationDate" json:"certExpirationDate,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *AttestedNodeEntry) Reset()         { *m = AttestedNodeEntry{} }
-func (m *AttestedNodeEntry) String() string { return proto.CompactTextString(m) }
-func (*AttestedNodeEntry) ProtoMessage()    {}
-func (*AttestedNodeEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{3}
-}
-func (m *AttestedNodeEntry) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_AttestedNodeEntry.Unmarshal(m, b)
-}
-func (m *AttestedNodeEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_AttestedNodeEntry.Marshal(b, m, deterministic)
-}
-func (dst *AttestedNodeEntry) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AttestedNodeEntry.Merge(dst, src)
-}
-func (m *AttestedNodeEntry) XXX_Size() int {
-	return xxx_messageInfo_AttestedNodeEntry.Size(m)
-}
-func (m *AttestedNodeEntry) XXX_DiscardUnknown() {
-	xxx_messageInfo_AttestedNodeEntry.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_AttestedNodeEntry proto.InternalMessageInfo
-
-func (m *AttestedNodeEntry) GetBaseSpiffeId() string {
-	if m != nil {
-		return m.BaseSpiffeId
-	}
-	return ""
-}
-
-func (m *AttestedNodeEntry) GetAttestationDataType() string {
-	if m != nil {
-		return m.AttestationDataType
-	}
-	return ""
-}
-
-func (m *AttestedNodeEntry) GetCertSerialNumber() string {
-	if m != nil {
-		return m.CertSerialNumber
-	}
-	return ""
-}
-
-func (m *AttestedNodeEntry) GetCertExpirationDate() string {
-	if m != nil {
-		return m.CertExpirationDate
-	}
-	return ""
-}
-
-// Represents an Attested Node entry to create
-type CreateAttestedNodeEntryRequest struct {
-	// Attested node entry
-	AttestedNodeEntry    *AttestedNodeEntry `protobuf:"bytes,1,opt,name=attestedNodeEntry" json:"attestedNodeEntry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *CreateAttestedNodeEntryRequest) Reset()         { *m = CreateAttestedNodeEntryRequest{} }
-func (m *CreateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*CreateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{4}
-}
-func (m *CreateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Unmarshal(m, b)
-}
-func (m *CreateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
-}
-func (dst *CreateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateAttestedNodeEntryRequest.Merge(dst, src)
-}
-func (m *CreateAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Size(m)
-}
-func (m *CreateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateAttestedNodeEntryRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateAttestedNodeEntryRequest proto.InternalMessageInfo
-
-func (m *CreateAttestedNodeEntryRequest) GetAttestedNodeEntry() *AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntry
-	}
-	return nil
-}
-
-// Represents the created Attested Node entry
-type CreateAttestedNodeEntryResponse struct {
-	// Attested node entry
-	AttestedNodeEntry    *AttestedNodeEntry `protobuf:"bytes,1,opt,name=attestedNodeEntry" json:"attestedNodeEntry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *CreateAttestedNodeEntryResponse) Reset()         { *m = CreateAttestedNodeEntryResponse{} }
-func (m *CreateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*CreateAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*CreateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{5}
-}
-func (m *CreateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Unmarshal(m, b)
-}
-func (m *CreateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
-}
-func (dst *CreateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateAttestedNodeEntryResponse.Merge(dst, src)
-}
-func (m *CreateAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Size(m)
-}
-func (m *CreateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateAttestedNodeEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateAttestedNodeEntryResponse proto.InternalMessageInfo
-
-func (m *CreateAttestedNodeEntryResponse) GetAttestedNodeEntry() *AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntry
-	}
-	return nil
-}
-
-// Represents the Spiffe ID of the node entry to retrieve
-type FetchAttestedNodeEntryRequest struct {
-	// SPIFFE ID
-	BaseSpiffeId         string   `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *FetchAttestedNodeEntryRequest) Reset()         { *m = FetchAttestedNodeEntryRequest{} }
-func (m *FetchAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*FetchAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{6}
-}
-func (m *FetchAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Unmarshal(m, b)
-}
-func (m *FetchAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Marshal(b, m, deterministic)
-}
-func (dst *FetchAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchAttestedNodeEntryRequest.Merge(dst, src)
-}
-func (m *FetchAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Size(m)
-}
-func (m *FetchAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchAttestedNodeEntryRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_FetchAttestedNodeEntryRequest proto.InternalMessageInfo
-
-func (m *FetchAttestedNodeEntryRequest) GetBaseSpiffeId() string {
-	if m != nil {
-		return m.BaseSpiffeId
-	}
-	return ""
-}
-
-// Represents an Attested Node entry
-type FetchAttestedNodeEntryResponse struct {
-	// Attested node entry
-	AttestedNodeEntry    *AttestedNodeEntry `protobuf:"bytes,1,opt,name=attestedNodeEntry" json:"attestedNodeEntry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *FetchAttestedNodeEntryResponse) Reset()         { *m = FetchAttestedNodeEntryResponse{} }
-func (m *FetchAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*FetchAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{7}
-}
-func (m *FetchAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Unmarshal(m, b)
-}
-func (m *FetchAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Marshal(b, m, deterministic)
-}
-func (dst *FetchAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchAttestedNodeEntryResponse.Merge(dst, src)
-}
-func (m *FetchAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Size(m)
-}
-func (m *FetchAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchAttestedNodeEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_FetchAttestedNodeEntryResponse proto.InternalMessageInfo
-
-func (m *FetchAttestedNodeEntryResponse) GetAttestedNodeEntry() *AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntry
-	}
-	return nil
-}
-
-// Empty Request
-type FetchStaleNodeEntriesRequest struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *FetchStaleNodeEntriesRequest) Reset()         { *m = FetchStaleNodeEntriesRequest{} }
-func (m *FetchStaleNodeEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchStaleNodeEntriesRequest) ProtoMessage()    {}
-func (*FetchStaleNodeEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{8}
-}
-func (m *FetchStaleNodeEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchStaleNodeEntriesRequest.Unmarshal(m, b)
-}
-func (m *FetchStaleNodeEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchStaleNodeEntriesRequest.Marshal(b, m, deterministic)
-}
-func (dst *FetchStaleNodeEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchStaleNodeEntriesRequest.Merge(dst, src)
-}
-func (m *FetchStaleNodeEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_FetchStaleNodeEntriesRequest.Size(m)
-}
-func (m *FetchStaleNodeEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchStaleNodeEntriesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_FetchStaleNodeEntriesRequest proto.InternalMessageInfo
-
-// Represents dead nodes for which the base SVID has expired
-type FetchStaleNodeEntriesResponse struct {
-	// List of attested node entries
-	AttestedNodeEntryList []*AttestedNodeEntry `protobuf:"bytes,1,rep,name=attestedNodeEntryList" json:"attestedNodeEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral  struct{}             `json:"-"`
-	XXX_unrecognized      []byte               `json:"-"`
-	XXX_sizecache         int32                `json:"-"`
-}
-
-func (m *FetchStaleNodeEntriesResponse) Reset()         { *m = FetchStaleNodeEntriesResponse{} }
-func (m *FetchStaleNodeEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchStaleNodeEntriesResponse) ProtoMessage()    {}
-func (*FetchStaleNodeEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{9}
-}
-func (m *FetchStaleNodeEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchStaleNodeEntriesResponse.Unmarshal(m, b)
-}
-func (m *FetchStaleNodeEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchStaleNodeEntriesResponse.Marshal(b, m, deterministic)
-}
-func (dst *FetchStaleNodeEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchStaleNodeEntriesResponse.Merge(dst, src)
-}
-func (m *FetchStaleNodeEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchStaleNodeEntriesResponse.Size(m)
-}
-func (m *FetchStaleNodeEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchStaleNodeEntriesResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_FetchStaleNodeEntriesResponse proto.InternalMessageInfo
-
-func (m *FetchStaleNodeEntriesResponse) GetAttestedNodeEntryList() []*AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntryList
-	}
-	return nil
-}
-
-// Represents Attested node entry fields to update
-type UpdateAttestedNodeEntryRequest struct {
-	// SPIFFE ID
-	BaseSpiffeId string `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
-	// Serial number
-	CertSerialNumber string `protobuf:"bytes,2,opt,name=certSerialNumber" json:"certSerialNumber,omitempty"`
-	// Expiration date
-	CertExpirationDate   string   `protobuf:"bytes,3,opt,name=certExpirationDate" json:"certExpirationDate,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *UpdateAttestedNodeEntryRequest) Reset()         { *m = UpdateAttestedNodeEntryRequest{} }
-func (m *UpdateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*UpdateAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*UpdateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{10}
-}
-func (m *UpdateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Unmarshal(m, b)
-}
-func (m *UpdateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
-}
-func (dst *UpdateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateAttestedNodeEntryRequest.Merge(dst, src)
-}
-func (m *UpdateAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Size(m)
-}
-func (m *UpdateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateAttestedNodeEntryRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_UpdateAttestedNodeEntryRequest proto.InternalMessageInfo
-
-func (m *UpdateAttestedNodeEntryRequest) GetBaseSpiffeId() string {
-	if m != nil {
-		return m.BaseSpiffeId
-	}
-	return ""
-}
-
-func (m *UpdateAttestedNodeEntryRequest) GetCertSerialNumber() string {
-	if m != nil {
-		return m.CertSerialNumber
-	}
-	return ""
-}
-
-func (m *UpdateAttestedNodeEntryRequest) GetCertExpirationDate() string {
-	if m != nil {
-		return m.CertExpirationDate
-	}
-	return ""
-}
-
-// Represents the updated Attested node entry
-type UpdateAttestedNodeEntryResponse struct {
-	// Attested node entry
-	AttestedNodeEntry    *AttestedNodeEntry `protobuf:"bytes,1,opt,name=attestedNodeEntry" json:"attestedNodeEntry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *UpdateAttestedNodeEntryResponse) Reset()         { *m = UpdateAttestedNodeEntryResponse{} }
-func (m *UpdateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*UpdateAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*UpdateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{11}
-}
-func (m *UpdateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Unmarshal(m, b)
-}
-func (m *UpdateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
-}
-func (dst *UpdateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateAttestedNodeEntryResponse.Merge(dst, src)
-}
-func (m *UpdateAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Size(m)
-}
-func (m *UpdateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateAttestedNodeEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_UpdateAttestedNodeEntryResponse proto.InternalMessageInfo
-
-func (m *UpdateAttestedNodeEntryResponse) GetAttestedNodeEntry() *AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntry
-	}
-	return nil
-}
-
-// Represents the Spiffe ID of the Attested node entry to delete
-type DeleteAttestedNodeEntryRequest struct {
-	// SPIFFE ID
-	BaseSpiffeId         string   `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *DeleteAttestedNodeEntryRequest) Reset()         { *m = DeleteAttestedNodeEntryRequest{} }
-func (m *DeleteAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*DeleteAttestedNodeEntryRequest) ProtoMessage()    {}
-func (*DeleteAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{12}
-}
-func (m *DeleteAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Unmarshal(m, b)
-}
-func (m *DeleteAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Marshal(b, m, deterministic)
-}
-func (dst *DeleteAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteAttestedNodeEntryRequest.Merge(dst, src)
-}
-func (m *DeleteAttestedNodeEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Size(m)
-}
-func (m *DeleteAttestedNodeEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteAttestedNodeEntryRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteAttestedNodeEntryRequest proto.InternalMessageInfo
-
-func (m *DeleteAttestedNodeEntryRequest) GetBaseSpiffeId() string {
-	if m != nil {
-		return m.BaseSpiffeId
-	}
-	return ""
-}
-
-// Represents the deleted Attested node entry
-type DeleteAttestedNodeEntryResponse struct {
-	AttestedNodeEntry    *AttestedNodeEntry `protobuf:"bytes,1,opt,name=attestedNodeEntry" json:"attestedNodeEntry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *DeleteAttestedNodeEntryResponse) Reset()         { *m = DeleteAttestedNodeEntryResponse{} }
-func (m *DeleteAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*DeleteAttestedNodeEntryResponse) ProtoMessage()    {}
-func (*DeleteAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{13}
-}
-func (m *DeleteAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Unmarshal(m, b)
-}
-func (m *DeleteAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Marshal(b, m, deterministic)
-}
-func (dst *DeleteAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DeleteAttestedNodeEntryResponse.Merge(dst, src)
-}
-func (m *DeleteAttestedNodeEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Size(m)
-}
-func (m *DeleteAttestedNodeEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_DeleteAttestedNodeEntryResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_DeleteAttestedNodeEntryResponse proto.InternalMessageInfo
-
-func (m *DeleteAttestedNodeEntryResponse) GetAttestedNodeEntry() *AttestedNodeEntry {
-	if m != nil {
-		return m.AttestedNodeEntry
-	}
-	return nil
-}
-
-// Represents a Node resolver map entry to create
 type CreateNodeResolverMapEntryRequest struct {
-	// Node resolver map entry
-	NodeResolverMapEntry *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=nodeResolverMapEntry" json:"nodeResolverMapEntry,omitempty"`
+	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`
@@ -681,7 +638,7 @@ func (m *CreateNodeResolverMapEntryRequest) Reset()         { *m = CreateNodeRes
 func (m *CreateNodeResolverMapEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateNodeResolverMapEntryRequest) ProtoMessage()    {}
 func (*CreateNodeResolverMapEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{14}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{14}
 }
 func (m *CreateNodeResolverMapEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateNodeResolverMapEntryRequest.Unmarshal(m, b)
@@ -701,17 +658,15 @@ func (m *CreateNodeResolverMapEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateNodeResolverMapEntryRequest proto.InternalMessageInfo
 
-func (m *CreateNodeResolverMapEntryRequest) GetNodeResolverMapEntry() *NodeResolverMapEntry {
+func (m *CreateNodeResolverMapEntryRequest) GetEntry() *NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents the created Node resolver map entry
 type CreateNodeResolverMapEntryResponse struct {
-	// Node resolver map entry
-	NodeResolverMapEntry *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=nodeResolverMapEntry" json:"nodeResolverMapEntry,omitempty"`
+	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`
@@ -721,7 +676,7 @@ func (m *CreateNodeResolverMapEntryResponse) Reset()         { *m = CreateNodeRe
 func (m *CreateNodeResolverMapEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateNodeResolverMapEntryResponse) ProtoMessage()    {}
 func (*CreateNodeResolverMapEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{15}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{15}
 }
 func (m *CreateNodeResolverMapEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateNodeResolverMapEntryResponse.Unmarshal(m, b)
@@ -741,97 +696,91 @@ func (m *CreateNodeResolverMapEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateNodeResolverMapEntryResponse proto.InternalMessageInfo
 
-func (m *CreateNodeResolverMapEntryResponse) GetNodeResolverMapEntry() *NodeResolverMapEntry {
+func (m *CreateNodeResolverMapEntryResponse) GetEntry() *NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents a Spiffe ID
-type FetchNodeResolverMapEntryRequest struct {
-	// SPIFFE ID
-	BaseSpiffeId         string   `protobuf:"bytes,1,opt,name=baseSpiffeId" json:"baseSpiffeId,omitempty"`
+type ListNodeResolverMapEntriesRequest struct {
+	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *FetchNodeResolverMapEntryRequest) Reset()         { *m = FetchNodeResolverMapEntryRequest{} }
-func (m *FetchNodeResolverMapEntryRequest) String() string { return proto.CompactTextString(m) }
-func (*FetchNodeResolverMapEntryRequest) ProtoMessage()    {}
-func (*FetchNodeResolverMapEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{16}
+func (m *ListNodeResolverMapEntriesRequest) Reset()         { *m = ListNodeResolverMapEntriesRequest{} }
+func (m *ListNodeResolverMapEntriesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListNodeResolverMapEntriesRequest) ProtoMessage()    {}
+func (*ListNodeResolverMapEntriesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{16}
 }
-func (m *FetchNodeResolverMapEntryRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchNodeResolverMapEntryRequest.Unmarshal(m, b)
+func (m *ListNodeResolverMapEntriesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Unmarshal(m, b)
 }
-func (m *FetchNodeResolverMapEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchNodeResolverMapEntryRequest.Marshal(b, m, deterministic)
+func (m *ListNodeResolverMapEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Marshal(b, m, deterministic)
 }
-func (dst *FetchNodeResolverMapEntryRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchNodeResolverMapEntryRequest.Merge(dst, src)
+func (dst *ListNodeResolverMapEntriesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListNodeResolverMapEntriesRequest.Merge(dst, src)
 }
-func (m *FetchNodeResolverMapEntryRequest) XXX_Size() int {
-	return xxx_messageInfo_FetchNodeResolverMapEntryRequest.Size(m)
+func (m *ListNodeResolverMapEntriesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListNodeResolverMapEntriesRequest.Size(m)
 }
-func (m *FetchNodeResolverMapEntryRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchNodeResolverMapEntryRequest.DiscardUnknown(m)
+func (m *ListNodeResolverMapEntriesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListNodeResolverMapEntriesRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FetchNodeResolverMapEntryRequest proto.InternalMessageInfo
+var xxx_messageInfo_ListNodeResolverMapEntriesRequest proto.InternalMessageInfo
 
-func (m *FetchNodeResolverMapEntryRequest) GetBaseSpiffeId() string {
+func (m *ListNodeResolverMapEntriesRequest) GetSpiffeId() string {
 	if m != nil {
-		return m.BaseSpiffeId
+		return m.SpiffeId
 	}
 	return ""
 }
 
-// Represents a list of Node resolver map entries for the specified Spiffe ID
-type FetchNodeResolverMapEntryResponse struct {
-	// List of Node resolver map entries
-	NodeResolverMapEntryList []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=nodeResolverMapEntryList" json:"nodeResolverMapEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral     struct{}                `json:"-"`
-	XXX_unrecognized         []byte                  `json:"-"`
-	XXX_sizecache            int32                   `json:"-"`
+type ListNodeResolverMapEntriesResponse struct {
+	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
 }
 
-func (m *FetchNodeResolverMapEntryResponse) Reset()         { *m = FetchNodeResolverMapEntryResponse{} }
-func (m *FetchNodeResolverMapEntryResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchNodeResolverMapEntryResponse) ProtoMessage()    {}
-func (*FetchNodeResolverMapEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{17}
+func (m *ListNodeResolverMapEntriesResponse) Reset()         { *m = ListNodeResolverMapEntriesResponse{} }
+func (m *ListNodeResolverMapEntriesResponse) String() string { return proto.CompactTextString(m) }
+func (*ListNodeResolverMapEntriesResponse) ProtoMessage()    {}
+func (*ListNodeResolverMapEntriesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{17}
 }
-func (m *FetchNodeResolverMapEntryResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchNodeResolverMapEntryResponse.Unmarshal(m, b)
+func (m *ListNodeResolverMapEntriesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Unmarshal(m, b)
 }
-func (m *FetchNodeResolverMapEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchNodeResolverMapEntryResponse.Marshal(b, m, deterministic)
+func (m *ListNodeResolverMapEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Marshal(b, m, deterministic)
 }
-func (dst *FetchNodeResolverMapEntryResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchNodeResolverMapEntryResponse.Merge(dst, src)
+func (dst *ListNodeResolverMapEntriesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListNodeResolverMapEntriesResponse.Merge(dst, src)
 }
-func (m *FetchNodeResolverMapEntryResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchNodeResolverMapEntryResponse.Size(m)
+func (m *ListNodeResolverMapEntriesResponse) XXX_Size() int {
+	return xxx_messageInfo_ListNodeResolverMapEntriesResponse.Size(m)
 }
-func (m *FetchNodeResolverMapEntryResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchNodeResolverMapEntryResponse.DiscardUnknown(m)
+func (m *ListNodeResolverMapEntriesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListNodeResolverMapEntriesResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FetchNodeResolverMapEntryResponse proto.InternalMessageInfo
+var xxx_messageInfo_ListNodeResolverMapEntriesResponse proto.InternalMessageInfo
 
-func (m *FetchNodeResolverMapEntryResponse) GetNodeResolverMapEntryList() []*NodeResolverMapEntry {
+func (m *ListNodeResolverMapEntriesResponse) GetEntries() []*NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntryList
+		return m.Entries
 	}
 	return nil
 }
 
-// Represents a Node resolver map entry to delete
 type DeleteNodeResolverMapEntryRequest struct {
-	// Node resolver map entry
-	NodeResolverMapEntry *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=nodeResolverMapEntry" json:"nodeResolverMapEntry,omitempty"`
+	Entry                *NodeResolverMapEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
 	XXX_sizecache        int32                 `json:"-"`
@@ -841,7 +790,7 @@ func (m *DeleteNodeResolverMapEntryRequest) Reset()         { *m = DeleteNodeRes
 func (m *DeleteNodeResolverMapEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteNodeResolverMapEntryRequest) ProtoMessage()    {}
 func (*DeleteNodeResolverMapEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{18}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{18}
 }
 func (m *DeleteNodeResolverMapEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteNodeResolverMapEntryRequest.Unmarshal(m, b)
@@ -861,27 +810,25 @@ func (m *DeleteNodeResolverMapEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteNodeResolverMapEntryRequest proto.InternalMessageInfo
 
-func (m *DeleteNodeResolverMapEntryRequest) GetNodeResolverMapEntry() *NodeResolverMapEntry {
+func (m *DeleteNodeResolverMapEntryRequest) GetEntry() *NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents a list of Node resolver map entries
 type DeleteNodeResolverMapEntryResponse struct {
-	// List of Node resolver map entries
-	NodeResolverMapEntryList []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=nodeResolverMapEntryList" json:"nodeResolverMapEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral     struct{}                `json:"-"`
-	XXX_unrecognized         []byte                  `json:"-"`
-	XXX_sizecache            int32                   `json:"-"`
+	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
 }
 
 func (m *DeleteNodeResolverMapEntryResponse) Reset()         { *m = DeleteNodeResolverMapEntryResponse{} }
 func (m *DeleteNodeResolverMapEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteNodeResolverMapEntryResponse) ProtoMessage()    {}
 func (*DeleteNodeResolverMapEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{19}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{19}
 }
 func (m *DeleteNodeResolverMapEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteNodeResolverMapEntryResponse.Unmarshal(m, b)
@@ -901,27 +848,25 @@ func (m *DeleteNodeResolverMapEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteNodeResolverMapEntryResponse proto.InternalMessageInfo
 
-func (m *DeleteNodeResolverMapEntryResponse) GetNodeResolverMapEntryList() []*NodeResolverMapEntry {
+func (m *DeleteNodeResolverMapEntryResponse) GetEntries() []*NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntryList
+		return m.Entries
 	}
 	return nil
 }
 
-// Represents a list of Node resolver map entries
 type RectifyNodeResolverMapEntriesRequest struct {
-	// List of Node resolver map entries
-	NodeResolverMapEntryList []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=nodeResolverMapEntryList" json:"nodeResolverMapEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral     struct{}                `json:"-"`
-	XXX_unrecognized         []byte                  `json:"-"`
-	XXX_sizecache            int32                   `json:"-"`
+	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
 }
 
 func (m *RectifyNodeResolverMapEntriesRequest) Reset()         { *m = RectifyNodeResolverMapEntriesRequest{} }
 func (m *RectifyNodeResolverMapEntriesRequest) String() string { return proto.CompactTextString(m) }
 func (*RectifyNodeResolverMapEntriesRequest) ProtoMessage()    {}
 func (*RectifyNodeResolverMapEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{20}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{20}
 }
 func (m *RectifyNodeResolverMapEntriesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RectifyNodeResolverMapEntriesRequest.Unmarshal(m, b)
@@ -941,27 +886,25 @@ func (m *RectifyNodeResolverMapEntriesRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RectifyNodeResolverMapEntriesRequest proto.InternalMessageInfo
 
-func (m *RectifyNodeResolverMapEntriesRequest) GetNodeResolverMapEntryList() []*NodeResolverMapEntry {
+func (m *RectifyNodeResolverMapEntriesRequest) GetEntries() []*NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntryList
+		return m.Entries
 	}
 	return nil
 }
 
-// Represents a list of Node resolver map entries
 type RectifyNodeResolverMapEntriesResponse struct {
-	// List of Node resolver map entries
-	NodeResolverMapEntryList []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=nodeResolverMapEntryList" json:"nodeResolverMapEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral     struct{}                `json:"-"`
-	XXX_unrecognized         []byte                  `json:"-"`
-	XXX_sizecache            int32                   `json:"-"`
+	Entries              []*NodeResolverMapEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
+	XXX_unrecognized     []byte                  `json:"-"`
+	XXX_sizecache        int32                   `json:"-"`
 }
 
 func (m *RectifyNodeResolverMapEntriesResponse) Reset()         { *m = RectifyNodeResolverMapEntriesResponse{} }
 func (m *RectifyNodeResolverMapEntriesResponse) String() string { return proto.CompactTextString(m) }
 func (*RectifyNodeResolverMapEntriesResponse) ProtoMessage()    {}
 func (*RectifyNodeResolverMapEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{21}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{21}
 }
 func (m *RectifyNodeResolverMapEntriesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RectifyNodeResolverMapEntriesResponse.Unmarshal(m, b)
@@ -981,17 +924,477 @@ func (m *RectifyNodeResolverMapEntriesResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RectifyNodeResolverMapEntriesResponse proto.InternalMessageInfo
 
-func (m *RectifyNodeResolverMapEntriesResponse) GetNodeResolverMapEntryList() []*NodeResolverMapEntry {
+func (m *RectifyNodeResolverMapEntriesResponse) GetEntries() []*NodeResolverMapEntry {
 	if m != nil {
-		return m.NodeResolverMapEntryList
+		return m.Entries
 	}
 	return nil
 }
 
-// Represents a Registration entry to create
+type AttestedNodeEntry struct {
+	// Node SPIFFE ID
+	SpiffeId string `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	// Attestation data type
+	AttestationDataType string `protobuf:"bytes,2,opt,name=attestation_data_type,json=attestationDataType" json:"attestation_data_type,omitempty"`
+	// Node certificate serial number
+	CertSerialNumber string `protobuf:"bytes,3,opt,name=cert_serial_number,json=certSerialNumber" json:"cert_serial_number,omitempty"`
+	// Node certificate not_after (seconds since unix epoch)
+	CertNotAfter         int64    `protobuf:"varint,4,opt,name=cert_not_after,json=certNotAfter" json:"cert_not_after,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *AttestedNodeEntry) Reset()         { *m = AttestedNodeEntry{} }
+func (m *AttestedNodeEntry) String() string { return proto.CompactTextString(m) }
+func (*AttestedNodeEntry) ProtoMessage()    {}
+func (*AttestedNodeEntry) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{22}
+}
+func (m *AttestedNodeEntry) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_AttestedNodeEntry.Unmarshal(m, b)
+}
+func (m *AttestedNodeEntry) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_AttestedNodeEntry.Marshal(b, m, deterministic)
+}
+func (dst *AttestedNodeEntry) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AttestedNodeEntry.Merge(dst, src)
+}
+func (m *AttestedNodeEntry) XXX_Size() int {
+	return xxx_messageInfo_AttestedNodeEntry.Size(m)
+}
+func (m *AttestedNodeEntry) XXX_DiscardUnknown() {
+	xxx_messageInfo_AttestedNodeEntry.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_AttestedNodeEntry proto.InternalMessageInfo
+
+func (m *AttestedNodeEntry) GetSpiffeId() string {
+	if m != nil {
+		return m.SpiffeId
+	}
+	return ""
+}
+
+func (m *AttestedNodeEntry) GetAttestationDataType() string {
+	if m != nil {
+		return m.AttestationDataType
+	}
+	return ""
+}
+
+func (m *AttestedNodeEntry) GetCertSerialNumber() string {
+	if m != nil {
+		return m.CertSerialNumber
+	}
+	return ""
+}
+
+func (m *AttestedNodeEntry) GetCertNotAfter() int64 {
+	if m != nil {
+		return m.CertNotAfter
+	}
+	return 0
+}
+
+type CreateAttestedNodeEntryRequest struct {
+	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *CreateAttestedNodeEntryRequest) Reset()         { *m = CreateAttestedNodeEntryRequest{} }
+func (m *CreateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateAttestedNodeEntryRequest) ProtoMessage()    {}
+func (*CreateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{23}
+}
+func (m *CreateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Unmarshal(m, b)
+}
+func (m *CreateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+}
+func (dst *CreateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateAttestedNodeEntryRequest.Merge(dst, src)
+}
+func (m *CreateAttestedNodeEntryRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateAttestedNodeEntryRequest.Size(m)
+}
+func (m *CreateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateAttestedNodeEntryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateAttestedNodeEntryRequest proto.InternalMessageInfo
+
+func (m *CreateAttestedNodeEntryRequest) GetEntry() *AttestedNodeEntry {
+	if m != nil {
+		return m.Entry
+	}
+	return nil
+}
+
+type CreateAttestedNodeEntryResponse struct {
+	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *CreateAttestedNodeEntryResponse) Reset()         { *m = CreateAttestedNodeEntryResponse{} }
+func (m *CreateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateAttestedNodeEntryResponse) ProtoMessage()    {}
+func (*CreateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{24}
+}
+func (m *CreateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Unmarshal(m, b)
+}
+func (m *CreateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+}
+func (dst *CreateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateAttestedNodeEntryResponse.Merge(dst, src)
+}
+func (m *CreateAttestedNodeEntryResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateAttestedNodeEntryResponse.Size(m)
+}
+func (m *CreateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateAttestedNodeEntryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateAttestedNodeEntryResponse proto.InternalMessageInfo
+
+func (m *CreateAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+	if m != nil {
+		return m.Entry
+	}
+	return nil
+}
+
+type FetchAttestedNodeEntryRequest struct {
+	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *FetchAttestedNodeEntryRequest) Reset()         { *m = FetchAttestedNodeEntryRequest{} }
+func (m *FetchAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchAttestedNodeEntryRequest) ProtoMessage()    {}
+func (*FetchAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{25}
+}
+func (m *FetchAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Unmarshal(m, b)
+}
+func (m *FetchAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+}
+func (dst *FetchAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchAttestedNodeEntryRequest.Merge(dst, src)
+}
+func (m *FetchAttestedNodeEntryRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchAttestedNodeEntryRequest.Size(m)
+}
+func (m *FetchAttestedNodeEntryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchAttestedNodeEntryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchAttestedNodeEntryRequest proto.InternalMessageInfo
+
+func (m *FetchAttestedNodeEntryRequest) GetSpiffeId() string {
+	if m != nil {
+		return m.SpiffeId
+	}
+	return ""
+}
+
+type FetchAttestedNodeEntryResponse struct {
+	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *FetchAttestedNodeEntryResponse) Reset()         { *m = FetchAttestedNodeEntryResponse{} }
+func (m *FetchAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchAttestedNodeEntryResponse) ProtoMessage()    {}
+func (*FetchAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{26}
+}
+func (m *FetchAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Unmarshal(m, b)
+}
+func (m *FetchAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+}
+func (dst *FetchAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchAttestedNodeEntryResponse.Merge(dst, src)
+}
+func (m *FetchAttestedNodeEntryResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchAttestedNodeEntryResponse.Size(m)
+}
+func (m *FetchAttestedNodeEntryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchAttestedNodeEntryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchAttestedNodeEntryResponse proto.InternalMessageInfo
+
+func (m *FetchAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+	if m != nil {
+		return m.Entry
+	}
+	return nil
+}
+
+type ListAttestedNodeEntriesRequest struct {
+	ByExpiresBefore      *wrappers.Int64Value `protobuf:"bytes,1,opt,name=by_expires_before,json=byExpiresBefore" json:"by_expires_before,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
+	XXX_unrecognized     []byte               `json:"-"`
+	XXX_sizecache        int32                `json:"-"`
+}
+
+func (m *ListAttestedNodeEntriesRequest) Reset()         { *m = ListAttestedNodeEntriesRequest{} }
+func (m *ListAttestedNodeEntriesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListAttestedNodeEntriesRequest) ProtoMessage()    {}
+func (*ListAttestedNodeEntriesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{27}
+}
+func (m *ListAttestedNodeEntriesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Unmarshal(m, b)
+}
+func (m *ListAttestedNodeEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Marshal(b, m, deterministic)
+}
+func (dst *ListAttestedNodeEntriesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListAttestedNodeEntriesRequest.Merge(dst, src)
+}
+func (m *ListAttestedNodeEntriesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListAttestedNodeEntriesRequest.Size(m)
+}
+func (m *ListAttestedNodeEntriesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListAttestedNodeEntriesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListAttestedNodeEntriesRequest proto.InternalMessageInfo
+
+func (m *ListAttestedNodeEntriesRequest) GetByExpiresBefore() *wrappers.Int64Value {
+	if m != nil {
+		return m.ByExpiresBefore
+	}
+	return nil
+}
+
+type ListAttestedNodeEntriesResponse struct {
+	Entries              []*AttestedNodeEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
+	XXX_unrecognized     []byte               `json:"-"`
+	XXX_sizecache        int32                `json:"-"`
+}
+
+func (m *ListAttestedNodeEntriesResponse) Reset()         { *m = ListAttestedNodeEntriesResponse{} }
+func (m *ListAttestedNodeEntriesResponse) String() string { return proto.CompactTextString(m) }
+func (*ListAttestedNodeEntriesResponse) ProtoMessage()    {}
+func (*ListAttestedNodeEntriesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{28}
+}
+func (m *ListAttestedNodeEntriesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Unmarshal(m, b)
+}
+func (m *ListAttestedNodeEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Marshal(b, m, deterministic)
+}
+func (dst *ListAttestedNodeEntriesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListAttestedNodeEntriesResponse.Merge(dst, src)
+}
+func (m *ListAttestedNodeEntriesResponse) XXX_Size() int {
+	return xxx_messageInfo_ListAttestedNodeEntriesResponse.Size(m)
+}
+func (m *ListAttestedNodeEntriesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListAttestedNodeEntriesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListAttestedNodeEntriesResponse proto.InternalMessageInfo
+
+func (m *ListAttestedNodeEntriesResponse) GetEntries() []*AttestedNodeEntry {
+	if m != nil {
+		return m.Entries
+	}
+	return nil
+}
+
+type UpdateAttestedNodeEntryRequest struct {
+	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	CertSerialNumber     string   `protobuf:"bytes,2,opt,name=cert_serial_number,json=certSerialNumber" json:"cert_serial_number,omitempty"`
+	CertNotAfter         int64    `protobuf:"varint,3,opt,name=cert_not_after,json=certNotAfter" json:"cert_not_after,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *UpdateAttestedNodeEntryRequest) Reset()         { *m = UpdateAttestedNodeEntryRequest{} }
+func (m *UpdateAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
+func (*UpdateAttestedNodeEntryRequest) ProtoMessage()    {}
+func (*UpdateAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{29}
+}
+func (m *UpdateAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Unmarshal(m, b)
+}
+func (m *UpdateAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+}
+func (dst *UpdateAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateAttestedNodeEntryRequest.Merge(dst, src)
+}
+func (m *UpdateAttestedNodeEntryRequest) XXX_Size() int {
+	return xxx_messageInfo_UpdateAttestedNodeEntryRequest.Size(m)
+}
+func (m *UpdateAttestedNodeEntryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateAttestedNodeEntryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UpdateAttestedNodeEntryRequest proto.InternalMessageInfo
+
+func (m *UpdateAttestedNodeEntryRequest) GetSpiffeId() string {
+	if m != nil {
+		return m.SpiffeId
+	}
+	return ""
+}
+
+func (m *UpdateAttestedNodeEntryRequest) GetCertSerialNumber() string {
+	if m != nil {
+		return m.CertSerialNumber
+	}
+	return ""
+}
+
+func (m *UpdateAttestedNodeEntryRequest) GetCertNotAfter() int64 {
+	if m != nil {
+		return m.CertNotAfter
+	}
+	return 0
+}
+
+type UpdateAttestedNodeEntryResponse struct {
+	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *UpdateAttestedNodeEntryResponse) Reset()         { *m = UpdateAttestedNodeEntryResponse{} }
+func (m *UpdateAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
+func (*UpdateAttestedNodeEntryResponse) ProtoMessage()    {}
+func (*UpdateAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{30}
+}
+func (m *UpdateAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Unmarshal(m, b)
+}
+func (m *UpdateAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+}
+func (dst *UpdateAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_UpdateAttestedNodeEntryResponse.Merge(dst, src)
+}
+func (m *UpdateAttestedNodeEntryResponse) XXX_Size() int {
+	return xxx_messageInfo_UpdateAttestedNodeEntryResponse.Size(m)
+}
+func (m *UpdateAttestedNodeEntryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_UpdateAttestedNodeEntryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_UpdateAttestedNodeEntryResponse proto.InternalMessageInfo
+
+func (m *UpdateAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+	if m != nil {
+		return m.Entry
+	}
+	return nil
+}
+
+type DeleteAttestedNodeEntryRequest struct {
+	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffe_id,json=spiffeId" json:"spiffe_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteAttestedNodeEntryRequest) Reset()         { *m = DeleteAttestedNodeEntryRequest{} }
+func (m *DeleteAttestedNodeEntryRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteAttestedNodeEntryRequest) ProtoMessage()    {}
+func (*DeleteAttestedNodeEntryRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{31}
+}
+func (m *DeleteAttestedNodeEntryRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Unmarshal(m, b)
+}
+func (m *DeleteAttestedNodeEntryRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Marshal(b, m, deterministic)
+}
+func (dst *DeleteAttestedNodeEntryRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteAttestedNodeEntryRequest.Merge(dst, src)
+}
+func (m *DeleteAttestedNodeEntryRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteAttestedNodeEntryRequest.Size(m)
+}
+func (m *DeleteAttestedNodeEntryRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteAttestedNodeEntryRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteAttestedNodeEntryRequest proto.InternalMessageInfo
+
+func (m *DeleteAttestedNodeEntryRequest) GetSpiffeId() string {
+	if m != nil {
+		return m.SpiffeId
+	}
+	return ""
+}
+
+type DeleteAttestedNodeEntryResponse struct {
+	Entry                *AttestedNodeEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *DeleteAttestedNodeEntryResponse) Reset()         { *m = DeleteAttestedNodeEntryResponse{} }
+func (m *DeleteAttestedNodeEntryResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteAttestedNodeEntryResponse) ProtoMessage()    {}
+func (*DeleteAttestedNodeEntryResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{32}
+}
+func (m *DeleteAttestedNodeEntryResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Unmarshal(m, b)
+}
+func (m *DeleteAttestedNodeEntryResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Marshal(b, m, deterministic)
+}
+func (dst *DeleteAttestedNodeEntryResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteAttestedNodeEntryResponse.Merge(dst, src)
+}
+func (m *DeleteAttestedNodeEntryResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteAttestedNodeEntryResponse.Size(m)
+}
+func (m *DeleteAttestedNodeEntryResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteAttestedNodeEntryResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteAttestedNodeEntryResponse proto.InternalMessageInfo
+
+func (m *DeleteAttestedNodeEntryResponse) GetEntry() *AttestedNodeEntry {
+	if m != nil {
+		return m.Entry
+	}
+	return nil
+}
+
 type CreateRegistrationEntryRequest struct {
-	// Registration entry
-	RegisteredEntry      *common.RegistrationEntry `protobuf:"bytes,1,opt,name=registeredEntry" json:"registeredEntry,omitempty"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -1001,7 +1404,7 @@ func (m *CreateRegistrationEntryRequest) Reset()         { *m = CreateRegistrati
 func (m *CreateRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*CreateRegistrationEntryRequest) ProtoMessage()    {}
 func (*CreateRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{22}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{33}
 }
 func (m *CreateRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateRegistrationEntryRequest.Unmarshal(m, b)
@@ -1021,17 +1424,15 @@ func (m *CreateRegistrationEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateRegistrationEntryRequest proto.InternalMessageInfo
 
-func (m *CreateRegistrationEntryRequest) GetRegisteredEntry() *common.RegistrationEntry {
+func (m *CreateRegistrationEntryRequest) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents the created Registration entry
 type CreateRegistrationEntryResponse struct {
-	// Registration entry ID
-	RegisteredEntryId    string   `protobuf:"bytes,1,opt,name=registeredEntryId" json:"registeredEntryId,omitempty"`
+	EntryId              string   `protobuf:"bytes,1,opt,name=entry_id,json=entryId" json:"entry_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1041,7 +1442,7 @@ func (m *CreateRegistrationEntryResponse) Reset()         { *m = CreateRegistrat
 func (m *CreateRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*CreateRegistrationEntryResponse) ProtoMessage()    {}
 func (*CreateRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{23}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{34}
 }
 func (m *CreateRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CreateRegistrationEntryResponse.Unmarshal(m, b)
@@ -1061,17 +1462,15 @@ func (m *CreateRegistrationEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_CreateRegistrationEntryResponse proto.InternalMessageInfo
 
-func (m *CreateRegistrationEntryResponse) GetRegisteredEntryId() string {
+func (m *CreateRegistrationEntryResponse) GetEntryId() string {
 	if m != nil {
-		return m.RegisteredEntryId
+		return m.EntryId
 	}
 	return ""
 }
 
-// Represents a Registration entry ID to fetch
 type FetchRegistrationEntryRequest struct {
-	// Registration entry ID
-	RegisteredEntryId    string   `protobuf:"bytes,1,opt,name=registeredEntryId" json:"registeredEntryId,omitempty"`
+	EntryId              string   `protobuf:"bytes,1,opt,name=entry_id,json=entryId" json:"entry_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1081,7 +1480,7 @@ func (m *FetchRegistrationEntryRequest) Reset()         { *m = FetchRegistration
 func (m *FetchRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchRegistrationEntryRequest) ProtoMessage()    {}
 func (*FetchRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{24}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{35}
 }
 func (m *FetchRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchRegistrationEntryRequest.Unmarshal(m, b)
@@ -1101,17 +1500,15 @@ func (m *FetchRegistrationEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FetchRegistrationEntryRequest proto.InternalMessageInfo
 
-func (m *FetchRegistrationEntryRequest) GetRegisteredEntryId() string {
+func (m *FetchRegistrationEntryRequest) GetEntryId() string {
 	if m != nil {
-		return m.RegisteredEntryId
+		return m.EntryId
 	}
 	return ""
 }
 
-// Represents a Registration entry
 type FetchRegistrationEntryResponse struct {
-	// Registration entry
-	RegisteredEntry      *common.RegistrationEntry `protobuf:"bytes,1,opt,name=registeredEntry" json:"registeredEntry,omitempty"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -1121,7 +1518,7 @@ func (m *FetchRegistrationEntryResponse) Reset()         { *m = FetchRegistratio
 func (m *FetchRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchRegistrationEntryResponse) ProtoMessage()    {}
 func (*FetchRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{25}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{36}
 }
 func (m *FetchRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchRegistrationEntryResponse.Unmarshal(m, b)
@@ -1141,59 +1538,153 @@ func (m *FetchRegistrationEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FetchRegistrationEntryResponse proto.InternalMessageInfo
 
-func (m *FetchRegistrationEntryResponse) GetRegisteredEntry() *common.RegistrationEntry {
+func (m *FetchRegistrationEntryResponse) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents a list of Registration entries
-type FetchRegistrationEntriesResponse struct {
-	// Registration entries
-	RegisteredEntries    *common.RegistrationEntries `protobuf:"bytes,1,opt,name=registeredEntries" json:"registeredEntries,omitempty"`
+type BySelectors struct {
+	Selectors            []*common.Selector `protobuf:"bytes,1,rep,name=selectors" json:"selectors,omitempty"`
+	AllowAnyCombination  bool               `protobuf:"varint,2,opt,name=allow_any_combination,json=allowAnyCombination" json:"allow_any_combination,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
+	XXX_unrecognized     []byte             `json:"-"`
+	XXX_sizecache        int32              `json:"-"`
+}
+
+func (m *BySelectors) Reset()         { *m = BySelectors{} }
+func (m *BySelectors) String() string { return proto.CompactTextString(m) }
+func (*BySelectors) ProtoMessage()    {}
+func (*BySelectors) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{37}
+}
+func (m *BySelectors) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_BySelectors.Unmarshal(m, b)
+}
+func (m *BySelectors) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_BySelectors.Marshal(b, m, deterministic)
+}
+func (dst *BySelectors) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BySelectors.Merge(dst, src)
+}
+func (m *BySelectors) XXX_Size() int {
+	return xxx_messageInfo_BySelectors.Size(m)
+}
+func (m *BySelectors) XXX_DiscardUnknown() {
+	xxx_messageInfo_BySelectors.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BySelectors proto.InternalMessageInfo
+
+func (m *BySelectors) GetSelectors() []*common.Selector {
+	if m != nil {
+		return m.Selectors
+	}
+	return nil
+}
+
+func (m *BySelectors) GetAllowAnyCombination() bool {
+	if m != nil {
+		return m.AllowAnyCombination
+	}
+	return false
+}
+
+type ListRegistrationEntriesRequest struct {
+	ByParentId           *wrappers.StringValue `protobuf:"bytes,1,opt,name=by_parent_id,json=byParentId" json:"by_parent_id,omitempty"`
+	BySelectors          *BySelectors          `protobuf:"bytes,2,opt,name=by_selectors,json=bySelectors" json:"by_selectors,omitempty"`
+	BySpiffeId           *wrappers.StringValue `protobuf:"bytes,3,opt,name=by_spiffe_id,json=bySpiffeId" json:"by_spiffe_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
+	XXX_unrecognized     []byte                `json:"-"`
+	XXX_sizecache        int32                 `json:"-"`
+}
+
+func (m *ListRegistrationEntriesRequest) Reset()         { *m = ListRegistrationEntriesRequest{} }
+func (m *ListRegistrationEntriesRequest) String() string { return proto.CompactTextString(m) }
+func (*ListRegistrationEntriesRequest) ProtoMessage()    {}
+func (*ListRegistrationEntriesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{38}
+}
+func (m *ListRegistrationEntriesRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListRegistrationEntriesRequest.Unmarshal(m, b)
+}
+func (m *ListRegistrationEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListRegistrationEntriesRequest.Marshal(b, m, deterministic)
+}
+func (dst *ListRegistrationEntriesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListRegistrationEntriesRequest.Merge(dst, src)
+}
+func (m *ListRegistrationEntriesRequest) XXX_Size() int {
+	return xxx_messageInfo_ListRegistrationEntriesRequest.Size(m)
+}
+func (m *ListRegistrationEntriesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListRegistrationEntriesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ListRegistrationEntriesRequest proto.InternalMessageInfo
+
+func (m *ListRegistrationEntriesRequest) GetByParentId() *wrappers.StringValue {
+	if m != nil {
+		return m.ByParentId
+	}
+	return nil
+}
+
+func (m *ListRegistrationEntriesRequest) GetBySelectors() *BySelectors {
+	if m != nil {
+		return m.BySelectors
+	}
+	return nil
+}
+
+func (m *ListRegistrationEntriesRequest) GetBySpiffeId() *wrappers.StringValue {
+	if m != nil {
+		return m.BySpiffeId
+	}
+	return nil
+}
+
+type ListRegistrationEntriesResponse struct {
+	Entries              []*common.RegistrationEntry `protobuf:"bytes,1,rep,name=entries" json:"entries,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
 	XXX_unrecognized     []byte                      `json:"-"`
 	XXX_sizecache        int32                       `json:"-"`
 }
 
-func (m *FetchRegistrationEntriesResponse) Reset()         { *m = FetchRegistrationEntriesResponse{} }
-func (m *FetchRegistrationEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*FetchRegistrationEntriesResponse) ProtoMessage()    {}
-func (*FetchRegistrationEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{26}
+func (m *ListRegistrationEntriesResponse) Reset()         { *m = ListRegistrationEntriesResponse{} }
+func (m *ListRegistrationEntriesResponse) String() string { return proto.CompactTextString(m) }
+func (*ListRegistrationEntriesResponse) ProtoMessage()    {}
+func (*ListRegistrationEntriesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{39}
 }
-func (m *FetchRegistrationEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FetchRegistrationEntriesResponse.Unmarshal(m, b)
+func (m *ListRegistrationEntriesResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ListRegistrationEntriesResponse.Unmarshal(m, b)
 }
-func (m *FetchRegistrationEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FetchRegistrationEntriesResponse.Marshal(b, m, deterministic)
+func (m *ListRegistrationEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ListRegistrationEntriesResponse.Marshal(b, m, deterministic)
 }
-func (dst *FetchRegistrationEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchRegistrationEntriesResponse.Merge(dst, src)
+func (dst *ListRegistrationEntriesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ListRegistrationEntriesResponse.Merge(dst, src)
 }
-func (m *FetchRegistrationEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_FetchRegistrationEntriesResponse.Size(m)
+func (m *ListRegistrationEntriesResponse) XXX_Size() int {
+	return xxx_messageInfo_ListRegistrationEntriesResponse.Size(m)
 }
-func (m *FetchRegistrationEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_FetchRegistrationEntriesResponse.DiscardUnknown(m)
+func (m *ListRegistrationEntriesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ListRegistrationEntriesResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FetchRegistrationEntriesResponse proto.InternalMessageInfo
+var xxx_messageInfo_ListRegistrationEntriesResponse proto.InternalMessageInfo
 
-func (m *FetchRegistrationEntriesResponse) GetRegisteredEntries() *common.RegistrationEntries {
+func (m *ListRegistrationEntriesResponse) GetEntries() []*common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntries
+		return m.Entries
 	}
 	return nil
 }
 
-// Represents a Registration entry to update
 type UpdateRegistrationEntryRequest struct {
-	// Registration entry ID
-	RegisteredEntryId string `protobuf:"bytes,1,opt,name=registeredEntryId" json:"registeredEntryId,omitempty"`
-	// Registration entry
-	RegisteredEntry      *common.RegistrationEntry `protobuf:"bytes,2,opt,name=registeredEntry" json:"registeredEntry,omitempty"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -1203,7 +1694,7 @@ func (m *UpdateRegistrationEntryRequest) Reset()         { *m = UpdateRegistrati
 func (m *UpdateRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*UpdateRegistrationEntryRequest) ProtoMessage()    {}
 func (*UpdateRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{27}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{40}
 }
 func (m *UpdateRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateRegistrationEntryRequest.Unmarshal(m, b)
@@ -1223,24 +1714,15 @@ func (m *UpdateRegistrationEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_UpdateRegistrationEntryRequest proto.InternalMessageInfo
 
-func (m *UpdateRegistrationEntryRequest) GetRegisteredEntryId() string {
+func (m *UpdateRegistrationEntryRequest) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntryId
-	}
-	return ""
-}
-
-func (m *UpdateRegistrationEntryRequest) GetRegisteredEntry() *common.RegistrationEntry {
-	if m != nil {
-		return m.RegisteredEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents the updated Registration entry
 type UpdateRegistrationEntryResponse struct {
-	// Registration entry
-	RegisteredEntry      *common.RegistrationEntry `protobuf:"bytes,1,opt,name=registeredEntry" json:"registeredEntry,omitempty"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -1250,7 +1732,7 @@ func (m *UpdateRegistrationEntryResponse) Reset()         { *m = UpdateRegistrat
 func (m *UpdateRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*UpdateRegistrationEntryResponse) ProtoMessage()    {}
 func (*UpdateRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{28}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{41}
 }
 func (m *UpdateRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_UpdateRegistrationEntryResponse.Unmarshal(m, b)
@@ -1270,17 +1752,15 @@ func (m *UpdateRegistrationEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_UpdateRegistrationEntryResponse proto.InternalMessageInfo
 
-func (m *UpdateRegistrationEntryResponse) GetRegisteredEntry() *common.RegistrationEntry {
+func (m *UpdateRegistrationEntryResponse) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents a Registration entry ID to delete
 type DeleteRegistrationEntryRequest struct {
-	// Registration entry ID
-	RegisteredEntryId    string   `protobuf:"bytes,1,opt,name=registeredEntryId" json:"registeredEntryId,omitempty"`
+	EntryId              string   `protobuf:"bytes,1,opt,name=entry_id,json=entryId" json:"entry_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
@@ -1290,7 +1770,7 @@ func (m *DeleteRegistrationEntryRequest) Reset()         { *m = DeleteRegistrati
 func (m *DeleteRegistrationEntryRequest) String() string { return proto.CompactTextString(m) }
 func (*DeleteRegistrationEntryRequest) ProtoMessage()    {}
 func (*DeleteRegistrationEntryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{29}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{42}
 }
 func (m *DeleteRegistrationEntryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteRegistrationEntryRequest.Unmarshal(m, b)
@@ -1310,17 +1790,15 @@ func (m *DeleteRegistrationEntryRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteRegistrationEntryRequest proto.InternalMessageInfo
 
-func (m *DeleteRegistrationEntryRequest) GetRegisteredEntryId() string {
+func (m *DeleteRegistrationEntryRequest) GetEntryId() string {
 	if m != nil {
-		return m.RegisteredEntryId
+		return m.EntryId
 	}
 	return ""
 }
 
-// Represents the deleted Registration entry
 type DeleteRegistrationEntryResponse struct {
-	// Registration entry
-	RegisteredEntry      *common.RegistrationEntry `protobuf:"bytes,1,opt,name=registeredEntry" json:"registeredEntry,omitempty"`
+	Entry                *common.RegistrationEntry `protobuf:"bytes,1,opt,name=entry" json:"entry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
 	XXX_unrecognized     []byte                    `json:"-"`
 	XXX_sizecache        int32                     `json:"-"`
@@ -1330,7 +1808,7 @@ func (m *DeleteRegistrationEntryResponse) Reset()         { *m = DeleteRegistrat
 func (m *DeleteRegistrationEntryResponse) String() string { return proto.CompactTextString(m) }
 func (*DeleteRegistrationEntryResponse) ProtoMessage()    {}
 func (*DeleteRegistrationEntryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{30}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{43}
 }
 func (m *DeleteRegistrationEntryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DeleteRegistrationEntryResponse.Unmarshal(m, b)
@@ -1350,257 +1828,17 @@ func (m *DeleteRegistrationEntryResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteRegistrationEntryResponse proto.InternalMessageInfo
 
-func (m *DeleteRegistrationEntryResponse) GetRegisteredEntry() *common.RegistrationEntry {
+func (m *DeleteRegistrationEntryResponse) GetEntry() *common.RegistrationEntry {
 	if m != nil {
-		return m.RegisteredEntry
+		return m.Entry
 	}
 	return nil
 }
 
-// Represents a Parent ID
-type ListParentIDEntriesRequest struct {
-	// Parent ID
-	ParentId             string   `protobuf:"bytes,1,opt,name=parentId" json:"parentId,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ListParentIDEntriesRequest) Reset()         { *m = ListParentIDEntriesRequest{} }
-func (m *ListParentIDEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListParentIDEntriesRequest) ProtoMessage()    {}
-func (*ListParentIDEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{31}
-}
-func (m *ListParentIDEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListParentIDEntriesRequest.Unmarshal(m, b)
-}
-func (m *ListParentIDEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListParentIDEntriesRequest.Marshal(b, m, deterministic)
-}
-func (dst *ListParentIDEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListParentIDEntriesRequest.Merge(dst, src)
-}
-func (m *ListParentIDEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListParentIDEntriesRequest.Size(m)
-}
-func (m *ListParentIDEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListParentIDEntriesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListParentIDEntriesRequest proto.InternalMessageInfo
-
-func (m *ListParentIDEntriesRequest) GetParentId() string {
-	if m != nil {
-		return m.ParentId
-	}
-	return ""
-}
-
-// Represents a list of Registered entries with the specified Parent ID
-type ListParentIDEntriesResponse struct {
-	// List of Registration entries
-	RegisteredEntryList  []*common.RegistrationEntry `protobuf:"bytes,1,rep,name=registeredEntryList" json:"registeredEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
-	XXX_unrecognized     []byte                      `json:"-"`
-	XXX_sizecache        int32                       `json:"-"`
-}
-
-func (m *ListParentIDEntriesResponse) Reset()         { *m = ListParentIDEntriesResponse{} }
-func (m *ListParentIDEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*ListParentIDEntriesResponse) ProtoMessage()    {}
-func (*ListParentIDEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{32}
-}
-func (m *ListParentIDEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListParentIDEntriesResponse.Unmarshal(m, b)
-}
-func (m *ListParentIDEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListParentIDEntriesResponse.Marshal(b, m, deterministic)
-}
-func (dst *ListParentIDEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListParentIDEntriesResponse.Merge(dst, src)
-}
-func (m *ListParentIDEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_ListParentIDEntriesResponse.Size(m)
-}
-func (m *ListParentIDEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListParentIDEntriesResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListParentIDEntriesResponse proto.InternalMessageInfo
-
-func (m *ListParentIDEntriesResponse) GetRegisteredEntryList() []*common.RegistrationEntry {
-	if m != nil {
-		return m.RegisteredEntryList
-	}
-	return nil
-}
-
-// Represents a selector
-type ListSelectorEntriesRequest struct {
-	// Selector
-	Selectors            []*common.Selector `protobuf:"bytes,1,rep,name=selectors" json:"selectors,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
-	XXX_unrecognized     []byte             `json:"-"`
-	XXX_sizecache        int32              `json:"-"`
-}
-
-func (m *ListSelectorEntriesRequest) Reset()         { *m = ListSelectorEntriesRequest{} }
-func (m *ListSelectorEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListSelectorEntriesRequest) ProtoMessage()    {}
-func (*ListSelectorEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{33}
-}
-func (m *ListSelectorEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListSelectorEntriesRequest.Unmarshal(m, b)
-}
-func (m *ListSelectorEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListSelectorEntriesRequest.Marshal(b, m, deterministic)
-}
-func (dst *ListSelectorEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListSelectorEntriesRequest.Merge(dst, src)
-}
-func (m *ListSelectorEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListSelectorEntriesRequest.Size(m)
-}
-func (m *ListSelectorEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListSelectorEntriesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListSelectorEntriesRequest proto.InternalMessageInfo
-
-func (m *ListSelectorEntriesRequest) GetSelectors() []*common.Selector {
-	if m != nil {
-		return m.Selectors
-	}
-	return nil
-}
-
-// Represents a list of Registered entries with the specified selector
-type ListSelectorEntriesResponse struct {
-	// List of Registration entries
-	RegisteredEntryList  []*common.RegistrationEntry `protobuf:"bytes,1,rep,name=registeredEntryList" json:"registeredEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
-	XXX_unrecognized     []byte                      `json:"-"`
-	XXX_sizecache        int32                       `json:"-"`
-}
-
-func (m *ListSelectorEntriesResponse) Reset()         { *m = ListSelectorEntriesResponse{} }
-func (m *ListSelectorEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*ListSelectorEntriesResponse) ProtoMessage()    {}
-func (*ListSelectorEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{34}
-}
-func (m *ListSelectorEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListSelectorEntriesResponse.Unmarshal(m, b)
-}
-func (m *ListSelectorEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListSelectorEntriesResponse.Marshal(b, m, deterministic)
-}
-func (dst *ListSelectorEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListSelectorEntriesResponse.Merge(dst, src)
-}
-func (m *ListSelectorEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_ListSelectorEntriesResponse.Size(m)
-}
-func (m *ListSelectorEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListSelectorEntriesResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListSelectorEntriesResponse proto.InternalMessageInfo
-
-func (m *ListSelectorEntriesResponse) GetRegisteredEntryList() []*common.RegistrationEntry {
-	if m != nil {
-		return m.RegisteredEntryList
-	}
-	return nil
-}
-
-// Represents a Spiffe ID
-type ListSpiffeEntriesRequest struct {
-	// SPIFFE ID
-	SpiffeId             string   `protobuf:"bytes,1,opt,name=spiffeId" json:"spiffeId,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *ListSpiffeEntriesRequest) Reset()         { *m = ListSpiffeEntriesRequest{} }
-func (m *ListSpiffeEntriesRequest) String() string { return proto.CompactTextString(m) }
-func (*ListSpiffeEntriesRequest) ProtoMessage()    {}
-func (*ListSpiffeEntriesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{35}
-}
-func (m *ListSpiffeEntriesRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListSpiffeEntriesRequest.Unmarshal(m, b)
-}
-func (m *ListSpiffeEntriesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListSpiffeEntriesRequest.Marshal(b, m, deterministic)
-}
-func (dst *ListSpiffeEntriesRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListSpiffeEntriesRequest.Merge(dst, src)
-}
-func (m *ListSpiffeEntriesRequest) XXX_Size() int {
-	return xxx_messageInfo_ListSpiffeEntriesRequest.Size(m)
-}
-func (m *ListSpiffeEntriesRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListSpiffeEntriesRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListSpiffeEntriesRequest proto.InternalMessageInfo
-
-func (m *ListSpiffeEntriesRequest) GetSpiffeId() string {
-	if m != nil {
-		return m.SpiffeId
-	}
-	return ""
-}
-
-// Represents a list of Registered entries with the specified Spiffe ID
-type ListSpiffeEntriesResponse struct {
-	// List of Registration entries
-	RegisteredEntryList  []*common.RegistrationEntry `protobuf:"bytes,1,rep,name=registeredEntryList" json:"registeredEntryList,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                    `json:"-"`
-	XXX_unrecognized     []byte                      `json:"-"`
-	XXX_sizecache        int32                       `json:"-"`
-}
-
-func (m *ListSpiffeEntriesResponse) Reset()         { *m = ListSpiffeEntriesResponse{} }
-func (m *ListSpiffeEntriesResponse) String() string { return proto.CompactTextString(m) }
-func (*ListSpiffeEntriesResponse) ProtoMessage()    {}
-func (*ListSpiffeEntriesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{36}
-}
-func (m *ListSpiffeEntriesResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ListSpiffeEntriesResponse.Unmarshal(m, b)
-}
-func (m *ListSpiffeEntriesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ListSpiffeEntriesResponse.Marshal(b, m, deterministic)
-}
-func (dst *ListSpiffeEntriesResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ListSpiffeEntriesResponse.Merge(dst, src)
-}
-func (m *ListSpiffeEntriesResponse) XXX_Size() int {
-	return xxx_messageInfo_ListSpiffeEntriesResponse.Size(m)
-}
-func (m *ListSpiffeEntriesResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ListSpiffeEntriesResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_ListSpiffeEntriesResponse proto.InternalMessageInfo
-
-func (m *ListSpiffeEntriesResponse) GetRegisteredEntryList() []*common.RegistrationEntry {
-	if m != nil {
-		return m.RegisteredEntryList
-	}
-	return nil
-}
-
-// Represents a join token and associated metadata, if known
 type JoinToken struct {
+	// Token value
 	Token string `protobuf:"bytes,1,opt,name=token" json:"token,omitempty"`
-	// Expiration date, represented in UNIX time
+	// Expiration in seconds since unix epoch
 	Expiry               int64    `protobuf:"varint,2,opt,name=expiry" json:"expiry,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -1611,7 +1849,7 @@ func (m *JoinToken) Reset()         { *m = JoinToken{} }
 func (m *JoinToken) String() string { return proto.CompactTextString(m) }
 func (*JoinToken) ProtoMessage()    {}
 func (*JoinToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_datastore_396395c57dd52724, []int{37}
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{44}
 }
 func (m *JoinToken) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_JoinToken.Unmarshal(m, b)
@@ -1645,45 +1883,356 @@ func (m *JoinToken) GetExpiry() int64 {
 	return 0
 }
 
+type CreateJoinTokenRequest struct {
+	JoinToken            *JoinToken `protobuf:"bytes,1,opt,name=join_token,json=joinToken" json:"join_token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
+}
+
+func (m *CreateJoinTokenRequest) Reset()         { *m = CreateJoinTokenRequest{} }
+func (m *CreateJoinTokenRequest) String() string { return proto.CompactTextString(m) }
+func (*CreateJoinTokenRequest) ProtoMessage()    {}
+func (*CreateJoinTokenRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{45}
+}
+func (m *CreateJoinTokenRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateJoinTokenRequest.Unmarshal(m, b)
+}
+func (m *CreateJoinTokenRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateJoinTokenRequest.Marshal(b, m, deterministic)
+}
+func (dst *CreateJoinTokenRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateJoinTokenRequest.Merge(dst, src)
+}
+func (m *CreateJoinTokenRequest) XXX_Size() int {
+	return xxx_messageInfo_CreateJoinTokenRequest.Size(m)
+}
+func (m *CreateJoinTokenRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateJoinTokenRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateJoinTokenRequest proto.InternalMessageInfo
+
+func (m *CreateJoinTokenRequest) GetJoinToken() *JoinToken {
+	if m != nil {
+		return m.JoinToken
+	}
+	return nil
+}
+
+type CreateJoinTokenResponse struct {
+	JoinToken            *JoinToken `protobuf:"bytes,1,opt,name=join_token,json=joinToken" json:"join_token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
+}
+
+func (m *CreateJoinTokenResponse) Reset()         { *m = CreateJoinTokenResponse{} }
+func (m *CreateJoinTokenResponse) String() string { return proto.CompactTextString(m) }
+func (*CreateJoinTokenResponse) ProtoMessage()    {}
+func (*CreateJoinTokenResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{46}
+}
+func (m *CreateJoinTokenResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_CreateJoinTokenResponse.Unmarshal(m, b)
+}
+func (m *CreateJoinTokenResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_CreateJoinTokenResponse.Marshal(b, m, deterministic)
+}
+func (dst *CreateJoinTokenResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CreateJoinTokenResponse.Merge(dst, src)
+}
+func (m *CreateJoinTokenResponse) XXX_Size() int {
+	return xxx_messageInfo_CreateJoinTokenResponse.Size(m)
+}
+func (m *CreateJoinTokenResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_CreateJoinTokenResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_CreateJoinTokenResponse proto.InternalMessageInfo
+
+func (m *CreateJoinTokenResponse) GetJoinToken() *JoinToken {
+	if m != nil {
+		return m.JoinToken
+	}
+	return nil
+}
+
+type FetchJoinTokenRequest struct {
+	Token                string   `protobuf:"bytes,1,opt,name=token" json:"token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *FetchJoinTokenRequest) Reset()         { *m = FetchJoinTokenRequest{} }
+func (m *FetchJoinTokenRequest) String() string { return proto.CompactTextString(m) }
+func (*FetchJoinTokenRequest) ProtoMessage()    {}
+func (*FetchJoinTokenRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{47}
+}
+func (m *FetchJoinTokenRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchJoinTokenRequest.Unmarshal(m, b)
+}
+func (m *FetchJoinTokenRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchJoinTokenRequest.Marshal(b, m, deterministic)
+}
+func (dst *FetchJoinTokenRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchJoinTokenRequest.Merge(dst, src)
+}
+func (m *FetchJoinTokenRequest) XXX_Size() int {
+	return xxx_messageInfo_FetchJoinTokenRequest.Size(m)
+}
+func (m *FetchJoinTokenRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchJoinTokenRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchJoinTokenRequest proto.InternalMessageInfo
+
+func (m *FetchJoinTokenRequest) GetToken() string {
+	if m != nil {
+		return m.Token
+	}
+	return ""
+}
+
+type FetchJoinTokenResponse struct {
+	JoinToken            *JoinToken `protobuf:"bytes,1,opt,name=join_token,json=joinToken" json:"join_token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
+}
+
+func (m *FetchJoinTokenResponse) Reset()         { *m = FetchJoinTokenResponse{} }
+func (m *FetchJoinTokenResponse) String() string { return proto.CompactTextString(m) }
+func (*FetchJoinTokenResponse) ProtoMessage()    {}
+func (*FetchJoinTokenResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{48}
+}
+func (m *FetchJoinTokenResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_FetchJoinTokenResponse.Unmarshal(m, b)
+}
+func (m *FetchJoinTokenResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_FetchJoinTokenResponse.Marshal(b, m, deterministic)
+}
+func (dst *FetchJoinTokenResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchJoinTokenResponse.Merge(dst, src)
+}
+func (m *FetchJoinTokenResponse) XXX_Size() int {
+	return xxx_messageInfo_FetchJoinTokenResponse.Size(m)
+}
+func (m *FetchJoinTokenResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_FetchJoinTokenResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_FetchJoinTokenResponse proto.InternalMessageInfo
+
+func (m *FetchJoinTokenResponse) GetJoinToken() *JoinToken {
+	if m != nil {
+		return m.JoinToken
+	}
+	return nil
+}
+
+type DeleteJoinTokenRequest struct {
+	Token                string   `protobuf:"bytes,1,opt,name=token" json:"token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DeleteJoinTokenRequest) Reset()         { *m = DeleteJoinTokenRequest{} }
+func (m *DeleteJoinTokenRequest) String() string { return proto.CompactTextString(m) }
+func (*DeleteJoinTokenRequest) ProtoMessage()    {}
+func (*DeleteJoinTokenRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{49}
+}
+func (m *DeleteJoinTokenRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteJoinTokenRequest.Unmarshal(m, b)
+}
+func (m *DeleteJoinTokenRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteJoinTokenRequest.Marshal(b, m, deterministic)
+}
+func (dst *DeleteJoinTokenRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteJoinTokenRequest.Merge(dst, src)
+}
+func (m *DeleteJoinTokenRequest) XXX_Size() int {
+	return xxx_messageInfo_DeleteJoinTokenRequest.Size(m)
+}
+func (m *DeleteJoinTokenRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteJoinTokenRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteJoinTokenRequest proto.InternalMessageInfo
+
+func (m *DeleteJoinTokenRequest) GetToken() string {
+	if m != nil {
+		return m.Token
+	}
+	return ""
+}
+
+type DeleteJoinTokenResponse struct {
+	JoinToken            *JoinToken `protobuf:"bytes,1,opt,name=join_token,json=joinToken" json:"join_token,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
+}
+
+func (m *DeleteJoinTokenResponse) Reset()         { *m = DeleteJoinTokenResponse{} }
+func (m *DeleteJoinTokenResponse) String() string { return proto.CompactTextString(m) }
+func (*DeleteJoinTokenResponse) ProtoMessage()    {}
+func (*DeleteJoinTokenResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{50}
+}
+func (m *DeleteJoinTokenResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DeleteJoinTokenResponse.Unmarshal(m, b)
+}
+func (m *DeleteJoinTokenResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DeleteJoinTokenResponse.Marshal(b, m, deterministic)
+}
+func (dst *DeleteJoinTokenResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DeleteJoinTokenResponse.Merge(dst, src)
+}
+func (m *DeleteJoinTokenResponse) XXX_Size() int {
+	return xxx_messageInfo_DeleteJoinTokenResponse.Size(m)
+}
+func (m *DeleteJoinTokenResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DeleteJoinTokenResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DeleteJoinTokenResponse proto.InternalMessageInfo
+
+func (m *DeleteJoinTokenResponse) GetJoinToken() *JoinToken {
+	if m != nil {
+		return m.JoinToken
+	}
+	return nil
+}
+
+type PruneJoinTokensRequest struct {
+	ExpiresBefore        int64    `protobuf:"varint,1,opt,name=expires_before,json=expiresBefore" json:"expires_before,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PruneJoinTokensRequest) Reset()         { *m = PruneJoinTokensRequest{} }
+func (m *PruneJoinTokensRequest) String() string { return proto.CompactTextString(m) }
+func (*PruneJoinTokensRequest) ProtoMessage()    {}
+func (*PruneJoinTokensRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{51}
+}
+func (m *PruneJoinTokensRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PruneJoinTokensRequest.Unmarshal(m, b)
+}
+func (m *PruneJoinTokensRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PruneJoinTokensRequest.Marshal(b, m, deterministic)
+}
+func (dst *PruneJoinTokensRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PruneJoinTokensRequest.Merge(dst, src)
+}
+func (m *PruneJoinTokensRequest) XXX_Size() int {
+	return xxx_messageInfo_PruneJoinTokensRequest.Size(m)
+}
+func (m *PruneJoinTokensRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_PruneJoinTokensRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PruneJoinTokensRequest proto.InternalMessageInfo
+
+func (m *PruneJoinTokensRequest) GetExpiresBefore() int64 {
+	if m != nil {
+		return m.ExpiresBefore
+	}
+	return 0
+}
+
+type PruneJoinTokensResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PruneJoinTokensResponse) Reset()         { *m = PruneJoinTokensResponse{} }
+func (m *PruneJoinTokensResponse) String() string { return proto.CompactTextString(m) }
+func (*PruneJoinTokensResponse) ProtoMessage()    {}
+func (*PruneJoinTokensResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_datastore_e3e0d519b06ed1bf, []int{52}
+}
+func (m *PruneJoinTokensResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PruneJoinTokensResponse.Unmarshal(m, b)
+}
+func (m *PruneJoinTokensResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PruneJoinTokensResponse.Marshal(b, m, deterministic)
+}
+func (dst *PruneJoinTokensResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PruneJoinTokensResponse.Merge(dst, src)
+}
+func (m *PruneJoinTokensResponse) XXX_Size() int {
+	return xxx_messageInfo_PruneJoinTokensResponse.Size(m)
+}
+func (m *PruneJoinTokensResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_PruneJoinTokensResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PruneJoinTokensResponse proto.InternalMessageInfo
+
 func init() {
 	proto.RegisterType((*Bundle)(nil), "spire.server.datastore.Bundle")
-	proto.RegisterType((*Bundles)(nil), "spire.server.datastore.Bundles")
+	proto.RegisterType((*CreateBundleRequest)(nil), "spire.server.datastore.CreateBundleRequest")
+	proto.RegisterType((*CreateBundleResponse)(nil), "spire.server.datastore.CreateBundleResponse")
+	proto.RegisterType((*FetchBundleRequest)(nil), "spire.server.datastore.FetchBundleRequest")
+	proto.RegisterType((*FetchBundleResponse)(nil), "spire.server.datastore.FetchBundleResponse")
+	proto.RegisterType((*ListBundlesRequest)(nil), "spire.server.datastore.ListBundlesRequest")
+	proto.RegisterType((*ListBundlesResponse)(nil), "spire.server.datastore.ListBundlesResponse")
+	proto.RegisterType((*UpdateBundleRequest)(nil), "spire.server.datastore.UpdateBundleRequest")
+	proto.RegisterType((*UpdateBundleResponse)(nil), "spire.server.datastore.UpdateBundleResponse")
+	proto.RegisterType((*AppendBundleRequest)(nil), "spire.server.datastore.AppendBundleRequest")
+	proto.RegisterType((*AppendBundleResponse)(nil), "spire.server.datastore.AppendBundleResponse")
+	proto.RegisterType((*DeleteBundleRequest)(nil), "spire.server.datastore.DeleteBundleRequest")
+	proto.RegisterType((*DeleteBundleResponse)(nil), "spire.server.datastore.DeleteBundleResponse")
 	proto.RegisterType((*NodeResolverMapEntry)(nil), "spire.server.datastore.NodeResolverMapEntry")
+	proto.RegisterType((*CreateNodeResolverMapEntryRequest)(nil), "spire.server.datastore.CreateNodeResolverMapEntryRequest")
+	proto.RegisterType((*CreateNodeResolverMapEntryResponse)(nil), "spire.server.datastore.CreateNodeResolverMapEntryResponse")
+	proto.RegisterType((*ListNodeResolverMapEntriesRequest)(nil), "spire.server.datastore.ListNodeResolverMapEntriesRequest")
+	proto.RegisterType((*ListNodeResolverMapEntriesResponse)(nil), "spire.server.datastore.ListNodeResolverMapEntriesResponse")
+	proto.RegisterType((*DeleteNodeResolverMapEntryRequest)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryRequest")
+	proto.RegisterType((*DeleteNodeResolverMapEntryResponse)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryResponse")
+	proto.RegisterType((*RectifyNodeResolverMapEntriesRequest)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesRequest")
+	proto.RegisterType((*RectifyNodeResolverMapEntriesResponse)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesResponse")
 	proto.RegisterType((*AttestedNodeEntry)(nil), "spire.server.datastore.AttestedNodeEntry")
 	proto.RegisterType((*CreateAttestedNodeEntryRequest)(nil), "spire.server.datastore.CreateAttestedNodeEntryRequest")
 	proto.RegisterType((*CreateAttestedNodeEntryResponse)(nil), "spire.server.datastore.CreateAttestedNodeEntryResponse")
 	proto.RegisterType((*FetchAttestedNodeEntryRequest)(nil), "spire.server.datastore.FetchAttestedNodeEntryRequest")
 	proto.RegisterType((*FetchAttestedNodeEntryResponse)(nil), "spire.server.datastore.FetchAttestedNodeEntryResponse")
-	proto.RegisterType((*FetchStaleNodeEntriesRequest)(nil), "spire.server.datastore.FetchStaleNodeEntriesRequest")
-	proto.RegisterType((*FetchStaleNodeEntriesResponse)(nil), "spire.server.datastore.FetchStaleNodeEntriesResponse")
+	proto.RegisterType((*ListAttestedNodeEntriesRequest)(nil), "spire.server.datastore.ListAttestedNodeEntriesRequest")
+	proto.RegisterType((*ListAttestedNodeEntriesResponse)(nil), "spire.server.datastore.ListAttestedNodeEntriesResponse")
 	proto.RegisterType((*UpdateAttestedNodeEntryRequest)(nil), "spire.server.datastore.UpdateAttestedNodeEntryRequest")
 	proto.RegisterType((*UpdateAttestedNodeEntryResponse)(nil), "spire.server.datastore.UpdateAttestedNodeEntryResponse")
 	proto.RegisterType((*DeleteAttestedNodeEntryRequest)(nil), "spire.server.datastore.DeleteAttestedNodeEntryRequest")
 	proto.RegisterType((*DeleteAttestedNodeEntryResponse)(nil), "spire.server.datastore.DeleteAttestedNodeEntryResponse")
-	proto.RegisterType((*CreateNodeResolverMapEntryRequest)(nil), "spire.server.datastore.CreateNodeResolverMapEntryRequest")
-	proto.RegisterType((*CreateNodeResolverMapEntryResponse)(nil), "spire.server.datastore.CreateNodeResolverMapEntryResponse")
-	proto.RegisterType((*FetchNodeResolverMapEntryRequest)(nil), "spire.server.datastore.FetchNodeResolverMapEntryRequest")
-	proto.RegisterType((*FetchNodeResolverMapEntryResponse)(nil), "spire.server.datastore.FetchNodeResolverMapEntryResponse")
-	proto.RegisterType((*DeleteNodeResolverMapEntryRequest)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryRequest")
-	proto.RegisterType((*DeleteNodeResolverMapEntryResponse)(nil), "spire.server.datastore.DeleteNodeResolverMapEntryResponse")
-	proto.RegisterType((*RectifyNodeResolverMapEntriesRequest)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesRequest")
-	proto.RegisterType((*RectifyNodeResolverMapEntriesResponse)(nil), "spire.server.datastore.RectifyNodeResolverMapEntriesResponse")
 	proto.RegisterType((*CreateRegistrationEntryRequest)(nil), "spire.server.datastore.CreateRegistrationEntryRequest")
 	proto.RegisterType((*CreateRegistrationEntryResponse)(nil), "spire.server.datastore.CreateRegistrationEntryResponse")
 	proto.RegisterType((*FetchRegistrationEntryRequest)(nil), "spire.server.datastore.FetchRegistrationEntryRequest")
 	proto.RegisterType((*FetchRegistrationEntryResponse)(nil), "spire.server.datastore.FetchRegistrationEntryResponse")
-	proto.RegisterType((*FetchRegistrationEntriesResponse)(nil), "spire.server.datastore.FetchRegistrationEntriesResponse")
+	proto.RegisterType((*BySelectors)(nil), "spire.server.datastore.BySelectors")
+	proto.RegisterType((*ListRegistrationEntriesRequest)(nil), "spire.server.datastore.ListRegistrationEntriesRequest")
+	proto.RegisterType((*ListRegistrationEntriesResponse)(nil), "spire.server.datastore.ListRegistrationEntriesResponse")
 	proto.RegisterType((*UpdateRegistrationEntryRequest)(nil), "spire.server.datastore.UpdateRegistrationEntryRequest")
 	proto.RegisterType((*UpdateRegistrationEntryResponse)(nil), "spire.server.datastore.UpdateRegistrationEntryResponse")
 	proto.RegisterType((*DeleteRegistrationEntryRequest)(nil), "spire.server.datastore.DeleteRegistrationEntryRequest")
 	proto.RegisterType((*DeleteRegistrationEntryResponse)(nil), "spire.server.datastore.DeleteRegistrationEntryResponse")
-	proto.RegisterType((*ListParentIDEntriesRequest)(nil), "spire.server.datastore.ListParentIDEntriesRequest")
-	proto.RegisterType((*ListParentIDEntriesResponse)(nil), "spire.server.datastore.ListParentIDEntriesResponse")
-	proto.RegisterType((*ListSelectorEntriesRequest)(nil), "spire.server.datastore.ListSelectorEntriesRequest")
-	proto.RegisterType((*ListSelectorEntriesResponse)(nil), "spire.server.datastore.ListSelectorEntriesResponse")
-	proto.RegisterType((*ListSpiffeEntriesRequest)(nil), "spire.server.datastore.ListSpiffeEntriesRequest")
-	proto.RegisterType((*ListSpiffeEntriesResponse)(nil), "spire.server.datastore.ListSpiffeEntriesResponse")
 	proto.RegisterType((*JoinToken)(nil), "spire.server.datastore.JoinToken")
+	proto.RegisterType((*CreateJoinTokenRequest)(nil), "spire.server.datastore.CreateJoinTokenRequest")
+	proto.RegisterType((*CreateJoinTokenResponse)(nil), "spire.server.datastore.CreateJoinTokenResponse")
+	proto.RegisterType((*FetchJoinTokenRequest)(nil), "spire.server.datastore.FetchJoinTokenRequest")
+	proto.RegisterType((*FetchJoinTokenResponse)(nil), "spire.server.datastore.FetchJoinTokenResponse")
+	proto.RegisterType((*DeleteJoinTokenRequest)(nil), "spire.server.datastore.DeleteJoinTokenRequest")
+	proto.RegisterType((*DeleteJoinTokenResponse)(nil), "spire.server.datastore.DeleteJoinTokenResponse")
+	proto.RegisterType((*PruneJoinTokensRequest)(nil), "spire.server.datastore.PruneJoinTokensRequest")
+	proto.RegisterType((*PruneJoinTokensResponse)(nil), "spire.server.datastore.PruneJoinTokensResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1697,62 +2246,54 @@ const _ = grpc.SupportPackageIsVersion4
 // Client API for DataStore service
 
 type DataStoreClient interface {
-	// Creates a Bundle
-	CreateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
-	// Updates the specified Bundle, overwriting existing certs
-	UpdateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
+	// Creates a bundle
+	CreateBundle(ctx context.Context, in *CreateBundleRequest, opts ...grpc.CallOption) (*CreateBundleResponse, error)
+	// Fetches a specific bundle
+	FetchBundle(ctx context.Context, in *FetchBundleRequest, opts ...grpc.CallOption) (*FetchBundleResponse, error)
+	// Lists bundles (optionally filtered)
+	ListBundles(ctx context.Context, in *ListBundlesRequest, opts ...grpc.CallOption) (*ListBundlesResponse, error)
+	// Updates a specific bundle, overwriting existing certs
+	UpdateBundle(ctx context.Context, in *UpdateBundleRequest, opts ...grpc.CallOption) (*UpdateBundleResponse, error)
 	// Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
-	AppendBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
-	// Deletes the specified Bundle
-	DeleteBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
-	// Returns the specified Bundle
-	FetchBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error)
-	// List all Bundles
-	ListBundles(ctx context.Context, in *common.Empty, opts ...grpc.CallOption) (*Bundles, error)
-	// Creates an Attested Node Entry
+	AppendBundle(ctx context.Context, in *AppendBundleRequest, opts ...grpc.CallOption) (*AppendBundleResponse, error)
+	// Deletes a specific bundle
+	DeleteBundle(ctx context.Context, in *DeleteBundleRequest, opts ...grpc.CallOption) (*DeleteBundleResponse, error)
+	// Creates an attested node entry
 	CreateAttestedNodeEntry(ctx context.Context, in *CreateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*CreateAttestedNodeEntryResponse, error)
-	// Retrieves the Attested Node Entry
+	// Fetches a specific attested node entry
 	FetchAttestedNodeEntry(ctx context.Context, in *FetchAttestedNodeEntryRequest, opts ...grpc.CallOption) (*FetchAttestedNodeEntryResponse, error)
-	// Retrieves dead nodes for which the base SVID has expired
-	FetchStaleNodeEntries(ctx context.Context, in *FetchStaleNodeEntriesRequest, opts ...grpc.CallOption) (*FetchStaleNodeEntriesResponse, error)
-	// Updates the Attested Node Entry
+	// Lists attested node entries (optionally filtered)
+	ListAttestedNodeEntries(ctx context.Context, in *ListAttestedNodeEntriesRequest, opts ...grpc.CallOption) (*ListAttestedNodeEntriesResponse, error)
+	// Updates a specific attested node entry
 	UpdateAttestedNodeEntry(ctx context.Context, in *UpdateAttestedNodeEntryRequest, opts ...grpc.CallOption) (*UpdateAttestedNodeEntryResponse, error)
-	// Deletes the Attested Node Entry
+	// Deletes a specific attested node entry
 	DeleteAttestedNodeEntry(ctx context.Context, in *DeleteAttestedNodeEntryRequest, opts ...grpc.CallOption) (*DeleteAttestedNodeEntryResponse, error)
-	// Creates a Node resolver map Entry
+	// Creates a node resolver map entry
 	CreateNodeResolverMapEntry(ctx context.Context, in *CreateNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*CreateNodeResolverMapEntryResponse, error)
-	// Retrieves all Node Resolver Map Entry for the specific base SPIFFEID
-	FetchNodeResolverMapEntry(ctx context.Context, in *FetchNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*FetchNodeResolverMapEntryResponse, error)
-	// Deletes all Node Resolver Map Entry for the specific base SPIFFEID
+	// Lists node resolver map entries for a specified SPIFFE ID
+	ListNodeResolverMapEntries(ctx context.Context, in *ListNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*ListNodeResolverMapEntriesResponse, error)
+	// Deletes a specific node resolver map entry
 	DeleteNodeResolverMapEntry(ctx context.Context, in *DeleteNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*DeleteNodeResolverMapEntryResponse, error)
-	// Used for rectifying updated node resolutions
+	// Sets the list of node resolver map entries for the specified SPIFFE ID
 	RectifyNodeResolverMapEntries(ctx context.Context, in *RectifyNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*RectifyNodeResolverMapEntriesResponse, error)
-	// Creates a Registered Entry
+	// Creates a registration entry
 	CreateRegistrationEntry(ctx context.Context, in *CreateRegistrationEntryRequest, opts ...grpc.CallOption) (*CreateRegistrationEntryResponse, error)
-	// Retrieve a specific registered entry
+	// Fetches a specific registration entry
 	FetchRegistrationEntry(ctx context.Context, in *FetchRegistrationEntryRequest, opts ...grpc.CallOption) (*FetchRegistrationEntryResponse, error)
-	// Retrieve all registration entries
-	FetchRegistrationEntries(ctx context.Context, in *common.Empty, opts ...grpc.CallOption) (*FetchRegistrationEntriesResponse, error)
-	// Updates a specific registered entry
+	// Lists registration entries (optionally filtered)
+	ListRegistrationEntries(ctx context.Context, in *ListRegistrationEntriesRequest, opts ...grpc.CallOption) (*ListRegistrationEntriesResponse, error)
+	// Updates a specific registration entry
 	UpdateRegistrationEntry(ctx context.Context, in *UpdateRegistrationEntryRequest, opts ...grpc.CallOption) (*UpdateRegistrationEntryResponse, error)
-	// Deletes a specific registered entry
+	// Deletes a specific registration entry
 	DeleteRegistrationEntry(ctx context.Context, in *DeleteRegistrationEntryRequest, opts ...grpc.CallOption) (*DeleteRegistrationEntryResponse, error)
-	// Retrieves all the registered entry with the same ParentID
-	ListParentIDEntries(ctx context.Context, in *ListParentIDEntriesRequest, opts ...grpc.CallOption) (*ListParentIDEntriesResponse, error)
-	// Retrieves all the registered entry matching exactly the compound Selector
-	ListSelectorEntries(ctx context.Context, in *ListSelectorEntriesRequest, opts ...grpc.CallOption) (*ListSelectorEntriesResponse, error)
-	// Retrieves registered entries containing all of the specified selectors
-	ListMatchingEntries(ctx context.Context, in *ListSelectorEntriesRequest, opts ...grpc.CallOption) (*ListSelectorEntriesResponse, error)
-	// Retrieves all the registered entry with the same SpiffeId
-	ListSpiffeEntries(ctx context.Context, in *ListSpiffeEntriesRequest, opts ...grpc.CallOption) (*ListSpiffeEntriesResponse, error)
-	// Register a new join token
-	RegisterToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error)
-	// Fetch a token record
-	FetchToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*JoinToken, error)
-	// Delete the referenced token
-	DeleteToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error)
-	// Delete all tokens with expiry less than the one specified
-	PruneTokens(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error)
+	// Creates a join token
+	CreateJoinToken(ctx context.Context, in *CreateJoinTokenRequest, opts ...grpc.CallOption) (*CreateJoinTokenResponse, error)
+	// Fetches a specific join token
+	FetchJoinToken(ctx context.Context, in *FetchJoinTokenRequest, opts ...grpc.CallOption) (*FetchJoinTokenResponse, error)
+	// Delete a specific join token
+	DeleteJoinToken(ctx context.Context, in *DeleteJoinTokenRequest, opts ...grpc.CallOption) (*DeleteJoinTokenResponse, error)
+	// Prunes all join tokens that expire before the specified timestamp
+	PruneJoinTokens(ctx context.Context, in *PruneJoinTokensRequest, opts ...grpc.CallOption) (*PruneJoinTokensResponse, error)
 	// Applies the plugin configuration
 	Configure(ctx context.Context, in *plugin.ConfigureRequest, opts ...grpc.CallOption) (*plugin.ConfigureResponse, error)
 	// Returns the version and related metadata of the installed plugin
@@ -1767,8 +2308,8 @@ func NewDataStoreClient(cc *grpc.ClientConn) DataStoreClient {
 	return &dataStoreClient{cc}
 }
 
-func (c *dataStoreClient) CreateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error) {
-	out := new(Bundle)
+func (c *dataStoreClient) CreateBundle(ctx context.Context, in *CreateBundleRequest, opts ...grpc.CallOption) (*CreateBundleResponse, error) {
+	out := new(CreateBundleResponse)
 	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/CreateBundle", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1776,35 +2317,8 @@ func (c *dataStoreClient) CreateBundle(ctx context.Context, in *Bundle, opts ...
 	return out, nil
 }
 
-func (c *dataStoreClient) UpdateBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error) {
-	out := new(Bundle)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/UpdateBundle", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) AppendBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error) {
-	out := new(Bundle)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/AppendBundle", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) DeleteBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error) {
-	out := new(Bundle)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteBundle", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) FetchBundle(ctx context.Context, in *Bundle, opts ...grpc.CallOption) (*Bundle, error) {
-	out := new(Bundle)
+func (c *dataStoreClient) FetchBundle(ctx context.Context, in *FetchBundleRequest, opts ...grpc.CallOption) (*FetchBundleResponse, error) {
+	out := new(FetchBundleResponse)
 	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchBundle", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
@@ -1812,9 +2326,36 @@ func (c *dataStoreClient) FetchBundle(ctx context.Context, in *Bundle, opts ...g
 	return out, nil
 }
 
-func (c *dataStoreClient) ListBundles(ctx context.Context, in *common.Empty, opts ...grpc.CallOption) (*Bundles, error) {
-	out := new(Bundles)
+func (c *dataStoreClient) ListBundles(ctx context.Context, in *ListBundlesRequest, opts ...grpc.CallOption) (*ListBundlesResponse, error) {
+	out := new(ListBundlesResponse)
 	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListBundles", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dataStoreClient) UpdateBundle(ctx context.Context, in *UpdateBundleRequest, opts ...grpc.CallOption) (*UpdateBundleResponse, error) {
+	out := new(UpdateBundleResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/UpdateBundle", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dataStoreClient) AppendBundle(ctx context.Context, in *AppendBundleRequest, opts ...grpc.CallOption) (*AppendBundleResponse, error) {
+	out := new(AppendBundleResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/AppendBundle", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *dataStoreClient) DeleteBundle(ctx context.Context, in *DeleteBundleRequest, opts ...grpc.CallOption) (*DeleteBundleResponse, error) {
+	out := new(DeleteBundleResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteBundle", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1839,9 +2380,9 @@ func (c *dataStoreClient) FetchAttestedNodeEntry(ctx context.Context, in *FetchA
 	return out, nil
 }
 
-func (c *dataStoreClient) FetchStaleNodeEntries(ctx context.Context, in *FetchStaleNodeEntriesRequest, opts ...grpc.CallOption) (*FetchStaleNodeEntriesResponse, error) {
-	out := new(FetchStaleNodeEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchStaleNodeEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) ListAttestedNodeEntries(ctx context.Context, in *ListAttestedNodeEntriesRequest, opts ...grpc.CallOption) (*ListAttestedNodeEntriesResponse, error) {
+	out := new(ListAttestedNodeEntriesResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListAttestedNodeEntries", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1875,9 +2416,9 @@ func (c *dataStoreClient) CreateNodeResolverMapEntry(ctx context.Context, in *Cr
 	return out, nil
 }
 
-func (c *dataStoreClient) FetchNodeResolverMapEntry(ctx context.Context, in *FetchNodeResolverMapEntryRequest, opts ...grpc.CallOption) (*FetchNodeResolverMapEntryResponse, error) {
-	out := new(FetchNodeResolverMapEntryResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchNodeResolverMapEntry", in, out, c.cc, opts...)
+func (c *dataStoreClient) ListNodeResolverMapEntries(ctx context.Context, in *ListNodeResolverMapEntriesRequest, opts ...grpc.CallOption) (*ListNodeResolverMapEntriesResponse, error) {
+	out := new(ListNodeResolverMapEntriesResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListNodeResolverMapEntries", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1920,9 +2461,9 @@ func (c *dataStoreClient) FetchRegistrationEntry(ctx context.Context, in *FetchR
 	return out, nil
 }
 
-func (c *dataStoreClient) FetchRegistrationEntries(ctx context.Context, in *common.Empty, opts ...grpc.CallOption) (*FetchRegistrationEntriesResponse, error) {
-	out := new(FetchRegistrationEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchRegistrationEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) ListRegistrationEntries(ctx context.Context, in *ListRegistrationEntriesRequest, opts ...grpc.CallOption) (*ListRegistrationEntriesResponse, error) {
+	out := new(ListRegistrationEntriesResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListRegistrationEntries", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -1947,72 +2488,36 @@ func (c *dataStoreClient) DeleteRegistrationEntry(ctx context.Context, in *Delet
 	return out, nil
 }
 
-func (c *dataStoreClient) ListParentIDEntries(ctx context.Context, in *ListParentIDEntriesRequest, opts ...grpc.CallOption) (*ListParentIDEntriesResponse, error) {
-	out := new(ListParentIDEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListParentIDEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) CreateJoinToken(ctx context.Context, in *CreateJoinTokenRequest, opts ...grpc.CallOption) (*CreateJoinTokenResponse, error) {
+	out := new(CreateJoinTokenResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/CreateJoinToken", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) ListSelectorEntries(ctx context.Context, in *ListSelectorEntriesRequest, opts ...grpc.CallOption) (*ListSelectorEntriesResponse, error) {
-	out := new(ListSelectorEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListSelectorEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) FetchJoinToken(ctx context.Context, in *FetchJoinTokenRequest, opts ...grpc.CallOption) (*FetchJoinTokenResponse, error) {
+	out := new(FetchJoinTokenResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchJoinToken", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) ListMatchingEntries(ctx context.Context, in *ListSelectorEntriesRequest, opts ...grpc.CallOption) (*ListSelectorEntriesResponse, error) {
-	out := new(ListSelectorEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListMatchingEntries", in, out, c.cc, opts...)
+func (c *dataStoreClient) DeleteJoinToken(ctx context.Context, in *DeleteJoinTokenRequest, opts ...grpc.CallOption) (*DeleteJoinTokenResponse, error) {
+	out := new(DeleteJoinTokenResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteJoinToken", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *dataStoreClient) ListSpiffeEntries(ctx context.Context, in *ListSpiffeEntriesRequest, opts ...grpc.CallOption) (*ListSpiffeEntriesResponse, error) {
-	out := new(ListSpiffeEntriesResponse)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/ListSpiffeEntries", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) RegisterToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error) {
-	out := new(common.Empty)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/RegisterToken", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) FetchToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*JoinToken, error) {
-	out := new(JoinToken)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/FetchToken", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) DeleteToken(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error) {
-	out := new(common.Empty)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/DeleteToken", in, out, c.cc, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *dataStoreClient) PruneTokens(ctx context.Context, in *JoinToken, opts ...grpc.CallOption) (*common.Empty, error) {
-	out := new(common.Empty)
-	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/PruneTokens", in, out, c.cc, opts...)
+func (c *dataStoreClient) PruneJoinTokens(ctx context.Context, in *PruneJoinTokensRequest, opts ...grpc.CallOption) (*PruneJoinTokensResponse, error) {
+	out := new(PruneJoinTokensResponse)
+	err := grpc.Invoke(ctx, "/spire.server.datastore.DataStore/PruneJoinTokens", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -2040,62 +2545,54 @@ func (c *dataStoreClient) GetPluginInfo(ctx context.Context, in *plugin.GetPlugi
 // Server API for DataStore service
 
 type DataStoreServer interface {
-	// Creates a Bundle
-	CreateBundle(context.Context, *Bundle) (*Bundle, error)
-	// Updates the specified Bundle, overwriting existing certs
-	UpdateBundle(context.Context, *Bundle) (*Bundle, error)
+	// Creates a bundle
+	CreateBundle(context.Context, *CreateBundleRequest) (*CreateBundleResponse, error)
+	// Fetches a specific bundle
+	FetchBundle(context.Context, *FetchBundleRequest) (*FetchBundleResponse, error)
+	// Lists bundles (optionally filtered)
+	ListBundles(context.Context, *ListBundlesRequest) (*ListBundlesResponse, error)
+	// Updates a specific bundle, overwriting existing certs
+	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
 	// Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
-	AppendBundle(context.Context, *Bundle) (*Bundle, error)
-	// Deletes the specified Bundle
-	DeleteBundle(context.Context, *Bundle) (*Bundle, error)
-	// Returns the specified Bundle
-	FetchBundle(context.Context, *Bundle) (*Bundle, error)
-	// List all Bundles
-	ListBundles(context.Context, *common.Empty) (*Bundles, error)
-	// Creates an Attested Node Entry
+	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
+	// Deletes a specific bundle
+	DeleteBundle(context.Context, *DeleteBundleRequest) (*DeleteBundleResponse, error)
+	// Creates an attested node entry
 	CreateAttestedNodeEntry(context.Context, *CreateAttestedNodeEntryRequest) (*CreateAttestedNodeEntryResponse, error)
-	// Retrieves the Attested Node Entry
+	// Fetches a specific attested node entry
 	FetchAttestedNodeEntry(context.Context, *FetchAttestedNodeEntryRequest) (*FetchAttestedNodeEntryResponse, error)
-	// Retrieves dead nodes for which the base SVID has expired
-	FetchStaleNodeEntries(context.Context, *FetchStaleNodeEntriesRequest) (*FetchStaleNodeEntriesResponse, error)
-	// Updates the Attested Node Entry
+	// Lists attested node entries (optionally filtered)
+	ListAttestedNodeEntries(context.Context, *ListAttestedNodeEntriesRequest) (*ListAttestedNodeEntriesResponse, error)
+	// Updates a specific attested node entry
 	UpdateAttestedNodeEntry(context.Context, *UpdateAttestedNodeEntryRequest) (*UpdateAttestedNodeEntryResponse, error)
-	// Deletes the Attested Node Entry
+	// Deletes a specific attested node entry
 	DeleteAttestedNodeEntry(context.Context, *DeleteAttestedNodeEntryRequest) (*DeleteAttestedNodeEntryResponse, error)
-	// Creates a Node resolver map Entry
+	// Creates a node resolver map entry
 	CreateNodeResolverMapEntry(context.Context, *CreateNodeResolverMapEntryRequest) (*CreateNodeResolverMapEntryResponse, error)
-	// Retrieves all Node Resolver Map Entry for the specific base SPIFFEID
-	FetchNodeResolverMapEntry(context.Context, *FetchNodeResolverMapEntryRequest) (*FetchNodeResolverMapEntryResponse, error)
-	// Deletes all Node Resolver Map Entry for the specific base SPIFFEID
+	// Lists node resolver map entries for a specified SPIFFE ID
+	ListNodeResolverMapEntries(context.Context, *ListNodeResolverMapEntriesRequest) (*ListNodeResolverMapEntriesResponse, error)
+	// Deletes a specific node resolver map entry
 	DeleteNodeResolverMapEntry(context.Context, *DeleteNodeResolverMapEntryRequest) (*DeleteNodeResolverMapEntryResponse, error)
-	// Used for rectifying updated node resolutions
+	// Sets the list of node resolver map entries for the specified SPIFFE ID
 	RectifyNodeResolverMapEntries(context.Context, *RectifyNodeResolverMapEntriesRequest) (*RectifyNodeResolverMapEntriesResponse, error)
-	// Creates a Registered Entry
+	// Creates a registration entry
 	CreateRegistrationEntry(context.Context, *CreateRegistrationEntryRequest) (*CreateRegistrationEntryResponse, error)
-	// Retrieve a specific registered entry
+	// Fetches a specific registration entry
 	FetchRegistrationEntry(context.Context, *FetchRegistrationEntryRequest) (*FetchRegistrationEntryResponse, error)
-	// Retrieve all registration entries
-	FetchRegistrationEntries(context.Context, *common.Empty) (*FetchRegistrationEntriesResponse, error)
-	// Updates a specific registered entry
+	// Lists registration entries (optionally filtered)
+	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
+	// Updates a specific registration entry
 	UpdateRegistrationEntry(context.Context, *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error)
-	// Deletes a specific registered entry
+	// Deletes a specific registration entry
 	DeleteRegistrationEntry(context.Context, *DeleteRegistrationEntryRequest) (*DeleteRegistrationEntryResponse, error)
-	// Retrieves all the registered entry with the same ParentID
-	ListParentIDEntries(context.Context, *ListParentIDEntriesRequest) (*ListParentIDEntriesResponse, error)
-	// Retrieves all the registered entry matching exactly the compound Selector
-	ListSelectorEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	// Retrieves registered entries containing all of the specified selectors
-	ListMatchingEntries(context.Context, *ListSelectorEntriesRequest) (*ListSelectorEntriesResponse, error)
-	// Retrieves all the registered entry with the same SpiffeId
-	ListSpiffeEntries(context.Context, *ListSpiffeEntriesRequest) (*ListSpiffeEntriesResponse, error)
-	// Register a new join token
-	RegisterToken(context.Context, *JoinToken) (*common.Empty, error)
-	// Fetch a token record
-	FetchToken(context.Context, *JoinToken) (*JoinToken, error)
-	// Delete the referenced token
-	DeleteToken(context.Context, *JoinToken) (*common.Empty, error)
-	// Delete all tokens with expiry less than the one specified
-	PruneTokens(context.Context, *JoinToken) (*common.Empty, error)
+	// Creates a join token
+	CreateJoinToken(context.Context, *CreateJoinTokenRequest) (*CreateJoinTokenResponse, error)
+	// Fetches a specific join token
+	FetchJoinToken(context.Context, *FetchJoinTokenRequest) (*FetchJoinTokenResponse, error)
+	// Delete a specific join token
+	DeleteJoinToken(context.Context, *DeleteJoinTokenRequest) (*DeleteJoinTokenResponse, error)
+	// Prunes all join tokens that expire before the specified timestamp
+	PruneJoinTokens(context.Context, *PruneJoinTokensRequest) (*PruneJoinTokensResponse, error)
 	// Applies the plugin configuration
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
 	// Returns the version and related metadata of the installed plugin
@@ -2107,7 +2604,7 @@ func RegisterDataStoreServer(s *grpc.Server, srv DataStoreServer) {
 }
 
 func _DataStore_CreateBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Bundle)
+	in := new(CreateBundleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -2119,67 +2616,13 @@ func _DataStore_CreateBundle_Handler(srv interface{}, ctx context.Context, dec f
 		FullMethod: "/spire.server.datastore.DataStore/CreateBundle",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).CreateBundle(ctx, req.(*Bundle))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_UpdateBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Bundle)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).UpdateBundle(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/UpdateBundle",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).UpdateBundle(ctx, req.(*Bundle))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_AppendBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Bundle)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).AppendBundle(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/AppendBundle",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).AppendBundle(ctx, req.(*Bundle))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_DeleteBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Bundle)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).DeleteBundle(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/DeleteBundle",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).DeleteBundle(ctx, req.(*Bundle))
+		return srv.(DataStoreServer).CreateBundle(ctx, req.(*CreateBundleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _DataStore_FetchBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Bundle)
+	in := new(FetchBundleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -2191,13 +2634,13 @@ func _DataStore_FetchBundle_Handler(srv interface{}, ctx context.Context, dec fu
 		FullMethod: "/spire.server.datastore.DataStore/FetchBundle",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchBundle(ctx, req.(*Bundle))
+		return srv.(DataStoreServer).FetchBundle(ctx, req.(*FetchBundleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _DataStore_ListBundles_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(common.Empty)
+	in := new(ListBundlesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -2209,7 +2652,61 @@ func _DataStore_ListBundles_Handler(srv interface{}, ctx context.Context, dec fu
 		FullMethod: "/spire.server.datastore.DataStore/ListBundles",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListBundles(ctx, req.(*common.Empty))
+		return srv.(DataStoreServer).ListBundles(ctx, req.(*ListBundlesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DataStore_UpdateBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateBundleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DataStoreServer).UpdateBundle(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.server.datastore.DataStore/UpdateBundle",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DataStoreServer).UpdateBundle(ctx, req.(*UpdateBundleRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DataStore_AppendBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppendBundleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DataStoreServer).AppendBundle(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.server.datastore.DataStore/AppendBundle",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DataStoreServer).AppendBundle(ctx, req.(*AppendBundleRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _DataStore_DeleteBundle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteBundleRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DataStoreServer).DeleteBundle(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.server.datastore.DataStore/DeleteBundle",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DataStoreServer).DeleteBundle(ctx, req.(*DeleteBundleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2250,20 +2747,20 @@ func _DataStore_FetchAttestedNodeEntry_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_FetchStaleNodeEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(FetchStaleNodeEntriesRequest)
+func _DataStore_ListAttestedNodeEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAttestedNodeEntriesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).FetchStaleNodeEntries(ctx, in)
+		return srv.(DataStoreServer).ListAttestedNodeEntries(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/FetchStaleNodeEntries",
+		FullMethod: "/spire.server.datastore.DataStore/ListAttestedNodeEntries",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchStaleNodeEntries(ctx, req.(*FetchStaleNodeEntriesRequest))
+		return srv.(DataStoreServer).ListAttestedNodeEntries(ctx, req.(*ListAttestedNodeEntriesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2322,20 +2819,20 @@ func _DataStore_CreateNodeResolverMapEntry_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_FetchNodeResolverMapEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(FetchNodeResolverMapEntryRequest)
+func _DataStore_ListNodeResolverMapEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListNodeResolverMapEntriesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).FetchNodeResolverMapEntry(ctx, in)
+		return srv.(DataStoreServer).ListNodeResolverMapEntries(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/FetchNodeResolverMapEntry",
+		FullMethod: "/spire.server.datastore.DataStore/ListNodeResolverMapEntries",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchNodeResolverMapEntry(ctx, req.(*FetchNodeResolverMapEntryRequest))
+		return srv.(DataStoreServer).ListNodeResolverMapEntries(ctx, req.(*ListNodeResolverMapEntriesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2412,20 +2909,20 @@ func _DataStore_FetchRegistrationEntry_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_FetchRegistrationEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(common.Empty)
+func _DataStore_ListRegistrationEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRegistrationEntriesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).FetchRegistrationEntries(ctx, in)
+		return srv.(DataStoreServer).ListRegistrationEntries(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/FetchRegistrationEntries",
+		FullMethod: "/spire.server.datastore.DataStore/ListRegistrationEntries",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchRegistrationEntries(ctx, req.(*common.Empty))
+		return srv.(DataStoreServer).ListRegistrationEntries(ctx, req.(*ListRegistrationEntriesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2466,146 +2963,74 @@ func _DataStore_DeleteRegistrationEntry_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListParentIDEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListParentIDEntriesRequest)
+func _DataStore_CreateJoinToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateJoinTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListParentIDEntries(ctx, in)
+		return srv.(DataStoreServer).CreateJoinToken(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListParentIDEntries",
+		FullMethod: "/spire.server.datastore.DataStore/CreateJoinToken",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListParentIDEntries(ctx, req.(*ListParentIDEntriesRequest))
+		return srv.(DataStoreServer).CreateJoinToken(ctx, req.(*CreateJoinTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListSelectorEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListSelectorEntriesRequest)
+func _DataStore_FetchJoinToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(FetchJoinTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListSelectorEntries(ctx, in)
+		return srv.(DataStoreServer).FetchJoinToken(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListSelectorEntries",
+		FullMethod: "/spire.server.datastore.DataStore/FetchJoinToken",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListSelectorEntries(ctx, req.(*ListSelectorEntriesRequest))
+		return srv.(DataStoreServer).FetchJoinToken(ctx, req.(*FetchJoinTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListMatchingEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListSelectorEntriesRequest)
+func _DataStore_DeleteJoinToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteJoinTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListMatchingEntries(ctx, in)
+		return srv.(DataStoreServer).DeleteJoinToken(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListMatchingEntries",
+		FullMethod: "/spire.server.datastore.DataStore/DeleteJoinToken",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListMatchingEntries(ctx, req.(*ListSelectorEntriesRequest))
+		return srv.(DataStoreServer).DeleteJoinToken(ctx, req.(*DeleteJoinTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataStore_ListSpiffeEntries_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListSpiffeEntriesRequest)
+func _DataStore_PruneJoinTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PruneJoinTokensRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataStoreServer).ListSpiffeEntries(ctx, in)
+		return srv.(DataStoreServer).PruneJoinTokens(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/ListSpiffeEntries",
+		FullMethod: "/spire.server.datastore.DataStore/PruneJoinTokens",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).ListSpiffeEntries(ctx, req.(*ListSpiffeEntriesRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_RegisterToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JoinToken)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).RegisterToken(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/RegisterToken",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).RegisterToken(ctx, req.(*JoinToken))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_FetchToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JoinToken)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).FetchToken(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/FetchToken",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).FetchToken(ctx, req.(*JoinToken))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_DeleteToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JoinToken)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).DeleteToken(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/DeleteToken",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).DeleteToken(ctx, req.(*JoinToken))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _DataStore_PruneTokens_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(JoinToken)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(DataStoreServer).PruneTokens(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/spire.server.datastore.DataStore/PruneTokens",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataStoreServer).PruneTokens(ctx, req.(*JoinToken))
+		return srv.(DataStoreServer).PruneJoinTokens(ctx, req.(*PruneJoinTokensRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -2655,6 +3080,14 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_CreateBundle_Handler,
 		},
 		{
+			MethodName: "FetchBundle",
+			Handler:    _DataStore_FetchBundle_Handler,
+		},
+		{
+			MethodName: "ListBundles",
+			Handler:    _DataStore_ListBundles_Handler,
+		},
+		{
 			MethodName: "UpdateBundle",
 			Handler:    _DataStore_UpdateBundle_Handler,
 		},
@@ -2667,14 +3100,6 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_DeleteBundle_Handler,
 		},
 		{
-			MethodName: "FetchBundle",
-			Handler:    _DataStore_FetchBundle_Handler,
-		},
-		{
-			MethodName: "ListBundles",
-			Handler:    _DataStore_ListBundles_Handler,
-		},
-		{
 			MethodName: "CreateAttestedNodeEntry",
 			Handler:    _DataStore_CreateAttestedNodeEntry_Handler,
 		},
@@ -2683,8 +3108,8 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_FetchAttestedNodeEntry_Handler,
 		},
 		{
-			MethodName: "FetchStaleNodeEntries",
-			Handler:    _DataStore_FetchStaleNodeEntries_Handler,
+			MethodName: "ListAttestedNodeEntries",
+			Handler:    _DataStore_ListAttestedNodeEntries_Handler,
 		},
 		{
 			MethodName: "UpdateAttestedNodeEntry",
@@ -2699,8 +3124,8 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_CreateNodeResolverMapEntry_Handler,
 		},
 		{
-			MethodName: "FetchNodeResolverMapEntry",
-			Handler:    _DataStore_FetchNodeResolverMapEntry_Handler,
+			MethodName: "ListNodeResolverMapEntries",
+			Handler:    _DataStore_ListNodeResolverMapEntries_Handler,
 		},
 		{
 			MethodName: "DeleteNodeResolverMapEntry",
@@ -2719,8 +3144,8 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_FetchRegistrationEntry_Handler,
 		},
 		{
-			MethodName: "FetchRegistrationEntries",
-			Handler:    _DataStore_FetchRegistrationEntries_Handler,
+			MethodName: "ListRegistrationEntries",
+			Handler:    _DataStore_ListRegistrationEntries_Handler,
 		},
 		{
 			MethodName: "UpdateRegistrationEntry",
@@ -2731,36 +3156,20 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 			Handler:    _DataStore_DeleteRegistrationEntry_Handler,
 		},
 		{
-			MethodName: "ListParentIDEntries",
-			Handler:    _DataStore_ListParentIDEntries_Handler,
+			MethodName: "CreateJoinToken",
+			Handler:    _DataStore_CreateJoinToken_Handler,
 		},
 		{
-			MethodName: "ListSelectorEntries",
-			Handler:    _DataStore_ListSelectorEntries_Handler,
+			MethodName: "FetchJoinToken",
+			Handler:    _DataStore_FetchJoinToken_Handler,
 		},
 		{
-			MethodName: "ListMatchingEntries",
-			Handler:    _DataStore_ListMatchingEntries_Handler,
+			MethodName: "DeleteJoinToken",
+			Handler:    _DataStore_DeleteJoinToken_Handler,
 		},
 		{
-			MethodName: "ListSpiffeEntries",
-			Handler:    _DataStore_ListSpiffeEntries_Handler,
-		},
-		{
-			MethodName: "RegisterToken",
-			Handler:    _DataStore_RegisterToken_Handler,
-		},
-		{
-			MethodName: "FetchToken",
-			Handler:    _DataStore_FetchToken_Handler,
-		},
-		{
-			MethodName: "DeleteToken",
-			Handler:    _DataStore_DeleteToken_Handler,
-		},
-		{
-			MethodName: "PruneTokens",
-			Handler:    _DataStore_PruneTokens_Handler,
+			MethodName: "PruneJoinTokens",
+			Handler:    _DataStore_PruneJoinTokens_Handler,
 		},
 		{
 			MethodName: "Configure",
@@ -2775,91 +3184,106 @@ var _DataStore_serviceDesc = grpc.ServiceDesc{
 	Metadata: "datastore.proto",
 }
 
-func init() { proto.RegisterFile("datastore.proto", fileDescriptor_datastore_396395c57dd52724) }
+func init() { proto.RegisterFile("datastore.proto", fileDescriptor_datastore_e3e0d519b06ed1bf) }
 
-var fileDescriptor_datastore_396395c57dd52724 = []byte{
-	// 1327 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xc4, 0x59, 0xcf, 0x6f, 0x1b, 0x45,
-	0x14, 0x66, 0x1b, 0x48, 0xe2, 0xe7, 0x54, 0x25, 0x93, 0x34, 0x38, 0x0b, 0xcd, 0x8f, 0x15, 0x45,
-	0x69, 0x55, 0x39, 0xad, 0xdb, 0x86, 0x04, 0xc1, 0xa1, 0x75, 0x92, 0x2a, 0x88, 0xa4, 0x61, 0x53,
-	0x84, 0xd4, 0x4b, 0xd8, 0xd8, 0xe3, 0x64, 0x15, 0x7b, 0x77, 0xd9, 0x19, 0x57, 0x4d, 0x0f, 0x88,
-	0x03, 0x3f, 0x24, 0x24, 0x50, 0x11, 0x27, 0x24, 0x0e, 0xfc, 0x33, 0xfc, 0x53, 0x9c, 0xd0, 0xce,
-	0xcc, 0x6e, 0x6c, 0xef, 0xcc, 0xac, 0xd7, 0xb5, 0xcd, 0x29, 0xd9, 0x9d, 0x79, 0xdf, 0xfb, 0xde,
-	0x9b, 0x99, 0x37, 0xef, 0x5b, 0xc3, 0xb5, 0xba, 0x43, 0x1d, 0x42, 0xfd, 0x10, 0x97, 0x83, 0xd0,
-	0xa7, 0x3e, 0x5a, 0x20, 0x81, 0x1b, 0xe2, 0x32, 0xc1, 0xe1, 0x0b, 0x1c, 0x96, 0x93, 0x51, 0x73,
-	0xf3, 0xd4, 0xa5, 0x67, 0xed, 0x93, 0x72, 0xcd, 0x6f, 0xad, 0x93, 0xc0, 0x6d, 0x34, 0xf0, 0x3a,
-	0x9b, 0xb9, 0xce, 0xcc, 0xd6, 0x6b, 0x7e, 0xab, 0xe5, 0x7b, 0xeb, 0x41, 0xb3, 0x7d, 0xea, 0xc6,
-	0x7f, 0x38, 0xa2, 0x79, 0xaf, 0x2f, 0x4b, 0xfe, 0x87, 0x9b, 0x58, 0xbb, 0x30, 0xf9, 0xb8, 0xed,
-	0xd5, 0x9b, 0x18, 0xad, 0xc2, 0x0c, 0x0d, 0xdb, 0x84, 0x1e, 0xd7, 0xfd, 0x96, 0xe3, 0x7a, 0x25,
-	0x63, 0xc5, 0x58, 0x2b, 0xd8, 0x45, 0xf6, 0x6e, 0x9b, 0xbd, 0x42, 0x8b, 0x30, 0x5d, 0x73, 0x8e,
-	0x6b, 0x38, 0xa4, 0xa4, 0x74, 0x65, 0xc5, 0x58, 0x9b, 0xb1, 0xa7, 0x6a, 0x4e, 0x35, 0x7a, 0xb4,
-	0xaa, 0x30, 0xc5, 0x71, 0x08, 0xda, 0x84, 0xa9, 0x13, 0xfe, 0x6f, 0xc9, 0x58, 0x99, 0x58, 0x2b,
-	0x56, 0x96, 0xca, 0xf2, 0x48, 0xcb, 0xdc, 0xc2, 0x8e, 0xa7, 0x5b, 0x1e, 0xcc, 0x1f, 0xf8, 0x75,
-	0x6c, 0x63, 0xe2, 0x37, 0x5f, 0xe0, 0x70, 0xdf, 0x09, 0x76, 0x3c, 0x1a, 0x5e, 0x20, 0x0b, 0x66,
-	0x4e, 0x1c, 0x82, 0x8f, 0x58, 0x48, 0x7b, 0x75, 0x41, 0xad, 0xeb, 0x1d, 0xaa, 0xc0, 0x34, 0xc1,
-	0x4d, 0x5c, 0xa3, 0x7e, 0xc8, 0xb8, 0x15, 0x2b, 0x0b, 0xc2, 0xad, 0x88, 0xf7, 0x48, 0x8c, 0xda,
-	0xc9, 0x3c, 0xeb, 0x1f, 0x03, 0x66, 0x1f, 0x51, 0x8a, 0x09, 0xc5, 0xf5, 0xc8, 0x71, 0xff, 0xde,
-	0xee, 0xc2, 0x9c, 0xc3, 0x0c, 0x1d, 0xea, 0xfa, 0xde, 0xb6, 0x43, 0x9d, 0x67, 0x17, 0x01, 0x66,
-	0x8e, 0x0b, 0xb6, 0x6c, 0x08, 0xdd, 0x86, 0x77, 0xa3, 0xc4, 0x1d, 0xe1, 0xd0, 0x75, 0x9a, 0x07,
-	0xed, 0xd6, 0x09, 0x0e, 0x4b, 0x13, 0x6c, 0x7a, 0xea, 0x3d, 0x2a, 0x03, 0x8a, 0xde, 0xed, 0xbc,
-	0x0c, 0xdc, 0x30, 0x46, 0xc1, 0xa5, 0xb7, 0xd9, 0x6c, 0xc9, 0x88, 0x75, 0x01, 0x4b, 0xd5, 0x10,
-	0x3b, 0x14, 0xa7, 0x82, 0xb1, 0xf1, 0xb7, 0x6d, 0x4c, 0x28, 0xfa, 0x1a, 0x66, 0x9d, 0xde, 0x31,
-	0x16, 0x58, 0xb1, 0x72, 0x4b, 0xb5, 0x3a, 0x69, 0xb0, 0x34, 0x86, 0xf5, 0x0a, 0x96, 0x95, 0xae,
-	0x49, 0xe0, 0x7b, 0x04, 0x8f, 0xce, 0x77, 0x15, 0x6e, 0xec, 0x62, 0x5a, 0x3b, 0x53, 0x46, 0xdd,
-	0xc7, 0x4a, 0x46, 0xb9, 0x53, 0x81, 0x8c, 0x9a, 0xff, 0x12, 0x7c, 0xc0, 0x5c, 0x1f, 0x51, 0xa7,
-	0x89, 0xe3, 0xd7, 0x2e, 0x26, 0x82, 0xbe, 0xf5, 0xbd, 0x21, 0x02, 0x4c, 0x4f, 0x10, 0xd4, 0x8e,
-	0xe1, 0x7a, 0x0a, 0xf6, 0x0b, 0x97, 0x50, 0x71, 0xf0, 0x72, 0xd0, 0x93, 0xe3, 0x58, 0x7f, 0x1b,
-	0xb0, 0xf4, 0x55, 0x50, 0xd7, 0x6d, 0xad, 0x7e, 0x8e, 0x8b, 0x6c, 0xf3, 0x5f, 0xc9, 0xb5, 0xf9,
-	0x27, 0x94, 0x9b, 0xff, 0x15, 0x2c, 0x2b, 0x19, 0x8e, 0x7a, 0x05, 0xb7, 0x61, 0x69, 0x1b, 0x37,
-	0xf1, 0x9b, 0x65, 0x27, 0x8a, 0x40, 0x89, 0x32, 0xea, 0x08, 0x7e, 0x34, 0x60, 0x95, 0x1f, 0x60,
-	0x59, 0xe5, 0x8d, 0xa3, 0xf8, 0x06, 0xe6, 0x3d, 0xc9, 0xb0, 0x60, 0x70, 0x47, 0xc5, 0x40, 0x0a,
-	0x29, 0x45, 0xb2, 0x7e, 0x32, 0xc0, 0xd2, 0xf1, 0x10, 0x79, 0x18, 0x3d, 0x91, 0x5d, 0x58, 0x61,
-	0x67, 0x4e, 0x97, 0x8e, 0x7e, 0x16, 0xf5, 0x57, 0x03, 0x56, 0x35, 0x40, 0x22, 0x9e, 0x33, 0x28,
-	0xc9, 0x58, 0x74, 0x9c, 0xe1, 0x7c, 0x31, 0x29, 0xd1, 0xd8, 0x42, 0xf3, 0x5d, 0xf6, 0xff, 0x2e,
-	0xf4, 0x6f, 0x06, 0x58, 0x3a, 0x1e, 0x63, 0x4f, 0xcc, 0x6b, 0x03, 0x3e, 0xb4, 0x71, 0x8d, 0xba,
-	0x8d, 0x0b, 0x89, 0xe5, 0x65, 0x39, 0x1e, 0x23, 0xa5, 0xdf, 0x0d, 0xb8, 0x99, 0x41, 0x69, 0xec,
-	0x69, 0x3a, 0x8f, 0x7b, 0x0c, 0x1b, 0x9f, 0xba, 0x84, 0xf2, 0x02, 0xdc, 0xb5, 0x77, 0xf6, 0xe0,
-	0x5a, 0xc8, 0xc6, 0x70, 0x88, 0xeb, 0x9d, 0xdb, 0x66, 0xb9, 0xbb, 0x11, 0x4b, 0x03, 0xf4, 0xda,
-	0x59, 0x4f, 0xe3, 0xae, 0x42, 0xe2, 0x4c, 0x44, 0x7e, 0x07, 0x66, 0x7b, 0xac, 0x92, 0x83, 0x98,
-	0x1e, 0xb0, 0xf6, 0xc5, 0x4d, 0xaa, 0x24, 0x9f, 0x0f, 0xee, 0x5c, 0x34, 0x0d, 0x6a, 0x7a, 0x43,
-	0x4c, 0x06, 0x11, 0x15, 0xa9, 0x77, 0x6a, 0xe7, 0x3e, 0x78, 0xda, 0x4b, 0xdf, 0x65, 0xdd, 0x77,
-	0xe4, 0x70, 0x55, 0xef, 0x30, 0x42, 0x49, 0xdb, 0x5a, 0x7f, 0x26, 0x17, 0xff, 0x70, 0x52, 0x26,
-	0x4b, 0xc8, 0x95, 0x01, 0x13, 0xd2, 0x8c, 0x6f, 0xfc, 0xb1, 0xa4, 0xff, 0x20, 0xbe, 0xe3, 0x87,
-	0xb4, 0x77, 0x9a, 0xf1, 0x6d, 0x3f, 0x16, 0xf6, 0x9b, 0x60, 0x46, 0xc7, 0xf7, 0xd0, 0x09, 0xb1,
-	0x47, 0xf7, 0xb6, 0x7b, 0x4a, 0x9a, 0x09, 0xd3, 0x01, 0x1f, 0x89, 0x09, 0x27, 0xcf, 0x56, 0x00,
-	0xef, 0x4b, 0x2d, 0x05, 0xc7, 0x2f, 0x61, 0xae, 0xc7, 0x57, 0x47, 0xd1, 0xc9, 0xe4, 0x29, 0xb3,
-	0xb5, 0x6c, 0xce, 0x35, 0x16, 0x6a, 0x3d, 0x5c, 0x1f, 0x40, 0x21, 0x16, 0x6e, 0xb1, 0xb0, 0x54,
-	0x29, 0xbc, 0xcb, 0x89, 0x71, 0x14, 0x29, 0xcc, 0xd1, 0x45, 0xb1, 0x01, 0x25, 0xe6, 0x91, 0x35,
-	0x02, 0xe9, 0x7c, 0x93, 0xee, 0xa6, 0x21, 0x79, 0xb6, 0x3c, 0x58, 0x94, 0xd8, 0x8d, 0x8e, 0xe7,
-	0x16, 0x14, 0x3e, 0xf7, 0x5d, 0xef, 0x99, 0x7f, 0x8e, 0x3d, 0x34, 0x0f, 0xef, 0xd0, 0xe8, 0x1f,
-	0xc1, 0x8a, 0x3f, 0xa0, 0x05, 0x98, 0xc4, 0x51, 0xb3, 0xcd, 0x8f, 0xea, 0x84, 0x2d, 0x9e, 0x2a,
-	0xff, 0x9a, 0x50, 0x88, 0x84, 0xed, 0x51, 0x74, 0x91, 0xa0, 0x03, 0x98, 0xe1, 0xc5, 0x5a, 0x7c,
-	0x48, 0xc8, 0x90, 0xfb, 0x66, 0xc6, 0x78, 0x84, 0xc7, 0x8f, 0xf7, 0xf0, 0xf0, 0x1e, 0x05, 0x01,
-	0xf6, 0xea, 0xc3, 0xc3, 0xe3, 0x07, 0x78, 0x48, 0x78, 0xfb, 0x50, 0x64, 0xf5, 0x7d, 0x48, 0x70,
-	0x55, 0x28, 0x46, 0xeb, 0x1b, 0x7f, 0x8d, 0x99, 0xeb, 0xde, 0x1c, 0x3b, 0xad, 0x80, 0x5e, 0x98,
-	0xcb, 0x7a, 0x0c, 0x82, 0x7e, 0x31, 0xe0, 0x3d, 0x85, 0xae, 0x47, 0x1b, 0x2a, 0x63, 0xfd, 0x37,
-	0x08, 0xf3, 0xe3, 0xdc, 0x76, 0x62, 0xf3, 0xff, 0x6c, 0xc0, 0x82, 0x5c, 0xa3, 0xa3, 0x87, 0x2a,
-	0x4c, 0xed, 0x87, 0x01, 0x73, 0x23, 0xaf, 0x99, 0x60, 0xf2, 0x83, 0x01, 0xd7, 0xa5, 0x8a, 0x1c,
-	0x3d, 0xd0, 0x22, 0x2a, 0x14, 0xbe, 0xf9, 0x30, 0xa7, 0x95, 0xa0, 0x11, 0xad, 0x8e, 0x42, 0xf3,
-	0xaa, 0x57, 0x47, 0x2f, 0xe3, 0xd5, 0xab, 0x93, 0x25, 0xae, 0x23, 0x32, 0x0a, 0xf9, 0xaa, 0x26,
-	0xa3, 0x57, 0xcd, 0x6a, 0x32, 0x59, 0x3a, 0xf9, 0x0f, 0x03, 0x4c, 0xb5, 0x8c, 0x44, 0x5b, 0xfa,
-	0x2d, 0xa8, 0x51, 0x46, 0xe6, 0x27, 0x83, 0x98, 0x0a, 0x56, 0xaf, 0x0d, 0x58, 0x54, 0x6a, 0x41,
-	0xb4, 0xa9, 0xdd, 0x04, 0x3a, 0x4e, 0x5b, 0x03, 0x58, 0x76, 0x24, 0x4a, 0x2d, 0xc3, 0xd4, 0x89,
-	0xca, 0x94, 0x90, 0xea, 0x44, 0xf5, 0xa1, 0xfa, 0xfe, 0x32, 0xe0, 0x86, 0x56, 0xf8, 0xa0, 0x4f,
-	0x55, 0xe8, 0xfd, 0x48, 0x38, 0xf3, 0xb3, 0x01, 0xad, 0x3b, 0xb6, 0xba, 0x42, 0x97, 0x64, 0x55,
-	0x45, 0x55, 0xf3, 0x98, 0x55, 0x15, 0xd5, 0x4d, 0x62, 0x52, 0x15, 0xd3, 0x5c, 0xf4, 0x65, 0x45,
-	0x49, 0x65, 0x23, 0xaf, 0x99, 0x60, 0xe2, 0x42, 0x49, 0x25, 0x50, 0xe4, 0xd7, 0xcf, 0x66, 0x2e,
-	0x47, 0xf2, 0xca, 0x97, 0x63, 0x05, 0xf4, 0x3a, 0x26, 0xab, 0xf2, 0xa9, 0xe3, 0xbe, 0xac, 0x7c,
-	0x39, 0xc8, 0xe8, 0xb5, 0x44, 0x56, 0xe5, 0x53, 0x93, 0xf9, 0x0e, 0xe6, 0x24, 0xed, 0x3a, 0xaa,
-	0xa8, 0xf0, 0xd4, 0xaa, 0xc0, 0xbc, 0x9f, 0xcb, 0xa6, 0xdb, 0x7f, 0x4f, 0xa3, 0xad, 0xf7, 0x2f,
-	0xef, 0xf4, 0xf5, 0xfe, 0x55, 0x9d, 0xbc, 0xf0, 0xbf, 0xef, 0xd0, 0xda, 0x99, 0xeb, 0x9d, 0x8e,
-	0xdd, 0xff, 0x4b, 0x98, 0x4d, 0xb5, 0xef, 0xe8, 0xae, 0x16, 0x49, 0xa2, 0x10, 0xcc, 0x7b, 0x39,
-	0x2c, 0x84, 0xe7, 0x27, 0x70, 0xd5, 0x16, 0xfd, 0x3d, 0x6f, 0xe6, 0x57, 0x55, 0x18, 0x49, 0xbf,
-	0x6f, 0xca, 0x8e, 0x25, 0xb2, 0x01, 0xd8, 0x01, 0xec, 0x1b, 0x25, 0x7b, 0x0a, 0xda, 0x81, 0x22,
-	0xdf, 0xb9, 0x6f, 0x46, 0x6d, 0x07, 0x8a, 0x87, 0x61, 0xdb, 0xe3, 0x28, 0x64, 0x60, 0x98, 0xe7,
-	0x50, 0xa8, 0xfa, 0x5e, 0xc3, 0x3d, 0x6d, 0x87, 0x18, 0xdd, 0xec, 0x9e, 0x21, 0x7e, 0x49, 0x4d,
-	0xc6, 0xe3, 0x15, 0xf9, 0x28, 0x6b, 0x9a, 0x58, 0x86, 0x06, 0x5c, 0x7d, 0x82, 0xe9, 0x21, 0x1b,
-	0xde, 0xf3, 0x1a, 0x3e, 0xba, 0x25, 0x35, 0xec, 0x9a, 0x13, 0xfb, 0xb8, 0xdd, 0xcf, 0x54, 0xee,
-	0xe7, 0x71, 0xf1, 0x79, 0x21, 0x89, 0xf7, 0xf0, 0xad, 0x43, 0xe3, 0x64, 0x92, 0xfd, 0x92, 0x7b,
-	0xff, 0xbf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x19, 0x54, 0x7e, 0x5e, 0x61, 0x1e, 0x00, 0x00,
+var fileDescriptor_datastore_e3e0d519b06ed1bf = []byte{
+	// 1562 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x59, 0xef, 0x72, 0xd3, 0xd6,
+	0x12, 0xbf, 0xc6, 0x97, 0x10, 0xaf, 0x0d, 0xb9, 0x28, 0x21, 0x24, 0xe6, 0xe2, 0x24, 0xba, 0x70,
+	0x87, 0xbf, 0xf6, 0x34, 0x85, 0xf0, 0xa7, 0x50, 0x48, 0x02, 0x61, 0xd2, 0x29, 0x69, 0x46, 0xa1,
+	0x85, 0x81, 0xce, 0x68, 0x24, 0xfb, 0xd8, 0x88, 0x3a, 0x3a, 0xaa, 0x74, 0x0c, 0xd5, 0x13, 0x74,
+	0xa6, 0xdf, 0x3a, 0xfd, 0xda, 0x07, 0xe9, 0x23, 0xf5, 0x05, 0xfa, 0xbd, 0xa3, 0x73, 0x8e, 0x6c,
+	0xcb, 0xd2, 0x4a, 0xb2, 0xa3, 0x7e, 0x8a, 0x7d, 0xce, 0xfe, 0xf9, 0xed, 0x9e, 0xdd, 0xf5, 0xee,
+	0x06, 0x16, 0x3a, 0x06, 0x33, 0x3c, 0x46, 0x5d, 0xd2, 0x74, 0x5c, 0xca, 0xa8, 0xb2, 0xec, 0x39,
+	0x96, 0x4b, 0x9a, 0x1e, 0x71, 0x3f, 0x12, 0xb7, 0x39, 0xbc, 0xad, 0x37, 0x7a, 0x94, 0xf6, 0xfa,
+	0xa4, 0xc5, 0xa9, 0xcc, 0x41, 0xb7, 0xf5, 0xc9, 0x35, 0x1c, 0x87, 0xb8, 0x9e, 0xe0, 0xab, 0xdf,
+	0xef, 0x59, 0xec, 0xfd, 0xc0, 0x6c, 0xb6, 0xe9, 0x71, 0xcb, 0x73, 0xac, 0x6e, 0x97, 0xb4, 0xb8,
+	0x24, 0xc1, 0xd0, 0x6a, 0xd3, 0xe3, 0x63, 0x6a, 0xb7, 0x9c, 0xfe, 0xa0, 0x67, 0x85, 0x7f, 0x24,
+	0xe7, 0x67, 0xb9, 0x38, 0xc5, 0x1f, 0xc1, 0xa2, 0xee, 0xc1, 0xdc, 0xce, 0xc0, 0xee, 0xf4, 0x89,
+	0xb2, 0x01, 0x35, 0xe6, 0x0e, 0x3c, 0xa6, 0x77, 0xe8, 0xb1, 0x61, 0xd9, 0x2b, 0xa5, 0xf5, 0xd2,
+	0xb5, 0x8a, 0x56, 0xe5, 0x67, 0xcf, 0xf8, 0x91, 0xb2, 0x0a, 0xf3, 0x6d, 0x43, 0x6f, 0x13, 0x97,
+	0x79, 0x2b, 0xa7, 0xd6, 0x4b, 0xd7, 0x6a, 0xda, 0x99, 0xb6, 0xb1, 0x1b, 0x7c, 0x55, 0x5f, 0xc2,
+	0xe2, 0xae, 0x4b, 0x0c, 0x46, 0x84, 0x34, 0x8d, 0xfc, 0x38, 0x20, 0x1e, 0x53, 0xb6, 0x60, 0xce,
+	0xe4, 0x07, 0x5c, 0x5c, 0x75, 0xb3, 0xd1, 0x4c, 0x76, 0x4a, 0x53, 0xb2, 0x49, 0x6a, 0xf5, 0x00,
+	0x96, 0xa2, 0xe2, 0x3c, 0x87, 0xda, 0x1e, 0x99, 0x59, 0xde, 0x3d, 0x50, 0xf6, 0x08, 0x6b, 0xbf,
+	0x8f, 0xa2, 0xcb, 0x36, 0x39, 0xb0, 0x2b, 0xc2, 0x78, 0x42, 0x1c, 0x4b, 0xa0, 0x7c, 0x6d, 0x79,
+	0x4c, 0x9c, 0x7a, 0x12, 0x87, 0xfa, 0x0d, 0x2c, 0x46, 0x4e, 0xa5, 0x92, 0xfb, 0x70, 0x46, 0xb0,
+	0x79, 0x2b, 0xa5, 0xf5, 0x72, 0x0e, 0x2d, 0x21, 0x79, 0x80, 0xfa, 0x5b, 0xa7, 0x53, 0xe4, 0x6b,
+	0x44, 0xc5, 0x9d, 0xd0, 0x0b, 0x2f, 0x61, 0x71, 0xdb, 0x71, 0x88, 0xdd, 0x29, 0x0c, 0x5e, 0x54,
+	0xdc, 0x09, 0xe1, 0xdd, 0x87, 0xc5, 0x67, 0xa4, 0x4f, 0x26, 0xbd, 0x97, 0x23, 0x5a, 0x0e, 0x60,
+	0x29, 0xca, 0x79, 0x42, 0x24, 0x3d, 0x58, 0x3a, 0xa0, 0x9d, 0x40, 0x0e, 0xed, 0x7f, 0x24, 0xee,
+	0x4b, 0xc3, 0x79, 0x6e, 0x33, 0xd7, 0x57, 0x2e, 0x41, 0x45, 0xe4, 0xb7, 0x6e, 0x75, 0x24, 0x8e,
+	0x79, 0x71, 0xb0, 0xdf, 0x51, 0x36, 0x61, 0xde, 0x23, 0x7d, 0xd2, 0x66, 0xd4, 0xe5, 0x59, 0x5a,
+	0xdd, 0x5c, 0x96, 0xea, 0x64, 0xe6, 0x1f, 0xc9, 0x5b, 0x6d, 0x48, 0xa7, 0xf6, 0x60, 0x43, 0xe4,
+	0x5b, 0x92, 0xba, 0xd0, 0x01, 0x3b, 0x70, 0x9a, 0x04, 0xdf, 0xa5, 0x11, 0xb7, 0x30, 0x23, 0x12,
+	0x65, 0x08, 0x56, 0xf5, 0x3d, 0xa8, 0x69, 0x8a, 0xa4, 0xbf, 0x8a, 0xd0, 0xf4, 0x14, 0x36, 0x82,
+	0xa4, 0x4a, 0x20, 0xb1, 0x86, 0x99, 0x97, 0xea, 0x48, 0xb5, 0x0f, 0x6a, 0x9a, 0x04, 0x89, 0x75,
+	0x0f, 0xce, 0x10, 0x71, 0x24, 0xb3, 0x74, 0x3a, 0xb4, 0x21, 0x73, 0xf0, 0x04, 0x22, 0x76, 0xfe,
+	0xe9, 0x27, 0xe8, 0x83, 0x9a, 0xa6, 0xa8, 0x60, 0xb3, 0x6c, 0xb8, 0xa2, 0x91, 0x36, 0xb3, 0xba,
+	0x7e, 0xfa, 0x4b, 0x14, 0xa5, 0x8f, 0xc2, 0xd5, 0x0c, 0x7d, 0x05, 0x1b, 0xf8, 0x47, 0x09, 0xce,
+	0x6f, 0x33, 0x46, 0x3c, 0x46, 0x3a, 0x01, 0x65, 0xae, 0x0c, 0xbd, 0x60, 0x70, 0x0e, 0x83, 0x59,
+	0xd4, 0xd6, 0x03, 0x4d, 0x3a, 0xf3, 0x1d, 0xc2, 0xd3, 0xb5, 0xa2, 0x2d, 0x8e, 0x5d, 0x3e, 0x33,
+	0x98, 0xf1, 0xca, 0x77, 0x88, 0x72, 0x0b, 0x94, 0xe0, 0x87, 0x57, 0xf7, 0x88, 0x6b, 0x19, 0x7d,
+	0xdd, 0x1e, 0x1c, 0x9b, 0xc4, 0x5d, 0x29, 0x73, 0x86, 0xff, 0x04, 0x37, 0x47, 0xfc, 0xe2, 0x80,
+	0x9f, 0x2b, 0x57, 0xe0, 0x1c, 0xa7, 0xb6, 0x29, 0xd3, 0x8d, 0x2e, 0x23, 0xee, 0xca, 0xbf, 0xd7,
+	0x4b, 0xd7, 0xca, 0x5a, 0x2d, 0x38, 0x3d, 0xa0, 0x6c, 0x3b, 0x38, 0x53, 0x0d, 0x68, 0x88, 0x64,
+	0x8c, 0xe1, 0x0f, 0x5f, 0xe5, 0x49, 0x34, 0xde, 0xae, 0x63, 0x2e, 0x8a, 0x0b, 0x90, 0xc1, 0x66,
+	0xc2, 0x1a, 0xaa, 0x42, 0x3e, 0xc4, 0x89, 0x75, 0x3c, 0x82, 0xcb, 0xfc, 0x37, 0x1a, 0xb5, 0x22,
+	0x35, 0xcb, 0x0d, 0x68, 0x60, 0xdc, 0x45, 0x01, 0xb4, 0xa0, 0x11, 0x14, 0x92, 0xc9, 0xfb, 0xb1,
+	0xe8, 0x7f, 0x01, 0xe7, 0x4d, 0x5f, 0x27, 0x3f, 0x05, 0x82, 0x3d, 0xdd, 0x24, 0x5d, 0xea, 0x86,
+	0xbf, 0x15, 0x97, 0x9a, 0xa2, 0x5f, 0x6c, 0x86, 0xfd, 0x62, 0x73, 0xdf, 0x66, 0x5b, 0x77, 0xbe,
+	0x33, 0xfa, 0x03, 0xa2, 0x2d, 0x98, 0xfe, 0x73, 0xc1, 0xb4, 0xc3, 0x79, 0xd4, 0x2e, 0xac, 0xa1,
+	0xaa, 0xa4, 0x39, 0xbb, 0x93, 0x81, 0x3f, 0x85, 0x41, 0xc3, 0xa8, 0xff, 0xb5, 0x04, 0x0d, 0xd1,
+	0x13, 0xcc, 0xe4, 0x75, 0x24, 0x9c, 0x4f, 0xe5, 0x0e, 0xe7, 0x72, 0x42, 0x38, 0x9b, 0xb0, 0x86,
+	0x42, 0x2a, 0xea, 0x29, 0x1f, 0x43, 0x43, 0x14, 0xcf, 0xd9, 0x82, 0xcd, 0x84, 0x35, 0x94, 0xbd,
+	0x28, 0x88, 0xaf, 0xc3, 0xac, 0xd6, 0x48, 0xcf, 0xf2, 0x98, 0xcb, 0xeb, 0x48, 0x04, 0xe2, 0xdd,
+	0xa8, 0x8a, 0xb5, 0x68, 0x7b, 0x10, 0x67, 0x1b, 0xe6, 0xd9, 0x1a, 0x2a, 0x58, 0x82, 0x5f, 0x85,
+	0x79, 0x4e, 0x3b, 0xb2, 0x9d, 0x47, 0x8c, 0xbf, 0xdf, 0x51, 0x1f, 0xca, 0x2c, 0x45, 0x51, 0xa5,
+	0xf0, 0xbe, 0x96, 0x39, 0x8a, 0x2b, 0x9e, 0xd1, 0xa4, 0x4f, 0x50, 0xdd, 0xf1, 0xc3, 0x7e, 0xc8,
+	0x53, 0xee, 0x40, 0x25, 0x6c, 0x89, 0xc2, 0xe4, 0xc0, 0x7a, 0xa7, 0x11, 0x21, 0x2f, 0xe7, 0xfd,
+	0x3e, 0xfd, 0xa4, 0x1b, 0xb6, 0xaf, 0xb7, 0xe9, 0xb1, 0x69, 0xd9, 0x5c, 0x13, 0x0f, 0xe7, 0x79,
+	0x6d, 0x91, 0x5f, 0x6e, 0xdb, 0xfe, 0xee, 0xe8, 0x4a, 0xfd, 0xb3, 0x24, 0x6a, 0xc2, 0x24, 0xb2,
+	0xb1, 0x9a, 0xf0, 0x25, 0xd4, 0x4c, 0x5f, 0x77, 0x0c, 0x97, 0xd8, 0x2c, 0xf4, 0x49, 0x75, 0xf3,
+	0xbf, 0xb1, 0x72, 0x70, 0xc4, 0x5c, 0xcb, 0xee, 0x89, 0x7a, 0x00, 0xa6, 0x7f, 0xc8, 0x19, 0xf6,
+	0x3b, 0xca, 0x1e, 0xe7, 0x1f, 0xd9, 0x23, 0x7a, 0xc1, 0xff, 0xa1, 0xad, 0xe7, 0xc8, 0x0f, 0x5a,
+	0xd5, 0x1c, 0x73, 0x8a, 0xc0, 0x31, 0x8a, 0xe9, 0x72, 0x3e, 0x1c, 0x47, 0x61, 0xcc, 0x7f, 0x2f,
+	0x4a, 0x52, 0xa2, 0xa5, 0xf2, 0xf5, 0x1e, 0x4c, 0x96, 0xa4, 0xcc, 0xf7, 0x1b, 0x16, 0xa2, 0xd7,
+	0x61, 0x1d, 0x2a, 0x3a, 0xda, 0xdf, 0x84, 0xd5, 0xa4, 0xf0, 0xa0, 0xfb, 0x22, 0xac, 0x21, 0xb3,
+	0xa4, 0xc2, 0x9b, 0xb0, 0x82, 0x14, 0x0e, 0xeb, 0x01, 0x54, 0xbe, 0xa2, 0x96, 0xfd, 0x8a, 0xfe,
+	0x40, 0x6c, 0x65, 0x09, 0x4e, 0xb3, 0xe0, 0x83, 0x54, 0x2f, 0xbe, 0x28, 0xcb, 0x30, 0xc7, 0x7f,
+	0xa3, 0x7c, 0x1e, 0x4c, 0x65, 0x4d, 0x7e, 0x53, 0xdf, 0xc2, 0xb2, 0xa8, 0x0c, 0x43, 0x01, 0xa1,
+	0x25, 0x4f, 0x01, 0x3e, 0x50, 0xcb, 0xd6, 0x47, 0xc2, 0xaa, 0x9b, 0x1b, 0x58, 0x08, 0x8e, 0xb8,
+	0x2b, 0x1f, 0xc2, 0x8f, 0xea, 0x3b, 0xb8, 0x18, 0x93, 0x2d, 0x0d, 0x3d, 0xb9, 0xf0, 0xdb, 0x70,
+	0x81, 0x17, 0x96, 0x18, 0xee, 0x44, 0xfb, 0x03, 0x3b, 0x27, 0xc9, 0x0b, 0x83, 0xd2, 0x84, 0x65,
+	0xf1, 0xb0, 0x39, 0xb1, 0xbc, 0x83, 0x8b, 0x31, 0xfa, 0xc2, 0xc0, 0x3c, 0x81, 0xe5, 0x43, 0x77,
+	0x60, 0x8f, 0x64, 0x0f, 0xab, 0xd2, 0x55, 0x38, 0x97, 0xd0, 0xa6, 0x94, 0xb5, 0xb3, 0x24, 0xd2,
+	0x87, 0xac, 0xc2, 0xc5, 0x98, 0x00, 0x81, 0x6e, 0xf3, 0xaf, 0x55, 0xa8, 0x04, 0x6d, 0xed, 0x51,
+	0xa0, 0x5e, 0xb1, 0xa0, 0x36, 0xbe, 0xe9, 0x51, 0x6e, 0x62, 0x38, 0x13, 0xd6, 0x4b, 0xf5, 0x5b,
+	0xf9, 0x88, 0xa5, 0x5b, 0xba, 0x50, 0x1d, 0xdb, 0xe5, 0x28, 0x37, 0x30, 0xe6, 0xf8, 0xa6, 0xa8,
+	0x7e, 0x33, 0x17, 0xed, 0x48, 0xcf, 0xd8, 0x3a, 0x07, 0xd7, 0x13, 0xdf, 0x04, 0xe1, 0x7a, 0x92,
+	0xf6, 0x43, 0x16, 0xd4, 0xc6, 0xd7, 0x32, 0xb8, 0xeb, 0x12, 0x76, 0x41, 0xb8, 0xeb, 0x12, 0x37,
+	0x3d, 0x16, 0xd4, 0xc6, 0x57, 0x2c, 0xb8, 0xaa, 0x84, 0xbd, 0x0e, 0xae, 0x2a, 0x71, 0x6b, 0x63,
+	0x41, 0x6d, 0x7c, 0x87, 0x82, 0xab, 0x4a, 0xd8, 0xd1, 0xe0, 0xaa, 0x12, 0xd7, 0x32, 0xbf, 0x94,
+	0xc2, 0xda, 0x12, 0x1f, 0xe0, 0xb6, 0xd2, 0x43, 0x0b, 0x6b, 0xff, 0xea, 0xf7, 0xa6, 0xe6, 0x93,
+	0x60, 0x7e, 0x2e, 0xc9, 0xe2, 0x12, 0xc7, 0x72, 0x37, 0x35, 0xfa, 0x50, 0x28, 0x5b, 0xd3, 0xb2,
+	0x8d, 0xb9, 0x05, 0x19, 0x22, 0x70, 0xb7, 0xa4, 0x0f, 0x38, 0xb8, 0x5b, 0xb2, 0xa6, 0x95, 0x00,
+	0x0c, 0xd2, 0xd5, 0xe3, 0x60, 0xd2, 0x27, 0x13, 0x1c, 0x4c, 0xd6, 0xf8, 0x10, 0x80, 0x41, 0xfa,
+	0x77, 0x1c, 0x4c, 0xfa, 0xbc, 0x80, 0x83, 0xc9, 0x1a, 0x14, 0x7e, 0x2b, 0x41, 0x1d, 0xdf, 0xa5,
+	0x29, 0x0f, 0xd2, 0x03, 0x31, 0x65, 0xcb, 0x54, 0x7f, 0x38, 0x0b, 0xeb, 0x18, 0x2a, 0x7c, 0x6b,
+	0x86, 0xa3, 0xca, 0xdc, 0xd5, 0xe1, 0xa8, 0x72, 0x2c, 0xe9, 0x02, 0x54, 0xf8, 0xd2, 0x0b, 0x47,
+	0x95, 0xb9, 0x91, 0xc3, 0x51, 0xe5, 0xd8, 0xb1, 0xfd, 0x5e, 0x82, 0xcb, 0xa9, 0xcb, 0x2a, 0xe5,
+	0x11, 0x26, 0x3d, 0xcf, 0x4e, 0xad, 0xfe, 0x78, 0x46, 0xee, 0x58, 0x79, 0x8c, 0xf5, 0x8c, 0x59,
+	0xe5, 0x11, 0xeb, 0x6c, 0xb3, 0xca, 0x23, 0xde, 0xd4, 0x0e, 0xcb, 0x63, 0x1c, 0x4b, 0x7a, 0x79,
+	0x44, 0xa1, 0x6c, 0x4d, 0xcb, 0x36, 0x51, 0x1e, 0x13, 0x06, 0x9a, 0xf4, 0xf2, 0x88, 0xcf, 0x7a,
+	0xe9, 0xe5, 0x31, 0x6d, 0x72, 0x1a, 0x95, 0xc7, 0x29, 0xde, 0x28, 0x7d, 0x60, 0xca, 0x2a, 0x8f,
+	0xe9, 0x9e, 0x41, 0x86, 0x93, 0xac, 0xf2, 0x38, 0x3d, 0x98, 0xac, 0x29, 0xc8, 0x85, 0x85, 0x89,
+	0xb9, 0x41, 0x69, 0xa6, 0x07, 0xdf, 0x64, 0xe3, 0x5d, 0x6f, 0xe5, 0xa6, 0x97, 0x3a, 0x29, 0x9c,
+	0x8b, 0xce, 0x07, 0xca, 0xed, 0xd4, 0x20, 0x8b, 0x69, 0x6c, 0xe6, 0x25, 0x1f, 0x19, 0x39, 0x31,
+	0x04, 0xe0, 0x46, 0x26, 0x4f, 0x17, 0xb8, 0x91, 0xd8, 0x74, 0xe1, 0xc2, 0xc2, 0x44, 0x6b, 0x8f,
+	0xeb, 0x4c, 0x1e, 0x22, 0x70, 0x9d, 0xc8, 0xcc, 0xa0, 0xbc, 0x85, 0xca, 0x2e, 0xb5, 0xbb, 0x56,
+	0x6f, 0xe0, 0x12, 0xe5, 0x6a, 0x74, 0xa0, 0x95, 0xff, 0x02, 0x1f, 0xde, 0x87, 0x4a, 0xfe, 0x9f,
+	0x45, 0x36, 0x6c, 0xd7, 0xcf, 0xbe, 0x20, 0xec, 0x90, 0x5f, 0xef, 0xdb, 0x5d, 0xaa, 0x5c, 0x4f,
+	0x64, 0x8c, 0xd0, 0x84, 0x3a, 0x6e, 0xe4, 0x21, 0x15, 0x7a, 0x76, 0xaa, 0x6f, 0x2b, 0x43, 0x43,
+	0x0f, 0xff, 0x75, 0x58, 0x3a, 0x3c, 0x65, 0xce, 0xf1, 0xe5, 0xc9, 0xe7, 0x7f, 0x07, 0x00, 0x00,
+	0xff, 0xff, 0x14, 0xfe, 0x43, 0x8a, 0x3c, 0x20, 0x00, 0x00,
 }

--- a/proto/server/datastore/datastore.proto
+++ b/proto/server/datastore/datastore.proto
@@ -2,348 +2,329 @@ syntax = "proto3";
 package spire.server.datastore;
 option go_package = "datastore";
 
+import public "google/protobuf/wrappers.proto";
 import public "github.com/spiffe/spire/proto/common/plugin/plugin.proto";
 import public "github.com/spiffe/spire/proto/common/common.proto";
 
-// Represents the trust bundle of a foreign trust domain
+/////////////////////////////////////////////////////////////////////////////
+// Bundle Messages
+/////////////////////////////////////////////////////////////////////////////
+
 message Bundle {
-    // SPIFFE ID of the foreign trust domain
+    // Trust domain SPIFFE ID
     string trust_domain = 1;
 
-    // CA Certificates
-    // ASN.1 DER encoded
+    // CA Certificates (ASN.1 DER encoded)
     bytes ca_certs = 2;
 }
 
-message Bundles {
+message CreateBundleRequest {
+    Bundle bundle = 1;
+}
+
+message CreateBundleResponse {
+    Bundle bundle = 1;
+}
+
+message FetchBundleRequest {
+    string trust_domain = 1;
+}
+
+message FetchBundleResponse {
+    Bundle bundle = 1;
+}
+
+message ListBundlesRequest {
+}
+
+message ListBundlesResponse {
     repeated Bundle bundles = 1;
 }
 
-// Represents a single entry in NodeResolverMap and maps node properties
-// to logical attributes (i.e. an AWS instance to its ASG).
+message UpdateBundleRequest {
+    Bundle bundle = 1;
+}
+
+message UpdateBundleResponse {
+    Bundle bundle = 1;
+}
+
+message AppendBundleRequest {
+    Bundle bundle = 1;
+}
+
+message AppendBundleResponse {
+    Bundle bundle = 1;
+}
+
+message DeleteBundleRequest {
+    string trust_domain = 1;
+}
+
+message DeleteBundleResponse {
+    Bundle bundle = 1;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+// NodeResolverMapEntry Messages
+/////////////////////////////////////////////////////////////////////////////
+
 message NodeResolverMapEntry {
-    string baseSpiffeId = 1;
+    // Node SPIFFE ID
+    string spiffe_id = 1;
+
+    // Node selector
     spire.common.Selector selector = 2;
 }
 
-// Represents a single entry in AttestedNodes and stores the node's
-// SPIFFE ID, the type of attestation it performed, as well as the serial
-// number and expiration date of its node SVID.
-message AttestedNodeEntry {
-    // Spiffe ID
-    string baseSpiffeId = 1;
-
-    // Attestation type
-    string attestationDataType = 2;
-
-    // Serial number
-    string certSerialNumber = 3;
-
-    // Expiration date
-    string certExpirationDate = 4;
-}
-
-//
-//
-//
-
-// Represents an Attested Node entry to create
-message CreateAttestedNodeEntryRequest {
-    // Attested node entry
-    AttestedNodeEntry attestedNodeEntry = 1;
-}
-
-// Represents the created Attested Node entry
-message CreateAttestedNodeEntryResponse {
-    // Attested node entry
-    AttestedNodeEntry attestedNodeEntry = 1;
-}
-
-
-// Represents the Spiffe ID of the node entry to retrieve
-message FetchAttestedNodeEntryRequest {
-    // SPIFFE ID
-    string baseSpiffeId = 1;
-}
-
-// Represents an Attested Node entry
-message FetchAttestedNodeEntryResponse {
-    // Attested node entry
-    AttestedNodeEntry attestedNodeEntry = 1;
-}
-
-
-// Empty Request
-message FetchStaleNodeEntriesRequest {
-}
-
-// Represents dead nodes for which the base SVID has expired
-message FetchStaleNodeEntriesResponse {
-    // List of attested node entries
-    repeated AttestedNodeEntry attestedNodeEntryList = 1;
-}
-
-// Represents Attested node entry fields to update
-message UpdateAttestedNodeEntryRequest {
-    // SPIFFE ID
-    string baseSpiffeId = 1;
-    // Serial number
-    string certSerialNumber = 2;
-    // Expiration date
-    string certExpirationDate = 3;
-}
-
-// Represents the updated Attested node entry
-message UpdateAttestedNodeEntryResponse {
-    // Attested node entry
-    AttestedNodeEntry attestedNodeEntry = 1;
-}
-
-
-// Represents the Spiffe ID of the Attested node entry to delete
-message DeleteAttestedNodeEntryRequest {
-    // SPIFFE ID
-    string baseSpiffeId = 1;
-}
-
-// Represents the deleted Attested node entry
-message DeleteAttestedNodeEntryResponse {
-    AttestedNodeEntry attestedNodeEntry = 1;
-}
-
-//
-//
-//
-
-// Represents a Node resolver map entry to create
 message CreateNodeResolverMapEntryRequest {
-    // Node resolver map entry
-    NodeResolverMapEntry nodeResolverMapEntry = 1;
+    NodeResolverMapEntry entry = 1;
 }
 
-// Represents the created Node resolver map entry
 message CreateNodeResolverMapEntryResponse {
-    // Node resolver map entry
-    NodeResolverMapEntry nodeResolverMapEntry = 1;
+    NodeResolverMapEntry entry = 1;
 }
 
-
-// Represents a Spiffe ID
-message FetchNodeResolverMapEntryRequest {
-    // SPIFFE ID
-    string baseSpiffeId = 1;
+message ListNodeResolverMapEntriesRequest {
+    string spiffe_id = 1;
 }
 
-// Represents a list of Node resolver map entries for the specified Spiffe ID
-message FetchNodeResolverMapEntryResponse {
-    // List of Node resolver map entries
-    repeated NodeResolverMapEntry nodeResolverMapEntryList = 1;
+message ListNodeResolverMapEntriesResponse {
+    repeated NodeResolverMapEntry entries = 1;
 }
 
-
-// Represents a Node resolver map entry to delete
 message DeleteNodeResolverMapEntryRequest {
-    // Node resolver map entry
-    NodeResolverMapEntry nodeResolverMapEntry = 1;
+    NodeResolverMapEntry entry = 1;
 }
 
-// Represents a list of Node resolver map entries
 message DeleteNodeResolverMapEntryResponse {
-    // List of Node resolver map entries
-    repeated NodeResolverMapEntry nodeResolverMapEntryList = 1;
+    repeated NodeResolverMapEntry entries = 1;
 }
 
-
-// Represents a list of Node resolver map entries
 message RectifyNodeResolverMapEntriesRequest {
-    // List of Node resolver map entries
-    repeated NodeResolverMapEntry nodeResolverMapEntryList = 1;
+    repeated NodeResolverMapEntry entries = 1;
 }
 
-// Represents a list of Node resolver map entries
 message RectifyNodeResolverMapEntriesResponse {
-    // List of Node resolver map entries
-    repeated NodeResolverMapEntry nodeResolverMapEntryList = 1;
+    repeated NodeResolverMapEntry entries = 1;
 }
 
-//
-//
-//
+/////////////////////////////////////////////////////////////////////////////
+// AttestedNodeEntry Messages
+/////////////////////////////////////////////////////////////////////////////
 
-// Represents a Registration entry to create
+message AttestedNodeEntry {
+    // Node SPIFFE ID
+    string spiffe_id = 1;
+
+    // Attestation data type
+    string attestation_data_type = 2;
+
+    // Node certificate serial number
+    string cert_serial_number = 3;
+
+    // Node certificate not_after (seconds since unix epoch)
+    int64 cert_not_after = 4;
+}
+
+message CreateAttestedNodeEntryRequest {
+    AttestedNodeEntry entry = 1;
+}
+
+message CreateAttestedNodeEntryResponse {
+    AttestedNodeEntry entry = 1;
+}
+
+message FetchAttestedNodeEntryRequest {
+    string spiffe_id = 1;
+}
+
+message FetchAttestedNodeEntryResponse {
+    AttestedNodeEntry entry = 1;
+}
+
+message ListAttestedNodeEntriesRequest {
+    google.protobuf.Int64Value by_expires_before = 1;
+}
+
+message ListAttestedNodeEntriesResponse {
+    repeated AttestedNodeEntry entries = 1;
+}
+
+message UpdateAttestedNodeEntryRequest {
+    string spiffe_id = 1;
+
+    string cert_serial_number = 2;
+
+    int64 cert_not_after = 3;
+}
+
+message UpdateAttestedNodeEntryResponse {
+    AttestedNodeEntry entry = 1;
+}
+
+message DeleteAttestedNodeEntryRequest {
+    string spiffe_id = 1;
+}
+
+message DeleteAttestedNodeEntryResponse {
+    AttestedNodeEntry entry = 1;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Registration Entries
+/////////////////////////////////////////////////////////////////////////////
+
 message CreateRegistrationEntryRequest {
-    // Registration entry
-    spire.common.RegistrationEntry registeredEntry = 1;
+    spire.common.RegistrationEntry entry = 1;
 }
 
-// Represents the created Registration entry
 message CreateRegistrationEntryResponse {
-    // Registration entry ID
-    string registeredEntryId = 1;
+    string entry_id = 1;
 }
 
-
-// Represents a Registration entry ID to fetch
 message FetchRegistrationEntryRequest {
-    // Registration entry ID
-    string registeredEntryId = 1;
+    string entry_id = 1;
 }
 
-// Represents a Registration entry
 message FetchRegistrationEntryResponse {
-    // Registration entry
-    spire.common.RegistrationEntry registeredEntry = 1;
+    spire.common.RegistrationEntry entry = 1;
 }
 
-// Represents a list of Registration entries
-message FetchRegistrationEntriesResponse {
-    // Registration entries
-    spire.common.RegistrationEntries registeredEntries = 1;
-}
-
-
-// Represents a Registration entry to update
-message UpdateRegistrationEntryRequest {
-    // Registration entry ID
-    string registeredEntryId = 1;
-
-    // Registration entry
-    spire.common.RegistrationEntry registeredEntry = 2;
-}
-
-// Represents the updated Registration entry
-message UpdateRegistrationEntryResponse {
-    // Registration entry
-    spire.common.RegistrationEntry registeredEntry = 1;
-}
-
-
-// Represents a Registration entry ID to delete
-message DeleteRegistrationEntryRequest {
-    // Registration entry ID
-    string registeredEntryId = 1;
-}
-
-// Represents the deleted Registration entry
-message DeleteRegistrationEntryResponse {
-    // Registration entry
-    spire.common.RegistrationEntry registeredEntry = 1;
-}
-
-//
-//
-//
-
-// Represents a Parent ID
-message ListParentIDEntriesRequest {
-    // Parent ID
-    string parentId = 1;
-}
-
-// Represents a list of Registered entries with the specified Parent ID
-message ListParentIDEntriesResponse {
-    // List of Registration entries
-    repeated spire.common.RegistrationEntry registeredEntryList = 1;
-}
-
-// Represents a selector
-message ListSelectorEntriesRequest {
-    // Selector
+message BySelectors {
     repeated spire.common.Selector selectors = 1;
+    bool allow_any_combination = 2;
 }
 
-// Represents a list of Registered entries with the specified selector
-message ListSelectorEntriesResponse {
-    // List of Registration entries
-    repeated spire.common.RegistrationEntry registeredEntryList = 1;
+message ListRegistrationEntriesRequest {
+    google.protobuf.StringValue by_parent_id = 1;
+    BySelectors by_selectors = 2;
+    google.protobuf.StringValue by_spiffe_id = 3;
 }
 
-// Represents a Spiffe ID
-message ListSpiffeEntriesRequest {
-    // SPIFFE ID
-    string spiffeId = 1;
+message ListRegistrationEntriesResponse {
+    repeated spire.common.RegistrationEntry entries = 1;
 }
 
-// Represents a list of Registered entries with the specified Spiffe ID
-message ListSpiffeEntriesResponse {
-    // List of Registration entries
-    repeated spire.common.RegistrationEntry registeredEntryList = 1;
+message UpdateRegistrationEntryRequest {
+    spire.common.RegistrationEntry entry = 1;
 }
 
-//
-//
-//
+message UpdateRegistrationEntryResponse {
+    spire.common.RegistrationEntry entry = 1;
+}
 
-// Represents a join token and associated metadata, if known
+message DeleteRegistrationEntryRequest {
+    string entry_id = 1;
+}
+
+message DeleteRegistrationEntryResponse {
+    spire.common.RegistrationEntry entry = 1;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// JoinToken Messages
+/////////////////////////////////////////////////////////////////////////////
+
 message JoinToken {
+    // Token value
     string token = 1;
 
-    // Expiration date, represented in UNIX time
+    // Expiration in seconds since unix epoch
     int64 expiry = 2;
 }
 
-service DataStore {
-    // Creates a Bundle
-    rpc CreateBundle(Bundle) returns (Bundle);
-    // Updates the specified Bundle, overwriting existing certs
-    rpc UpdateBundle(Bundle) returns (Bundle);
-    // Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
-    rpc AppendBundle(Bundle) returns (Bundle);
-    // Deletes the specified Bundle
-    rpc DeleteBundle(Bundle) returns (Bundle);
-    // Returns the specified Bundle
-    rpc FetchBundle(Bundle) returns (Bundle);
-    // List all Bundles
-    rpc ListBundles(spire.common.Empty) returns (Bundles);
+message CreateJoinTokenRequest {
+    JoinToken join_token = 1;
+}
 
-    // Creates an Attested Node Entry
+message CreateJoinTokenResponse {
+    JoinToken join_token = 1;
+}
+
+message FetchJoinTokenRequest {
+    string token = 1;
+}
+
+message FetchJoinTokenResponse {
+    JoinToken join_token = 1;
+}
+
+message DeleteJoinTokenRequest {
+    string token = 1;
+}
+
+message DeleteJoinTokenResponse {
+    JoinToken join_token = 1;
+}
+
+message PruneJoinTokensRequest {
+    int64 expires_before = 1;
+}
+
+message PruneJoinTokensResponse {
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
+// Service Definition
+/////////////////////////////////////////////////////////////////////////////
+
+service DataStore {
+    // Creates a bundle
+    rpc CreateBundle(CreateBundleRequest) returns (CreateBundleResponse);
+    // Fetches a specific bundle
+    rpc FetchBundle(FetchBundleRequest) returns (FetchBundleResponse);
+    // Lists bundles (optionally filtered)
+    rpc ListBundles(ListBundlesRequest) returns (ListBundlesResponse);
+    // Updates a specific bundle, overwriting existing certs
+    rpc UpdateBundle(UpdateBundleRequest) returns (UpdateBundleResponse);
+    // Appends the provided certs onto an existing bundle, creating a new bundle if one doesn't exist
+    rpc AppendBundle(AppendBundleRequest) returns (AppendBundleResponse);
+    // Deletes a specific bundle
+    rpc DeleteBundle(DeleteBundleRequest) returns (DeleteBundleResponse);
+
+    // Creates an attested node entry
     rpc CreateAttestedNodeEntry(CreateAttestedNodeEntryRequest) returns (CreateAttestedNodeEntryResponse);
-    // Retrieves the Attested Node Entry
+    // Fetches a specific attested node entry
     rpc FetchAttestedNodeEntry(FetchAttestedNodeEntryRequest) returns (FetchAttestedNodeEntryResponse);
-    // Retrieves dead nodes for which the base SVID has expired
-    rpc FetchStaleNodeEntries(FetchStaleNodeEntriesRequest) returns (FetchStaleNodeEntriesResponse);
-    // Updates the Attested Node Entry
+    // Lists attested node entries (optionally filtered)
+    rpc ListAttestedNodeEntries(ListAttestedNodeEntriesRequest) returns (ListAttestedNodeEntriesResponse);
+    // Updates a specific attested node entry
     rpc UpdateAttestedNodeEntry(UpdateAttestedNodeEntryRequest) returns (UpdateAttestedNodeEntryResponse);
-    // Deletes the Attested Node Entry
+    // Deletes a specific attested node entry
     rpc DeleteAttestedNodeEntry(DeleteAttestedNodeEntryRequest) returns (DeleteAttestedNodeEntryResponse);
 
-    // Creates a Node resolver map Entry
+    // Creates a node resolver map entry
     rpc CreateNodeResolverMapEntry(CreateNodeResolverMapEntryRequest) returns (CreateNodeResolverMapEntryResponse);
-    // Retrieves all Node Resolver Map Entry for the specific base SPIFFEID
-    rpc FetchNodeResolverMapEntry(FetchNodeResolverMapEntryRequest) returns (FetchNodeResolverMapEntryResponse);
-    // Deletes all Node Resolver Map Entry for the specific base SPIFFEID
+    // Lists node resolver map entries for a specified SPIFFE ID
+    rpc ListNodeResolverMapEntries(ListNodeResolverMapEntriesRequest) returns (ListNodeResolverMapEntriesResponse);
+    // Deletes a specific node resolver map entry
     rpc DeleteNodeResolverMapEntry(DeleteNodeResolverMapEntryRequest) returns (DeleteNodeResolverMapEntryResponse);
-    // Used for rectifying updated node resolutions
+    // Sets the list of node resolver map entries for the specified SPIFFE ID
     rpc RectifyNodeResolverMapEntries(RectifyNodeResolverMapEntriesRequest) returns (RectifyNodeResolverMapEntriesResponse);
 
-    // Creates a Registered Entry
+    // Creates a registration entry
     rpc CreateRegistrationEntry(CreateRegistrationEntryRequest) returns (CreateRegistrationEntryResponse);
-    // Retrieve a specific registered entry
+    // Fetches a specific registration entry
     rpc FetchRegistrationEntry(FetchRegistrationEntryRequest) returns (FetchRegistrationEntryResponse);
-    // Retrieve all registration entries
-    rpc FetchRegistrationEntries(spire.common.Empty) returns (FetchRegistrationEntriesResponse);
-    // Updates a specific registered entry
+    // Lists registration entries (optionally filtered)
+    rpc ListRegistrationEntries(ListRegistrationEntriesRequest) returns (ListRegistrationEntriesResponse);
+    // Updates a specific registration entry
     rpc UpdateRegistrationEntry(UpdateRegistrationEntryRequest) returns (UpdateRegistrationEntryResponse);
-    // Deletes a specific registered entry
+    // Deletes a specific registration entry
     rpc DeleteRegistrationEntry(DeleteRegistrationEntryRequest) returns (DeleteRegistrationEntryResponse);
 
-    // Retrieves all the registered entry with the same ParentID
-    rpc ListParentIDEntries(ListParentIDEntriesRequest) returns (ListParentIDEntriesResponse);
-    // Retrieves all the registered entry matching exactly the compound Selector
-    rpc ListSelectorEntries(ListSelectorEntriesRequest) returns (ListSelectorEntriesResponse);
-    // Retrieves registered entries containing all of the specified selectors
-    rpc ListMatchingEntries(ListSelectorEntriesRequest) returns (ListSelectorEntriesResponse);
-    // Retrieves all the registered entry with the same SpiffeId
-    rpc ListSpiffeEntries(ListSpiffeEntriesRequest) returns (ListSpiffeEntriesResponse);
-
-    // Register a new join token
-    rpc RegisterToken(JoinToken) returns (spire.common.Empty);
-    // Fetch a token record
-    rpc FetchToken(JoinToken) returns (JoinToken);
-    // Delete the referenced token
-    rpc DeleteToken(JoinToken) returns (spire.common.Empty);
-    // Delete all tokens with expiry less than the one specified
-    rpc PruneTokens(JoinToken) returns (spire.common.Empty);
+    // Creates a join token
+    rpc CreateJoinToken(CreateJoinTokenRequest) returns (CreateJoinTokenResponse);
+    // Fetches a specific join token
+    rpc FetchJoinToken(FetchJoinTokenRequest) returns (FetchJoinTokenResponse);
+    // Delete a specific join token
+    rpc DeleteJoinToken(DeleteJoinTokenRequest) returns (DeleteJoinTokenResponse);
+    // Prunes all join tokens that expire before the specified timestamp
+    rpc PruneJoinTokens(PruneJoinTokensRequest) returns (PruneJoinTokensResponse);
 
     // Applies the plugin configuration
     rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);

--- a/proto/server/datastore/datastore.proto
+++ b/proto/server/datastore/datastore.proto
@@ -67,54 +67,37 @@ message DeleteBundleResponse {
 
 
 /////////////////////////////////////////////////////////////////////////////
-// NodeResolverMapEntry Messages
+// NodeSelector Messages
 /////////////////////////////////////////////////////////////////////////////
 
-message NodeResolverMapEntry {
+message NodeSelectors {
     // Node SPIFFE ID
     string spiffe_id = 1;
 
-    // Node selector
-    spire.common.Selector selector = 2;
+    // Node selectors
+    repeated spire.common.Selector selectors = 2;
 }
 
-message CreateNodeResolverMapEntryRequest {
-    NodeResolverMapEntry entry = 1;
+message SetNodeSelectorsRequest {
+    NodeSelectors selectors = 1;
 }
 
-message CreateNodeResolverMapEntryResponse {
-    NodeResolverMapEntry entry = 1;
+message SetNodeSelectorsResponse {
 }
 
-message ListNodeResolverMapEntriesRequest {
+message GetNodeSelectorsRequest{
     string spiffe_id = 1;
 }
 
-message ListNodeResolverMapEntriesResponse {
-    repeated NodeResolverMapEntry entries = 1;
-}
-
-message DeleteNodeResolverMapEntryRequest {
-    NodeResolverMapEntry entry = 1;
-}
-
-message DeleteNodeResolverMapEntryResponse {
-    repeated NodeResolverMapEntry entries = 1;
-}
-
-message RectifyNodeResolverMapEntriesRequest {
-    repeated NodeResolverMapEntry entries = 1;
-}
-
-message RectifyNodeResolverMapEntriesResponse {
-    repeated NodeResolverMapEntry entries = 1;
+message GetNodeSelectorsResponse {
+    NodeSelectors selectors = 1;
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// AttestedNodeEntry Messages
+// AttestedNode Messages
 /////////////////////////////////////////////////////////////////////////////
 
-message AttestedNodeEntry {
+message AttestedNode {
     // Node SPIFFE ID
     string spiffe_id = 1;
 
@@ -128,31 +111,31 @@ message AttestedNodeEntry {
     int64 cert_not_after = 4;
 }
 
-message CreateAttestedNodeEntryRequest {
-    AttestedNodeEntry entry = 1;
+message CreateAttestedNodeRequest {
+    AttestedNode node = 1;
 }
 
-message CreateAttestedNodeEntryResponse {
-    AttestedNodeEntry entry = 1;
+message CreateAttestedNodeResponse {
+    AttestedNode node = 1;
 }
 
-message FetchAttestedNodeEntryRequest {
+message FetchAttestedNodeRequest {
     string spiffe_id = 1;
 }
 
-message FetchAttestedNodeEntryResponse {
-    AttestedNodeEntry entry = 1;
+message FetchAttestedNodeResponse {
+    AttestedNode node = 1;
 }
 
-message ListAttestedNodeEntriesRequest {
+message ListAttestedNodesRequest {
     google.protobuf.Int64Value by_expires_before = 1;
 }
 
-message ListAttestedNodeEntriesResponse {
-    repeated AttestedNodeEntry entries = 1;
+message ListAttestedNodesResponse {
+    repeated AttestedNode nodes = 1;
 }
 
-message UpdateAttestedNodeEntryRequest {
+message UpdateAttestedNodeRequest {
     string spiffe_id = 1;
 
     string cert_serial_number = 2;
@@ -160,16 +143,16 @@ message UpdateAttestedNodeEntryRequest {
     int64 cert_not_after = 3;
 }
 
-message UpdateAttestedNodeEntryResponse {
-    AttestedNodeEntry entry = 1;
+message UpdateAttestedNodeResponse {
+    AttestedNode node = 1;
 }
 
-message DeleteAttestedNodeEntryRequest {
+message DeleteAttestedNodeRequest {
     string spiffe_id = 1;
 }
 
-message DeleteAttestedNodeEntryResponse {
-    AttestedNodeEntry entry = 1;
+message DeleteAttestedNodeResponse {
+    AttestedNode node = 1;
 }
 
 
@@ -182,7 +165,7 @@ message CreateRegistrationEntryRequest {
 }
 
 message CreateRegistrationEntryResponse {
-    string entry_id = 1;
+    spire.common.RegistrationEntry entry = 1;
 }
 
 message FetchRegistrationEntryRequest {
@@ -194,8 +177,12 @@ message FetchRegistrationEntryResponse {
 }
 
 message BySelectors {
+    enum MatchBehavior {
+        MATCH_EXACT = 0;
+        MATCH_SUBSET = 1;
+    }
     repeated spire.common.Selector selectors = 1;
-    bool allow_any_combination = 2;
+    MatchBehavior match = 2;
 }
 
 message ListRegistrationEntriesRequest {
@@ -286,25 +273,21 @@ service DataStore {
     // Deletes a specific bundle
     rpc DeleteBundle(DeleteBundleRequest) returns (DeleteBundleResponse);
 
-    // Creates an attested node entry
-    rpc CreateAttestedNodeEntry(CreateAttestedNodeEntryRequest) returns (CreateAttestedNodeEntryResponse);
-    // Fetches a specific attested node entry
-    rpc FetchAttestedNodeEntry(FetchAttestedNodeEntryRequest) returns (FetchAttestedNodeEntryResponse);
-    // Lists attested node entries (optionally filtered)
-    rpc ListAttestedNodeEntries(ListAttestedNodeEntriesRequest) returns (ListAttestedNodeEntriesResponse);
-    // Updates a specific attested node entry
-    rpc UpdateAttestedNodeEntry(UpdateAttestedNodeEntryRequest) returns (UpdateAttestedNodeEntryResponse);
-    // Deletes a specific attested node entry
-    rpc DeleteAttestedNodeEntry(DeleteAttestedNodeEntryRequest) returns (DeleteAttestedNodeEntryResponse);
+    // Creates an attested node
+    rpc CreateAttestedNode(CreateAttestedNodeRequest) returns (CreateAttestedNodeResponse);
+    // Fetches a specific attested node
+    rpc FetchAttestedNode(FetchAttestedNodeRequest) returns (FetchAttestedNodeResponse);
+    // Lists attested nodes (optionally filtered)
+    rpc ListAttestedNodes(ListAttestedNodesRequest) returns (ListAttestedNodesResponse);
+    // Updates a specific attested node
+    rpc UpdateAttestedNode(UpdateAttestedNodeRequest) returns (UpdateAttestedNodeResponse);
+    // Deletes a specific attested node
+    rpc DeleteAttestedNode(DeleteAttestedNodeRequest) returns (DeleteAttestedNodeResponse);
 
-    // Creates a node resolver map entry
-    rpc CreateNodeResolverMapEntry(CreateNodeResolverMapEntryRequest) returns (CreateNodeResolverMapEntryResponse);
-    // Lists node resolver map entries for a specified SPIFFE ID
-    rpc ListNodeResolverMapEntries(ListNodeResolverMapEntriesRequest) returns (ListNodeResolverMapEntriesResponse);
-    // Deletes a specific node resolver map entry
-    rpc DeleteNodeResolverMapEntry(DeleteNodeResolverMapEntryRequest) returns (DeleteNodeResolverMapEntryResponse);
-    // Sets the list of node resolver map entries for the specified SPIFFE ID
-    rpc RectifyNodeResolverMapEntries(RectifyNodeResolverMapEntriesRequest) returns (RectifyNodeResolverMapEntriesResponse);
+    // Sets the set of selectors for a specific node id
+    rpc SetNodeSelectors(SetNodeSelectorsRequest) returns (SetNodeSelectorsResponse);
+    // Gets the set of node selectors for a specific node id
+    rpc GetNodeSelectors(GetNodeSelectorsRequest) returns (GetNodeSelectorsResponse);
 
     // Creates a registration entry
     rpc CreateRegistrationEntry(CreateRegistrationEntryRequest) returns (CreateRegistrationEntryResponse);

--- a/test/mock/proto/server/datastore/datastore.go
+++ b/test/mock/proto/server/datastore/datastore.go
@@ -7,7 +7,6 @@ package mock_datastore
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	common "github.com/spiffe/spire/proto/common"
 	plugin "github.com/spiffe/spire/proto/common/plugin"
 	datastore "github.com/spiffe/spire/proto/server/datastore"
 	reflect "reflect"
@@ -37,9 +36,9 @@ func (m *MockDataStore) EXPECT() *MockDataStoreMockRecorder {
 }
 
 // AppendBundle mocks base method
-func (m *MockDataStore) AppendBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockDataStore) AppendBundle(arg0 context.Context, arg1 *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
 	ret := m.ctrl.Call(m, "AppendBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.AppendBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -63,9 +62,9 @@ func (mr *MockDataStoreMockRecorder) CreateAttestedNodeEntry(arg0, arg1 interfac
 }
 
 // CreateBundle mocks base method
-func (m *MockDataStore) CreateBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockDataStore) CreateBundle(arg0 context.Context, arg1 *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {
 	ret := m.ctrl.Call(m, "CreateBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.CreateBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -73,6 +72,19 @@ func (m *MockDataStore) CreateBundle(arg0 context.Context, arg1 *datastore.Bundl
 // CreateBundle indicates an expected call of CreateBundle
 func (mr *MockDataStoreMockRecorder) CreateBundle(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBundle", reflect.TypeOf((*MockDataStore)(nil).CreateBundle), arg0, arg1)
+}
+
+// CreateJoinToken mocks base method
+func (m *MockDataStore) CreateJoinToken(arg0 context.Context, arg1 *datastore.CreateJoinTokenRequest) (*datastore.CreateJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "CreateJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.CreateJoinTokenResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateJoinToken indicates an expected call of CreateJoinToken
+func (mr *MockDataStoreMockRecorder) CreateJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJoinToken", reflect.TypeOf((*MockDataStore)(nil).CreateJoinToken), arg0, arg1)
 }
 
 // CreateNodeResolverMapEntry mocks base method
@@ -115,9 +127,9 @@ func (mr *MockDataStoreMockRecorder) DeleteAttestedNodeEntry(arg0, arg1 interfac
 }
 
 // DeleteBundle mocks base method
-func (m *MockDataStore) DeleteBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockDataStore) DeleteBundle(arg0 context.Context, arg1 *datastore.DeleteBundleRequest) (*datastore.DeleteBundleResponse, error) {
 	ret := m.ctrl.Call(m, "DeleteBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.DeleteBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -125,6 +137,19 @@ func (m *MockDataStore) DeleteBundle(arg0 context.Context, arg1 *datastore.Bundl
 // DeleteBundle indicates an expected call of DeleteBundle
 func (mr *MockDataStoreMockRecorder) DeleteBundle(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBundle", reflect.TypeOf((*MockDataStore)(nil).DeleteBundle), arg0, arg1)
+}
+
+// DeleteJoinToken mocks base method
+func (m *MockDataStore) DeleteJoinToken(arg0 context.Context, arg1 *datastore.DeleteJoinTokenRequest) (*datastore.DeleteJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "DeleteJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.DeleteJoinTokenResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteJoinToken indicates an expected call of DeleteJoinToken
+func (mr *MockDataStoreMockRecorder) DeleteJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJoinToken", reflect.TypeOf((*MockDataStore)(nil).DeleteJoinToken), arg0, arg1)
 }
 
 // DeleteNodeResolverMapEntry mocks base method
@@ -153,19 +178,6 @@ func (mr *MockDataStoreMockRecorder) DeleteRegistrationEntry(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegistrationEntry", reflect.TypeOf((*MockDataStore)(nil).DeleteRegistrationEntry), arg0, arg1)
 }
 
-// DeleteToken mocks base method
-func (m *MockDataStore) DeleteToken(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "DeleteToken", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteToken indicates an expected call of DeleteToken
-func (mr *MockDataStoreMockRecorder) DeleteToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteToken", reflect.TypeOf((*MockDataStore)(nil).DeleteToken), arg0, arg1)
-}
-
 // FetchAttestedNodeEntry mocks base method
 func (m *MockDataStore) FetchAttestedNodeEntry(arg0 context.Context, arg1 *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
 	ret := m.ctrl.Call(m, "FetchAttestedNodeEntry", arg0, arg1)
@@ -180,9 +192,9 @@ func (mr *MockDataStoreMockRecorder) FetchAttestedNodeEntry(arg0, arg1 interface
 }
 
 // FetchBundle mocks base method
-func (m *MockDataStore) FetchBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockDataStore) FetchBundle(arg0 context.Context, arg1 *datastore.FetchBundleRequest) (*datastore.FetchBundleResponse, error) {
 	ret := m.ctrl.Call(m, "FetchBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.FetchBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -192,30 +204,17 @@ func (mr *MockDataStoreMockRecorder) FetchBundle(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBundle", reflect.TypeOf((*MockDataStore)(nil).FetchBundle), arg0, arg1)
 }
 
-// FetchNodeResolverMapEntry mocks base method
-func (m *MockDataStore) FetchNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.FetchNodeResolverMapEntryRequest) (*datastore.FetchNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "FetchNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchNodeResolverMapEntryResponse)
+// FetchJoinToken mocks base method
+func (m *MockDataStore) FetchJoinToken(arg0 context.Context, arg1 *datastore.FetchJoinTokenRequest) (*datastore.FetchJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "FetchJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.FetchJoinTokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchNodeResolverMapEntry indicates an expected call of FetchNodeResolverMapEntry
-func (mr *MockDataStoreMockRecorder) FetchNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNodeResolverMapEntry", reflect.TypeOf((*MockDataStore)(nil).FetchNodeResolverMapEntry), arg0, arg1)
-}
-
-// FetchRegistrationEntries mocks base method
-func (m *MockDataStore) FetchRegistrationEntries(arg0 context.Context, arg1 *common.Empty) (*datastore.FetchRegistrationEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "FetchRegistrationEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchRegistrationEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchRegistrationEntries indicates an expected call of FetchRegistrationEntries
-func (mr *MockDataStoreMockRecorder) FetchRegistrationEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntries", reflect.TypeOf((*MockDataStore)(nil).FetchRegistrationEntries), arg0, arg1)
+// FetchJoinToken indicates an expected call of FetchJoinToken
+func (mr *MockDataStoreMockRecorder) FetchJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJoinToken", reflect.TypeOf((*MockDataStore)(nil).FetchJoinToken), arg0, arg1)
 }
 
 // FetchRegistrationEntry mocks base method
@@ -231,36 +230,23 @@ func (mr *MockDataStoreMockRecorder) FetchRegistrationEntry(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntry", reflect.TypeOf((*MockDataStore)(nil).FetchRegistrationEntry), arg0, arg1)
 }
 
-// FetchStaleNodeEntries mocks base method
-func (m *MockDataStore) FetchStaleNodeEntries(arg0 context.Context, arg1 *datastore.FetchStaleNodeEntriesRequest) (*datastore.FetchStaleNodeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "FetchStaleNodeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchStaleNodeEntriesResponse)
+// ListAttestedNodeEntries mocks base method
+func (m *MockDataStore) ListAttestedNodeEntries(arg0 context.Context, arg1 *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListAttestedNodeEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListAttestedNodeEntriesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchStaleNodeEntries indicates an expected call of FetchStaleNodeEntries
-func (mr *MockDataStoreMockRecorder) FetchStaleNodeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchStaleNodeEntries", reflect.TypeOf((*MockDataStore)(nil).FetchStaleNodeEntries), arg0, arg1)
-}
-
-// FetchToken mocks base method
-func (m *MockDataStore) FetchToken(arg0 context.Context, arg1 *datastore.JoinToken) (*datastore.JoinToken, error) {
-	ret := m.ctrl.Call(m, "FetchToken", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.JoinToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchToken indicates an expected call of FetchToken
-func (mr *MockDataStoreMockRecorder) FetchToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchToken", reflect.TypeOf((*MockDataStore)(nil).FetchToken), arg0, arg1)
+// ListAttestedNodeEntries indicates an expected call of ListAttestedNodeEntries
+func (mr *MockDataStoreMockRecorder) ListAttestedNodeEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodeEntries", reflect.TypeOf((*MockDataStore)(nil).ListAttestedNodeEntries), arg0, arg1)
 }
 
 // ListBundles mocks base method
-func (m *MockDataStore) ListBundles(arg0 context.Context, arg1 *common.Empty) (*datastore.Bundles, error) {
+func (m *MockDataStore) ListBundles(arg0 context.Context, arg1 *datastore.ListBundlesRequest) (*datastore.ListBundlesResponse, error) {
 	ret := m.ctrl.Call(m, "ListBundles", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundles)
+	ret0, _ := ret[0].(*datastore.ListBundlesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -270,69 +256,43 @@ func (mr *MockDataStoreMockRecorder) ListBundles(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockDataStore)(nil).ListBundles), arg0, arg1)
 }
 
-// ListMatchingEntries mocks base method
-func (m *MockDataStore) ListMatchingEntries(arg0 context.Context, arg1 *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListMatchingEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSelectorEntriesResponse)
+// ListNodeResolverMapEntries mocks base method
+func (m *MockDataStore) ListNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListNodeResolverMapEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListNodeResolverMapEntriesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListMatchingEntries indicates an expected call of ListMatchingEntries
-func (mr *MockDataStoreMockRecorder) ListMatchingEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMatchingEntries", reflect.TypeOf((*MockDataStore)(nil).ListMatchingEntries), arg0, arg1)
+// ListNodeResolverMapEntries indicates an expected call of ListNodeResolverMapEntries
+func (mr *MockDataStoreMockRecorder) ListNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResolverMapEntries", reflect.TypeOf((*MockDataStore)(nil).ListNodeResolverMapEntries), arg0, arg1)
 }
 
-// ListParentIDEntries mocks base method
-func (m *MockDataStore) ListParentIDEntries(arg0 context.Context, arg1 *datastore.ListParentIDEntriesRequest) (*datastore.ListParentIDEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListParentIDEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListParentIDEntriesResponse)
+// ListRegistrationEntries mocks base method
+func (m *MockDataStore) ListRegistrationEntries(arg0 context.Context, arg1 *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListRegistrationEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListRegistrationEntriesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListParentIDEntries indicates an expected call of ListParentIDEntries
-func (mr *MockDataStoreMockRecorder) ListParentIDEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParentIDEntries", reflect.TypeOf((*MockDataStore)(nil).ListParentIDEntries), arg0, arg1)
+// ListRegistrationEntries indicates an expected call of ListRegistrationEntries
+func (mr *MockDataStoreMockRecorder) ListRegistrationEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegistrationEntries", reflect.TypeOf((*MockDataStore)(nil).ListRegistrationEntries), arg0, arg1)
 }
 
-// ListSelectorEntries mocks base method
-func (m *MockDataStore) ListSelectorEntries(arg0 context.Context, arg1 *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListSelectorEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSelectorEntriesResponse)
+// PruneJoinTokens mocks base method
+func (m *MockDataStore) PruneJoinTokens(arg0 context.Context, arg1 *datastore.PruneJoinTokensRequest) (*datastore.PruneJoinTokensResponse, error) {
+	ret := m.ctrl.Call(m, "PruneJoinTokens", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.PruneJoinTokensResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListSelectorEntries indicates an expected call of ListSelectorEntries
-func (mr *MockDataStoreMockRecorder) ListSelectorEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSelectorEntries", reflect.TypeOf((*MockDataStore)(nil).ListSelectorEntries), arg0, arg1)
-}
-
-// ListSpiffeEntries mocks base method
-func (m *MockDataStore) ListSpiffeEntries(arg0 context.Context, arg1 *datastore.ListSpiffeEntriesRequest) (*datastore.ListSpiffeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListSpiffeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSpiffeEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSpiffeEntries indicates an expected call of ListSpiffeEntries
-func (mr *MockDataStoreMockRecorder) ListSpiffeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSpiffeEntries", reflect.TypeOf((*MockDataStore)(nil).ListSpiffeEntries), arg0, arg1)
-}
-
-// PruneTokens mocks base method
-func (m *MockDataStore) PruneTokens(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "PruneTokens", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PruneTokens indicates an expected call of PruneTokens
-func (mr *MockDataStoreMockRecorder) PruneTokens(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneTokens", reflect.TypeOf((*MockDataStore)(nil).PruneTokens), arg0, arg1)
+// PruneJoinTokens indicates an expected call of PruneJoinTokens
+func (mr *MockDataStoreMockRecorder) PruneJoinTokens(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneJoinTokens", reflect.TypeOf((*MockDataStore)(nil).PruneJoinTokens), arg0, arg1)
 }
 
 // RectifyNodeResolverMapEntries mocks base method
@@ -346,19 +306,6 @@ func (m *MockDataStore) RectifyNodeResolverMapEntries(arg0 context.Context, arg1
 // RectifyNodeResolverMapEntries indicates an expected call of RectifyNodeResolverMapEntries
 func (mr *MockDataStoreMockRecorder) RectifyNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RectifyNodeResolverMapEntries", reflect.TypeOf((*MockDataStore)(nil).RectifyNodeResolverMapEntries), arg0, arg1)
-}
-
-// RegisterToken mocks base method
-func (m *MockDataStore) RegisterToken(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "RegisterToken", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RegisterToken indicates an expected call of RegisterToken
-func (mr *MockDataStoreMockRecorder) RegisterToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterToken", reflect.TypeOf((*MockDataStore)(nil).RegisterToken), arg0, arg1)
 }
 
 // UpdateAttestedNodeEntry mocks base method
@@ -375,9 +322,9 @@ func (mr *MockDataStoreMockRecorder) UpdateAttestedNodeEntry(arg0, arg1 interfac
 }
 
 // UpdateBundle mocks base method
-func (m *MockDataStore) UpdateBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockDataStore) UpdateBundle(arg0 context.Context, arg1 *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
 	ret := m.ctrl.Call(m, "UpdateBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.UpdateBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -424,9 +371,9 @@ func (m *MockPlugin) EXPECT() *MockPluginMockRecorder {
 }
 
 // AppendBundle mocks base method
-func (m *MockPlugin) AppendBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockPlugin) AppendBundle(arg0 context.Context, arg1 *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
 	ret := m.ctrl.Call(m, "AppendBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.AppendBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -463,9 +410,9 @@ func (mr *MockPluginMockRecorder) CreateAttestedNodeEntry(arg0, arg1 interface{}
 }
 
 // CreateBundle mocks base method
-func (m *MockPlugin) CreateBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockPlugin) CreateBundle(arg0 context.Context, arg1 *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {
 	ret := m.ctrl.Call(m, "CreateBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.CreateBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -473,6 +420,19 @@ func (m *MockPlugin) CreateBundle(arg0 context.Context, arg1 *datastore.Bundle) 
 // CreateBundle indicates an expected call of CreateBundle
 func (mr *MockPluginMockRecorder) CreateBundle(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBundle", reflect.TypeOf((*MockPlugin)(nil).CreateBundle), arg0, arg1)
+}
+
+// CreateJoinToken mocks base method
+func (m *MockPlugin) CreateJoinToken(arg0 context.Context, arg1 *datastore.CreateJoinTokenRequest) (*datastore.CreateJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "CreateJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.CreateJoinTokenResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateJoinToken indicates an expected call of CreateJoinToken
+func (mr *MockPluginMockRecorder) CreateJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJoinToken", reflect.TypeOf((*MockPlugin)(nil).CreateJoinToken), arg0, arg1)
 }
 
 // CreateNodeResolverMapEntry mocks base method
@@ -515,9 +475,9 @@ func (mr *MockPluginMockRecorder) DeleteAttestedNodeEntry(arg0, arg1 interface{}
 }
 
 // DeleteBundle mocks base method
-func (m *MockPlugin) DeleteBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockPlugin) DeleteBundle(arg0 context.Context, arg1 *datastore.DeleteBundleRequest) (*datastore.DeleteBundleResponse, error) {
 	ret := m.ctrl.Call(m, "DeleteBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.DeleteBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -525,6 +485,19 @@ func (m *MockPlugin) DeleteBundle(arg0 context.Context, arg1 *datastore.Bundle) 
 // DeleteBundle indicates an expected call of DeleteBundle
 func (mr *MockPluginMockRecorder) DeleteBundle(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBundle", reflect.TypeOf((*MockPlugin)(nil).DeleteBundle), arg0, arg1)
+}
+
+// DeleteJoinToken mocks base method
+func (m *MockPlugin) DeleteJoinToken(arg0 context.Context, arg1 *datastore.DeleteJoinTokenRequest) (*datastore.DeleteJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "DeleteJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.DeleteJoinTokenResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteJoinToken indicates an expected call of DeleteJoinToken
+func (mr *MockPluginMockRecorder) DeleteJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJoinToken", reflect.TypeOf((*MockPlugin)(nil).DeleteJoinToken), arg0, arg1)
 }
 
 // DeleteNodeResolverMapEntry mocks base method
@@ -553,19 +526,6 @@ func (mr *MockPluginMockRecorder) DeleteRegistrationEntry(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegistrationEntry", reflect.TypeOf((*MockPlugin)(nil).DeleteRegistrationEntry), arg0, arg1)
 }
 
-// DeleteToken mocks base method
-func (m *MockPlugin) DeleteToken(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "DeleteToken", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteToken indicates an expected call of DeleteToken
-func (mr *MockPluginMockRecorder) DeleteToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteToken", reflect.TypeOf((*MockPlugin)(nil).DeleteToken), arg0, arg1)
-}
-
 // FetchAttestedNodeEntry mocks base method
 func (m *MockPlugin) FetchAttestedNodeEntry(arg0 context.Context, arg1 *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
 	ret := m.ctrl.Call(m, "FetchAttestedNodeEntry", arg0, arg1)
@@ -580,9 +540,9 @@ func (mr *MockPluginMockRecorder) FetchAttestedNodeEntry(arg0, arg1 interface{})
 }
 
 // FetchBundle mocks base method
-func (m *MockPlugin) FetchBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockPlugin) FetchBundle(arg0 context.Context, arg1 *datastore.FetchBundleRequest) (*datastore.FetchBundleResponse, error) {
 	ret := m.ctrl.Call(m, "FetchBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.FetchBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -592,30 +552,17 @@ func (mr *MockPluginMockRecorder) FetchBundle(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchBundle", reflect.TypeOf((*MockPlugin)(nil).FetchBundle), arg0, arg1)
 }
 
-// FetchNodeResolverMapEntry mocks base method
-func (m *MockPlugin) FetchNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.FetchNodeResolverMapEntryRequest) (*datastore.FetchNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "FetchNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchNodeResolverMapEntryResponse)
+// FetchJoinToken mocks base method
+func (m *MockPlugin) FetchJoinToken(arg0 context.Context, arg1 *datastore.FetchJoinTokenRequest) (*datastore.FetchJoinTokenResponse, error) {
+	ret := m.ctrl.Call(m, "FetchJoinToken", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.FetchJoinTokenResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchNodeResolverMapEntry indicates an expected call of FetchNodeResolverMapEntry
-func (mr *MockPluginMockRecorder) FetchNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchNodeResolverMapEntry", reflect.TypeOf((*MockPlugin)(nil).FetchNodeResolverMapEntry), arg0, arg1)
-}
-
-// FetchRegistrationEntries mocks base method
-func (m *MockPlugin) FetchRegistrationEntries(arg0 context.Context, arg1 *common.Empty) (*datastore.FetchRegistrationEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "FetchRegistrationEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchRegistrationEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchRegistrationEntries indicates an expected call of FetchRegistrationEntries
-func (mr *MockPluginMockRecorder) FetchRegistrationEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntries", reflect.TypeOf((*MockPlugin)(nil).FetchRegistrationEntries), arg0, arg1)
+// FetchJoinToken indicates an expected call of FetchJoinToken
+func (mr *MockPluginMockRecorder) FetchJoinToken(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchJoinToken", reflect.TypeOf((*MockPlugin)(nil).FetchJoinToken), arg0, arg1)
 }
 
 // FetchRegistrationEntry mocks base method
@@ -631,32 +578,6 @@ func (mr *MockPluginMockRecorder) FetchRegistrationEntry(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntry", reflect.TypeOf((*MockPlugin)(nil).FetchRegistrationEntry), arg0, arg1)
 }
 
-// FetchStaleNodeEntries mocks base method
-func (m *MockPlugin) FetchStaleNodeEntries(arg0 context.Context, arg1 *datastore.FetchStaleNodeEntriesRequest) (*datastore.FetchStaleNodeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "FetchStaleNodeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchStaleNodeEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchStaleNodeEntries indicates an expected call of FetchStaleNodeEntries
-func (mr *MockPluginMockRecorder) FetchStaleNodeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchStaleNodeEntries", reflect.TypeOf((*MockPlugin)(nil).FetchStaleNodeEntries), arg0, arg1)
-}
-
-// FetchToken mocks base method
-func (m *MockPlugin) FetchToken(arg0 context.Context, arg1 *datastore.JoinToken) (*datastore.JoinToken, error) {
-	ret := m.ctrl.Call(m, "FetchToken", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.JoinToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FetchToken indicates an expected call of FetchToken
-func (mr *MockPluginMockRecorder) FetchToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchToken", reflect.TypeOf((*MockPlugin)(nil).FetchToken), arg0, arg1)
-}
-
 // GetPluginInfo mocks base method
 func (m *MockPlugin) GetPluginInfo(arg0 context.Context, arg1 *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error) {
 	ret := m.ctrl.Call(m, "GetPluginInfo", arg0, arg1)
@@ -670,10 +591,23 @@ func (mr *MockPluginMockRecorder) GetPluginInfo(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPluginInfo", reflect.TypeOf((*MockPlugin)(nil).GetPluginInfo), arg0, arg1)
 }
 
+// ListAttestedNodeEntries mocks base method
+func (m *MockPlugin) ListAttestedNodeEntries(arg0 context.Context, arg1 *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListAttestedNodeEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListAttestedNodeEntriesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAttestedNodeEntries indicates an expected call of ListAttestedNodeEntries
+func (mr *MockPluginMockRecorder) ListAttestedNodeEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodeEntries", reflect.TypeOf((*MockPlugin)(nil).ListAttestedNodeEntries), arg0, arg1)
+}
+
 // ListBundles mocks base method
-func (m *MockPlugin) ListBundles(arg0 context.Context, arg1 *common.Empty) (*datastore.Bundles, error) {
+func (m *MockPlugin) ListBundles(arg0 context.Context, arg1 *datastore.ListBundlesRequest) (*datastore.ListBundlesResponse, error) {
 	ret := m.ctrl.Call(m, "ListBundles", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundles)
+	ret0, _ := ret[0].(*datastore.ListBundlesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -683,69 +617,43 @@ func (mr *MockPluginMockRecorder) ListBundles(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockPlugin)(nil).ListBundles), arg0, arg1)
 }
 
-// ListMatchingEntries mocks base method
-func (m *MockPlugin) ListMatchingEntries(arg0 context.Context, arg1 *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListMatchingEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSelectorEntriesResponse)
+// ListNodeResolverMapEntries mocks base method
+func (m *MockPlugin) ListNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListNodeResolverMapEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListNodeResolverMapEntriesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListMatchingEntries indicates an expected call of ListMatchingEntries
-func (mr *MockPluginMockRecorder) ListMatchingEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMatchingEntries", reflect.TypeOf((*MockPlugin)(nil).ListMatchingEntries), arg0, arg1)
+// ListNodeResolverMapEntries indicates an expected call of ListNodeResolverMapEntries
+func (mr *MockPluginMockRecorder) ListNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResolverMapEntries", reflect.TypeOf((*MockPlugin)(nil).ListNodeResolverMapEntries), arg0, arg1)
 }
 
-// ListParentIDEntries mocks base method
-func (m *MockPlugin) ListParentIDEntries(arg0 context.Context, arg1 *datastore.ListParentIDEntriesRequest) (*datastore.ListParentIDEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListParentIDEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListParentIDEntriesResponse)
+// ListRegistrationEntries mocks base method
+func (m *MockPlugin) ListRegistrationEntries(arg0 context.Context, arg1 *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {
+	ret := m.ctrl.Call(m, "ListRegistrationEntries", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListRegistrationEntriesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListParentIDEntries indicates an expected call of ListParentIDEntries
-func (mr *MockPluginMockRecorder) ListParentIDEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListParentIDEntries", reflect.TypeOf((*MockPlugin)(nil).ListParentIDEntries), arg0, arg1)
+// ListRegistrationEntries indicates an expected call of ListRegistrationEntries
+func (mr *MockPluginMockRecorder) ListRegistrationEntries(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRegistrationEntries", reflect.TypeOf((*MockPlugin)(nil).ListRegistrationEntries), arg0, arg1)
 }
 
-// ListSelectorEntries mocks base method
-func (m *MockPlugin) ListSelectorEntries(arg0 context.Context, arg1 *datastore.ListSelectorEntriesRequest) (*datastore.ListSelectorEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListSelectorEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSelectorEntriesResponse)
+// PruneJoinTokens mocks base method
+func (m *MockPlugin) PruneJoinTokens(arg0 context.Context, arg1 *datastore.PruneJoinTokensRequest) (*datastore.PruneJoinTokensResponse, error) {
+	ret := m.ctrl.Call(m, "PruneJoinTokens", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.PruneJoinTokensResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListSelectorEntries indicates an expected call of ListSelectorEntries
-func (mr *MockPluginMockRecorder) ListSelectorEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSelectorEntries", reflect.TypeOf((*MockPlugin)(nil).ListSelectorEntries), arg0, arg1)
-}
-
-// ListSpiffeEntries mocks base method
-func (m *MockPlugin) ListSpiffeEntries(arg0 context.Context, arg1 *datastore.ListSpiffeEntriesRequest) (*datastore.ListSpiffeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListSpiffeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListSpiffeEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSpiffeEntries indicates an expected call of ListSpiffeEntries
-func (mr *MockPluginMockRecorder) ListSpiffeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSpiffeEntries", reflect.TypeOf((*MockPlugin)(nil).ListSpiffeEntries), arg0, arg1)
-}
-
-// PruneTokens mocks base method
-func (m *MockPlugin) PruneTokens(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "PruneTokens", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PruneTokens indicates an expected call of PruneTokens
-func (mr *MockPluginMockRecorder) PruneTokens(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneTokens", reflect.TypeOf((*MockPlugin)(nil).PruneTokens), arg0, arg1)
+// PruneJoinTokens indicates an expected call of PruneJoinTokens
+func (mr *MockPluginMockRecorder) PruneJoinTokens(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneJoinTokens", reflect.TypeOf((*MockPlugin)(nil).PruneJoinTokens), arg0, arg1)
 }
 
 // RectifyNodeResolverMapEntries mocks base method
@@ -759,19 +667,6 @@ func (m *MockPlugin) RectifyNodeResolverMapEntries(arg0 context.Context, arg1 *d
 // RectifyNodeResolverMapEntries indicates an expected call of RectifyNodeResolverMapEntries
 func (mr *MockPluginMockRecorder) RectifyNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RectifyNodeResolverMapEntries", reflect.TypeOf((*MockPlugin)(nil).RectifyNodeResolverMapEntries), arg0, arg1)
-}
-
-// RegisterToken mocks base method
-func (m *MockPlugin) RegisterToken(arg0 context.Context, arg1 *datastore.JoinToken) (*common.Empty, error) {
-	ret := m.ctrl.Call(m, "RegisterToken", arg0, arg1)
-	ret0, _ := ret[0].(*common.Empty)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RegisterToken indicates an expected call of RegisterToken
-func (mr *MockPluginMockRecorder) RegisterToken(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterToken", reflect.TypeOf((*MockPlugin)(nil).RegisterToken), arg0, arg1)
 }
 
 // UpdateAttestedNodeEntry mocks base method
@@ -788,9 +683,9 @@ func (mr *MockPluginMockRecorder) UpdateAttestedNodeEntry(arg0, arg1 interface{}
 }
 
 // UpdateBundle mocks base method
-func (m *MockPlugin) UpdateBundle(arg0 context.Context, arg1 *datastore.Bundle) (*datastore.Bundle, error) {
+func (m *MockPlugin) UpdateBundle(arg0 context.Context, arg1 *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
 	ret := m.ctrl.Call(m, "UpdateBundle", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.Bundle)
+	ret0, _ := ret[0].(*datastore.UpdateBundleResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/mock/proto/server/datastore/datastore.go
+++ b/test/mock/proto/server/datastore/datastore.go
@@ -48,17 +48,17 @@ func (mr *MockDataStoreMockRecorder) AppendBundle(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendBundle", reflect.TypeOf((*MockDataStore)(nil).AppendBundle), arg0, arg1)
 }
 
-// CreateAttestedNodeEntry mocks base method
-func (m *MockDataStore) CreateAttestedNodeEntry(arg0 context.Context, arg1 *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "CreateAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.CreateAttestedNodeEntryResponse)
+// CreateAttestedNode mocks base method
+func (m *MockDataStore) CreateAttestedNode(arg0 context.Context, arg1 *datastore.CreateAttestedNodeRequest) (*datastore.CreateAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "CreateAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.CreateAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateAttestedNodeEntry indicates an expected call of CreateAttestedNodeEntry
-func (mr *MockDataStoreMockRecorder) CreateAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAttestedNodeEntry", reflect.TypeOf((*MockDataStore)(nil).CreateAttestedNodeEntry), arg0, arg1)
+// CreateAttestedNode indicates an expected call of CreateAttestedNode
+func (mr *MockDataStoreMockRecorder) CreateAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAttestedNode", reflect.TypeOf((*MockDataStore)(nil).CreateAttestedNode), arg0, arg1)
 }
 
 // CreateBundle mocks base method
@@ -87,19 +87,6 @@ func (mr *MockDataStoreMockRecorder) CreateJoinToken(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJoinToken", reflect.TypeOf((*MockDataStore)(nil).CreateJoinToken), arg0, arg1)
 }
 
-// CreateNodeResolverMapEntry mocks base method
-func (m *MockDataStore) CreateNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "CreateNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.CreateNodeResolverMapEntryResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNodeResolverMapEntry indicates an expected call of CreateNodeResolverMapEntry
-func (mr *MockDataStoreMockRecorder) CreateNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodeResolverMapEntry", reflect.TypeOf((*MockDataStore)(nil).CreateNodeResolverMapEntry), arg0, arg1)
-}
-
 // CreateRegistrationEntry mocks base method
 func (m *MockDataStore) CreateRegistrationEntry(arg0 context.Context, arg1 *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
 	ret := m.ctrl.Call(m, "CreateRegistrationEntry", arg0, arg1)
@@ -113,17 +100,17 @@ func (mr *MockDataStoreMockRecorder) CreateRegistrationEntry(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegistrationEntry", reflect.TypeOf((*MockDataStore)(nil).CreateRegistrationEntry), arg0, arg1)
 }
 
-// DeleteAttestedNodeEntry mocks base method
-func (m *MockDataStore) DeleteAttestedNodeEntry(arg0 context.Context, arg1 *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "DeleteAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.DeleteAttestedNodeEntryResponse)
+// DeleteAttestedNode mocks base method
+func (m *MockDataStore) DeleteAttestedNode(arg0 context.Context, arg1 *datastore.DeleteAttestedNodeRequest) (*datastore.DeleteAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "DeleteAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.DeleteAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteAttestedNodeEntry indicates an expected call of DeleteAttestedNodeEntry
-func (mr *MockDataStoreMockRecorder) DeleteAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttestedNodeEntry", reflect.TypeOf((*MockDataStore)(nil).DeleteAttestedNodeEntry), arg0, arg1)
+// DeleteAttestedNode indicates an expected call of DeleteAttestedNode
+func (mr *MockDataStoreMockRecorder) DeleteAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttestedNode", reflect.TypeOf((*MockDataStore)(nil).DeleteAttestedNode), arg0, arg1)
 }
 
 // DeleteBundle mocks base method
@@ -152,19 +139,6 @@ func (mr *MockDataStoreMockRecorder) DeleteJoinToken(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJoinToken", reflect.TypeOf((*MockDataStore)(nil).DeleteJoinToken), arg0, arg1)
 }
 
-// DeleteNodeResolverMapEntry mocks base method
-func (m *MockDataStore) DeleteNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "DeleteNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.DeleteNodeResolverMapEntryResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteNodeResolverMapEntry indicates an expected call of DeleteNodeResolverMapEntry
-func (mr *MockDataStoreMockRecorder) DeleteNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeResolverMapEntry", reflect.TypeOf((*MockDataStore)(nil).DeleteNodeResolverMapEntry), arg0, arg1)
-}
-
 // DeleteRegistrationEntry mocks base method
 func (m *MockDataStore) DeleteRegistrationEntry(arg0 context.Context, arg1 *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
 	ret := m.ctrl.Call(m, "DeleteRegistrationEntry", arg0, arg1)
@@ -178,17 +152,17 @@ func (mr *MockDataStoreMockRecorder) DeleteRegistrationEntry(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegistrationEntry", reflect.TypeOf((*MockDataStore)(nil).DeleteRegistrationEntry), arg0, arg1)
 }
 
-// FetchAttestedNodeEntry mocks base method
-func (m *MockDataStore) FetchAttestedNodeEntry(arg0 context.Context, arg1 *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "FetchAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchAttestedNodeEntryResponse)
+// FetchAttestedNode mocks base method
+func (m *MockDataStore) FetchAttestedNode(arg0 context.Context, arg1 *datastore.FetchAttestedNodeRequest) (*datastore.FetchAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "FetchAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.FetchAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchAttestedNodeEntry indicates an expected call of FetchAttestedNodeEntry
-func (mr *MockDataStoreMockRecorder) FetchAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAttestedNodeEntry", reflect.TypeOf((*MockDataStore)(nil).FetchAttestedNodeEntry), arg0, arg1)
+// FetchAttestedNode indicates an expected call of FetchAttestedNode
+func (mr *MockDataStoreMockRecorder) FetchAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAttestedNode", reflect.TypeOf((*MockDataStore)(nil).FetchAttestedNode), arg0, arg1)
 }
 
 // FetchBundle mocks base method
@@ -230,17 +204,30 @@ func (mr *MockDataStoreMockRecorder) FetchRegistrationEntry(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntry", reflect.TypeOf((*MockDataStore)(nil).FetchRegistrationEntry), arg0, arg1)
 }
 
-// ListAttestedNodeEntries mocks base method
-func (m *MockDataStore) ListAttestedNodeEntries(arg0 context.Context, arg1 *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListAttestedNodeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListAttestedNodeEntriesResponse)
+// GetNodeSelectors mocks base method
+func (m *MockDataStore) GetNodeSelectors(arg0 context.Context, arg1 *datastore.GetNodeSelectorsRequest) (*datastore.GetNodeSelectorsResponse, error) {
+	ret := m.ctrl.Call(m, "GetNodeSelectors", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.GetNodeSelectorsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListAttestedNodeEntries indicates an expected call of ListAttestedNodeEntries
-func (mr *MockDataStoreMockRecorder) ListAttestedNodeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodeEntries", reflect.TypeOf((*MockDataStore)(nil).ListAttestedNodeEntries), arg0, arg1)
+// GetNodeSelectors indicates an expected call of GetNodeSelectors
+func (mr *MockDataStoreMockRecorder) GetNodeSelectors(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeSelectors", reflect.TypeOf((*MockDataStore)(nil).GetNodeSelectors), arg0, arg1)
+}
+
+// ListAttestedNodes mocks base method
+func (m *MockDataStore) ListAttestedNodes(arg0 context.Context, arg1 *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
+	ret := m.ctrl.Call(m, "ListAttestedNodes", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListAttestedNodesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAttestedNodes indicates an expected call of ListAttestedNodes
+func (mr *MockDataStoreMockRecorder) ListAttestedNodes(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodes", reflect.TypeOf((*MockDataStore)(nil).ListAttestedNodes), arg0, arg1)
 }
 
 // ListBundles mocks base method
@@ -254,19 +241,6 @@ func (m *MockDataStore) ListBundles(arg0 context.Context, arg1 *datastore.ListBu
 // ListBundles indicates an expected call of ListBundles
 func (mr *MockDataStoreMockRecorder) ListBundles(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockDataStore)(nil).ListBundles), arg0, arg1)
-}
-
-// ListNodeResolverMapEntries mocks base method
-func (m *MockDataStore) ListNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListNodeResolverMapEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListNodeResolverMapEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodeResolverMapEntries indicates an expected call of ListNodeResolverMapEntries
-func (mr *MockDataStoreMockRecorder) ListNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResolverMapEntries", reflect.TypeOf((*MockDataStore)(nil).ListNodeResolverMapEntries), arg0, arg1)
 }
 
 // ListRegistrationEntries mocks base method
@@ -295,30 +269,30 @@ func (mr *MockDataStoreMockRecorder) PruneJoinTokens(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneJoinTokens", reflect.TypeOf((*MockDataStore)(nil).PruneJoinTokens), arg0, arg1)
 }
 
-// RectifyNodeResolverMapEntries mocks base method
-func (m *MockDataStore) RectifyNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.RectifyNodeResolverMapEntriesRequest) (*datastore.RectifyNodeResolverMapEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "RectifyNodeResolverMapEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.RectifyNodeResolverMapEntriesResponse)
+// SetNodeSelectors mocks base method
+func (m *MockDataStore) SetNodeSelectors(arg0 context.Context, arg1 *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
+	ret := m.ctrl.Call(m, "SetNodeSelectors", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.SetNodeSelectorsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RectifyNodeResolverMapEntries indicates an expected call of RectifyNodeResolverMapEntries
-func (mr *MockDataStoreMockRecorder) RectifyNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RectifyNodeResolverMapEntries", reflect.TypeOf((*MockDataStore)(nil).RectifyNodeResolverMapEntries), arg0, arg1)
+// SetNodeSelectors indicates an expected call of SetNodeSelectors
+func (mr *MockDataStoreMockRecorder) SetNodeSelectors(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeSelectors", reflect.TypeOf((*MockDataStore)(nil).SetNodeSelectors), arg0, arg1)
 }
 
-// UpdateAttestedNodeEntry mocks base method
-func (m *MockDataStore) UpdateAttestedNodeEntry(arg0 context.Context, arg1 *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "UpdateAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.UpdateAttestedNodeEntryResponse)
+// UpdateAttestedNode mocks base method
+func (m *MockDataStore) UpdateAttestedNode(arg0 context.Context, arg1 *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "UpdateAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.UpdateAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateAttestedNodeEntry indicates an expected call of UpdateAttestedNodeEntry
-func (mr *MockDataStoreMockRecorder) UpdateAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAttestedNodeEntry", reflect.TypeOf((*MockDataStore)(nil).UpdateAttestedNodeEntry), arg0, arg1)
+// UpdateAttestedNode indicates an expected call of UpdateAttestedNode
+func (mr *MockDataStoreMockRecorder) UpdateAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAttestedNode", reflect.TypeOf((*MockDataStore)(nil).UpdateAttestedNode), arg0, arg1)
 }
 
 // UpdateBundle mocks base method
@@ -396,17 +370,17 @@ func (mr *MockPluginMockRecorder) Configure(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Configure", reflect.TypeOf((*MockPlugin)(nil).Configure), arg0, arg1)
 }
 
-// CreateAttestedNodeEntry mocks base method
-func (m *MockPlugin) CreateAttestedNodeEntry(arg0 context.Context, arg1 *datastore.CreateAttestedNodeEntryRequest) (*datastore.CreateAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "CreateAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.CreateAttestedNodeEntryResponse)
+// CreateAttestedNode mocks base method
+func (m *MockPlugin) CreateAttestedNode(arg0 context.Context, arg1 *datastore.CreateAttestedNodeRequest) (*datastore.CreateAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "CreateAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.CreateAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateAttestedNodeEntry indicates an expected call of CreateAttestedNodeEntry
-func (mr *MockPluginMockRecorder) CreateAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAttestedNodeEntry", reflect.TypeOf((*MockPlugin)(nil).CreateAttestedNodeEntry), arg0, arg1)
+// CreateAttestedNode indicates an expected call of CreateAttestedNode
+func (mr *MockPluginMockRecorder) CreateAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAttestedNode", reflect.TypeOf((*MockPlugin)(nil).CreateAttestedNode), arg0, arg1)
 }
 
 // CreateBundle mocks base method
@@ -435,19 +409,6 @@ func (mr *MockPluginMockRecorder) CreateJoinToken(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateJoinToken", reflect.TypeOf((*MockPlugin)(nil).CreateJoinToken), arg0, arg1)
 }
 
-// CreateNodeResolverMapEntry mocks base method
-func (m *MockPlugin) CreateNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.CreateNodeResolverMapEntryRequest) (*datastore.CreateNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "CreateNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.CreateNodeResolverMapEntryResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateNodeResolverMapEntry indicates an expected call of CreateNodeResolverMapEntry
-func (mr *MockPluginMockRecorder) CreateNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodeResolverMapEntry", reflect.TypeOf((*MockPlugin)(nil).CreateNodeResolverMapEntry), arg0, arg1)
-}
-
 // CreateRegistrationEntry mocks base method
 func (m *MockPlugin) CreateRegistrationEntry(arg0 context.Context, arg1 *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
 	ret := m.ctrl.Call(m, "CreateRegistrationEntry", arg0, arg1)
@@ -461,17 +422,17 @@ func (mr *MockPluginMockRecorder) CreateRegistrationEntry(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRegistrationEntry", reflect.TypeOf((*MockPlugin)(nil).CreateRegistrationEntry), arg0, arg1)
 }
 
-// DeleteAttestedNodeEntry mocks base method
-func (m *MockPlugin) DeleteAttestedNodeEntry(arg0 context.Context, arg1 *datastore.DeleteAttestedNodeEntryRequest) (*datastore.DeleteAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "DeleteAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.DeleteAttestedNodeEntryResponse)
+// DeleteAttestedNode mocks base method
+func (m *MockPlugin) DeleteAttestedNode(arg0 context.Context, arg1 *datastore.DeleteAttestedNodeRequest) (*datastore.DeleteAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "DeleteAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.DeleteAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteAttestedNodeEntry indicates an expected call of DeleteAttestedNodeEntry
-func (mr *MockPluginMockRecorder) DeleteAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttestedNodeEntry", reflect.TypeOf((*MockPlugin)(nil).DeleteAttestedNodeEntry), arg0, arg1)
+// DeleteAttestedNode indicates an expected call of DeleteAttestedNode
+func (mr *MockPluginMockRecorder) DeleteAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttestedNode", reflect.TypeOf((*MockPlugin)(nil).DeleteAttestedNode), arg0, arg1)
 }
 
 // DeleteBundle mocks base method
@@ -500,19 +461,6 @@ func (mr *MockPluginMockRecorder) DeleteJoinToken(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJoinToken", reflect.TypeOf((*MockPlugin)(nil).DeleteJoinToken), arg0, arg1)
 }
 
-// DeleteNodeResolverMapEntry mocks base method
-func (m *MockPlugin) DeleteNodeResolverMapEntry(arg0 context.Context, arg1 *datastore.DeleteNodeResolverMapEntryRequest) (*datastore.DeleteNodeResolverMapEntryResponse, error) {
-	ret := m.ctrl.Call(m, "DeleteNodeResolverMapEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.DeleteNodeResolverMapEntryResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteNodeResolverMapEntry indicates an expected call of DeleteNodeResolverMapEntry
-func (mr *MockPluginMockRecorder) DeleteNodeResolverMapEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeResolverMapEntry", reflect.TypeOf((*MockPlugin)(nil).DeleteNodeResolverMapEntry), arg0, arg1)
-}
-
 // DeleteRegistrationEntry mocks base method
 func (m *MockPlugin) DeleteRegistrationEntry(arg0 context.Context, arg1 *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
 	ret := m.ctrl.Call(m, "DeleteRegistrationEntry", arg0, arg1)
@@ -526,17 +474,17 @@ func (mr *MockPluginMockRecorder) DeleteRegistrationEntry(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRegistrationEntry", reflect.TypeOf((*MockPlugin)(nil).DeleteRegistrationEntry), arg0, arg1)
 }
 
-// FetchAttestedNodeEntry mocks base method
-func (m *MockPlugin) FetchAttestedNodeEntry(arg0 context.Context, arg1 *datastore.FetchAttestedNodeEntryRequest) (*datastore.FetchAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "FetchAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.FetchAttestedNodeEntryResponse)
+// FetchAttestedNode mocks base method
+func (m *MockPlugin) FetchAttestedNode(arg0 context.Context, arg1 *datastore.FetchAttestedNodeRequest) (*datastore.FetchAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "FetchAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.FetchAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FetchAttestedNodeEntry indicates an expected call of FetchAttestedNodeEntry
-func (mr *MockPluginMockRecorder) FetchAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAttestedNodeEntry", reflect.TypeOf((*MockPlugin)(nil).FetchAttestedNodeEntry), arg0, arg1)
+// FetchAttestedNode indicates an expected call of FetchAttestedNode
+func (mr *MockPluginMockRecorder) FetchAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchAttestedNode", reflect.TypeOf((*MockPlugin)(nil).FetchAttestedNode), arg0, arg1)
 }
 
 // FetchBundle mocks base method
@@ -578,6 +526,19 @@ func (mr *MockPluginMockRecorder) FetchRegistrationEntry(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchRegistrationEntry", reflect.TypeOf((*MockPlugin)(nil).FetchRegistrationEntry), arg0, arg1)
 }
 
+// GetNodeSelectors mocks base method
+func (m *MockPlugin) GetNodeSelectors(arg0 context.Context, arg1 *datastore.GetNodeSelectorsRequest) (*datastore.GetNodeSelectorsResponse, error) {
+	ret := m.ctrl.Call(m, "GetNodeSelectors", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.GetNodeSelectorsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodeSelectors indicates an expected call of GetNodeSelectors
+func (mr *MockPluginMockRecorder) GetNodeSelectors(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeSelectors", reflect.TypeOf((*MockPlugin)(nil).GetNodeSelectors), arg0, arg1)
+}
+
 // GetPluginInfo mocks base method
 func (m *MockPlugin) GetPluginInfo(arg0 context.Context, arg1 *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error) {
 	ret := m.ctrl.Call(m, "GetPluginInfo", arg0, arg1)
@@ -591,17 +552,17 @@ func (mr *MockPluginMockRecorder) GetPluginInfo(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPluginInfo", reflect.TypeOf((*MockPlugin)(nil).GetPluginInfo), arg0, arg1)
 }
 
-// ListAttestedNodeEntries mocks base method
-func (m *MockPlugin) ListAttestedNodeEntries(arg0 context.Context, arg1 *datastore.ListAttestedNodeEntriesRequest) (*datastore.ListAttestedNodeEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListAttestedNodeEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListAttestedNodeEntriesResponse)
+// ListAttestedNodes mocks base method
+func (m *MockPlugin) ListAttestedNodes(arg0 context.Context, arg1 *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
+	ret := m.ctrl.Call(m, "ListAttestedNodes", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.ListAttestedNodesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListAttestedNodeEntries indicates an expected call of ListAttestedNodeEntries
-func (mr *MockPluginMockRecorder) ListAttestedNodeEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodeEntries", reflect.TypeOf((*MockPlugin)(nil).ListAttestedNodeEntries), arg0, arg1)
+// ListAttestedNodes indicates an expected call of ListAttestedNodes
+func (mr *MockPluginMockRecorder) ListAttestedNodes(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttestedNodes", reflect.TypeOf((*MockPlugin)(nil).ListAttestedNodes), arg0, arg1)
 }
 
 // ListBundles mocks base method
@@ -615,19 +576,6 @@ func (m *MockPlugin) ListBundles(arg0 context.Context, arg1 *datastore.ListBundl
 // ListBundles indicates an expected call of ListBundles
 func (mr *MockPluginMockRecorder) ListBundles(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBundles", reflect.TypeOf((*MockPlugin)(nil).ListBundles), arg0, arg1)
-}
-
-// ListNodeResolverMapEntries mocks base method
-func (m *MockPlugin) ListNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.ListNodeResolverMapEntriesRequest) (*datastore.ListNodeResolverMapEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "ListNodeResolverMapEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.ListNodeResolverMapEntriesResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListNodeResolverMapEntries indicates an expected call of ListNodeResolverMapEntries
-func (mr *MockPluginMockRecorder) ListNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNodeResolverMapEntries", reflect.TypeOf((*MockPlugin)(nil).ListNodeResolverMapEntries), arg0, arg1)
 }
 
 // ListRegistrationEntries mocks base method
@@ -656,30 +604,30 @@ func (mr *MockPluginMockRecorder) PruneJoinTokens(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneJoinTokens", reflect.TypeOf((*MockPlugin)(nil).PruneJoinTokens), arg0, arg1)
 }
 
-// RectifyNodeResolverMapEntries mocks base method
-func (m *MockPlugin) RectifyNodeResolverMapEntries(arg0 context.Context, arg1 *datastore.RectifyNodeResolverMapEntriesRequest) (*datastore.RectifyNodeResolverMapEntriesResponse, error) {
-	ret := m.ctrl.Call(m, "RectifyNodeResolverMapEntries", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.RectifyNodeResolverMapEntriesResponse)
+// SetNodeSelectors mocks base method
+func (m *MockPlugin) SetNodeSelectors(arg0 context.Context, arg1 *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
+	ret := m.ctrl.Call(m, "SetNodeSelectors", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.SetNodeSelectorsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RectifyNodeResolverMapEntries indicates an expected call of RectifyNodeResolverMapEntries
-func (mr *MockPluginMockRecorder) RectifyNodeResolverMapEntries(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RectifyNodeResolverMapEntries", reflect.TypeOf((*MockPlugin)(nil).RectifyNodeResolverMapEntries), arg0, arg1)
+// SetNodeSelectors indicates an expected call of SetNodeSelectors
+func (mr *MockPluginMockRecorder) SetNodeSelectors(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNodeSelectors", reflect.TypeOf((*MockPlugin)(nil).SetNodeSelectors), arg0, arg1)
 }
 
-// UpdateAttestedNodeEntry mocks base method
-func (m *MockPlugin) UpdateAttestedNodeEntry(arg0 context.Context, arg1 *datastore.UpdateAttestedNodeEntryRequest) (*datastore.UpdateAttestedNodeEntryResponse, error) {
-	ret := m.ctrl.Call(m, "UpdateAttestedNodeEntry", arg0, arg1)
-	ret0, _ := ret[0].(*datastore.UpdateAttestedNodeEntryResponse)
+// UpdateAttestedNode mocks base method
+func (m *MockPlugin) UpdateAttestedNode(arg0 context.Context, arg1 *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+	ret := m.ctrl.Call(m, "UpdateAttestedNode", arg0, arg1)
+	ret0, _ := ret[0].(*datastore.UpdateAttestedNodeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateAttestedNodeEntry indicates an expected call of UpdateAttestedNodeEntry
-func (mr *MockPluginMockRecorder) UpdateAttestedNodeEntry(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAttestedNodeEntry", reflect.TypeOf((*MockPlugin)(nil).UpdateAttestedNodeEntry), arg0, arg1)
+// UpdateAttestedNode indicates an expected call of UpdateAttestedNode
+func (mr *MockPluginMockRecorder) UpdateAttestedNode(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAttestedNode", reflect.TypeOf((*MockPlugin)(nil).UpdateAttestedNode), arg0, arg1)
 }
 
 // UpdateBundle mocks base method


### PR DESCRIPTION
This PR cleans up the datastore proto interface. Highlights include:

1. Consistent Request/Response messages
2. Consistent field naming
3. Consistent CRUD operation names (fetch, list, update, create, delete)
4. Unified registration entry list operations under a single method with optional (and combinable) filters
5. Attested node entry certificate expiration is now int64 seconds since unix epoch to ease usage (no special date formatting needed)
