### PR TITLE
Fix CA, Server and SVID TTL logging

### DIFF
--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/cryptoutil"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/jwtsvid"
@@ -24,6 +25,7 @@ const (
 )
 
 type serverCAConfig struct {
+	Log         logrus.FieldLogger
 	Catalog     catalog.Catalog
 	TrustDomain url.URL
 	DefaultTTL  time.Duration
@@ -94,6 +96,8 @@ func (ca *serverCA) SignX509SVID(ctx context.Context, csrDER []byte, ttl time.Du
 	if err != nil {
 		return nil, err
 	}
+
+	ca.c.Log.Debugf("Signed x509 SVID %q (expires %s)", cert.URIs[0].String(), cert.NotAfter.Format(time.RFC3339))
 
 	// build and return the certificate chain, starting with the newly signed cert and any
 	// intermediates back to the signing root of the keypair. the keypair chain

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spiffe/spire/pkg/common/cryptoutil"
 	"github.com/spiffe/spire/pkg/common/jwtsvid"
+	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager/memory"
 	"github.com/spiffe/spire/proto/api/node"
@@ -68,7 +69,11 @@ func (s *CATestSuite) SetupTest() {
 	catalog := fakeservercatalog.New()
 	catalog.SetKeyManagers(km)
 
+	logger, err := log.NewLogger("DEBUG", "")
+	s.Require().NoError(err)
+
 	s.ca = newServerCA(serverCAConfig{
+		Log:     logger,
 		Catalog: catalog,
 		TrustDomain: url.URL{
 			Scheme: "spiffe",

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -124,6 +124,7 @@ func NewManager(c *ManagerConfig) *manager {
 	m := &manager{
 		c: c,
 		ca: newServerCA(serverCAConfig{
+			Log:         c.Log,
 			Catalog:     c.Catalog,
 			TrustDomain: c.TrustDomain,
 			DefaultTTL:  c.SVIDTTL,
@@ -140,8 +141,6 @@ func NewManager(c *ManagerConfig) *manager {
 }
 
 func (m *manager) Initialize(ctx context.Context) error {
-	m.c.Log.Debugf("TTL: CA=%s SVID=%s", m.c.CATTL, m.c.SVIDTTL)
-
 	if err := m.loadKeypairSets(ctx); err != nil {
 		return err
 	}
@@ -387,6 +386,7 @@ func (m *manager) prepareKeypairSet(ctx context.Context, kps *keypairSet) error 
 	}
 	kps.jwtSigningKey = jwtSigningKey
 	m.writeKeypairSets()
+	m.c.Log.Debugf("Keypair set %q will expire %s", kps.slot, cert.NotAfter.Format(time.RFC3339))
 	return nil
 }
 


### PR DESCRIPTION
Instead of logging a misleading TTL configuration, log the expiration of
each cert as it is minted, like so:

```
DEBU[0000] Keypair set "A" will expire 2018-11-06T00:38:31Z  subsystem_name=ca_manager
DEBU[0000] Activating keypair set "A"                    subsystem_name=ca_manager
DEBU[0000] Rotating server SVID                          subsystem_name=svid_rotator
DEBU[0000] Signed x509 SVID "spiffe://example.org/spire/server" (expires 2018-11-06T00:38:31Z)  subsystem_name=ca_manager
```

Fixes #604 