### PR TITLE
Make entry show to print TTL 'default' when it's 0

### DIFF
--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -60,7 +60,12 @@ func printEntry(e *common.RegistrationEntry) {
 	fmt.Printf("Entry ID:\t%s\n", e.EntryId)
 	fmt.Printf("SPIFFE ID:\t%s\n", e.SpiffeId)
 	fmt.Printf("Parent ID:\t%s\n", e.ParentId)
-	fmt.Printf("TTL:\t\t%v\n", e.Ttl)
+
+	if e.Ttl == 0 {
+		fmt.Printf("TTL:\t\t%v\n", "default")
+	} else {
+		fmt.Printf("TTL:\t\t%v\n", e.Ttl)
+	}
 
 	for _, s := range e.Selectors {
 		fmt.Printf("Selector:\t%s:%s\n", s.Type, s.Value)


### PR DESCRIPTION
Signed-off-by: Marcos G. Yedro <marcosyedro@gmail.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
spire server entry show

**Description of change**
Printing 'default' instead of '0' when TTL is not set and default configuration values are used.

**Which issue this PR fixes**
Fixes #619

