### PR TITLE
Move Registration API Endpoint to a Unix Domain Socket

### DIFF
--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -110,7 +110,7 @@ func (s *BundleSuite) TestShowHelp() {
 	s.showCmd.Help()
 	s.Require().Equal(`Usage of bundle show:
   -registrationUDSPath string
-    	Registration API UDS Path (default "./spire_api")
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
 `, s.stderr.String())
 }
 
@@ -142,7 +142,7 @@ func (s *BundleSuite) TestSetHelp() {
   -path string
     	Path to the bundle data
   -registrationUDSPath string
-    	Registration API UDS Path (default "./spire_api")
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
 `, s.stderr.String())
 }
 
@@ -201,7 +201,7 @@ func (s *BundleSuite) TestListHelp() {
   -id string
     	SPIFFE ID of the trust domain
   -registrationUDSPath string
-    	Registration API UDS Path (default "./spire_api")
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
 `, s.stderr.String())
 }
 
@@ -277,7 +277,7 @@ func (s *BundleSuite) TestDeleteHelp() {
   -mode string
     	Deletion mode: one of restrict, delete, or dissociate (default "restrict")
   -registrationUDSPath string
-    	Registration API UDS Path (default "./spire_api")
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
 `, s.stderr.String())
 }
 

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -82,7 +82,7 @@ func (s *BundleSuite) SetupTest() {
 		stdout: s.stdout,
 		stderr: s.stderr,
 	}
-	clientMaker := func(context.Context, string) (*clients, error) {
+	clientMaker := func(string) (*clients, error) {
 		return &clients{
 			r: s.registrationClient,
 		}, nil
@@ -109,8 +109,8 @@ func (s *BundleSuite) AfterTest(suiteName, testName string) {
 func (s *BundleSuite) TestShowHelp() {
 	s.showCmd.Help()
 	s.Require().Equal(`Usage of bundle show:
-  -serverAddr string
-    	Address of the SPIRE server (default "localhost:8081")
+  -registrationUDSPath string
+    	Registration API UDS Path (default "./spire_api")
 `, s.stderr.String())
 }
 
@@ -141,8 +141,8 @@ func (s *BundleSuite) TestSetHelp() {
     	SPIFFE ID of the trust domain
   -path string
     	Path to the bundle data
-  -serverAddr string
-    	Address of the SPIRE server (default "localhost:8081")
+  -registrationUDSPath string
+    	Registration API UDS Path (default "./spire_api")
 `, s.stderr.String())
 }
 
@@ -200,8 +200,8 @@ func (s *BundleSuite) TestListHelp() {
 	s.Require().Equal(`Usage of bundle list:
   -id string
     	SPIFFE ID of the trust domain
-  -serverAddr string
-    	Address of the SPIRE server (default "localhost:8081")
+  -registrationUDSPath string
+    	Registration API UDS Path (default "./spire_api")
 `, s.stderr.String())
 }
 
