### PR TITLE
Fix agent key persistence bug

### DIFF
--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -50,6 +50,7 @@ func New(c *Config) (*manager, error) {
 	cache := cache.New(c.Log, c.TrustDomain.String(), c.Bundle)
 
 	rotCfg := &svid.RotatorConfig{
+		Catalog:      c.Catalog,
 		Log:          c.Log,
 		SVID:         c.SVID,
 		SVIDKey:      c.SVIDKey,

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -19,11 +19,13 @@ import (
 
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
+	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/api/node"
 	"github.com/spiffe/spire/proto/common"
+	"github.com/spiffe/spire/test/fakes/fakeagentcatalog"
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/require"
 
@@ -256,7 +258,11 @@ func TestSVIDRotation(t *testing.T) {
 	baseTTL := 3 * time.Second
 	baseSVID, baseSVIDKey := apiHandler.newSVID("spiffe://"+trustDomain+"/spire/agent/join_token/abcd", baseTTL)
 
+	cat := fakeagentcatalog.New()
+	cat.SetKeyManagers(memory.New())
+
 	c := &Config{
+		Catalog:          cat,
 		ServerAddr:       l.Addr().String(),
 		SVID:             baseSVID,
 		SVIDKey:          baseSVIDKey,

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 
@@ -15,6 +16,7 @@ import (
 )
 
 type RotatorConfig struct {
+	Catalog     catalog.Catalog
 	Log         logrus.FieldLogger
 	TrustDomain url.URL
 	ServerAddr  string


### PR DESCRIPTION
This fixes a bug that was introduced in which the agent bypasses the
keymanager plugin when generating new keys for its own SVID rotation.
This results in the persisted key becoming stale, leading to a mismatch
between the stored SVID and the private key from KeyManager.

This commit includes a regression test

Signed-off-by: Evan Gilman <evan@scytale.io>