### PR TITLE
cli support for registration entry "federates with" list

### DIFF
--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -15,11 +15,12 @@ import (
 // TODO: Test additional scenarios
 func TestCreateParseConfig(t *testing.T) {
 	c := &CreateConfig{
-		Addr:      cmdutil.DefaultServerAddr,
-		ParentID:  "spiffe://example.org/foo",
-		SpiffeID:  "spiffe://example.org/bar",
-		Ttl:       60,
-		Selectors: SelectorFlag{"unix:uid:1000", "unix:gid:1000"},
+		Addr:          cmdutil.DefaultServerAddr,
+		ParentID:      "spiffe://example.org/foo",
+		SpiffeID:      "spiffe://example.org/bar",
+		Ttl:           60,
+		Selectors:     StringsFlag{"unix:uid:1000", "unix:gid:1000"},
+		FederatesWith: StringsFlag{"spiffe://domain1.test", "spiffe://domain2.test"},
 	}
 
 	entries, err := CreateCLI{}.parseConfig(c)
@@ -32,6 +33,10 @@ func TestCreateParseConfig(t *testing.T) {
 		Selectors: []*common.Selector{
 			{Type: "unix", Value: "uid:1000"},
 			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"spiffe://domain1.test",
+			"spiffe://domain2.test",
 		},
 	}
 

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -144,6 +144,21 @@ func (s *ShowTestSuite) TestRunWithParentIDAndSelectors() {
 	s.Assert().Equal(entries[0:1], s.cli.Entries)
 }
 
+func (s *ShowTestSuite) TestRunWithFederatesWith() {
+	resp := &common.RegistrationEntries{
+		Entries: s.registrationEntries(4),
+	}
+	s.mockClient.EXPECT().FetchEntries(gomock.Any(), &common.Empty{}).Return(resp, nil)
+
+	args := []string{
+		"-federatesWith",
+		"spiffe://domain.test",
+	}
+
+	s.Require().Equal(0, s.cli.Run(args))
+	s.Assert().Equal(s.registrationEntries(4)[2:3], s.cli.Entries)
+}
+
 // registrationEntries returns `count` registration entry records. At most 4.
 func (ShowTestSuite) registrationEntries(count int) []*common.RegistrationEntry {
 	selectors := []*common.Selector{
@@ -165,10 +180,11 @@ func (ShowTestSuite) registrationEntries(count int) []*common.RegistrationEntry 
 			EntryId:   "00000000-0000-0000-0000-000000000001",
 		},
 		{
-			ParentId:  "spiffe://example.org/mother",
-			SpiffeId:  "spiffe://example.org/daughter",
-			Selectors: []*common.Selector{selectors[1], selectors[2]},
-			EntryId:   "00000000-0000-0000-0000-000000000002",
+			ParentId:      "spiffe://example.org/mother",
+			SpiffeId:      "spiffe://example.org/daughter",
+			Selectors:     []*common.Selector{selectors[1], selectors[2]},
+			EntryId:       "00000000-0000-0000-0000-000000000002",
+			FederatesWith: []string{"spiffe://domain.test"},
 		},
 		{
 			ParentId:  "spiffe://example.org/mother",

--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -10,7 +10,7 @@ import (
 // hasSelectors takes a registration entry and a selector flag set. It returns
 // true if the registration entry possesses all selectors in the set. An error
 // is returned if we run into trouble parsing the selector flags.
-func hasSelectors(entry *common.RegistrationEntry, flags SelectorFlag) (bool, error) {
+func hasSelectors(entry *common.RegistrationEntry, flags StringsFlag) (bool, error) {
 	for _, f := range flags {
 		selector, err := parseSelector(f)
 		if err != nil {
@@ -65,19 +65,22 @@ func printEntry(e *common.RegistrationEntry) {
 	for _, s := range e.Selectors {
 		fmt.Printf("Selector:\t%s:%s\n", s.Type, s.Value)
 	}
+	for _, id := range e.FederatesWith {
+		fmt.Printf("FederatesWith:\t%s\n", id)
+	}
 
 	fmt.Println()
 }
 
-// Define a custom type for selectors. Doing
-// this allows us to support repeatable flags
-type SelectorFlag []string
+// Define a custom type for string lists. Doing
+// this allows us to support repeatable string flags.
+type StringsFlag []string
 
-func (s *SelectorFlag) String() string {
+func (s *StringsFlag) String() string {
 	return fmt.Sprint(*s)
 }
 
-func (s *SelectorFlag) Set(val string) error {
+func (s *StringsFlag) Set(val string) error {
 	*s = append(*s, val)
 	return nil
 }

--- a/cmd/spire-server/cli/entry/util_test.go
+++ b/cmd/spire-server/cli/entry/util_test.go
@@ -35,8 +35,8 @@ func TestHasSelectors(t *testing.T) {
 	a.False(hasSelectors(entry, selectorToFlag(selectors[2:4])))
 }
 
-func selectorToFlag(selectors []*common.Selector) SelectorFlag {
-	resp := SelectorFlag{}
+func selectorToFlag(selectors []*common.Selector) StringsFlag {
+	resp := StringsFlag{}
 	for _, s := range selectors {
 		str := s.Type + ":" + s.Value
 		resp.Set(str)

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -76,14 +76,15 @@ human-readable registration entry name in addition to the token-based entry.
 
 Creates registration entries.
 
-| Command       | Action                                                                 | Default        |
-|:--------------|:-----------------------------------------------------------------------|:---------------|
-| `-data`       | Path to a file containing registration data in JSON format (optional). |                |
-| `-parentID`   | The SPIFFE ID of this record's parent.                                 |                |
-| `-selector`   | A colon-delimeted type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
-| `-serverAddr` | Address of the SPIRE server.                                           | localhost:8081 |
-| `-spiffeID`   | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
-| `-ttl`        | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| Command          | Action                                                                 | Default        |
+|:-----------------|:-----------------------------------------------------------------------|:---------------|
+| `-data`          | Path to a file containing registration data in JSON format (optional). |                |
+| `-parentID`      | The SPIFFE ID of this record's parent.                                 |                |
+| `-selector`      | A colon-delimeted type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
+| `-serverAddr`    | Address of the SPIRE server.                                           | localhost:8081 |
+| `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
+| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| `-federatesWith` | A list of trust domain SPIFFE IDs representing the trust domains this registration entry federates with. A bundle for that trust domain must already exist | |
 
 ### `spire-server entry delete`
 
@@ -106,6 +107,39 @@ Displays configured registration entries.
 | `-serverAddr` | Address of the SPIRE server.                                       | localhost:8081 |
 | `-spiffeID`   | The SPIFFE ID of the records to show.                              |                |
 | `-selector`   | A TTL, in seconds, for any SVID issued as a result of this record. | 3600           |
+
+### `spire-server bundle show`
+
+Displays the bundle for the trust domain of the server.
+
+| Command       | 
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-serverAddr` | Address of the SPIRE server.                                       | localhost:8081 |
+
+### `spire-server bundle list`
+
+Displays bundles from other trust domains.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id`         | The trust domain SPIFFE ID of the bundle to show. If unset, all trust bundles are shown | |
+
+### `spire-server bundle set`
+
+Creates or updates bundle data for a trust domain. This command cannot be used to alter the server trust domain bundle, only bundles for other trust domains.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id`         | The trust domain SPIFFE ID of the bundle to set. | |
+| `-path`       | Path on disk to the file containing the bundle data. If unset, data is read from stdin. | |
+
+### `spire-server bundle delete`
+
+Deletes bundle data for a trust domain. This command cannot be used to delete the server trust domain bundle, only bundles for other trust domains.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id`         | The trust domain SPIFFE ID of the bundle to delete. | |
 
 ## Architecture
 


### PR DESCRIPTION
This PR adds support for specifying trust domain SPIFFE IDs that a registration entry federates with.