@@ -276,8 +276,8 @@ func (s *BundleSuite) TestDeleteHelp() {
     	SPIFFE ID of the trust domain
   -mode string
     	Deletion mode: one of restrict, delete, or dissociate (default "restrict")
-  -serverAddr string
-    	Address of the SPIRE server (default "localhost:8081")
+  -registrationUDSPath string
+    	Registration API UDS Path (default "./spire_api")
 `, s.stderr.String())
 }
 

--- a/cmd/spire-server/cli/bundle/common.go
+++ b/cmd/spire-server/cli/bundle/common.go
@@ -66,7 +66,7 @@ func adaptCommand(env *env, clientsMaker clientsMaker, cmd command) *adapter {
 
 	f := flag.NewFlagSet(cmd.name(), flag.ContinueOnError)
 	f.SetOutput(env.stderr)
-	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
+	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	a.cmd.appendFlags(f)
 	a.flags = f
 

--- a/cmd/spire-server/cli/bundle/common.go
+++ b/cmd/spire-server/cli/bundle/common.go
@@ -24,11 +24,11 @@ type clients struct {
 	r registration.RegistrationClient
 }
 
-type clientsMaker func(ctx context.Context, addr string) (*clients, error)
+type clientsMaker func(registrationUDSPath string) (*clients, error)
 
 // newClients is the default client maker
-func newClients(ctx context.Context, addr string) (*clients, error) {
-	registrationClient, err := util.NewRegistrationClient(ctx, addr)
+func newClients(registrationUDSPath string) (*clients, error) {
+	registrationClient, err := util.NewRegistrationClient(registrationUDSPath)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +52,8 @@ type adapter struct {
 	clientsMaker clientsMaker
 	cmd          command
 
-	addr  string
-	flags *flag.FlagSet
+	registrationUDSPath string
+	flags               *flag.FlagSet
 }
 
 // adaptCommand converts a command into one conforming to the Command interface from github.com/mitchellh/cli
@@ -66,7 +66,7 @@ func adaptCommand(env *env, clientsMaker clientsMaker, cmd command) *adapter {
 
 	f := flag.NewFlagSet(cmd.name(), flag.ContinueOnError)
 	f.SetOutput(env.stderr)
-	f.StringVar(&a.addr, "serverAddr", util.DefaultServerAddr, "Address of the SPIRE server")
+	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
 	a.cmd.appendFlags(f)
 	a.flags = f
 
@@ -81,7 +81,7 @@ func (a *adapter) Run(args []string) int {
 		return 1
 	}
 
-	clients, err := a.clientsMaker(ctx, a.addr)
+	clients, err := a.clientsMaker(a.registrationUDSPath)
 	if err != nil {
 		fmt.Fprintln(a.env.stderr, err)
 		return 1

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -16,8 +16,8 @@ import (
 )
 
 type CreateConfig struct {
-	// Address of SPIRE server
-	Addr string
+	// Socket path of registration API
+	RegistrationUDSPath string
 
 	// Path to an optional data file. If set, other
 	// opts will be ignored.
@@ -38,8 +38,8 @@ type CreateConfig struct {
 // Perform basic validation, even on fields that we
 // have defaults defined for
 func (rc *CreateConfig) Validate() error {
-	if rc.Addr == "" {
-		return errors.New("a server address is required")
+	if rc.RegistrationUDSPath == "" {
+		return errors.New("a socket path for registration api is required")
 	}
 
 	// If a path is set, we have all we need
@@ -115,7 +115,7 @@ func (c CreateCLI) Run(args []string) int {
 		return 1
 	}
 
-	cl, err := util.NewRegistrationClient(ctx, config.Addr)
+	cl, err := util.NewRegistrationClient(config.RegistrationUDSPath)
 	if err != nil {
 		fmt.Println(err.Error())
 		return 1
@@ -187,7 +187,7 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 	f := flag.NewFlagSet("entry create", flag.ContinueOnError)
 	c := &CreateConfig{}
 
-	f.StringVar(&c.Addr, "serverAddr", util.DefaultServerAddr, "Address of the SPIRE server")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
 	f.IntVar(&c.Ttl, "ttl", 3600, "A TTL, in seconds, for any SVID issued as a result of this record")

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -187,7 +187,7 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 	f := flag.NewFlagSet("entry create", flag.ContinueOnError)
 	c := &CreateConfig{}
 
-	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
 	f.IntVar(&c.Ttl, "ttl", 3600, "A TTL, in seconds, for any SVID issued as a result of this record")

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -15,12 +15,12 @@ import (
 // TODO: Test additional scenarios
 func TestCreateParseConfig(t *testing.T) {
 	c := &CreateConfig{
-		Addr:          cmdutil.DefaultServerAddr,
-		ParentID:      "spiffe://example.org/foo",
-		SpiffeID:      "spiffe://example.org/bar",
-		Ttl:           60,
-		Selectors:     StringsFlag{"unix:uid:1000", "unix:gid:1000"},
-		FederatesWith: StringsFlag{"spiffe://domain1.test", "spiffe://domain2.test"},
+		RegistrationUDSPath: cmdutil.DefaultSocketPath,
+		ParentID:            "spiffe://example.org/foo",
+		SpiffeID:            "spiffe://example.org/bar",
+		Ttl:                 60,
+		Selectors:           StringsFlag{"unix:uid:1000", "unix:gid:1000"},
+		FederatesWith:       StringsFlag{"spiffe://domain1.test", "spiffe://domain2.test"},
 	}
 
 	entries, err := CreateCLI{}.parseConfig(c)

--- a/cmd/spire-server/cli/entry/delete.go
+++ b/cmd/spire-server/cli/entry/delete.go
@@ -77,7 +77,7 @@ func (DeleteCLI) newConfig(args []string) (*DeleteConfig, error) {
 	f := flag.NewFlagSet("entry delete", flag.ContinueOnError)
 	c := &DeleteConfig{}
 
-	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.EntryID, "entryID", "", "The Registration Entry ID of the record to delete")
 
 	return c, f.Parse(args)

--- a/cmd/spire-server/cli/entry/delete.go
+++ b/cmd/spire-server/cli/entry/delete.go
@@ -12,8 +12,8 @@ import (
 )
 
 type DeleteConfig struct {
-	// Address of SPIRE server
-	Addr string
+	// Socket path of registration API
+	RegistrationUDSPath string
 
 	// ID of the record to delete
 	EntryID string
@@ -21,8 +21,8 @@ type DeleteConfig struct {
 
 // Perform basic validation
 func (dc *DeleteConfig) Validate() error {
-	if dc.Addr == "" {
-		return errors.New("a server address is required")
+	if dc.RegistrationUDSPath == "" {
+		return errors.New("a socket path for registration api is required")
 	}
 
 	if dc.EntryID == "" {
@@ -55,7 +55,7 @@ func (d DeleteCLI) Run(args []string) int {
 		return d.printErr(err)
 	}
 
-	cl, err := util.NewRegistrationClient(ctx, config.Addr)
+	cl, err := util.NewRegistrationClient(config.RegistrationUDSPath)
 	if err != nil {
 		return d.printErr(err)
 	}
@@ -77,7 +77,7 @@ func (DeleteCLI) newConfig(args []string) (*DeleteConfig, error) {
 	f := flag.NewFlagSet("entry delete", flag.ContinueOnError)
 	c := &DeleteConfig{}
 
-	f.StringVar(&c.Addr, "serverAddr", util.DefaultServerAddr, "Address of the SPIRE server")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
 	f.StringVar(&c.EntryID, "entryID", "", "The Registration Entry ID of the record to delete")
 
 	return c, f.Parse(args)

--- a/cmd/spire-server/cli/entry/show.go
+++ b/cmd/spire-server/cli/entry/show.go
@@ -274,7 +274,7 @@ func (s *ShowCLI) loadConfig(args []string) error {
 	f := flag.NewFlagSet("entry show", flag.ContinueOnError)
 	c := &ShowConfig{}
 
-	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.EntryID, "entryID", "", "The Entry ID of the records to show")
 	f.StringVar(&c.ParentID, "parentID", "", "The Parent ID of the records to show")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID of the records to show")

--- a/cmd/spire-server/cli/entry/show.go
+++ b/cmd/spire-server/cli/entry/show.go
@@ -15,8 +15,8 @@ import (
 // ShowConfig is a configuration struct for the
 // `spire-server entry show` CLI command
 type ShowConfig struct {
-	// Address of SPIRE server
-	Addr string
+	// Socket path of registration API
+	RegistrationUDSPath string
 
 	// Type and value are delimited by a colon (:)
 	// ex. "unix:uid:1000" or "spiffe_id:spiffe://example.org/foo"
@@ -73,7 +73,7 @@ func (s *ShowCLI) Run(args []string) int {
 	}
 
 	if s.Client == nil {
-		s.Client, err = util.NewRegistrationClient(ctx, s.Config.Addr)
+		s.Client, err = util.NewRegistrationClient(s.Config.RegistrationUDSPath)
 		if err != nil {
 			fmt.Printf("Error creating new registration client: %v", err)
 			return 1
@@ -274,7 +274,7 @@ func (s *ShowCLI) loadConfig(args []string) error {
 	f := flag.NewFlagSet("entry show", flag.ContinueOnError)
 	c := &ShowConfig{}
 
-	f.StringVar(&c.Addr, "serverAddr", util.DefaultServerAddr, "Address of the SPIRE server")
+	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
 	f.StringVar(&c.EntryID, "entryID", "", "The Entry ID of the records to show")
 	f.StringVar(&c.ParentID, "parentID", "", "The Parent ID of the records to show")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID of the records to show")

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	defaultConfigPath = "conf/server/server.conf"
-	defaultSocketPath = "./spire_api"
+	defaultSocketPath = "/tmp/spire-registration.sock"
 	defaultLogLevel   = "INFO"
 	defaultUmask      = 0077
 )

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -16,7 +16,7 @@ func TestParseConfigGood(t *testing.T) {
 	// Check for server configurations
 	assert.Equal(t, c.Server.BindAddress, "127.0.0.1")
 	assert.Equal(t, c.Server.BindPort, 8081)
-	assert.Equal(t, c.Server.BindHTTPPort, 8080)
+	assert.Equal(t, c.Server.RegistrationUDSPath, "/tmp/server.sock")
 	assert.Equal(t, c.Server.TrustDomain, "example.org")
 	assert.Equal(t, c.Server.LogLevel, "INFO")
 	assert.Equal(t, c.Server.Umask, "")
@@ -58,14 +58,14 @@ func TestParseConfigGood(t *testing.T) {
 func TestParseFlagsGood(t *testing.T) {
 	c, err := parseFlags([]string{
 		"-bindAddress=127.0.0.1",
-		"-bindHTTPPort=8080",
+		"-registrationUDSPath=/tmp/flag.sock",
 		"-trustDomain=example.org",
 		"-logLevel=INFO",
 		"-umask=",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, c.Server.BindAddress, "127.0.0.1")
-	assert.Equal(t, c.Server.BindHTTPPort, 8080)
+	assert.Equal(t, c.Server.RegistrationUDSPath, "/tmp/flag.sock")
 	assert.Equal(t, c.Server.TrustDomain, "example.org")
 	assert.Equal(t, c.Server.LogLevel, "INFO")
 	assert.Equal(t, c.Server.Umask, "")
@@ -73,12 +73,12 @@ func TestParseFlagsGood(t *testing.T) {
 
 func TestMergeConfigGood(t *testing.T) {
 	sc := &serverConfig{
-		BindAddress:  "127.0.0.1",
-		BindPort:     8081,
-		BindHTTPPort: 8080,
-		TrustDomain:  "example.org",
-		LogLevel:     "INFO",
-		Umask:        "",
+		BindAddress:         "127.0.0.1",
+		BindPort:            8081,
+		RegistrationUDSPath: "/tmp/server.sock",
+		TrustDomain:         "example.org",
+		LogLevel:            "INFO",
+		Umask:               "",
 	}
 
 	c := &runConfig{
@@ -89,9 +89,9 @@ func TestMergeConfigGood(t *testing.T) {
 	err := mergeConfig(orig, c)
 	require.NoError(t, err)
 	assert.Equal(t, orig.BindAddress.IP.String(), "127.0.0.1")
-	assert.Equal(t, orig.BindHTTPAddress.IP.String(), "127.0.0.1")
+	assert.Equal(t, orig.BindUDSAddress.Name, "/tmp/server.sock")
+	assert.Equal(t, orig.BindUDSAddress.Net, "unix")
 	assert.Equal(t, orig.BindAddress.Port, 8081)
-	assert.Equal(t, orig.BindHTTPAddress.Port, 8080)
 	assert.Equal(t, orig.TrustDomain.Scheme, "spiffe")
 	assert.Equal(t, orig.TrustDomain.Host, "example.org")
 	assert.Equal(t, orig.GlobalConfig().TrustDomain, "example.org")

--- a/cmd/spire-server/cli/token/generate.go
+++ b/cmd/spire-server/cli/token/generate.go
@@ -16,8 +16,8 @@ import (
 type GenerateCLI struct{}
 
 type GenerateConfig struct {
-	// Address of the SPIRE server
-	Addr string
+	// Socket path of registration API
+	RegistrationUDSPath string
 
 	// Optional SPIFFE ID to create with the token
 	SpiffeID string
@@ -44,7 +44,7 @@ func (g GenerateCLI) Run(args []string) int {
 		return 1
 	}
 
-	c, err := util.NewRegistrationClient(ctx, config.Addr)
+	c, err := util.NewRegistrationClient(config.RegistrationUDSPath)
 	if err != nil {
 		fmt.Println(err.Error())
 		return 1
@@ -121,7 +121,7 @@ func (GenerateCLI) newConfig(args []string) (GenerateConfig, error) {
 
 	flags.IntVar(&c.TTL, "ttl", 600, "Token TTL in seconds")
 	flags.StringVar(&c.SpiffeID, "spiffeID", "", "Additional SPIFFE ID to assign the token owner (optional)")
-	flags.StringVar(&c.Addr, "serverAddr", util.DefaultServerAddr, "Address of the SPIRE server")
+	flags.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
 
 	err := flags.Parse(args)
 	if err != nil {

--- a/cmd/spire-server/cli/token/generate.go
+++ b/cmd/spire-server/cli/token/generate.go
@@ -121,7 +121,7 @@ func (GenerateCLI) newConfig(args []string) (GenerateConfig, error) {
 
 	flags.IntVar(&c.TTL, "ttl", 600, "Token TTL in seconds")
 	flags.StringVar(&c.SpiffeID, "spiffeID", "", "Additional SPIFFE ID to assign the token owner (optional)")
-	flags.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS Path")
+	flags.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 
 	err := flags.Parse(args)
 	if err != nil {

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultSocketPath = "./spire_api"
+	DefaultSocketPath = "/tmp/spire-registration.sock"
 )
 
 func NewRegistrationClient(socketPath string) (registration.RegistrationClient, error) {

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -1,39 +1,27 @@
 package util
 
 import (
-	"context"
-	"crypto/tls"
-	"log"
-	"os"
+	"net"
+	"time"
 
-	"github.com/spiffe/spire/pkg/common/grpcutil"
 	"github.com/spiffe/spire/proto/api/registration"
-
-	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc"
 )
 
 const (
-	DefaultServerAddr = "localhost:8081"
+	DefaultSocketPath = "./spire_api"
 )
 
-func NewRegistrationClient(ctx context.Context, address string) (registration.RegistrationClient, error) {
-	// TODO: Pass a bundle in here
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
-	}
-	credFunc := func() (credentials.TransportCredentials, error) { return credentials.NewTLS(tlsConfig), nil }
-
-	dc := grpcutil.GRPCDialerConfig{
-		Log:      log.New(os.Stdout, "", 0),
-		CredFunc: credFunc,
-	}
-	dialer := grpcutil.NewGRPCDialer(dc)
-
-	conn, err := dialer.Dial(ctx, address)
+func NewRegistrationClient(socketPath string) (registration.RegistrationClient, error) {
+	conn, err := grpc.Dial(socketPath, grpc.WithInsecure(), grpc.WithDialer(dialer))
 	if err != nil {
 		return nil, err
 	}
 	return registration.NewRegistrationClient(conn), err
+}
+
+func dialer(addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout("unix", addr, timeout)
 }
 
 // Pluralizer concatenates `singular` to `msg` when `val` is one, and

--- a/conf/server/ha-postgres.conf
+++ b/conf/server/ha-postgres.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    bind_http_port = "8080"
+    registration_uds_path ="./spire_api"
     trust_domain = "example.org"
     data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/conf/server/ha-postgres.conf
+++ b/conf/server/ha-postgres.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path ="./spire_api"
+    registration_uds_path ="/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path = "./spire_api"
+    registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    bind_http_port = "8080"
+    registration_uds_path = "./spire_api"
     trust_domain = "example.org"
     data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -77,7 +77,7 @@ Note: If you don't already have Docker installed, please follow these [installat
 server {
         bind_address = "127.0.0.1"
         bind_port = "8081"
-        bind_http_port = "8080"
+        registration_uds_path ="./spire_api"
         trust_domain = "example.org"
         plugin_dir = "conf/server/plugin"
         log_level = "DEBUG"

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -77,7 +77,7 @@ Note: If you don't already have Docker installed, please follow these [installat
 server {
         bind_address = "127.0.0.1"
         bind_port = "8081"
-        registration_uds_path ="./spire_api"
+        registration_uds_path ="/tmp/spire-registration.sock"
         trust_domain = "example.org"
         plugin_dir = "conf/server/plugin"
         log_level = "DEBUG"

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -9,17 +9,17 @@ backed by the SPIRE Server datastore.
 The following details the configurations for the spire server. The configurations can be set through
 a .conf file or passed as command line args, the command line configurations takes precedence.
 
-| Configuration     | Description                                            | Default                       |
-|:------------------|:-------------------------------------------------------|:------------------------------|
-| `base_svid_ttl`   | TTL to use when creating the base SPIFFE ID            |                               |
-| `bind_address`    | IP address or DNS name of the SPIRE server             |                               |
-| `bind_port`       | HTTP Port number of the SPIRE server                   |                               |
-| `bind_http_port`  | The HTTP port where the SPIRE Service is set to listen |                               |
-| `log_file`        | File to write logs to                                  |                               |
-| `log_level`       | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>    | INFO                          |
-| `trust_domain`    | The trust domain that this server belongs to           |                               |
-| `umask`           | Umask value to use for new files                       | 0077                          |
-| `upstream_bundle` | Include upstream CA certificates in the trust bundle   | false                         |
+| Configuration               | Description                                            | Default                       |
+|:----------------------------|:-------------------------------------------------------|:------------------------------|
+| `base_svid_ttl`             | TTL to use when creating the base SPIFFE ID            |                               |
+| `bind_address`              | IP address or DNS name of the SPIRE server             |                               |
+| `bind_port`                 | HTTP Port number of the SPIRE server                   |                               |
+| `registration_uds_path`     | Location to bind the registration API socket           | $PWD/spire_api                |
+| `log_file`                  | File to write logs to                                  |                               |
+| `log_level`                 | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>    | INFO                          |
+| `trust_domain`              | The trust domain that this server belongs to           |                               |
+| `umask`                     | Umask value to use for new files                       | 0077                          |
+| `upstream_bundle`           | Include upstream CA certificates in the trust bundle   | false                         |
 
 **Note:** Changing the umask may expose your signing authority to users other than the SPIRE
 agent/server.

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -16,7 +16,7 @@ import (
 type Config struct {
 	// Addresses to bind the servers to
 	GRPCAddr *net.TCPAddr
-	HTTPAddr *net.TCPAddr
+	UDSAddr  *net.UnixAddr
 
 	// A hook allowing the consumer to customize the gRPC server before it starts.
 	GRPCHook func(*grpc.Server) error

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -57,7 +57,7 @@ func (s *EndpointsTestSuite) SetupTest() {
 	s.svidState = observer.NewProperty(svid.State{})
 	c := &Config{
 		GRPCAddr:    &net.TCPAddr{IP: ip, Port: 8000},
-		HTTPAddr:    &net.TCPAddr{IP: ip, Port: 8001},
+		UDSAddr:     &net.UnixAddr{Name: "./spire_api", Net: "unix"},
 		SVIDStream:  s.svidState.Observe(),
 		TrustDomain: td,
 		Catalog:     catalog,
@@ -71,8 +71,8 @@ func (s *EndpointsTestSuite) TestCreateGRPCServer() {
 	s.Assert().NotNil(s.e.createGRPCServer(ctx))
 }
 
-func (s *EndpointsTestSuite) TestCreateHTTPServer() {
-	s.Assert().NotNil(s.e.createHTTPServer(ctx))
+func (s *EndpointsTestSuite) TestCreateUDSServer() {
+	s.Assert().NotNil(s.e.createUDSServer(ctx))
 }
 
 func (s *EndpointsTestSuite) TestRegisterNodeAPI() {
@@ -80,8 +80,7 @@ func (s *EndpointsTestSuite) TestRegisterNodeAPI() {
 }
 
 func (s *EndpointsTestSuite) TestRegisterRegistrationAPI() {
-	err := s.e.registerRegistrationAPI(ctx, s.e.createGRPCServer(ctx), s.e.createHTTPServer(ctx))
-	s.Assert().Nil(err)
+	s.Assert().NotPanics(func() { s.e.registerRegistrationAPI(s.e.createUDSServer(ctx)) })
 }
 
 func (s *EndpointsTestSuite) TestListenAndServe() {

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -57,7 +57,7 @@ func (s *EndpointsTestSuite) SetupTest() {
 	s.svidState = observer.NewProperty(svid.State{})
 	c := &Config{
 		GRPCAddr:    &net.TCPAddr{IP: ip, Port: 8000},
-		UDSAddr:     &net.UnixAddr{Name: "./spire_api", Net: "unix"},
+		UDSAddr:     &net.UnixAddr{Name: "/tmp/spire-registration.sock", Net: "unix"},
 		SVIDStream:  s.svidState.Observe(),
 		TrustDomain: td,
 		Catalog:     catalog,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,8 +37,8 @@ type Config struct {
 	// Address of SPIRE server
 	BindAddress *net.TCPAddr
 
-	// Address of the HTTP SPIRE server
-	BindHTTPAddress *net.TCPAddr
+	// Address of the UDS SPIRE server
+	BindUDSAddress *net.UnixAddr
 
 	// Directory to store runtime data
 	DataDir string
@@ -250,7 +250,7 @@ func (s *Server) newSVIDRotator(ctx context.Context, serverCA ca.ServerCA) (svid
 func (s *Server) newEndpointsServer(catalog catalog.Catalog, svidRotator svid.Rotator, serverCA ca.ServerCA) endpoints.Server {
 	return endpoints.New(&endpoints.Config{
 		GRPCAddr:    s.config.BindAddress,
-		HTTPAddr:    s.config.BindHTTPAddress,
+		UDSAddr:     s.config.BindUDSAddress,
 		SVIDStream:  svidRotator.Subscribe(),
 		TrustDomain: s.config.TrustDomain,
 		Catalog:     catalog,

--- a/test/configs/server/postgres.conf
+++ b/test/configs/server/postgres.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path ="./spire_api"
+    registration_uds_path ="/tmp/spire-registration.sock"
     trust_domain = "example.org"
 	data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/test/configs/server/postgres.conf
+++ b/test/configs/server/postgres.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    bind_http_port = "8080"
+    registration_uds_path ="./spire_api"
     trust_domain = "example.org"
 	data_dir = "./.data"
     plugin_dir = "./conf/server/plugin"

--- a/test/fixture/config/server_good.conf
+++ b/test/fixture/config/server_good.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    bind_http_port = "8080"
+    registration_uds_path ="/tmp/server.sock"
     trust_domain = "example.org"
     plugin_dir = "conf/server/plugin"
     log_level = "INFO"


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Refactor registration API to connect using unix domain socket

**Description of change**
Refactor registration api to use UDS instead of http, and update commands to provide registration socket path.

**Which issue this PR fixes**
fixes #316

