### PR TITLE
Fix keypair loading when B active but A unprepared

### DIFF
--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -454,9 +454,11 @@ func (m *manager) loadKeypairSets(ctx context.Context) error {
 		m.next.Reset()
 	}
 
-	if m.current.x509CA != nil && m.next.x509CA != nil &&
-		m.current.x509CA.cert.NotBefore.After(m.next.x509CA.cert.NotBefore) {
-		// swap the current and next keypair to get ascending order
+	// if B (next) was loaded but A (current) was not, OR if B comes before
+	// A, then swap B into the current slot.
+	if (m.current.x509CA == nil && m.next.x509CA != nil) ||
+		(m.current.x509CA != nil && m.next.x509CA != nil &&
+			m.current.x509CA.cert.NotBefore.After(m.next.x509CA.cert.NotBefore)) {
 		m.current, m.next = m.next, m.current
 	}
 
@@ -468,11 +470,13 @@ func (m *manager) loadKeypairSets(ctx context.Context) error {
 }
 
 func (m *manager) getCurrentKeypairSet() *keypairSet {
-	return m.current
+	copy := *m.current
+	return &copy
 }
 
 func (m *manager) getNextKeypairSet() *keypairSet {
-	return m.next
+	copy := *m.next
+	return &copy
 }
 
 func (m *manager) setKeypairSet() {

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -55,6 +55,16 @@ func (m *ManagerTestSuite) SetupTest() {
 	m.catalog.SetKeyManagers(m.keymanager)
 	m.catalog.SetDataStores(m.datastore)
 
+	m.newManager()
+	m.m.hooks.now = m.nowHook
+	m.now = time.Now().Truncate(time.Second).UTC()
+}
+
+func (m *ManagerTestSuite) TearDownTest() {
+	os.RemoveAll(m.tmpDir)
+}
+
+func (m *ManagerTestSuite) newManager() {
 	logger, err := log.NewLogger("DEBUG", "")
 	m.NoError(err)
 
@@ -71,11 +81,6 @@ func (m *ManagerTestSuite) SetupTest() {
 
 	m.m = NewManager(config)
 	m.m.hooks.now = m.nowHook
-	m.now = time.Now().Truncate(time.Second).UTC()
-}
-
-func (m *ManagerTestSuite) TearDownTest() {
-	os.RemoveAll(m.tmpDir)
 }
 
 func (m *ManagerTestSuite) certsPath() string {
@@ -133,24 +138,34 @@ func (m *ManagerTestSuite) TestPersistence() {
 	current1 := m.m.getCurrentKeypairSet()
 
 	// "reload" the manager and assert the keypairs are the same
-	m.m = NewManager(m.m.c)
+	m.newManager()
 	m.Require().NoError(m.m.Initialize(ctx))
 	current2 := m.m.getCurrentKeypairSet()
 	m.requireKeypairSetKeysEqual(current1, current2)
 
 	// drop the keys, "reload" the manager, and assert the keypairs are new
 	m.catalog.SetKeyManagers(memory.New())
-	m.m = NewManager(m.m.c)
+	m.newManager()
 	m.Require().NoError(m.m.Initialize(ctx))
 	current3 := m.m.getCurrentKeypairSet()
 	m.requireKeypairSetKeysNotEqual(current2, current3)
 
 	// load the old keys, "reload" the manager, and assert the keypairs are new
 	m.catalog.SetKeyManagers(m.keymanager)
-	m.m = NewManager(m.m.c)
+	m.newManager()
 	m.Require().NoError(m.m.Initialize(ctx))
 	current4 := m.m.getCurrentKeypairSet()
 	m.requireKeypairSetKeysNotEqual(current3, current4)
+
+	// rotate the keypairs, "reload" the manager, and make sure current is persisted.
+	m.setTime(activationThreshold(current4.x509CA.cert).Add(time.Second))
+	m.Require().NoError(m.m.rotateCAs(ctx))
+	current5 := m.m.getCurrentKeypairSet()
+	m.requireKeypairSetKeysNotEqual(current4, current5)
+	m.newManager()
+	m.Require().NoError(m.m.Initialize(ctx))
+	current6 := m.m.getCurrentKeypairSet()
+	m.requireKeypairSetKeysEqual(current5, current6)
 }
 
 func (m *ManagerTestSuite) TestSelfSigning() {
@@ -331,6 +346,10 @@ func (m *ManagerTestSuite) requireKeypairSetKeysEqual(set1, set2 *keypairSet) {
 }
 
 func (m *ManagerTestSuite) requireKeypairSetKeysNotEqual(set1, set2 *keypairSet) {
+	m.Require().NotNil(set1)
+	m.Require().NotNil(set1.x509CA)
+	m.Require().NotNil(set2)
+	m.Require().NotNil(set2.x509CA)
 	m.Require().NotEqual(set1.x509CA.chain, set2.x509CA.chain)
 	m.Assert().NotEqual(set1.jwtSigningKey.PublicKey.String(), set2.jwtSigningKey.PublicKey.String())
 }


### PR DESCRIPTION
When loading keypair sets, the manager always loads A into the "current" slot and B into the "next" slot and then performs a swap if B is supposed to be active. In other words, B gets moved to "current".

When B has been activated but the next A has yet to be prepared, the loading code has a bug and would not perform the swap.

This commit fixes the bug so that B is properly swapped into "current" under this condition.