### PR TITLE
fix journal_mode and foreign_keys support

### DIFF
--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -1,6 +1,8 @@
 package sql
 
 import (
+	"net/url"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
@@ -8,18 +10,46 @@ import (
 type sqlite struct{}
 
 func (s sqlite) connect(connectionString string) (*gorm.DB, error) {
-	db, err := gorm.Open("sqlite3", connectionString)
+	embellished, err := embellishSQLite3ConnString(connectionString)
 	if err != nil {
-		return nil, sqlError.Wrap(err)
+		return nil, err
 	}
-	if err := db.Exec("PRAGMA journal_mode = WAL").Error; err != nil {
-		db.Close()
-		return nil, sqlError.Wrap(err)
-	}
-	if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
-		db.Close()
+	db, err := gorm.Open("sqlite3", embellished)
+	if err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
 	return db, nil
+}
+
+// embellishSQLite3ConnString adds query values supported by
+// github.com/mattn/go-sqlite3 to enable journal mode and foreign key support.
+// These query values MUST be part of the connection string in order to be
+// enabled for *each* connection opened by db/sql. If the connection string is
+// not already a file: URI, it is converted first.
+func embellishSQLite3ConnString(connectionString string) (string, error) {
+	u, err := url.Parse(connectionString)
+	if err != nil {
+		return "", sqlError.Wrap(err)
+	}
+
+	switch {
+	case u.Scheme == "":
+		// connection string is a path. move the path section into the
+		// opaque section so it renders propertly for sqlite3, for example:
+		// data.db = file:data.db
+		// ./data.db = file:./data.db
+		// /data.db = file:/data.db
+		u.Scheme = "file"
+		u.Opaque, u.Path = u.Path, ""
+	case u.Scheme != "file":
+		// only no scheme (i.e. file path) or file scheme is supported
+		return "", sqlError.New("unsupported scheme %q", u.Scheme)
+	}
+
+	q := u.Query()
+	q.Set("_foreign_keys", "ON")
+	q.Set("_journal_mode", "WAL")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
 }

--- a/pkg/server/plugin/datastore/sql/sqlite_test.go
+++ b/pkg/server/plugin/datastore/sql/sqlite_test.go
@@ -1,0 +1,74 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbellishSQLite3ConnString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{
+			name:     "non-URI relative path",
+			in:       "data.db",
+			expected: "file:data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "non-URI relative path with directory component",
+			in:       "./data.db",
+			expected: "file:./data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "non-URI absolute path",
+			in:       "/home/fred/data.db",
+			expected: "file:/home/fred/data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with no authority and relative",
+			in:       "file:data.db",
+			expected: "file:data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with no authority and absolute path",
+			in:       "file:/home/fred/data.db",
+			expected: "file:///home/fred/data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with empty authority",
+			in:       "file:///home/fred/data.db",
+			expected: "file:///home/fred/data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with localhost authority",
+			in:       "file://localhost/home/fred/data.db",
+			expected: "file://localhost/home/fred/data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with empty authority and windows file path",
+			in:       "file:///C:/Documents%20and%20Settings/fred/Desktop/data.db",
+			expected: "file:///C:/Documents%20and%20Settings/fred/Desktop/data.db?_foreign_keys=ON&_journal_mode=WAL",
+		},
+		{
+			name:     "URI with no authority, relative path, and query params",
+			in:       "file:data.db?mode=ro",
+			expected: "file:data.db?_foreign_keys=ON&_journal_mode=WAL&mode=ro",
+		},
+		{
+			name:     "URI with no authority, absolute path, and query params",
+			in:       "file:/home/fred/data.db?vfs=unix-dotfile",
+			expected: "file:///home/fred/data.db?_foreign_keys=ON&_journal_mode=WAL&vfs=unix-dotfile",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual, err := embellishSQLite3ConnString(testCase.in)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
`journal_mode` and `foreign_key` settings are per-connection in
sqlite3. The existing code sets the right PRAGMAs when the database is
first opened, but that only impacts the first connection in the
database/sql.(*DB) connection pool. When a new connection is created, it
will not have those settings, which could lead to unecessary errors in
the case of journal_mode (e.g. "database locked") or database
inconsistencies in the case of foreign_keys.

This change takes advantage of github.com/mattn/go-sqlite3 query value
support for enabling those features for each connection. The code now
parses the connection string, converts it into a file: URI if needed,
and adds the proper _journal_mode and _foreign_keys query values.