### PR TITLE
user/group name support in unix workload attestor

### DIFF
--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -7,4 +7,6 @@ This plugin does not accept any configuration options.
 | Selector | Value |
 | -------- | ----- |
 | unix:uid | The user ID of the workload (e.g. `unix:uid:1000`) |
+| unix:user | The user name of the workload (e.g. `unix:user:nginx`) |
 | unix:gid | The group ID of the workload (e.g. `unix:gid:1000`) |
+| unix:group | The group name of the workload (e.g. `unix:gid:www-data`) |

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -2,72 +2,140 @@ package unix
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"os/user"
 
 	"github.com/shirou/gopsutil/process"
 	"github.com/spiffe/spire/proto/agent/workloadattestor"
 	"github.com/spiffe/spire/proto/common"
 	spi "github.com/spiffe/spire/proto/common/plugin"
+	"github.com/zeebo/errs"
 )
+
+const (
+	selectorType = "unix"
+)
+
+var (
+	unixErr = errs.Class("unix")
+
+	// hooks for tests
+	newProcess      = func(pid int32) (processInfo, error) { return process.NewProcess(pid) }
+	lookupUserById  = user.LookupId
+	lookupGroupById = user.LookupGroupId
+)
+
+type processInfo interface {
+	Uids() ([]int32, error)
+	Gids() ([]int32, error)
+}
 
 type UnixPlugin struct{}
 
