### PR TITLE
incorrect syntax for aws_iid resolver example in docs

### DIFF
--- a/doc/plugin_server_noderesolver_aws_iid.md
+++ b/doc/plugin_server_noderesolver_aws_iid.md
@@ -12,7 +12,7 @@ of selectors.
 | Instance Tag        | `tag:name:blog`                                   | The key (e.g. `name`) and value (e.g. `blog`) of an instance tag |
 | Security Group ID   | `sg:id:sg-01234567`                               | The id of the security group the instance belongs to             |
 | Security Group Name | `sg:name:blog`                                    | The name of the security group the instance belongs to           |
-| IAM role            | `arn:aws:iam::123456789012:instance-profile/Blog` | An IAM role within the instance profile for the instance         |
+| IAM role            | `iamrole:arn:aws:iam::123456789012:instance-profile/Blog` | An IAM role within the instance profile for the instance         |
 
  All of the selectors have the type `aws_iid`.
 


### PR DESCRIPTION
updated example in aws_iid resolver docs
from: arn:aws:iam::123456789012:instance-profile/Blog
to: iamrole:arn:aws:iam::123456789012:instance-profile/Blog