### PR TITLE
Fix server handshake when upstream_bundle is false

### DIFF
--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -103,7 +103,8 @@ func (ca *serverCA) SignX509SVID(ctx context.Context, csrDER []byte, ttl time.Du
 	// intermediates back to the signing root of the keypair. the keypair chain
 	// is a full chain from the ca back to the signing root, so all but the
 	// last element (i.e., the signing root) form the list of intermediates.
-	return append([]*x509.Certificate{cert}, kp.x509CA.chain[:len(kp.x509CA.chain)-1]...), nil
+	//return append([]*x509.Certificate{cert}, kp.x509CA.chain[:len(kp.x509CA.chain)-1]...), nil
+	return append([]*x509.Certificate{cert}, kp.x509CA.chain...), nil
 }
 
 func (ca *serverCA) SignJWTSVID(ctx context.Context, jsr *node.JSR) (string, error) {

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -99,11 +99,10 @@ func (ca *serverCA) SignX509SVID(ctx context.Context, csrDER []byte, ttl time.Du
 
 	ca.c.Log.Debugf("Signed x509 SVID %q (expires %s)", cert.URIs[0].String(), cert.NotAfter.Format(time.RFC3339))
 
-	// build and return the certificate chain, starting with the newly signed cert and any
-	// intermediates back to the signing root of the keypair. the keypair chain
-	// is a full chain from the ca back to the signing root, so all but the
-	// last element (i.e., the signing root) form the list of intermediates.
-	//return append([]*x509.Certificate{cert}, kp.x509CA.chain[:len(kp.x509CA.chain)-1]...), nil
+	// build and return the certificate chain, starting with the newly signed
+	// cert all the way back to the signing root of the keypair. if an
+	// upstream ca was used, and upstream_bundle is true, this will include
+	// the upstream certificates, otherwise the root will be the server CA.
 	return append([]*x509.Certificate{cert}, kp.x509CA.chain...), nil
 }
 

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -103,7 +103,7 @@ func (s *CATestSuite) TestNoX509KeypairSet() {
 func (s *CATestSuite) TestSignX509SVIDUsesDefaultTTLIfTTLUnspecified() {
 	svid, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), 0)
 	s.Require().NoError(err)
-	s.Require().Len(svid, 1)
+	s.Require().Len(svid, 2)
 	s.Require().Equal(s.now.Add(-backdate), svid[0].NotBefore)
 	s.Require().Equal(s.now.Add(time.Minute), svid[0].NotAfter)
 }
@@ -111,7 +111,7 @@ func (s *CATestSuite) TestSignX509SVIDUsesDefaultTTLIfTTLUnspecified() {
 func (s *CATestSuite) TestSignX509SVIDReturnsEmptyIntermediatesIfServerCASelfSigned() {
 	svid, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), 0)
 	s.Require().NoError(err)
-	s.Require().Len(svid, 1)
+	s.Require().Len(svid, 2)
 }
 
 func (s *CATestSuite) TestSignX509SVIDReturnsIntermediatesIfNotSelfSigned() {
@@ -121,14 +121,14 @@ func (s *CATestSuite) TestSignX509SVIDReturnsIntermediatesIfNotSelfSigned() {
 	kp.x509CA.chain = []*x509.Certificate{intermediate, kp.x509CA.chain[0]}
 	svid, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), 0)
 	s.Require().NoError(err)
-	s.Require().Len(svid, 2)
+	s.Require().Len(svid, 3)
 	s.Require().Equal(intermediate, svid[1])
 }
 
 func (s *CATestSuite) TestSignX509SVIDUsesTTLIfSpecified() {
 	svid, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), time.Minute+time.Second)
 	s.Require().NoError(err)
-	s.Require().Len(svid, 1)
+	s.Require().Len(svid, 2)
 	s.Require().Equal(s.now.Add(-backdate), svid[0].NotBefore)
 	s.Require().Equal(s.now.Add(time.Minute+time.Second), svid[0].NotAfter)
 }
@@ -136,7 +136,7 @@ func (s *CATestSuite) TestSignX509SVIDUsesTTLIfSpecified() {
 func (s *CATestSuite) TestSignX509SVIDCapsTTLToKeypairTTL() {
 	svid, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), time.Hour)
 	s.Require().NoError(err)
-	s.Require().Len(svid, 1)
+	s.Require().Len(svid, 2)
 	s.Require().Equal(s.now.Add(-backdate), svid[0].NotBefore)
 	s.Require().Equal(s.now.Add(10*time.Minute), svid[0].NotAfter)
 }
@@ -149,11 +149,11 @@ func (s *CATestSuite) TestSignX509SVIDValidatesCSR() {
 func (s *CATestSuite) TestSignX509SVIDIncrementsSerialNumber() {
 	svid1, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), 0)
 	s.Require().NoError(err)
-	s.Require().Len(svid1, 1)
+	s.Require().Len(svid1, 2)
 	s.Require().Equal(0, svid1[0].SerialNumber.Cmp(big.NewInt(1)))
 	svid2, err := s.ca.SignX509SVID(ctx, s.generateCSR("example.org"), 0)
 	s.Require().NoError(err)
-	s.Require().Len(svid2, 1)
+	s.Require().Len(svid2, 2)
 	s.Require().Equal(0, svid2[0].SerialNumber.Cmp(big.NewInt(2)))
 }
 

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -250,6 +250,7 @@ func (e *endpoints) getCerts(ctx context.Context) ([]tls.Certificate, *x509.Cert
 			caPool.AddCert(cert)
 		}
 	}
+
 	tlsCert := tls.Certificate{
 		Certificate: certChain,
 		PrivateKey:  e.svidKey,

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -732,7 +732,7 @@ func getSpiffeIDFromCert(cert *x509.Certificate) (string, error) {
 
 func makeX509SVID(svid []*x509.Certificate) *node.X509SVID {
 	var certChain []byte
-	for _, cert := range svid {
+	for _, cert := range svid[:len(svid)-1] {
 		certChain = append(certChain, cert.Raw...)
 	}
 	return &node.X509SVID{

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -732,6 +732,9 @@ func getSpiffeIDFromCert(cert *x509.Certificate) (string, error) {
 
 func makeX509SVID(svid []*x509.Certificate) *node.X509SVID {
 	var certChain []byte
+	// The svid slice contains all of the certificates back to the signing
+	// root. We only want to return the SVID and intermediates necessary to
+	// chain back to the root, so skip the last element.
 	for _, cert := range svid[:len(svid)-1] {
 		certChain = append(certChain, cert.Raw...)
 	}


### PR DESCRIPTION
Recent changes in SPIRE broke the trust between the agent and server
during agent bootstrapping when upstream_bundle is false. The server was
changed to no longer present the server CA in its certificate chain
during the TLS handshake, which prevents the agent from chaining back to
the bootstrap certificate.

This PR fixes that by returning the whole chain back to the root
from the CA X509 SVID signing code, instead of only the intermediates
necessary to chain to the root. The server receives this whole chain via
the server SVID rotator and presents all certificates to the agent
during handshake. The node API handler then takes care to strip the root
from the SVID cert chain before returning it to agents.