### PR TITLE
Fix typo in error message

### DIFF
--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -258,7 +258,7 @@ func (c *catalog) configurePlugins(ctx context.Context) error {
 		c.l.Debugf("%s(%s): configuring plugin", pluginType, pluginName)
 		_, err := p.Plugin.Configure(ctx, req)
 		if err != nil {
-			return fmt.Errorf("%s(%s): failed to configuring plugin: %v", pluginType, pluginName, err)
+			return fmt.Errorf("%s(%s): failed to configure plugin: %v", pluginType, pluginName, err)
 		}
 	}
 


### PR DESCRIPTION
`failed to configuring plugin` -> `failed to configure plugin`

Signed-off-by: Evan Gilman <evan@scytale.io>