### PR TITLE
update cached registration entry on sync

### DIFF
--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -72,8 +72,8 @@ func (b *BundleStream) Clone() *BundleStream {
 }
 
 type Cache interface {
-	// Entry gets the cache entry for the specified RegistrationEntry.
-	Entry(regEntry *common.RegistrationEntry) *Entry
+	// FetchEntry gets the cache entry for the specified registration entry id
+	FetchEntry(entryId string) *Entry
 	// SetEntry puts a new cache entry for the entry's RegistrationEntry.
 	SetEntry(entry *Entry)
 	// DeleteEntry removes the cache entry for the specified RegistrationEntry if it exists,
@@ -185,10 +185,10 @@ func (c *cacheImpl) Subscribe(selectors Selectors) Subscriber {
 	return sub
 }
 
-func (c *cacheImpl) Entry(regEntry *common.RegistrationEntry) *Entry {
+func (c *cacheImpl) FetchEntry(entryID string) *Entry {
 	c.m.Lock()
 	defer c.m.Unlock()
-	if entry, found := c.cache[regEntry.EntryId]; found {
+	if entry, found := c.cache[entryID]; found {
 		return entry
 	}
 	return nil

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -62,51 +62,9 @@ func TestCacheImpl_Valid(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cache.SetEntry(test.ce)
-			actual := cache.Entry(test.ce.RegistrationEntry)
+			actual := cache.FetchEntry(test.ce.RegistrationEntry.EntryId)
 			assert.Equal(t, actual, test.ce)
 
-		})
-	}
-}
-
-func TestCacheImpl_Invalid(t *testing.T) {
-	cache := New(logger, "spiffe://example.org", nil)
-	tests := []struct {
-		name string
-		ce   *Entry
-	}{
-		{name: "test_single_selector",
-			ce: &Entry{
-				RegistrationEntry: &common.RegistrationEntry{
-					Selectors: Selectors{&common.Selector{Type: "testtype", Value: "testValue"}},
-					ParentId:  "spiffe:parent",
-					SpiffeId:  "spiffe:test",
-					EntryId:   "00000000-0000-0000-0000-000000000000",
-				},
-				SVID:       &x509.Certificate{},
-				PrivateKey: privateKey,
-			}},
-
-		{name: "test_multiple_selectors_sort_different_types",
-			ce: &Entry{
-				RegistrationEntry: &common.RegistrationEntry{
-					Selectors: Selectors{&common.Selector{Type: "testtype3", Value: "testValue1"},
-						&common.Selector{Type: "testtype2", Value: "testValue2"},
-						&common.Selector{Type: "testtype1", Value: "testValue3"}},
-					ParentId: "spiffe:parent",
-					SpiffeId: "spiffe:test",
-					EntryId:  "00000000-0000-0000-0000-000000000001",
-				},
-				SVID:       &x509.Certificate{},
-				PrivateKey: privateKey,
-			}}}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cache.SetEntry(test.ce)
-			actual := cache.Entry(&common.RegistrationEntry{
-				Selectors: Selectors{&common.Selector{Type: "invalid", Value: "testValue1"}},
-			})
-			assert.Empty(t, actual)
 		})
 	}
 }
@@ -143,7 +101,7 @@ func TestCacheImpl_DeleteEntry(t *testing.T) {
 			cache.SetEntry(test.ce)
 			deleted := cache.DeleteEntry(test.ce.RegistrationEntry)
 			assert.True(t, deleted)
-			entry := cache.Entry(test.ce.RegistrationEntry)
+			entry := cache.FetchEntry(test.ce.RegistrationEntry.EntryId)
 			assert.Empty(t, entry)
 			deleted = cache.DeleteEntry(test.ce.RegistrationEntry)
 			assert.False(t, deleted)

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -155,10 +155,6 @@ func (m *manager) runBundleObserver(ctx context.Context) error {
 	}
 }
 
-func (m *manager) isAlreadyCached(regEntry *common.RegistrationEntry) bool {
-	return m.cache.Entry(regEntry) != nil
-}
-
 func (m *manager) storeSVID(svid *x509.Certificate) {
 	err := StoreSVID(m.svidCachePath, svid)
 	if err != nil {

--- a/test/fixture/registration/manager_test_entries.json
+++ b/test/fixture/registration/manager_test_entries.json
@@ -45,5 +45,35 @@
                 "ttl": 200
             }
         ]
+    },
+    "resp3" : {
+        "entries": [
+            {
+                "selectors": [
+                    {
+                        "type": "unix",
+                        "value": "uid:1111"
+                    }
+                ],
+                "entry_id": "0002",
+                "spiffe_id": "spiffe://example.org/blog",
+                "parent_id": "spiffe://example.org/spire/agent",
+                "ttl": 200
+            },
+            {
+                "selectors": [
+                    {
+                        "type": "unix",
+                        "value": "uid:1111"
+                    }
+                ],
+                "entry_id": "0003",
+                "spiffe_id": "spiffe://example.org/database",
+                "parent_id": "spiffe://example.org/spire/agent",
+                "ttl": 200,
+                "federates_with": ["spiffe://otherdomain.test"]
+            }
+        ]
     }
+
 }


### PR DESCRIPTION
The agent sync code ignores registration entries that are already in the
cache. This commit changes the behavior to update the cache if the
registration entry has changed (notifying subscribers).

This fix is preparatory to adding registration entry update support (#609) to
SPIRE server.
