### PR TITLE
deprecate use of github.com/satori/go.uuid for github.com/gofrs/uuid

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -166,6 +166,14 @@
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:c594a691090b434d55c67f6cc8e326ef5ba49452abc059821bd5d4fd4cdef08c"
+  name = "github.com/gofrs/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7077aa61129615a0d7f45c49101cd011ab221c27"
+  version = "v3.1.2"
+
+[[projects]]
   branch = "master"
   digest = "1:1ba1d79f2810270045c328ae5d674321db34e3aae468eb4233883b473c5c0467"
   name = "github.com/golang/glog"
@@ -420,14 +428,6 @@
   version = "v1.1.2"
 
 [[projects]]
-  digest = "1:274f67cb6fed9588ea2521ecdac05a6d62a8c51c074c1fccc6a49a40ba80e925"
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
-  version = "v1.2.0"
-
-[[projects]]
   digest = "1:7395b855a6078ad2e6c40311402a057a91125fb9f32cf228e1b32cdc57c33538"
   name = "github.com/shirou/gopsutil"
   packages = [
@@ -660,12 +660,15 @@
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/aws/aws-sdk-go/service/iam",
     "github.com/dgrijalva/jwt-go",
+    "github.com/gofrs/uuid",
     "github.com/golang/mock/gomock",
+    "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/protoc-gen-go/plugin",
     "github.com/golang/protobuf/ptypes/empty",
+    "github.com/golang/protobuf/ptypes/struct",
     "github.com/golang/protobuf/ptypes/wrappers",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
     "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
@@ -682,7 +685,6 @@
     "github.com/jinzhu/gorm/dialects/sqlite",
     "github.com/jteeuwen/go-bindata/go-bindata",
     "github.com/mitchellh/cli",
-    "github.com/satori/go.uuid",
     "github.com/shirou/gopsutil/process",
     "github.com/sirupsen/logrus",
     "github.com/sirupsen/logrus/hooks/test",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
 #   unused-packages = true
 
 required = ["github.com/hashicorp/go-plugin",
-  "github.com/satori/go.uuid",
+  "github.com/gofrs/uuid",
   "github.com/golang/protobuf/protoc-gen-go",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
   "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
@@ -88,8 +88,8 @@ required = ["github.com/hashicorp/go-plugin",
   version = "1.0.0"
 
 [[constraint]]
-  name = "github.com/satori/go.uuid"
-  version = "1.2.0"
+  name = "github.com/gofrs/uuid"
+  version = "3.1.2"
 
 [[constraint]]
   name = "github.com/shirou/gopsutil"

--- a/pkg/agent/manager/cache/subscriber.go
+++ b/pkg/agent/manager/cache/subscriber.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"sync"
 
-	"github.com/satori/go.uuid"
+	"github.com/gofrs/uuid"
 	"github.com/spiffe/spire/pkg/common/selector"
 )
 
@@ -33,10 +33,14 @@ type subscribers struct {
 }
 
 func NewSubscriber(selectors Selectors) (*subscriber, error) {
+	u, err := uuid.NewV4()
+	if err != nil {
+		return nil, err
+	}
 	return &subscriber{
 		c:      make(chan *WorkloadUpdate, 1),
 		sel:    selectors,
-		sid:    uuid.NewV4(),
+		sid:    u,
 		active: true,
 	}, nil
 }

--- a/pkg/agent/plugin/nodeattestor/k8s/sat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat_test.go
@@ -116,8 +116,8 @@ func (s *SATAttestorSuite) TestGetPluginInfo() {
 
 func (s *SATAttestorSuite) newAttestor() {
 	attestor := NewSATAttestorPlugin()
-	attestor.hooks.newUUID = func() string {
-		return "UUID"
+	attestor.hooks.newUUID = func() (string, error) {
+		return "UUID", nil
 	}
 	s.attestor = nodeattestor.NewBuiltIn(attestor)
 }

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -425,7 +425,11 @@ func (h *Handler) CreateJoinToken(
 
 	// Generate a token if one wasn't specified
 	if request.Token == "" {
-		request.Token = uuid.NewV4().String()
+		u, err := uuid.NewV4()
+		if err != nil {
+			return nil, errors.New("Error generating uuid token: %v")
+		}
+		request.Token = u.String()
 	}
 
 	ds := h.getDataStore()

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/hcl"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	uuid "github.com/satori/go.uuid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/selector"
@@ -772,7 +772,10 @@ func createRegistrationEntry(tx *gorm.DB,
 		return nil, err
 	}
 
-	entryID := newRegistrationEntryID()
+	entryID, err := newRegistrationEntryID()
+	if err != nil {
+		return nil, err
+	}
 
 	newRegisteredEntry := RegisteredEntry{
 		EntryID:  entryID,
@@ -1235,8 +1238,12 @@ func modelToEntry(tx *gorm.DB, model RegisteredEntry) (*common.RegistrationEntry
 	}, nil
 }
 
-func newRegistrationEntryID() string {
-	return uuid.NewV4().String()
+func newRegistrationEntryID() (string, error) {
+	u, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
 }
 
 func modelToAttestedNode(model AttestedNode) *datastore.AttestedNode {

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -7,9 +7,9 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/proto"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
-	uuid "github.com/satori/go.uuid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/selector"
 	"github.com/spiffe/spire/pkg/common/util"
@@ -310,7 +310,10 @@ func (s *DataStore) CreateRegistrationEntry(ctx context.Context,
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	entryID := newRegistrationEntryID()
+	entryID, err := newRegistrationEntryID()
+	if err != nil {
+		return nil, err
+	}
 
 	entry := cloneRegistrationEntry(req.Entry)
 	entry.EntryId = entryID
@@ -603,8 +606,12 @@ func cloneJoinToken(token *datastore.JoinToken) *datastore.JoinToken {
 	return proto.Clone(token).(*datastore.JoinToken)
 }
 
-func newRegistrationEntryID() string {
-	return uuid.NewV4().String()
+func newRegistrationEntryID() (string, error) {
+	u, err := uuid.NewV4()
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
 }
 
 func containsSelectors(selectors, subset []*common.Selector) bool {


### PR DESCRIPTION
Gopkg.toml version of go.uuid@1.2.0 did not include non-random uuid fix:
https://github.com/satori/go.uuid/issues/73

also, deprecation notice for satori/go.uuid posted via issue:
https://github.com/satori/go.uuid/issues/84

community recommended replacement is available at github.com/gofrs/uuid

* updated Gopkg.toml to use github.com/gofrs/uuid @ 3.1.2
* rebuilt Gopkg.lock
* incorporate symmantics of uuid.NewV4() can return error

Signed-off-by: David Gervais <dgervais@gmail.com>