### PR TITLE
fix x509pop signature mismatch test

### DIFF
--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -87,10 +87,10 @@ func TestChallengeResponse(t *testing.T) {
 	require.EqualError(err, "expecting ECDSA response")
 
 	// mutate the signatures and assert verification fails
-	rsaResponse.RSASignature.Signature[0] ^= rsaResponse.RSASignature.Signature[0]
+	rsaResponse.RSASignature.Signature[0] += 1
 	err = VerifyChallengeResponse(rsaPublicKey, rsaChallenge, rsaResponse)
 	require.EqualError(err, "RSA signature verify failed")
-	ecdsaResponse.ECDSASignature.R[0] ^= ecdsaResponse.ECDSASignature.R[0]
+	ecdsaResponse.ECDSASignature.R[0] += 1
 	err = VerifyChallengeResponse(ecdsaPublicKey, ecdsaChallenge, ecdsaResponse)
 	require.EqualError(err, "ECDSA signature verify failed")
 


### PR DESCRIPTION
The test would "mutate" the signature by XOR'ing the first byte with
itself. Since a XOR a == 0, the signature would remain unchanged if the
first byte was zero, causing the test to fail. I am ashamed.
