### PR TITLE
HTTP CONNECT proxy support

### DIFF
--- a/pkg/common/grpcutil/dialer.go
+++ b/pkg/common/grpcutil/dialer.go
@@ -54,7 +54,7 @@ func (d *grpcDialer) Dial(ctx context.Context, addr string) (*grpc.ClientConn, e
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		conn, err := new(net.Dialer).DialContext(ctx, "tcp", addr)
+		conn, err := proxyDial(ctx, addr)
 		if err != nil {
 			d.log.Print(err)
 			return nil, err

--- a/pkg/common/grpcutil/proxy.go
+++ b/pkg/common/grpcutil/proxy.go
@@ -1,0 +1,131 @@
+// The following source code has been taken, with minor modification, from the
+// gRPC codebase. We'd rather use their dialer, which supports HTTP-CONNECT
+// proxies, but need richer error logging on handshake failure.
+
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package grpcutil
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+const grpcUA = "grpc-go/" + grpc.Version
+
+func mapAddress(ctx context.Context, address string) (string, error) {
+	req := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   address,
+		},
+	}
+	url, err := http.ProxyFromEnvironment(req)
+	if err != nil {
+		return "", err
+	}
+	if url == nil {
+		return "", nil
+	}
+	return url.Host, nil
+}
+
+// To read a response from a net.Conn, http.ReadResponse() takes a bufio.Reader.
+// It's possible that this reader reads more than what's need for the response and stores
+// those bytes in the buffer.
+// bufConn wraps the original net.Conn and the bufio.Reader to make sure we don't lose the
+// bytes in the buffer.
+type bufConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c *bufConn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}
+
+func doHTTPConnectHandshake(ctx context.Context, conn net.Conn, addr string) (_ net.Conn, err error) {
+	defer func() {
+		if err != nil {
+			conn.Close()
+		}
+	}()
+
+	req := (&http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Host: addr},
+		Header: map[string][]string{"User-Agent": {grpcUA}},
+	})
+
+	req = req.WithContext(ctx)
+	if err := req.Write(conn); err != nil {
+		return nil, fmt.Errorf("failed to write the HTTP request: %v", err)
+	}
+
+	r := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(r, req)
+	if err != nil {
+		return nil, fmt.Errorf("reading server HTTP response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		dump, err := httputil.DumpResponse(resp, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to do connect handshake, status code: %s", resp.Status)
+		}
+		return nil, fmt.Errorf("failed to do connect handshake, response: %q", dump)
+	}
+
+	return &bufConn{Conn: conn, r: r}, nil
+}
+
+// proxyDial dials to a proxy and does an HTTP CONNECT handshake if proxying is
+// enabled. Otherwise, it just does a regular TCP dial. It is based on the
+// newProxyDialer wrapper implementation from the gRPC codebase.
+func proxyDial(ctx context.Context, addr string) (conn net.Conn, err error) {
+	var skipHandshake bool
+	newAddr, err := mapAddress(ctx, addr)
+	if err != nil {
+		return nil, err
+	}
+	if newAddr == "" {
+		skipHandshake = true
+		newAddr = addr
+	}
+
+	conn, err = new(net.Dialer).DialContext(ctx, "tcp", newAddr)
+	if err != nil {
+		return nil, err
+	}
+	if !skipHandshake {
+		conn, err = doHTTPConnectHandshake(ctx, conn, addr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return conn, nil
+}


### PR DESCRIPTION
SPIRE uses a custom dialer in order to get better diagnostics on
handshake failures. Unfortunately the custom dialer does not support
HTTP CONNECT proxies.

This commit cribs the proxy support code from the gRPC codebase and
incorporates it into the custom dialer.