-const selectorType string = "unix"
-
-func (UnixPlugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
-	p, err := process.NewProcess(req.Pid)
-	resp := workloadattestor.AttestResponse{}
-
-	if err != nil {
-		return &resp, err
-	}
-
-	uids, err := p.Uids()
-
-	if err != nil {
-		return &resp, err
-	}
-
-	// Check if it's only the effective UID
-	if len(uids) == 1 {
-		resp.Selectors = append(resp.Selectors, &common.Selector{Type: selectorType, Value: fmt.Sprintf("uid:%v", uids[0])})
-	} else if len(uids) > 1 {
-		// We got at least real and effective UIDs
-		// use the effective UID
-		resp.Selectors = append(resp.Selectors, &common.Selector{Type: selectorType, Value: fmt.Sprintf("uid:%v", uids[1])})
-	} else {
-		return &resp, errors.New(fmt.Sprintf("Unable to get effective UID for PID: %v", req.Pid))
-	}
-
-	gids, err := p.Gids()
-
-	if err != nil {
-		return &resp, err
-	}
-
-	// Check if it's only the effective GID
-	if len(gids) == 1 {
-		resp.Selectors = append(resp.Selectors, &common.Selector{Type: selectorType, Value: fmt.Sprintf("gid:%v", gids[0])})
-	} else if len(gids) > 1 {
-		// We got at least real and effective GIDs
-		// use the effective GID
-		resp.Selectors = append(resp.Selectors, &common.Selector{Type: selectorType, Value: fmt.Sprintf("gid:%v", gids[1])})
-	} else {
-		return &resp, errors.New(fmt.Sprintf("Unable to get effective GID for PID: %v", req.Pid))
-	}
-
-	return &resp, nil
+func New() *UnixPlugin {
+	return &UnixPlugin{}
 }
 
-func (UnixPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *UnixPlugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
+	uid, err := getUid(req.Pid)
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := getUserName(uid)
+	if err != nil {
+		return nil, err
+	}
+
+	gid, err := getGid(req.Pid)
+	if err != nil {
+		return nil, err
+	}
+
+	group, err := getGroupName(gid)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workloadattestor.AttestResponse{
+		Selectors: []*common.Selector{
+			makeSelector("uid", uid),
+			makeSelector("user", user),
+			makeSelector("gid", gid),
+			makeSelector("group", group),
+		},
+	}, nil
+}
+
+func (p *UnixPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	return &spi.ConfigureResponse{}, nil
 }
 
-func (UnixPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+func (p *UnixPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func New() *UnixPlugin {
-	return &UnixPlugin{}
+func getUid(pid int32) (string, error) {
+	proc, err := newProcess(pid)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	uids, err := proc.Uids()
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	switch len(uids) {
+	case 0:
+		return "", unixErr.New("unable to get effective UID for PID %d", pid)
+	case 1:
+		return fmt.Sprint(uids[0]), nil
+	default:
+		return fmt.Sprint(uids[1]), nil
+	}
+}
+
+func getUserName(uid string) (string, error) {
+	u, err := lookupUserById(uid)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+	return u.Username, nil
+}
+
+func getGid(pid int32) (string, error) {
+	proc, err := newProcess(pid)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	gids, err := proc.Gids()
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	switch len(gids) {
+	case 0:
+		return "", unixErr.New("unable to get effective GID for PID %d", pid)
+	case 1:
+		return fmt.Sprint(gids[0]), nil
+	default:
+		return fmt.Sprint(gids[1]), nil
+	}
+}
+
+func getGroupName(gid string) (string, error) {
+	g, err := lookupGroupById(gid)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+	return g.Name, nil
+}
+
+func makeSelector(kind, value string) *common.Selector {
+	return &common.Selector{
+		Type:  selectorType,
+		Value: fmt.Sprintf("%s:%s", kind, value),
+	}
 }

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -2,8 +2,8 @@ package unix
 
 import (
 	"context"
-	"os"
-	"runtime"
+	"fmt"
+	"os/user"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,29 +13,55 @@ import (
 	spi "github.com/spiffe/spire/proto/common/plugin"
 )
 
+func init() {
+	newProcess = newFakeProcess
+	lookupUserById = fakeLookupUserById
+	lookupGroupById = fakeLookupGroupById
+}
+
 var (
 	ctx = context.Background()
 )
 
-func TestUnix_AttestValidPID(t *testing.T) {
-	plugin := New()
-	req := workloadattestor.AttestRequest{Pid: int32(os.Getpid())}
-	resp, err := plugin.Attest(ctx, &req)
-	require.NoError(t, err)
-	require.NotEmpty(t, resp.Selectors)
-}
-
-func TestUnix_AttestInvalidPID(t *testing.T) {
-	switch runtime.GOOS {
-	case "darwin":
-		// all PIDs including -1 are valid on Darwin
-		t.Skip("skipping test on ", runtime.GOOS)
+func TestUnix_Attest(t *testing.T) {
+	testCases := []struct {
+		name      string
+		pid       int32
+		err       string
+		selectors []string
+	}{
+		{name: "pid with no uids", pid: 1, err: "unix: unable to get effective UID for PID 1"},
+		{name: "fail to get uids", pid: 2, err: "unix: unable to get UIDs for PID 2"},
+		{name: "user lookup fails", pid: 3, err: "unix: no user with UID 1999"},
+		{name: "pid with no gids", pid: 4, err: "unix: unable to get effective GID for PID 4"},
+		{name: "fail to get gids", pid: 5, err: "unix: unable to get GIDs for PID 5"},
+		{name: "group lookup fails", pid: 6, err: "unix: no group with GID 2999"},
+		{name: "primary user and gid", pid: 7, selectors: []string{"uid:1000", "user:u1000", "gid:2000", "group:g2000"}},
+		{name: "effective user and gid", pid: 8, selectors: []string{"uid:1100", "user:u1100", "gid:2100", "group:g2100"}},
 	}
+
 	plugin := New()
-	req := workloadattestor.AttestRequest{Pid: -1}
-	resp, err := plugin.Attest(ctx, &req)
-	require.Error(t, err)
-	require.Empty(t, resp.Selectors)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			resp, err := plugin.Attest(ctx, &workloadattestor.AttestRequest{
+				Pid: testCase.pid,
+			})
+			if testCase.err != "" {
+				require.EqualError(t, err, testCase.err)
+				require.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			var selectors []string
+			for _, selector := range resp.Selectors {
+				require.Equal(t, "unix", selector.Type)
+				selectors = append(selectors, selector.Value)
+			}
+			require.Equal(t, testCase.selectors, selectors)
+		})
+	}
 }
 
 func TestUnix_Configure(t *testing.T) {
@@ -50,4 +76,68 @@ func TestUnix_GetPluginInfo(t *testing.T) {
 	data, e := plugin.GetPluginInfo(ctx, &spi.GetPluginInfoRequest{})
 	assert.Equal(t, &spi.GetPluginInfoResponse{}, data)
 	assert.Equal(t, nil, e)
+}
+
+type fakeProcess struct {
+	pid int32
+}
+
+func (p fakeProcess) Uids() ([]int32, error) {
+	switch p.pid {
+	case 1:
+		return []int32{}, nil
+	case 2:
+		return nil, fmt.Errorf("unable to get UIDs for PID %d", p.pid)
+	case 3:
+		return []int32{1999}, nil
+	case 4, 5, 6, 7:
+		return []int32{1000}, nil
+	case 8:
+		return []int32{1000, 1100}, nil
+	default:
+		return nil, fmt.Errorf("unhandled uid test case %d", p.pid)
+	}
+}
+
+func (p fakeProcess) Gids() ([]int32, error) {
+	switch p.pid {
+	case 4:
+		return []int32{}, nil
+	case 5:
+		return nil, fmt.Errorf("unable to get GIDs for PID %d", p.pid)
+	case 6:
+		return []int32{2999}, nil
+	case 7:
+		return []int32{2000}, nil
+	case 8:
+		return []int32{2000, 2100}, nil
+	default:
+		return nil, fmt.Errorf("unhandled gid test case %d", p.pid)
+	}
+}
+
+func newFakeProcess(pid int32) (processInfo, error) {
+	return fakeProcess{pid: pid}, nil
+}
+
+func fakeLookupUserById(uid string) (*user.User, error) {
+	switch uid {
+	case "1000":
+		return &user.User{Username: "u1000"}, nil
+	case "1100":
+		return &user.User{Username: "u1100"}, nil
+	default:
+		return nil, fmt.Errorf("no user with UID %s", uid)
+	}
+}
+
+func fakeLookupGroupById(gid string) (*user.Group, error) {
+	switch gid {
+	case "2000":
+		return &user.Group{Name: "g2000"}, nil
+	case "2100":
+		return &user.Group{Name: "g2100"}, nil
+	default:
+		return nil, fmt.Errorf("no group with GID %s", gid)
+	}
 }


### PR DESCRIPTION
This adds support for the unix workload attestor to build selectors based on the user and group name of the process being attested.

New selectors:

- `unix:user:<USERNAME>`
- `unix:group:<GROUPNAME>`

fixes #571 