### PR TITLE
Add a CurrentSVID() function to the X509-SVID API client

### DIFF
--- a/api/workload/x509_client.go
+++ b/api/workload/x509_client.go
@@ -11,6 +11,8 @@ import (
 type X509Client interface {
 	Start() error
 	Stop()
+
+	CurrentSVID() (*workload.X509SVIDResponse, error)
 	UpdateChan() <-chan *workload.X509SVIDResponse
 }
 
@@ -68,6 +70,10 @@ func (x *x509Client) Start() error {
 
 func (x *x509Client) Stop() {
 	close(x.stopChan)
+}
+
+func (x *x509Client) CurrentSVID() (*workload.X509SVIDResponse, error) {
+	return x.stream.current()
 }
 
 func (x *x509Client) UpdateChan() <-chan *workload.X509SVIDResponse {

--- a/api/workload/x509_client_test.go
+++ b/api/workload/x509_client_test.go
@@ -35,6 +35,12 @@ func TestClient_StartAndStop(t *testing.T) {
 	}
 	c := NewX509Client(config)
 
+	// Current should return an error if there isn't an SVID yet
+	_, err := c.CurrentSVID()
+	if err == nil {
+		t.Error("wanted error, got nil")
+	}
+
 	// Test single update and clean shutdown
 	handler.setDelay(10 * time.Second)
 	errChan := make(chan error)
@@ -88,6 +94,15 @@ func TestClient_StartAndStop(t *testing.T) {
 		if !reflect.DeepEqual(u, handler.resp1()) {
 			t.Errorf("want %v; got %v", handler.resp1(), u)
 		}
+	}
+
+	// Current should always return the latest SVID
+	curr, err := c.CurrentSVID()
+	if err != nil {
+		t.Errorf("got error %v", err)
+	}
+	if !reflect.DeepEqual(curr, handler.resp1()) {
+		t.Errorf("want %v; got %v", handler.resp1(), curr)
 	}
 
 	c.Stop()

--- a/api/workload/x509_handler.go
+++ b/api/workload/x509_handler.go
@@ -1,6 +1,7 @@
 package workload
 
 import (
+	"errors"
 	"reflect"
 	"sync"
 
@@ -57,6 +58,17 @@ func (x *x509Handler) update(u *workload.X509SVIDResponse) {
 	default:
 		break
 	}
+}
+
+func (x *x509Handler) current() (*workload.X509SVIDResponse, error) {
+	x.mtx.RLock()
+	defer x.mtx.RUnlock()
+
+	if x.latest == nil {
+		return nil, errors.New("no SVID received yet")
+	}
+
+	return x.latest, nil
 }
 
 // updateChan returns a channel on which a client will receive X509-SVID updates

--- a/api/workload/x509_stream.go
+++ b/api/workload/x509_stream.go
@@ -89,6 +89,11 @@ func (x *x509Stream) stop() {
 	close(x.stopChan)
 }
 
+// current returns the currently-held SVID, useful for client dialers
+func (x *x509Stream) current() (*workload.X509SVIDResponse, error) {
+	return x.handler.current()
+}
+
 // updateChan returns a channel over which updates will be delivered.
 func (x *x509Stream) updateChan() <-chan *workload.X509SVIDResponse {
 	return x.handler.updateChan()


### PR DESCRIPTION
Lightweight client dialers are often uninterested in receiving SVID
updates, and need only the latest SVID to make a quick connection.
Instead of having to deal with an update channel, expose a convenience
function for fetching the most current SVID from the client's internal
cache.

Signed-off-by: Evan Gilman <evan@scytale.io>