### PR TITLE
Refactor plugin template to make it enabled as default

### DIFF
--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -28,10 +28,30 @@ func TestParseConfigGood(t *testing.T) {
 	err = printer.DefaultConfig.Fprint(&data, c.PluginConfigs["plugin_type_agent"]["plugin_name_agent"].PluginData)
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(c.PluginConfigs), 1)
-	assert.Equal(t, c.PluginConfigs["plugin_type_agent"]["plugin_name_agent"].Enabled, true)
-	assert.Equal(t, c.PluginConfigs["plugin_type_agent"]["plugin_name_agent"].PluginChecksum, "pluginAgentChecksum")
-	assert.Equal(t, c.PluginConfigs["plugin_type_agent"]["plugin_name_agent"].PluginCmd, "./pluginAgentCmd")
+	assert.Len(t, c.PluginConfigs, 1)
+	assert.Len(t, c.PluginConfigs["plugin_type_agent"], 3)
+
+	pluginConfig := c.PluginConfigs["plugin_type_agent"]["plugin_name_agent"]
+	assert.Nil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), true)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginAgentCmd")
+	assert.Equal(t, expectedData, data.String())
+
+	// Disabled plugin
+	pluginConfig = c.PluginConfigs["plugin_type_agent"]["plugin_disabled"]
+	assert.NotNil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), false)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginAgentCmd")
+	assert.Equal(t, expectedData, data.String())
+
+	// Enabled plugin
+	pluginConfig = c.PluginConfigs["plugin_type_agent"]["plugin_enabled"]
+	assert.NotNil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), true)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginAgentCmd")
 	assert.Equal(t, expectedData, data.String())
 }
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -27,10 +27,31 @@ func TestParseConfigGood(t *testing.T) {
 	err = printer.DefaultConfig.Fprint(&data, c.PluginConfigs["plugin_type_server"]["plugin_name_server"].PluginData)
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(c.PluginConfigs), 1)
-	assert.Equal(t, c.PluginConfigs["plugin_type_server"]["plugin_name_server"].Enabled, true)
-	assert.Equal(t, c.PluginConfigs["plugin_type_server"]["plugin_name_server"].PluginChecksum, "pluginServerChecksum")
-	assert.Equal(t, c.PluginConfigs["plugin_type_server"]["plugin_name_server"].PluginCmd, "./pluginServerCmd")
+	assert.Len(t, c.PluginConfigs, 1)
+	assert.Len(t, c.PluginConfigs["plugin_type_server"], 3)
+
+	// Default config
+	pluginConfig := c.PluginConfigs["plugin_type_server"]["plugin_name_server"]
+	assert.Nil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), true)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
+	assert.Equal(t, expectedData, data.String())
+
+	// Disabled plugin
+	pluginConfig = c.PluginConfigs["plugin_type_server"]["plugin_disabled"]
+	assert.NotNil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), false)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
+	assert.Equal(t, expectedData, data.String())
+
+	// Enabled plugin
+	pluginConfig = c.PluginConfigs["plugin_type_server"]["plugin_enabled"]
+	assert.NotNil(t, pluginConfig.Enabled)
+	assert.Equal(t, pluginConfig.IsEnabled(), true)
+	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
+	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
 	assert.Equal(t, expectedData, data.String())
 }
 

