### PR TITLE
Store CA intermediates in bundle

### DIFF
--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -213,11 +213,12 @@ func (m *ManagerTestSuite) TestUpstreamSigning() {
 	upstreamCert := upstreamCA.Cert()
 
 	// generate a keypair make sure it was signed up upstream and that
-	// the upstream cert is in the bundle
+	// the upstream cert is in the bundle. The server CA intermediate should
+	// also be in the bundle until SPIRE 0.8.0.
 	m.Require().NoError(m.m.Initialize(ctx))
 	a := m.m.getCurrentKeypairSet()
 	m.Require().Equal(upstreamCert.Subject, a.x509CA.cert.Issuer)
-	m.requireBundleRootCAs(upstreamCert)
+	m.requireBundleRootCAs(a.x509CA.cert, upstreamCert)
 }
 
 func (m *ManagerTestSuite) TestRotation() {

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -695,12 +695,12 @@ func getExpectedFetchX509SVID(data *fetchSVIDData) *node.X509SVIDUpdate {
 	caCert, _, _ := util.LoadCAFixture()
 	svidUpdate := &node.X509SVIDUpdate{
 		Svids:               svids,
-		DEPRECATEDBundle:    append(caCert.Raw, data.caCert.Raw...),
+		DEPRECATEDBundle:    caCert.Raw,
 		RegistrationEntries: registrationEntries,
 		DEPRECATEDBundles: map[string]*node.Bundle{
 			testTrustDomain.String(): {
 				Id:      testTrustDomain.String(),
-				CaCerts: append(caCert.Raw, data.caCert.Raw...),
+				CaCerts: caCert.Raw,
 			},
 			"spiffe://otherdomain.test": {
 				Id:      "spiffe://otherdomain.test",
@@ -712,7 +712,6 @@ func getExpectedFetchX509SVID(data *fetchSVIDData) *node.X509SVIDUpdate {
 				TrustDomainId: testTrustDomain.String(),
 				RootCas: []*common.Certificate{
 					{DerBytes: caCert.Raw},
-					{DerBytes: data.caCert.Raw},
 				},
 			},
 			"spiffe://otherdomain.test": {


### PR DESCRIPTION
SPIRE was recently refactored to properly convey signing intermediates
down through the Node and Workload APIs. At that time the bundle was
changed to only include the signing root. Backwards compatability with
old agents was done at the Node API layer; intermediate certificates
from minted SVIDs were appended to the bundle before the result was
returned to the agent.

This approach was insufficient and broken since 1) the intermediates
would not be appended to bundles returned to agents talking with other
servers (in an HA scenario), and 2) the agent uses the same fetch call
to learn about new registration entries without asking for anything to
be signed, which caused the server to return a bundle without
intermediates.

This change removes the shim in the Node API and instead stores the
intermediates in the bundle so they are consistently returned from the
Node API and available in HA depoloyments. SPIRE 0.8.0 can revert the
change to no longer store the intermediates.