### PR TITLE
path based selector support for unix attestation

### DIFF
--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -5,6 +5,7 @@ The `unix` plugin generates unix-based selectors for workloads calling the agent
 | Configuration | Description | Default |
 | ------------- | ----------- | ------- |
 | `discover_workload_path` | If true, the workload path will be discovered by the plugin and used to provide additional selectors | false |
+| `workload_size_limit` | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. | 0 | 
 
 If configured with `discover_workload_path = true`, the plugin will discover
 the workload path to provide additional selectors. If the plugin cannot
@@ -31,3 +32,14 @@ Workload path enabled selectors (available when configured with `discover_worklo
 | -------- | ----- |
 | `unix:path` | The path to the workload binary (e.g. `unix:path:/usr/bin/nginx`) |
 | `unix:sha256` | The SHA256 digest of the workload binary (e.g. `unix:sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7`) |
+
+Security Considerations:
+
+Malicious workloads could cause the SPIRE agent to do expensive work
+calculating a sha256 for large workload binaries, causing a denial-of-service.
+This plugin includes a configuration value that can be used to mitigate such an
+attack (i.e. `workload_size_limit`) by enforcing a limit on the binary size the
+plugin is willing to hash. The same attack could be performed by spawning a
+bunch of processes under the limit. The workload API does not yet support rate
+limiting, but when it does, this attack can be mitigated by using rate limiting
+in conjunction with `workload_size_limit`.

--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -2,11 +2,32 @@
 
 The `unix` plugin generates unix-based selectors for workloads calling the agent.
 
-This plugin does not accept any configuration options.
+| Configuration | Description | Default |
+| ------------- | ----------- | ------- |
+| `discover_workload_path` | If true, the workload path will be discovered by the plugin and used to provide additional selectors | false |
+
+If configured with `discover_workload_path = true`, the plugin will discover
+the workload path to provide additional selectors. If the plugin cannot
+discover the workload path or gather selectors based on the path, it will fail
+the attestation attempt. Discovering the workload path requires the agent to
+have _sufficient_ platform-specific permissions. For example, on Linux, the
+agent would need to be able to read `/proc/<WORKLOAD PID>/exe`, likely
+requiring the agent to either run as root or the same user as the workload.
+Care must be taken to only enable this option if the agent will be run with
+sufficient permissions.
+
+General selectors:
 
 | Selector | Value |
 | -------- | ----- |
-| unix:uid | The user ID of the workload (e.g. `unix:uid:1000`) |
-| unix:user | The user name of the workload (e.g. `unix:user:nginx`) |
-| unix:gid | The group ID of the workload (e.g. `unix:gid:1000`) |
-| unix:group | The group name of the workload (e.g. `unix:gid:www-data`) |
+| `unix:uid` | The user ID of the workload (e.g. `unix:uid:1000`) |
+| `unix:user` | The user name of the workload (e.g. `unix:user:nginx`) |
+| `unix:gid` | The group ID of the workload (e.g. `unix:gid:1000`) |
+| `unix:group` | The group name of the workload (e.g. `unix:gid:www-data`) |
+
+Workload path enabled selectors (available when configured with `discover_workload_path = true`):
+
+| Selector | Value |
+| -------- | ----- |
+| `unix:path` | The path to the workload binary (e.g. `unix:path:/usr/bin/nginx`) |
+| `unix:sha256` | The SHA256 digest of the workload binary (e.g. `unix:sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7`) |

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -2,9 +2,15 @@ package unix
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"os"
 	"os/user"
+	"sync"
 
+	"github.com/hashicorp/hcl"
 	"github.com/shirou/gopsutil/process"
 	"github.com/spiffe/spire/proto/agent/workloadattestor"
 	"github.com/spiffe/spire/proto/common"
@@ -18,56 +24,104 @@ const (
 
 var (
 	unixErr = errs.Class("unix")
-
-	// hooks for tests
-	newProcess      = func(pid int32) (processInfo, error) { return process.NewProcess(pid) }
-	lookupUserById  = user.LookupId
-	lookupGroupById = user.LookupGroupId
 )
 
 type processInfo interface {
 	Uids() ([]int32, error)
 	Gids() ([]int32, error)
+	Exe() (string, error)
 }
 
-type UnixPlugin struct{}
+type Configuration struct {
+	DiscoverWorkloadPath bool `hcl:"discover_workload_path"`
+}
+
+type UnixPlugin struct {
+	mu     sync.Mutex
+	config *Configuration
+
+	// hooks for tests
+	hooks struct {
+		newProcess      func(pid int32) (processInfo, error)
+		lookupUserById  func(id string) (*user.User, error)
+		lookupGroupById func(id string) (*user.Group, error)
+	}
+}
 
 func New() *UnixPlugin {
-	return &UnixPlugin{}
+	p := &UnixPlugin{}
+	p.hooks.newProcess = func(pid int32) (processInfo, error) { return process.NewProcess(pid) }
+	p.hooks.lookupUserById = user.LookupId
+	p.hooks.lookupGroupById = user.LookupGroupId
+	return p
 }
 
 func (p *UnixPlugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
-	uid, err := getUid(req.Pid)
+	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	user, err := getUserName(uid)
+	uid, err := p.getUid(req.Pid)
 	if err != nil {
 		return nil, err
 	}
 
-	gid, err := getGid(req.Pid)
+	user, err := p.getUserName(uid)
 	if err != nil {
 		return nil, err
 	}
 
-	group, err := getGroupName(gid)
+	gid, err := p.getGid(req.Pid)
 	if err != nil {
 		return nil, err
+	}
+
+	group, err := p.getGroupName(gid)
+	if err != nil {
+		return nil, err
+	}
+
+	// obtaining the workload process path and digest are behind a config flag
+	// since it requires the agent to have permissions that might not be
+	// available.
+	var processPath string
+	var sha256Digest string
+	if config.DiscoverWorkloadPath {
+		processPath, err = p.getPath(req.Pid)
+		if err != nil {
+			return nil, err
+		}
+		sha256Digest, err = getSHA256Digest(processPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	selectors := []*common.Selector{
+		makeSelector("uid", uid),
+		makeSelector("user", user),
+		makeSelector("gid", gid),
+		makeSelector("group", group),
+	}
+	if processPath != "" {
+		selectors = append(selectors, makeSelector("path", processPath))
+	}
+	if sha256Digest != "" {
+		selectors = append(selectors, makeSelector("sha256", sha256Digest))
 	}
 
 	return &workloadattestor.AttestResponse{
-		Selectors: []*common.Selector{
-			makeSelector("uid", uid),
-			makeSelector("user", user),
-			makeSelector("gid", gid),
-			makeSelector("group", group),
-		},
+		Selectors: selectors,
 	}, nil
 }
 
-func (p *UnixPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *UnixPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := new(Configuration)
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, unixErr.Wrap(err)
+	}
+	p.setConfig(config)
 	return &spi.ConfigureResponse{}, nil
 }
 
@@ -75,8 +129,24 @@ func (p *UnixPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func getUid(pid int32) (string, error) {
-	proc, err := newProcess(pid)
+func (p *UnixPlugin) getConfig() (*Configuration, error) {
+	p.mu.Lock()
+	config := p.config
+	p.mu.Unlock()
+	if config == nil {
+		return nil, unixErr.New("not configured")
+	}
+	return config, nil
+}
+
+func (p *UnixPlugin) setConfig(config *Configuration) {
+	p.mu.Lock()
+	p.config = config
+	p.mu.Unlock()
+}
+
+func (p *UnixPlugin) getUid(pid int32) (string, error) {
+	proc, err := p.hooks.newProcess(pid)
 	if err != nil {
 		return "", unixErr.Wrap(err)
 	}
@@ -96,16 +166,16 @@ func getUid(pid int32) (string, error) {
 	}
 }
 
-func getUserName(uid string) (string, error) {
-	u, err := lookupUserById(uid)
+func (p *UnixPlugin) getUserName(uid string) (string, error) {
+	u, err := p.hooks.lookupUserById(uid)
 	if err != nil {
 		return "", unixErr.Wrap(err)
 	}
 	return u.Username, nil
 }
 
-func getGid(pid int32) (string, error) {
-	proc, err := newProcess(pid)
+func (p *UnixPlugin) getGid(pid int32) (string, error) {
+	proc, err := p.hooks.newProcess(pid)
 	if err != nil {
 		return "", unixErr.Wrap(err)
 	}
@@ -125,12 +195,40 @@ func getGid(pid int32) (string, error) {
 	}
 }
 
-func getGroupName(gid string) (string, error) {
-	g, err := lookupGroupById(gid)
+func (p *UnixPlugin) getGroupName(gid string) (string, error) {
+	g, err := p.hooks.lookupGroupById(gid)
 	if err != nil {
 		return "", unixErr.Wrap(err)
 	}
 	return g.Name, nil
+}
+
+func (p *UnixPlugin) getPath(pid int32) (string, error) {
+	proc, err := p.hooks.newProcess(pid)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	path, err := proc.Exe()
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+
+	return path, nil
+}
+
+func getSHA256Digest(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", unixErr.Wrap(err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", unixErr.Wrap(err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func makeSelector(kind, value string) *common.Selector {

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -114,8 +114,14 @@ func (s *Suite) TestAttest() {
 			err:    fmt.Sprintf("unix: open %s: no such file or directory", filepath.Join(s.dir, "unreadable-exe")),
 		},
 		{
-			name:   "success getting path and hashing process binary",
+			name:   "process binary exceeds size limits",
 			pid:    11,
+			config: "discover_workload_path = true\nworkload_size_limit = 2",
+			err:    fmt.Sprintf("unix: workload %s exceeds size limit (4 > 2)", filepath.Join(s.dir, "exe")),
+		},
+		{
+			name:   "success getting path and hashing process binary",
+			pid:    12,
 			config: "discover_workload_path = true",
 			selectors: []string{
 				"uid:1000",
@@ -191,7 +197,7 @@ func (p fakeProcess) Uids() ([]int32, error) {
 		return nil, fmt.Errorf("unable to get UIDs for PID %d", p.pid)
 	case 3:
 		return []int32{1999}, nil
-	case 4, 5, 6, 7, 9, 10, 11:
+	case 4, 5, 6, 7, 9, 10, 11, 12:
 		return []int32{1000}, nil
 	case 8:
 		return []int32{1000, 1100}, nil
@@ -208,7 +214,7 @@ func (p fakeProcess) Gids() ([]int32, error) {
 		return nil, fmt.Errorf("unable to get GIDs for PID %d", p.pid)
 	case 6:
 		return []int32{2999}, nil
-	case 7, 9, 10, 11:
+	case 7, 9, 10, 11, 12:
 		return []int32{2000}, nil
 	case 8:
 		return []int32{2000, 2100}, nil
@@ -223,7 +229,7 @@ func (p fakeProcess) Exe() (string, error) {
 		return "", fmt.Errorf("unable to get EXE for PID %d", p.pid)
 	case 10:
 		return filepath.Join(p.dir, "unreadable-exe"), nil
-	case 11:
+	case 11, 12:
 		return filepath.Join(p.dir, "exe"), nil
 	default:
 		return "", fmt.Errorf("unhandled exe test case %d", p.pid)

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -61,27 +61,33 @@ func (s *Suite) TestAttest() {
 		{
 			name: "pid with no uids",
 			pid:  1,
-			err:  "unix: unable to get effective UID for PID 1"},
+			err:  "unix: UIDs lookup: no UIDs for process",
+		},
 		{
 			name: "fail to get uids",
 			pid:  2,
-			err:  "unix: unable to get UIDs for PID 2"},
+			err:  "unix: UIDs lookup: unable to get UIDs for PID 2",
+		},
 		{
 			name: "user lookup fails",
 			pid:  3,
-			err:  "unix: no user with UID 1999"},
+			err:  "unix: user lookup: no user with UID 1999",
+		},
 		{
 			name: "pid with no gids",
 			pid:  4,
-			err:  "unix: unable to get effective GID for PID 4"},
+			err:  "unix: GIDs lookup: no GIDs for process",
+		},
 		{
 			name: "fail to get gids",
 			pid:  5,
-			err:  "unix: unable to get GIDs for PID 5"},
+			err:  "unix: GIDs lookup: unable to get GIDs for PID 5",
+		},
 		{
 			name: "group lookup fails",
 			pid:  6,
-			err:  "unix: no group with GID 2999"},
+			err:  "unix: group lookup: no group with GID 2999",
+		},
 		{
 			name: "primary user and gid",
 			pid:  7,
@@ -90,7 +96,8 @@ func (s *Suite) TestAttest() {
 				"user:u1000",
 				"gid:2000",
 				"group:g2000",
-			}},
+			},
+		},
 		{
 			name: "effective user and gid",
 			pid:  8,
@@ -105,19 +112,19 @@ func (s *Suite) TestAttest() {
 			name:   "fail to get process binary path",
 			pid:    9,
 			config: "discover_workload_path = true",
-			err:    "unix: unable to get EXE for PID 9",
+			err:    "unix: path lookup: unable to get EXE for PID 9",
 		},
 		{
 			name:   "fail to hash process binary",
 			pid:    10,
 			config: "discover_workload_path = true",
-			err:    fmt.Sprintf("unix: open %s: no such file or directory", filepath.Join(s.dir, "unreadable-exe")),
+			err:    fmt.Sprintf("unix: SHA256 digest: open %s: no such file or directory", filepath.Join(s.dir, "unreadable-exe")),
 		},
 		{
 			name:   "process binary exceeds size limits",
 			pid:    11,
 			config: "discover_workload_path = true\nworkload_size_limit = 2",
-			err:    fmt.Sprintf("unix: workload %s exceeds size limit (4 > 2)", filepath.Join(s.dir, "exe")),
+			err:    fmt.Sprintf("unix: SHA256 digest: workload %s exceeds size limit (4 > 2)", filepath.Join(s.dir, "exe")),
 		},
 		{
 			name:   "success getting path and hashing process binary",


### PR DESCRIPTION
Provides the `unix:path` and `unix:sha256` selectors. Support is
optional and enabled via the `discover_workload_path` configuration
value. The agent must be run with sufficient permissions to determine
the workload path or attestation will fail.