--- a/conf/agent/agent.conf
+++ b/conf/agent/agent.conf
@@ -15,23 +15,19 @@ agent {
 
 plugins {
     NodeAttestor "join_token" {
-        enabled = true
         plugin_data {
         }
     }
     KeyManager "memory" {
-        enabled = true
         plugin_data {
         }
     }
     WorkloadAttestor "k8s" {
-        enabled = true
         plugin_data {
             kubelet_read_only_port = "10255"
         }
     }
     WorkloadAttestor "unix" {
-        enabled = true
         plugin_data {
         }
     }

--- a/conf/agent/ha-postgres.conf
+++ b/conf/agent/ha-postgres.conf
@@ -13,23 +13,19 @@ agent {
 
 plugins {
     NodeAttestor "join_token" {
-        enabled = true
         plugin_data {
         }
     }
     KeyManager "memory" {
-        enabled = true
         plugin_data {
         }
     }
     WorkloadAttestor "k8s" {
-        enabled = true
         plugin_data {
             kubelet_read_only_port = "10255"
         }
     }
     WorkloadAttestor "unix" {
-        enabled = true
         plugin_data {
         }
     }

--- a/conf/server/ha-postgres.conf
+++ b/conf/server/ha-postgres.conf
@@ -19,7 +19,6 @@ server {
 
 plugins {
     DataStore "sql" {
-        enabled = true
         plugin_data {
             database_type = "postgres"
             connection_string = "dbname=postgres user=postgres password=password host=datastore sslmode=disable"
@@ -27,23 +26,19 @@ plugins {
     }
 
     NodeAttestor "join_token" {
-        enabled = true
         plugin_data {
         }
     }
 
     NodeResolver "noop" {
-        enabled = true
         plugin_data {}
     }
 
     KeyManager "memory" {
-        enabled = true
         plugin_data {}
     }
 
     UpstreamCA "disk" {
-        enabled = true
         plugin_data {
             ttl = "15m"
             key_file_path = "./conf/server/dummy_upstream_ca.key"

--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -18,7 +18,6 @@ server {
 
 plugins {
     DataStore "sql" {
-        enabled = true
         plugin_data {
             database_type = "sqlite3"
             connection_string = "./.data/datastore.sqlite3"
@@ -26,23 +25,19 @@ plugins {
     }
 
     NodeAttestor "join_token" {
-        enabled = true
         plugin_data {
         }
     }
 
     NodeResolver "noop" {
-        enabled = true
         plugin_data {}
     }
 
     KeyManager "memory" {
-        enabled = true
         plugin_data = {}
     }
 
     UpstreamCA "disk" {
-        enabled = true
         plugin_data {
             ttl = "1h"
             key_file_path = "./conf/server/dummy_upstream_ca.key"

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -88,7 +88,6 @@ server {
 
 plugins {
         ServerCA "memory" { 
-        enabled = true
         plugin_data {
                 key_size = 2048,
                 backdate_seconds = 1,
@@ -101,7 +100,6 @@ plugins {
         }
 
         DataStore "datastore" {
-                enabled = true
                 plugin_data {
                         database_type = "sqlite3"
                         connection_string = "./.data/datastore.sqlite3"
@@ -109,18 +107,15 @@ plugins {
         }
 
         NodeAttestor "join_token" {
-                enabled = true
                 plugin_data {
                 }
         }
 
         NodeResolver "noop" {
-                enabled = true
                 plugin_data {}
         }
 
         UpstreamCA "disk" {
-                enabled = true
                 plugin_data {
                         ttl = "1h"
                         key_file_path = "conf/server/dummy_upstream_ca.key"
@@ -164,17 +159,14 @@ plugins {
 
     plugins {
         NodeAttestor "join_token" {
-            enabled = true
             plugin_data {
             }
         }
         KeyManager "memory" {
-            enabled = true
             plugin_data {
             }
         }
         WorkloadAttestor "unix" {
-            enabled = true
             plugin_data {
             }
         }

--- a/doc/plugin_agent_nodeattestor_azure_msi.md
+++ b/doc/plugin_agent_nodeattestor_azure_msi.md
@@ -33,7 +33,6 @@ A sample configuration with the default resource ID (i.e. resource manager):
 
 ```
     NodeAttestor "azure_msi" {
-        enabled = true
         plugin_data {
         }
     }
@@ -43,7 +42,6 @@ A sample configuration with a custom resource ID:
 
 ```
     NodeAttestor "azure_msi" {
-        enabled = true
         plugin_data {
             resource_id = "http://example.org/app/"
         }

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -44,7 +44,7 @@ The following configuration options are available to configure a plugin:
 | --------------- | ---------------------------------------- |
 | plugin_cmd      | Path to the plugin implementation binary (optional, not needed for built-ins) |
 | plugin_checksum | An optional sha256 of the plugin binary  (optional, not needed for built-ins) |
-| enabled         | Enable or disable the plugin             |
+| enabled         | Enable or disable the plugin, enabled as default.             |
 | plugin_data     | Plugin-specific data                     |
 
 Please see the [built-in plugins](#built-in-plugins) section below for information on plugins that are available out-of-the-box.

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -45,7 +45,7 @@ The following configuration options are available to configure a plugin:
 | --------------- | ---------------------------------------- |
 | plugin_cmd      | Path to the plugin implementation binary (optional, not needed for built-ins) |
 | plugin_checksum | An optional sha256 of the plugin binary  (optional, not needed for built-ins) |
-| enabled         | Enable or disable the plugin             |
+| enabled         | Enable or disable the plugin, enabled as default.             |
 | plugin_data     | Plugin-specific data                     |
 
 Please see the [built-in plugins](#built-in-plugins) section below for information on plugins that are available out-of-the-box.

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-plugin"
 	"github.com/hashicorp/hcl"
@@ -47,7 +48,7 @@ func (c *CatalogTestSuite) SetupTest() {
 	cat := &catalog{
 		pluginConfigs: PluginConfigMap{"NodeAttestor": {"join_token": HclPluginConfig{
 			PluginCmd:  "./attestor",
-			Enabled:    true,
+			Enabled:    to.BoolPtr(true),
 			PluginData: pluginData,
 		}}},
 		supportedPlugins: supportedPlugins,

--- a/pkg/common/catalog/plugin.go
+++ b/pkg/common/catalog/plugin.go
@@ -36,7 +36,15 @@ type HclPluginConfig struct {
 
 	PluginData ast.Node `hcl:"plugin_data"`
 	PluginType string
-	Enabled    bool `hcl:"enabled"`
+	Enabled    *bool `hcl:"enabled"`
+}
+
+func (c HclPluginConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+
+	return *c.Enabled
 }
 
 type ManagedPlugin struct {
@@ -59,7 +67,7 @@ func parsePluginConfig(hclPluginConfig HclPluginConfig) (PluginConfig, error) {
 		PluginCmd:      hclPluginConfig.PluginCmd,
 		PluginChecksum: hclPluginConfig.PluginChecksum,
 		PluginType:     hclPluginConfig.PluginType,
-		Enabled:        hclPluginConfig.Enabled,
+		Enabled:        hclPluginConfig.IsEnabled(),
 
 		// Handle PluginData as opaque string. This gets fed
 		// to the plugin, whos job it is to parse it.

--- a/test/configs/server/postgres.conf
+++ b/test/configs/server/postgres.conf
@@ -19,7 +19,6 @@ server {
 
 plugins {
     DataStore "sql" {
-        enabled = true
         plugin_data {
             database_type = "postgres"
             connection_string = "dbname=postgres user=postgres password=password host=localhost sslmode=disable"
@@ -27,23 +26,19 @@ plugins {
     }
 
     NodeAttestor "join_token" {
-        enabled = true
         plugin_data {
         }
     }
 
     NodeResolver "noop" {
-        enabled = true
         plugin_data {}
     }
 
     KeyManager "memory" {
-        enabled = true
         plugin_data {}
     }
 
     UpstreamCA "disk" {
-        enabled = true
         plugin_data {
             ttl = "1h"
             key_file_path = "./conf/server/dummy_upstream_ca.key"

--- a/test/fixture/config/agent_good.conf
+++ b/test/fixture/config/agent_good.conf
@@ -16,7 +16,22 @@ plugins {
     plugin_type_agent "plugin_name_agent" {
         plugin_cmd = "./pluginAgentCmd"
         plugin_checksum = "pluginAgentChecksum"
+        plugin_data {
+            join_token = "PLUGIN-AGENT-NOT-A-SECRET"
+        }
+    }
+    plugin_type_agent "plugin_disabled" {
+        plugin_cmd = "./pluginAgentCmd"
+        enabled = false
+        plugin_checksum = "pluginAgentChecksum"
+        plugin_data {
+            join_token = "PLUGIN-AGENT-NOT-A-SECRET"
+        }
+    }
+     plugin_type_agent "plugin_enabled" {
+        plugin_cmd = "./pluginAgentCmd"
         enabled = true
+        plugin_checksum = "pluginAgentChecksum"
         plugin_data {
             join_token = "PLUGIN-AGENT-NOT-A-SECRET"
         }

--- a/test/fixture/config/plugin_good.conf
+++ b/test/fixture/config/plugin_good.conf
@@ -1,7 +1,6 @@
 pluginName = "join_token"
 pluginCmd = "./attestor"
 pluginChecksum = ""
-enabled = true
 pluginType = "NodeAttestor"
 pluginData {
 	join_token = "NOT-A-SECRET"

--- a/test/fixture/config/server_good.conf
+++ b/test/fixture/config/server_good.conf
@@ -14,7 +14,22 @@ plugins {
     plugin_type_server "plugin_name_server" {
         plugin_cmd = "./pluginServerCmd"
         plugin_checksum = "pluginServerChecksum"
+        plugin_data {
+            join_token = "PLUGIN-SERVER-NOT-A-SECRET"
+        }
+    }
+    plugin_type_server "plugin_disabled" {
+        plugin_cmd = "./pluginServerCmd"
+        enabled = false
+        plugin_checksum = "pluginServerChecksum"
+        plugin_data {
+            join_token = "PLUGIN-SERVER-NOT-A-SECRET"
+        }
+    }
+    plugin_type_server "plugin_enabled" {
+        plugin_cmd = "./pluginServerCmd"
         enabled = true
+        plugin_checksum = "pluginServerChecksum"
         plugin_data {
             join_token = "PLUGIN-SERVER-NOT-A-SECRET"
         }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
All plugins in config files are now enabled as default.

**Description of change**
Refactor catalog.plugin to make plugins enabled as default, it is still possible to use `enabled = true`, but now we can jut remove enabled an plugin will be enabled as defautl.
To disable a plugin `enabled = false` must be provided

**Which issue this PR fixes**
fixes #573

