### PR TITLE
Add federated bundles information to spire-agent api fetch command

### DIFF
--- a/cmd/spire-agent/cli/api/fetch_cli.go
+++ b/cmd/spire-agent/cli/api/fetch_cli.go
@@ -107,24 +107,28 @@ func (f FetchCLI) writeResponse(resp *workload.X509SVIDResponse) error {
 		svidName := fmt.Sprintf("svid.%v.pem", i)
 		keyName := fmt.Sprintf("svid.%v.key", i)
 		bundleName := fmt.Sprintf("bundle.%v.pem", i)
-		federatedBundleName := fmt.Sprintf("federated_bundle.%v.pem", i)
 
+		fmt.Printf("Writing SVID #%v to file %v.\n", i, path.Join(f.config.writePath, svidName))
 		err := f.writeCerts(svidName, svid.X509Svid)
 		if err != nil {
 			return err
 		}
 
+		fmt.Printf("Writing key #%v to file %v.\n", i, path.Join(f.config.writePath, keyName))
 		err = f.writeKey(keyName, svid.X509SvidKey)
 		if err != nil {
 			return err
 		}
 
+		fmt.Printf("Writing bundle #%v to file %v.\n", i, path.Join(f.config.writePath, bundleName))
 		err = f.writeCerts(bundleName, svid.Bundle)
 		if err != nil {
 			return err
 		}
 
-		for _, trustDomain := range svid.FederatesWith {
+		for j, trustDomain := range svid.FederatesWith {
+			federatedBundleName := fmt.Sprintf("federated_bundle.%v.%v.pem", j, i)
+			fmt.Printf("Writing federated bundle #%v for trust domain %v to file %v.\n", i, trustDomain, path.Join(f.config.writePath, federatedBundleName))
 			err = f.writeCerts(federatedBundleName, resp.FederatedBundles[trustDomain])
 			if err != nil {
 				return err

--- a/cmd/spire-agent/cli/api/fetch_cli.go
+++ b/cmd/spire-agent/cli/api/fetch_cli.go
@@ -107,6 +107,7 @@ func (f FetchCLI) writeResponse(resp *workload.X509SVIDResponse) error {
 		svidName := fmt.Sprintf("svid.%v.pem", i)
 		keyName := fmt.Sprintf("svid.%v.key", i)
 		bundleName := fmt.Sprintf("bundle.%v.pem", i)
+		federatedBundleName := fmt.Sprintf("federated_bundle.%v.pem", i)
 
 		err := f.writeCerts(svidName, svid.X509Svid)
 		if err != nil {
@@ -121,6 +122,13 @@ func (f FetchCLI) writeResponse(resp *workload.X509SVIDResponse) error {
 		err = f.writeCerts(bundleName, svid.Bundle)
 		if err != nil {
 			return err
+		}
+
+		for _, trustDomain := range svid.FederatesWith {
+			err = f.writeCerts(federatedBundleName, resp.FederatedBundles[trustDomain])
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/spire-agent/cli/api/printer.go
+++ b/cmd/spire-agent/cli/api/printer.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/x509"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/spiffe/spire/proto/api/workload"
@@ -36,13 +37,13 @@ func printX509SVID(msg *workload.X509SVID) {
 	// simply print it and return so we can go to the next bundle
 	svid, err := x509.ParseCertificate(msg.X509Svid)
 	if err != nil {
-		fmt.Printf("ERROR: Could not parse SVID: %s\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Could not parse SVID: %s\n", err)
 		return
 	}
 
 	svidBundle, err := x509.ParseCertificates(msg.Bundle)
 	if err != nil {
-		fmt.Printf("ERROR: Could not parse CA Certificates: %s\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Could not parse CA Certificates: %s\n", err)
 		return
 	}
 
@@ -58,7 +59,7 @@ func printX509SVID(msg *workload.X509SVID) {
 func printX509FederatedBundle(resp *workload.X509SVIDResponse, trustDomain string) {
 	federatedBundle, err := x509.ParseCertificates(resp.FederatedBundles[trustDomain])
 	if err != nil {
-		fmt.Printf("ERROR: Could not parse CA Certificates of federated bundle: %s\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: Could not parse CA Certificates of federated bundle: %s\n", err)
 		return
 	}
 

--- a/cmd/spire-agent/cli/api/printer.go
+++ b/cmd/spire-agent/cli/api/printer.go
@@ -19,6 +19,9 @@ func printX509SVIDResponse(resp *workload.X509SVIDResponse, respTime time.Durati
 	for _, s := range resp.Svids {
 		fmt.Println()
 		printX509SVID(s)
+		for _, trustDomain := range s.FederatesWith {
+			printX509FederatedBundle(resp, trustDomain)
+		}
 	}
 
 	fmt.Println()
@@ -49,5 +52,19 @@ func printX509SVID(msg *workload.X509SVID) {
 		num := i + 1
 		fmt.Printf("CA #%v Valid After:\t%v\n", num, ca.NotBefore)
 		fmt.Printf("CA #%v Valid Until:\t%v\n", num, ca.NotAfter)
+	}
+}
+
+func printX509FederatedBundle(resp *workload.X509SVIDResponse, trustDomain string) {
+	federatedBundle, err := x509.ParseCertificates(resp.FederatedBundles[trustDomain])
+	if err != nil {
+		fmt.Printf("ERROR: Could not parse CA Certificates of federated bundle: %s\n", err)
+		return
+	}
+
+	for i, ca := range federatedBundle {
+		num := i + 1
+		fmt.Printf("[%s] CA #%v Valid After:\t%v\n", trustDomain, num, ca.NotBefore)
+		fmt.Printf("[%s] CA #%v Valid Until:\t%v\n", trustDomain, num, ca.NotAfter)
 	}
 }


### PR DESCRIPTION
Add federated bundles information to `spire-agent api fetch` cli.

This is an example of how it looks like when a SVID has federated bundles (federates with spiffe://td2.test trust domain) :

```
spire-agent api fetch
Received 1 bundle after 3.364809ms

SPIFFE ID:		spiffe://example.org/host/front-end
SVID Valid After:	2018-09-28 15:28:32 +0000 UTC
SVID Valid Until:	2018-09-28 16:08:49 +0000 UTC
CA #1 Valid After:	2018-05-13 19:33:47 +0000 UTC
CA #1 Valid Until:	2023-05-12 19:33:47 +0000 UTC
CA #2 Valid After:	2018-09-28 15:08:39 +0000 UTC
CA #2 Valid Until:	2018-09-28 16:08:49 +0000 UTC
CA #3 Valid After:	2018-09-28 15:08:39 +0000 UTC
CA #3 Valid Until:	2018-09-28 16:08:49 +0000 UTC
[spiffe://td2.test] CA #1 Valid After:	2018-05-13 19:33:47 +0000 UTC
[spiffe://td2.test] CA #1 Valid Until:	2023-05-12 19:33:47 +0000 UTC
```