### PR TITLE
Fix panic during svid rotation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -61,7 +61,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		return err
 	}
 
-	manager, err := a.newManager(ctx, tel, as)
+	manager, err := a.newManager(ctx, cat, tel, as)
 	if err != nil {
 		return err
 	}
@@ -146,11 +146,12 @@ func (a *Agent) attest(ctx context.Context, cat catalog.Catalog) (*attestor.Atte
 	return attestor.New(&config).Attest(ctx)
 }
 
-func (a *Agent) newManager(ctx context.Context, tel telemetry.Sink, as *attestor.AttestationResult) (manager.Manager, error) {
+func (a *Agent) newManager(ctx context.Context, cat catalog.Catalog, tel telemetry.Sink, as *attestor.AttestationResult) (manager.Manager, error) {
 	config := &manager.Config{
 		SVID:            as.SVID,
 		SVIDKey:         as.Key,
 		Bundle:          as.Bundle,
+		Catalog:         cat,
 		TrustDomain:     a.c.TrustDomain,
 		ServerAddr:      a.c.ServerAddress,
 		Log:             a.c.Log.WithField("subsystem_name", "manager"),

--- a/pkg/common/util/task.go
+++ b/pkg/common/util/task.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sync"
 )
 
@@ -27,11 +28,7 @@ func RunTasks(ctx context.Context, tasks ...func(context.Context) error) error {
 	runTask := func(task func(context.Context) error) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
-				if e, ok := r.(error); ok {
-					errch <- e
-				} else {
-					errch <- fmt.Errorf("panic: %v", r)
-				}
+				errch <- fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack()))
 			} else {
 				errch <- err
 			}


### PR DESCRIPTION
Recent work properly integrated the agent key manager into agent SVID rotation but that catalog was not plumbed through, causing a panic during rotation.

This PR fixes the bug by passing the catalog to the agent manager.

There is also a quality of life commit that appends the stacktrace to panic's caught by the task runner.