### PR TITLE
Prevent agent from storing an invalid key on failed SVID rotation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -23,7 +23,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZPc=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
-github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dimchansky/utfbom v1.0.0 h1:fGC2kkf4qOoKqZ4q7iIh+Vef4ubC1c38UDsEyZynZPc=
 github.com/dimchansky/utfbom v1.0.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/docker/docker v1.13.1 h1:5VBhsO6ckUxB0A8CE5LlUJdXzik9cbEbBTQ/ggeml7M=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=

--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -30,26 +30,12 @@ type diskPlugin struct {
 }
 
 func (d *diskPlugin) GenerateKeyPair(context.Context, *keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
-	d.mtx.RLock()
-	if d.dir == "" {
-		d.mtx.RUnlock()
-		return nil, errors.New("path not configured")
-	}
-
-	keyPath := path.Join(d.dir, keyFileName)
-	d.mtx.RUnlock()
-
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
 
 	privData, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		return nil, err
-	}
-
-	err = ioutil.WriteFile(keyPath, privData, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -61,6 +47,23 @@ func (d *diskPlugin) GenerateKeyPair(context.Context, *keymanager.GenerateKeyPai
 
 	resp := &keymanager.GenerateKeyPairResponse{PublicKey: pubData, PrivateKey: privData}
 	return resp, nil
+}
+
+func (d *diskPlugin) StorePrivateKey(ctx context.Context, req *keymanager.StorePrivateKeyRequest) (*keymanager.StorePrivateKeyResponse, error) {
+	d.mtx.RLock()
+	if d.dir == "" {
+		d.mtx.RUnlock()
+		return nil, errors.New("path not configured")
+	}
+
+	keyPath := path.Join(d.dir, keyFileName)
+	d.mtx.RUnlock()
+
+	if err := ioutil.WriteFile(keyPath, req.PrivateKey, 0600); err != nil {
+		return nil, err
+	}
+
+	return &keymanager.StorePrivateKeyResponse{}, nil
 }
 
 func (d *diskPlugin) FetchPrivateKey(context.Context, *keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -19,7 +19,7 @@ var (
 	ctx = context.Background()
 )
 
-func TestMemory_GenerateKeyPair(t *testing.T) {
+func TestDisk_GenerateKeyPair(t *testing.T) {
 	plugin := New()
 	tempDir, err := ioutil.TempDir("", "km-disk-test")
 	require.NoError(t, err)
@@ -27,6 +27,8 @@ func TestMemory_GenerateKeyPair(t *testing.T) {
 	defer os.RemoveAll(tempDir)
 
 	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	require.NoError(t, err)
+	_, err = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
 	require.NoError(t, err)
 	_, err = os.Stat(path.Join(tempDir, keyFileName))
 	assert.False(t, os.IsNotExist(err))
@@ -40,7 +42,7 @@ func TestMemory_GenerateKeyPair(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestMemory_FetchPrivateKey(t *testing.T) {
+func TestDisk_FetchPrivateKey(t *testing.T) {
 	plugin := New()
 	tempDir, err := ioutil.TempDir("", "km-disk-test")
 	require.NoError(t, err)
@@ -49,13 +51,15 @@ func TestMemory_FetchPrivateKey(t *testing.T) {
 
 	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
 	require.NoError(t, err)
+	_, err = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
+	require.NoError(t, err)
 
 	fetchResp, err := plugin.FetchPrivateKey(ctx, &keymanager.FetchPrivateKeyRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, genResp.PrivateKey, fetchResp.PrivateKey)
 }
 
-func TestMemory_Configure(t *testing.T) {
+func TestDisk_Configure(t *testing.T) {
 	plugin := New()
 	cReq := &spi.ConfigureRequest{
 		Configuration: "directory = \"foo/bar\"",
@@ -65,7 +69,7 @@ func TestMemory_Configure(t *testing.T) {
 	assert.Equal(t, "foo/bar", plugin.dir)
 }
 
-func TestMemory_GetPluginInfo(t *testing.T) {
+func TestDisk_GetPluginInfo(t *testing.T) {
 	plugin := New()
 	_, e := plugin.GetPluginInfo(ctx, &spi.GetPluginInfoRequest{})
 	require.NoError(t, e)

--- a/pkg/agent/plugin/keymanager/memory/memory_test.go
+++ b/pkg/agent/plugin/keymanager/memory/memory_test.go
@@ -20,6 +20,8 @@ func TestMemory_GenerateKeyPair(t *testing.T) {
 	plugin := New()
 	data, e := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
 	require.NoError(t, e)
+	_, e = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
+	require.NoError(t, e)
 	priv, err := x509.ParseECPrivateKey(data.PrivateKey)
 	require.NoError(t, err)
 	assert.Equal(t, plugin.key, priv)
@@ -28,6 +30,8 @@ func TestMemory_GenerateKeyPair(t *testing.T) {
 func TestMemory_FetchPrivateKey(t *testing.T) {
 	plugin := New()
 	data, e := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	require.NoError(t, e)
+	_, e = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
 	require.NoError(t, e)
 
 	priv, e := plugin.FetchPrivateKey(ctx, &keymanager.FetchPrivateKeyRequest{})

--- a/proto/agent/keymanager/README_pb.md
+++ b/proto/agent/keymanager/README_pb.md
@@ -1,24 +1,15 @@
 # Protocol Documentation
-<a name="top"/>
+<a name="top"></a>
 
 ## Table of Contents
-
-- [plugin.proto](#plugin.proto)
-    - [ConfigureRequest](#spire.common.plugin.ConfigureRequest)
-    - [ConfigureRequest.GlobalConfig](#spire.common.plugin.ConfigureRequest.GlobalConfig)
-    - [ConfigureResponse](#spire.common.plugin.ConfigureResponse)
-    - [GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest)
-    - [GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoResponse)
-  
-  
-  
-  
 
 - [keymanager.proto](#keymanager.proto)
     - [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest)
     - [FetchPrivateKeyResponse](#spire.agent.keymanager.FetchPrivateKeyResponse)
     - [GenerateKeyPairRequest](#spire.agent.keymanager.GenerateKeyPairRequest)
     - [GenerateKeyPairResponse](#spire.agent.keymanager.GenerateKeyPairResponse)
+    - [StorePrivateKeyRequest](#spire.agent.keymanager.StorePrivateKeyRequest)
+    - [StorePrivateKeyResponse](#spire.agent.keymanager.StorePrivateKeyResponse)
   
   
   
@@ -29,110 +20,14 @@
 
 
 
-<a name="plugin.proto"/>
-<p align="right"><a href="#top">Top</a></p>
-
-## plugin.proto
-
-
-
-<a name="spire.common.plugin.ConfigureRequest"/>
-
-### ConfigureRequest
-Represents the plugin-specific configuration string.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| configuration | [string](#string) |  | The configuration for the plugin. |
-| globalConfig | [ConfigureRequest.GlobalConfig](#spire.common.plugin.ConfigureRequest.GlobalConfig) |  | Global configurations. |
-
-
-
-
-
-
-<a name="spire.common.plugin.ConfigureRequest.GlobalConfig"/>
-
-### ConfigureRequest.GlobalConfig
-Global configuration nested type.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| trustDomain | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="spire.common.plugin.ConfigureResponse"/>
-
-### ConfigureResponse
-Represents a list of configuration problems
-found in the configuration string.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| errorList | [string](#string) | repeated | A list of errors |
-
-
-
-
-
-
-<a name="spire.common.plugin.GetPluginInfoRequest"/>
-
-### GetPluginInfoRequest
-Represents an empty request.
-
-
-
-
-
-
-<a name="spire.common.plugin.GetPluginInfoResponse"/>
-
-### GetPluginInfoResponse
-Represents the plugin metadata.
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| name | [string](#string) |  |  |
-| category | [string](#string) |  |  |
-| type | [string](#string) |  |  |
-| description | [string](#string) |  |  |
-| dateCreated | [string](#string) |  |  |
-| location | [string](#string) |  |  |
-| version | [string](#string) |  |  |
-| author | [string](#string) |  |  |
-| company | [string](#string) |  |  |
-
-
-
-
-
- 
-
- 
-
- 
-
- 
-
-
-
-<a name="keymanager.proto"/>
+<a name="keymanager.proto"></a>
 <p align="right"><a href="#top">Top</a></p>
 
 ## keymanager.proto
 
 
 
-<a name="spire.agent.keymanager.FetchPrivateKeyRequest"/>
+<a name="spire.agent.keymanager.FetchPrivateKeyRequest"></a>
 
 ### FetchPrivateKeyRequest
 Represents an empty request
@@ -142,7 +37,7 @@ Represents an empty request
 
 
 
-<a name="spire.agent.keymanager.FetchPrivateKeyResponse"/>
+<a name="spire.agent.keymanager.FetchPrivateKeyResponse"></a>
 
 ### FetchPrivateKeyResponse
 Represents a private key
@@ -150,14 +45,14 @@ Represents a private key
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| privateKey | [bytes](#bytes) |  | Priavte key |
+| privateKey | [bytes](#bytes) |  | Private key |
 
 
 
 
 
 
-<a name="spire.agent.keymanager.GenerateKeyPairRequest"/>
+<a name="spire.agent.keymanager.GenerateKeyPairRequest"></a>
 
 ### GenerateKeyPairRequest
 Represents an empty request
@@ -167,7 +62,7 @@ Represents an empty request
 
 
 
-<a name="spire.agent.keymanager.GenerateKeyPairResponse"/>
+<a name="spire.agent.keymanager.GenerateKeyPairResponse"></a>
 
 ### GenerateKeyPairResponse
 Represents a public and private key pair
@@ -182,24 +77,50 @@ Represents a public and private key pair
 
 
 
- 
+
+<a name="spire.agent.keymanager.StorePrivateKeyRequest"></a>
+
+### StorePrivateKeyRequest
+Represents a private key
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| privateKey | [bytes](#bytes) |  | Private key |
+
+
+
+
+
+
+<a name="spire.agent.keymanager.StorePrivateKeyResponse"></a>
+
+### StorePrivateKeyResponse
+Represents an empty response
+
+
+
+
 
  
 
  
 
+ 
 
-<a name="spire.agent.keymanager.KeyManager"/>
+
+<a name="spire.agent.keymanager.KeyManager"></a>
 
 ### KeyManager
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GenerateKeyPair | [GenerateKeyPairRequest](#spire.agent.keymanager.GenerateKeyPairRequest) | [GenerateKeyPairResponse](#spire.agent.keymanager.GenerateKeyPairRequest) | Creates a key pair that is bound to hardware. |
-| FetchPrivateKey | [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest) | [FetchPrivateKeyResponse](#spire.agent.keymanager.FetchPrivateKeyRequest) | Returns previously generated private key. For use after node restarts. |
-| Configure | [spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureRequest) | Applies the plugin configuration and returns configuration errors. |
-| GetPluginInfo | [spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoRequest) | Returns the version and related metadata of the plugin. |
+| GenerateKeyPair | [GenerateKeyPairRequest](#spire.agent.keymanager.GenerateKeyPairRequest) | [GenerateKeyPairResponse](#spire.agent.keymanager.GenerateKeyPairResponse) | Creates a new key pair. |
+| StorePrivateKey | [StorePrivateKeyRequest](#spire.agent.keymanager.StorePrivateKeyRequest) | [StorePrivateKeyResponse](#spire.agent.keymanager.StorePrivateKeyResponse) | Persists a private key to the key manager&#39;s storage system. |
+| FetchPrivateKey | [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest) | [FetchPrivateKeyResponse](#spire.agent.keymanager.FetchPrivateKeyResponse) | Returns the most recently stored private key. For use after node restarts. |
+| Configure | [.spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [.spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureResponse) | Applies the plugin configuration and returns configuration errors. |
+| GetPluginInfo | [.spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [.spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoResponse) | Returns the version and related metadata of the plugin. |
 
  
 

--- a/proto/agent/keymanager/README_pb.md
+++ b/proto/agent/keymanager/README_pb.md
@@ -1,7 +1,18 @@
 # Protocol Documentation
-<a name="top"></a>
+<a name="top"/>
 
 ## Table of Contents
+
+- [plugin.proto](#plugin.proto)
+    - [ConfigureRequest](#spire.common.plugin.ConfigureRequest)
+    - [ConfigureRequest.GlobalConfig](#spire.common.plugin.ConfigureRequest.GlobalConfig)
+    - [ConfigureResponse](#spire.common.plugin.ConfigureResponse)
+    - [GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest)
+    - [GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoResponse)
+  
+  
+  
+  
 
 - [keymanager.proto](#keymanager.proto)
     - [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest)
@@ -20,14 +31,110 @@
 
 
 
-<a name="keymanager.proto"></a>
+<a name="plugin.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## plugin.proto
+
+
+
+<a name="spire.common.plugin.ConfigureRequest"/>
+
+### ConfigureRequest
+Represents the plugin-specific configuration string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| configuration | [string](#string) |  | The configuration for the plugin. |
+| globalConfig | [ConfigureRequest.GlobalConfig](#spire.common.plugin.ConfigureRequest.GlobalConfig) |  | Global configurations. |
+
+
+
+
+
+
+<a name="spire.common.plugin.ConfigureRequest.GlobalConfig"/>
+
+### ConfigureRequest.GlobalConfig
+Global configuration nested type.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| trustDomain | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="spire.common.plugin.ConfigureResponse"/>
+
+### ConfigureResponse
+Represents a list of configuration problems
+found in the configuration string.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| errorList | [string](#string) | repeated | A list of errors |
+
+
+
+
+
+
+<a name="spire.common.plugin.GetPluginInfoRequest"/>
+
+### GetPluginInfoRequest
+Represents an empty request.
+
+
+
+
+
+
+<a name="spire.common.plugin.GetPluginInfoResponse"/>
+
+### GetPluginInfoResponse
+Represents the plugin metadata.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| name | [string](#string) |  |  |
+| category | [string](#string) |  |  |
+| type | [string](#string) |  |  |
+| description | [string](#string) |  |  |
+| dateCreated | [string](#string) |  |  |
+| location | [string](#string) |  |  |
+| version | [string](#string) |  |  |
+| author | [string](#string) |  |  |
+| company | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="keymanager.proto"/>
 <p align="right"><a href="#top">Top</a></p>
 
 ## keymanager.proto
 
 
 
-<a name="spire.agent.keymanager.FetchPrivateKeyRequest"></a>
+<a name="spire.agent.keymanager.FetchPrivateKeyRequest"/>
 
 ### FetchPrivateKeyRequest
 Represents an empty request
@@ -37,7 +144,7 @@ Represents an empty request
 
 
 
-<a name="spire.agent.keymanager.FetchPrivateKeyResponse"></a>
+<a name="spire.agent.keymanager.FetchPrivateKeyResponse"/>
 
 ### FetchPrivateKeyResponse
 Represents a private key
@@ -52,7 +159,7 @@ Represents a private key
 
 
 
-<a name="spire.agent.keymanager.GenerateKeyPairRequest"></a>
+<a name="spire.agent.keymanager.GenerateKeyPairRequest"/>
 
 ### GenerateKeyPairRequest
 Represents an empty request
@@ -62,7 +169,7 @@ Represents an empty request
 
 
 
-<a name="spire.agent.keymanager.GenerateKeyPairResponse"></a>
+<a name="spire.agent.keymanager.GenerateKeyPairResponse"/>
 
 ### GenerateKeyPairResponse
 Represents a public and private key pair
@@ -78,7 +185,7 @@ Represents a public and private key pair
 
 
 
-<a name="spire.agent.keymanager.StorePrivateKeyRequest"></a>
+<a name="spire.agent.keymanager.StorePrivateKeyRequest"/>
 
 ### StorePrivateKeyRequest
 Represents a private key
@@ -93,7 +200,7 @@ Represents a private key
 
 
 
-<a name="spire.agent.keymanager.StorePrivateKeyResponse"></a>
+<a name="spire.agent.keymanager.StorePrivateKeyResponse"/>
 
 ### StorePrivateKeyResponse
 Represents an empty response
@@ -109,18 +216,18 @@ Represents an empty response
  
 
 
-<a name="spire.agent.keymanager.KeyManager"></a>
+<a name="spire.agent.keymanager.KeyManager"/>
 
 ### KeyManager
 
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
-| GenerateKeyPair | [GenerateKeyPairRequest](#spire.agent.keymanager.GenerateKeyPairRequest) | [GenerateKeyPairResponse](#spire.agent.keymanager.GenerateKeyPairResponse) | Creates a new key pair. |
-| StorePrivateKey | [StorePrivateKeyRequest](#spire.agent.keymanager.StorePrivateKeyRequest) | [StorePrivateKeyResponse](#spire.agent.keymanager.StorePrivateKeyResponse) | Persists a private key to the key manager&#39;s storage system. |
-| FetchPrivateKey | [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest) | [FetchPrivateKeyResponse](#spire.agent.keymanager.FetchPrivateKeyResponse) | Returns the most recently stored private key. For use after node restarts. |
-| Configure | [.spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [.spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureResponse) | Applies the plugin configuration and returns configuration errors. |
-| GetPluginInfo | [.spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [.spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoResponse) | Returns the version and related metadata of the plugin. |
+| GenerateKeyPair | [GenerateKeyPairRequest](#spire.agent.keymanager.GenerateKeyPairRequest) | [GenerateKeyPairResponse](#spire.agent.keymanager.GenerateKeyPairRequest) | Creates a new key pair. |
+| StorePrivateKey | [StorePrivateKeyRequest](#spire.agent.keymanager.StorePrivateKeyRequest) | [StorePrivateKeyResponse](#spire.agent.keymanager.StorePrivateKeyRequest) | Persists a private key to the key manager&#39;s storage system. |
+| FetchPrivateKey | [FetchPrivateKeyRequest](#spire.agent.keymanager.FetchPrivateKeyRequest) | [FetchPrivateKeyResponse](#spire.agent.keymanager.FetchPrivateKeyRequest) | Returns the most recently stored private key. For use after node restarts. |
+| Configure | [spire.common.plugin.ConfigureRequest](#spire.common.plugin.ConfigureRequest) | [spire.common.plugin.ConfigureResponse](#spire.common.plugin.ConfigureRequest) | Applies the plugin configuration and returns configuration errors. |
+| GetPluginInfo | [spire.common.plugin.GetPluginInfoRequest](#spire.common.plugin.GetPluginInfoRequest) | [spire.common.plugin.GetPluginInfoResponse](#spire.common.plugin.GetPluginInfoRequest) | Returns the version and related metadata of the plugin. |
 
  
 

--- a/proto/agent/keymanager/keymanager.go
+++ b/proto/agent/keymanager/keymanager.go
@@ -13,12 +13,14 @@ import (
 // KeyManager is the interface used by all non-catalog components.
 type KeyManager interface {
 	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
+	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
 	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
 }
 
 // Plugin is the interface implemented by plugin implementations
 type Plugin interface {
 	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
+	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
 	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
@@ -38,6 +40,14 @@ func NewBuiltIn(plugin Plugin) *BuiltIn {
 
 func (b BuiltIn) GenerateKeyPair(ctx context.Context, req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
 	resp, err := b.plugin.GenerateKeyPair(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func (b BuiltIn) StorePrivateKey(ctx context.Context, req *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error) {
+	resp, err := b.plugin.StorePrivateKey(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -102,6 +112,9 @@ type GRPCServer struct {
 func (s *GRPCServer) GenerateKeyPair(ctx context.Context, req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
 	return s.Plugin.GenerateKeyPair(ctx, req)
 }
+func (s *GRPCServer) StorePrivateKey(ctx context.Context, req *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error) {
+	return s.Plugin.StorePrivateKey(ctx, req)
+}
 func (s *GRPCServer) FetchPrivateKey(ctx context.Context, req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
 	return s.Plugin.FetchPrivateKey(ctx, req)
 }
@@ -118,6 +131,9 @@ type GRPCClient struct {
 
 func (c *GRPCClient) GenerateKeyPair(ctx context.Context, req *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
 	return c.client.GenerateKeyPair(ctx, req)
+}
+func (c *GRPCClient) StorePrivateKey(ctx context.Context, req *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error) {
+	return c.client.StorePrivateKey(ctx, req)
 }
 func (c *GRPCClient) FetchPrivateKey(ctx context.Context, req *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
 	return c.client.FetchPrivateKey(ctx, req)

--- a/proto/agent/keymanager/keymanager.pb.go
+++ b/proto/agent/keymanager/keymanager.pb.go
@@ -3,13 +3,14 @@
 
 package keymanager
 
+import proto "github.com/golang/protobuf/proto"
+import fmt "fmt"
+import math "math"
+import plugin "github.com/spiffe/spire/proto/common/plugin"
+
 import (
-	context "context"
-	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
-	plugin "github.com/spiffe/spire/proto/common/plugin"
+	context "golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -21,12 +22,12 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
 // ConfigureRequest from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type ConfigureRequest = plugin.ConfigureRequest
 
-// ConfigureRequest_GlobalConfig from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
+// GlobalConfig from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type ConfigureRequest_GlobalConfig = plugin.ConfigureRequest_GlobalConfig
 
 // ConfigureResponse from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
@@ -38,7 +39,7 @@ type GetPluginInfoRequest = plugin.GetPluginInfoRequest
 // GetPluginInfoResponse from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type GetPluginInfoResponse = plugin.GetPluginInfoResponse
 
-//* Represents an empty request
+// * Represents an empty request
 type GenerateKeyPairRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -49,17 +50,16 @@ func (m *GenerateKeyPairRequest) Reset()         { *m = GenerateKeyPairRequest{}
 func (m *GenerateKeyPairRequest) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairRequest) ProtoMessage()    {}
 func (*GenerateKeyPairRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{0}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{0}
 }
-
 func (m *GenerateKeyPairRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairRequest.Unmarshal(m, b)
 }
 func (m *GenerateKeyPairRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GenerateKeyPairRequest.Marshal(b, m, deterministic)
 }
-func (m *GenerateKeyPairRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GenerateKeyPairRequest.Merge(m, src)
+func (dst *GenerateKeyPairRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GenerateKeyPairRequest.Merge(dst, src)
 }
 func (m *GenerateKeyPairRequest) XXX_Size() int {
 	return xxx_messageInfo_GenerateKeyPairRequest.Size(m)
@@ -70,11 +70,11 @@ func (m *GenerateKeyPairRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GenerateKeyPairRequest proto.InternalMessageInfo
 
-//* Represents a public and private key pair
+// * Represents a public and private key pair
 type GenerateKeyPairResponse struct {
-	//* Public key
+	// * Public key
 	PublicKey []byte `protobuf:"bytes,1,opt,name=publicKey,proto3" json:"publicKey,omitempty"`
-	//* Private key
+	// * Private key
 	PrivateKey           []byte   `protobuf:"bytes,2,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -85,17 +85,16 @@ func (m *GenerateKeyPairResponse) Reset()         { *m = GenerateKeyPairResponse
 func (m *GenerateKeyPairResponse) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairResponse) ProtoMessage()    {}
 func (*GenerateKeyPairResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{1}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{1}
 }
-
 func (m *GenerateKeyPairResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairResponse.Unmarshal(m, b)
 }
 func (m *GenerateKeyPairResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GenerateKeyPairResponse.Marshal(b, m, deterministic)
 }
-func (m *GenerateKeyPairResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GenerateKeyPairResponse.Merge(m, src)
+func (dst *GenerateKeyPairResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GenerateKeyPairResponse.Merge(dst, src)
 }
 func (m *GenerateKeyPairResponse) XXX_Size() int {
 	return xxx_messageInfo_GenerateKeyPairResponse.Size(m)
@@ -120,9 +119,9 @@ func (m *GenerateKeyPairResponse) GetPrivateKey() []byte {
 	return nil
 }
 
-//* Represents a private key
+// * Represents a private key
 type StorePrivateKeyRequest struct {
-	//* Private key
+	// * Private key
 	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -133,17 +132,16 @@ func (m *StorePrivateKeyRequest) Reset()         { *m = StorePrivateKeyRequest{}
 func (m *StorePrivateKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*StorePrivateKeyRequest) ProtoMessage()    {}
 func (*StorePrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{2}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{2}
 }
-
 func (m *StorePrivateKeyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorePrivateKeyRequest.Unmarshal(m, b)
 }
 func (m *StorePrivateKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StorePrivateKeyRequest.Marshal(b, m, deterministic)
 }
-func (m *StorePrivateKeyRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StorePrivateKeyRequest.Merge(m, src)
+func (dst *StorePrivateKeyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyRequest.Merge(dst, src)
 }
 func (m *StorePrivateKeyRequest) XXX_Size() int {
 	return xxx_messageInfo_StorePrivateKeyRequest.Size(m)
@@ -161,7 +159,7 @@ func (m *StorePrivateKeyRequest) GetPrivateKey() []byte {
 	return nil
 }
 
-//* Represents an empty response
+// * Represents an empty response
 type StorePrivateKeyResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -172,17 +170,16 @@ func (m *StorePrivateKeyResponse) Reset()         { *m = StorePrivateKeyResponse
 func (m *StorePrivateKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*StorePrivateKeyResponse) ProtoMessage()    {}
 func (*StorePrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{3}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{3}
 }
-
 func (m *StorePrivateKeyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorePrivateKeyResponse.Unmarshal(m, b)
 }
 func (m *StorePrivateKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StorePrivateKeyResponse.Marshal(b, m, deterministic)
 }
-func (m *StorePrivateKeyResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StorePrivateKeyResponse.Merge(m, src)
+func (dst *StorePrivateKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyResponse.Merge(dst, src)
 }
 func (m *StorePrivateKeyResponse) XXX_Size() int {
 	return xxx_messageInfo_StorePrivateKeyResponse.Size(m)
@@ -193,7 +190,7 @@ func (m *StorePrivateKeyResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_StorePrivateKeyResponse proto.InternalMessageInfo
 
-//* Represents an empty request
+// * Represents an empty request
 type FetchPrivateKeyRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -204,17 +201,16 @@ func (m *FetchPrivateKeyRequest) Reset()         { *m = FetchPrivateKeyRequest{}
 func (m *FetchPrivateKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyRequest) ProtoMessage()    {}
 func (*FetchPrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{4}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{4}
 }
-
 func (m *FetchPrivateKeyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Unmarshal(m, b)
 }
 func (m *FetchPrivateKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Marshal(b, m, deterministic)
 }
-func (m *FetchPrivateKeyRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchPrivateKeyRequest.Merge(m, src)
+func (dst *FetchPrivateKeyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchPrivateKeyRequest.Merge(dst, src)
 }
 func (m *FetchPrivateKeyRequest) XXX_Size() int {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Size(m)
@@ -225,9 +221,9 @@ func (m *FetchPrivateKeyRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FetchPrivateKeyRequest proto.InternalMessageInfo
 
-//* Represents a private key
+// * Represents a private key
 type FetchPrivateKeyResponse struct {
-	//* Private key
+	// * Private key
 	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -238,17 +234,16 @@ func (m *FetchPrivateKeyResponse) Reset()         { *m = FetchPrivateKeyResponse
 func (m *FetchPrivateKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyResponse) ProtoMessage()    {}
 func (*FetchPrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_217d89b504f0b25a, []int{5}
+	return fileDescriptor_keymanager_e9d4b64145aa1c10, []int{5}
 }
-
 func (m *FetchPrivateKeyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Unmarshal(m, b)
 }
 func (m *FetchPrivateKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Marshal(b, m, deterministic)
 }
-func (m *FetchPrivateKeyResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchPrivateKeyResponse.Merge(m, src)
+func (dst *FetchPrivateKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchPrivateKeyResponse.Merge(dst, src)
 }
 func (m *FetchPrivateKeyResponse) XXX_Size() int {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Size(m)
@@ -275,34 +270,6 @@ func init() {
 	proto.RegisterType((*FetchPrivateKeyResponse)(nil), "spire.agent.keymanager.FetchPrivateKeyResponse")
 }
 
-func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_217d89b504f0b25a) }
-
-var fileDescriptor_217d89b504f0b25a = []byte{
-	// 343 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x4b, 0xc3, 0x30,
-	0x14, 0xc6, 0x9d, 0x88, 0xb0, 0xc7, 0x64, 0x92, 0xc3, 0x36, 0x87, 0x88, 0x14, 0x14, 0xf5, 0x90,
-	0x82, 0x5e, 0xe6, 0x55, 0xc1, 0x21, 0x43, 0x28, 0xf3, 0x20, 0xec, 0xd6, 0x95, 0xd7, 0x2e, 0xb8,
-	0x26, 0x31, 0x4d, 0x85, 0xfe, 0x4f, 0xfe, 0x91, 0xb2, 0x26, 0xdb, 0xb4, 0x6d, 0xd8, 0x4e, 0x85,
-	0xf7, 0xbd, 0xef, 0xfd, 0xf2, 0xbe, 0xa4, 0x70, 0xfa, 0x89, 0x45, 0x1a, 0xf2, 0x30, 0x41, 0x45,
-	0xa5, 0x12, 0x5a, 0x90, 0x5e, 0x26, 0x99, 0x42, 0x1a, 0x26, 0xc8, 0x35, 0xdd, 0xaa, 0xc3, 0x51,
-	0xc2, 0xf4, 0x22, 0x9f, 0xd3, 0x48, 0xa4, 0x7e, 0x26, 0x59, 0x1c, 0xa3, 0x5f, 0x76, 0xfa, 0xa5,
-	0xcd, 0x8f, 0x44, 0x9a, 0x0a, 0xee, 0xcb, 0x65, 0x9e, 0xb0, 0xf5, 0xc7, 0x4c, 0xf4, 0x06, 0xd0,
-	0x1b, 0x23, 0x47, 0x15, 0x6a, 0x9c, 0x60, 0x11, 0x84, 0x4c, 0x4d, 0xf1, 0x2b, 0xc7, 0x4c, 0x7b,
-	0x1f, 0xd0, 0xaf, 0x29, 0x99, 0x14, 0x3c, 0x43, 0x72, 0x0e, 0x6d, 0x99, 0xcf, 0x97, 0x2c, 0x9a,
-	0x60, 0x31, 0x68, 0x5d, 0xb6, 0x6e, 0x3a, 0xd3, 0x6d, 0x81, 0x5c, 0x00, 0x48, 0xc5, 0xbe, 0x8d,
-	0x6f, 0x70, 0x58, 0xca, 0x7f, 0x2a, 0xde, 0x08, 0x7a, 0xef, 0x5a, 0x28, 0x0c, 0x36, 0x25, 0x8b,
-	0xac, 0x38, 0x5b, 0x35, 0xe7, 0x19, 0xf4, 0x6b, 0x4e, 0x73, 0xa4, 0xd5, 0x1e, 0x2f, 0xa8, 0xa3,
-	0x45, 0x6d, 0xa8, 0xf7, 0x08, 0xfd, 0x9a, 0x62, 0xf7, 0xd8, 0xc1, 0xbb, 0xff, 0x39, 0x02, 0x98,
-	0x60, 0xf1, 0x66, 0x52, 0x26, 0x0a, 0xba, 0x95, 0x44, 0x08, 0xa5, 0xcd, 0x37, 0x42, 0x9b, 0x43,
-	0x1d, 0xfa, 0x7b, 0xf7, 0xdb, 0x23, 0x2a, 0xe8, 0x56, 0x56, 0x76, 0x33, 0x9b, 0x53, 0x75, 0x33,
-	0x1d, 0x59, 0xae, 0x98, 0x95, 0xc4, 0xdc, 0xcc, 0xe6, 0xd0, 0xdd, 0x4c, 0xd7, 0x55, 0xcc, 0xa0,
-	0xfd, 0x2c, 0x78, 0xcc, 0x92, 0x5c, 0x21, 0xb9, 0xb2, 0x6e, 0xf3, 0x6e, 0xa9, 0x7d, 0xb0, 0x1b,
-	0x7d, 0x0d, 0xb9, 0xde, 0xd5, 0x66, 0x67, 0xc7, 0x70, 0x32, 0x46, 0x1d, 0x94, 0xf2, 0x2b, 0x8f,
-	0x05, 0xb9, 0x6d, 0x34, 0xfe, 0xeb, 0x59, 0x33, 0xee, 0xf6, 0x69, 0x35, 0x9c, 0xa7, 0xce, 0x0c,
-	0xb6, 0x9b, 0x06, 0x07, 0xf3, 0xe3, 0xf2, 0x17, 0x7b, 0xf8, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x5f,
-	0xc0, 0xc2, 0xe6, 0xc8, 0x03, 0x00, 0x00,
-}
-
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
@@ -315,15 +282,15 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type KeyManagerClient interface {
-	//* Creates a new key pair.
+	// * Creates a new key pair.
 	GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest, opts ...grpc.CallOption) (*GenerateKeyPairResponse, error)
-	//* Persists a private key to the key manager's storage system.
+	// * Persists a private key to the key manager's storage system.
 	StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest, opts ...grpc.CallOption) (*StorePrivateKeyResponse, error)
-	//* Returns the most recently stored private key. For use after node restarts.
+	// * Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(ctx context.Context, in *FetchPrivateKeyRequest, opts ...grpc.CallOption) (*FetchPrivateKeyResponse, error)
-	//* Applies the plugin configuration and returns configuration errors.
+	// * Applies the plugin configuration and returns configuration errors.
 	Configure(ctx context.Context, in *plugin.ConfigureRequest, opts ...grpc.CallOption) (*plugin.ConfigureResponse, error)
-	//* Returns the version and related metadata of the plugin.
+	// * Returns the version and related metadata of the plugin.
 	GetPluginInfo(ctx context.Context, in *plugin.GetPluginInfoRequest, opts ...grpc.CallOption) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -382,15 +349,15 @@ func (c *keyManagerClient) GetPluginInfo(ctx context.Context, in *plugin.GetPlug
 
 // KeyManagerServer is the server API for KeyManager service.
 type KeyManagerServer interface {
-	//* Creates a new key pair.
+	// * Creates a new key pair.
 	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
-	//* Persists a private key to the key manager's storage system.
+	// * Persists a private key to the key manager's storage system.
 	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
-	//* Returns the most recently stored private key. For use after node restarts.
+	// * Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
-	//* Applies the plugin configuration and returns configuration errors.
+	// * Applies the plugin configuration and returns configuration errors.
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
-	//* Returns the version and related metadata of the plugin.
+	// * Returns the version and related metadata of the plugin.
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -515,4 +482,32 @@ var _KeyManager_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "keymanager.proto",
+}
+
+func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_keymanager_e9d4b64145aa1c10) }
+
+var fileDescriptor_keymanager_e9d4b64145aa1c10 = []byte{
+	// 343 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x4b, 0xc3, 0x30,
+	0x14, 0xc6, 0x9d, 0x88, 0xb0, 0xc7, 0x64, 0x92, 0xc3, 0x36, 0x87, 0x88, 0x14, 0x14, 0xf5, 0x90,
+	0x82, 0x5e, 0xe6, 0x55, 0xc1, 0x21, 0x43, 0x28, 0xf3, 0x20, 0xec, 0xd6, 0x95, 0xd7, 0x2e, 0xb8,
+	0x26, 0x31, 0x4d, 0x85, 0xfe, 0x4f, 0xfe, 0x91, 0xb2, 0x26, 0xdb, 0xb4, 0x6d, 0xd8, 0x4e, 0x85,
+	0xf7, 0xbd, 0xef, 0xfd, 0xf2, 0xbe, 0xa4, 0x70, 0xfa, 0x89, 0x45, 0x1a, 0xf2, 0x30, 0x41, 0x45,
+	0xa5, 0x12, 0x5a, 0x90, 0x5e, 0x26, 0x99, 0x42, 0x1a, 0x26, 0xc8, 0x35, 0xdd, 0xaa, 0xc3, 0x51,
+	0xc2, 0xf4, 0x22, 0x9f, 0xd3, 0x48, 0xa4, 0x7e, 0x26, 0x59, 0x1c, 0xa3, 0x5f, 0x76, 0xfa, 0xa5,
+	0xcd, 0x8f, 0x44, 0x9a, 0x0a, 0xee, 0xcb, 0x65, 0x9e, 0xb0, 0xf5, 0xc7, 0x4c, 0xf4, 0x06, 0xd0,
+	0x1b, 0x23, 0x47, 0x15, 0x6a, 0x9c, 0x60, 0x11, 0x84, 0x4c, 0x4d, 0xf1, 0x2b, 0xc7, 0x4c, 0x7b,
+	0x1f, 0xd0, 0xaf, 0x29, 0x99, 0x14, 0x3c, 0x43, 0x72, 0x0e, 0x6d, 0x99, 0xcf, 0x97, 0x2c, 0x9a,
+	0x60, 0x31, 0x68, 0x5d, 0xb6, 0x6e, 0x3a, 0xd3, 0x6d, 0x81, 0x5c, 0x00, 0x48, 0xc5, 0xbe, 0x8d,
+	0x6f, 0x70, 0x58, 0xca, 0x7f, 0x2a, 0xde, 0x08, 0x7a, 0xef, 0x5a, 0x28, 0x0c, 0x36, 0x25, 0x8b,
+	0xac, 0x38, 0x5b, 0x35, 0xe7, 0x19, 0xf4, 0x6b, 0x4e, 0x73, 0xa4, 0xd5, 0x1e, 0x2f, 0xa8, 0xa3,
+	0x45, 0x6d, 0xa8, 0xf7, 0x08, 0xfd, 0x9a, 0x62, 0xf7, 0xd8, 0xc1, 0xbb, 0xff, 0x39, 0x02, 0x98,
+	0x60, 0xf1, 0x66, 0x52, 0x26, 0x0a, 0xba, 0x95, 0x44, 0x08, 0xa5, 0xcd, 0x37, 0x42, 0x9b, 0x43,
+	0x1d, 0xfa, 0x7b, 0xf7, 0xdb, 0x23, 0x2a, 0xe8, 0x56, 0x56, 0x76, 0x33, 0x9b, 0x53, 0x75, 0x33,
+	0x1d, 0x59, 0xae, 0x98, 0x95, 0xc4, 0xdc, 0xcc, 0xe6, 0xd0, 0xdd, 0x4c, 0xd7, 0x55, 0xcc, 0xa0,
+	0xfd, 0x2c, 0x78, 0xcc, 0x92, 0x5c, 0x21, 0xb9, 0xb2, 0x6e, 0xf3, 0x6e, 0xa9, 0x7d, 0xb0, 0x1b,
+	0x7d, 0x0d, 0xb9, 0xde, 0xd5, 0x66, 0x67, 0xc7, 0x70, 0x32, 0x46, 0x1d, 0x94, 0xf2, 0x2b, 0x8f,
+	0x05, 0xb9, 0x6d, 0x34, 0xfe, 0xeb, 0x59, 0x33, 0xee, 0xf6, 0x69, 0x35, 0x9c, 0xa7, 0xce, 0x0c,
+	0xb6, 0x9b, 0x06, 0x07, 0xf3, 0xe3, 0xf2, 0x17, 0x7b, 0xf8, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x5f,
+	0xc0, 0xc2, 0xe6, 0xc8, 0x03, 0x00, 0x00,
 }

--- a/proto/agent/keymanager/keymanager.pb.go
+++ b/proto/agent/keymanager/keymanager.pb.go
@@ -50,7 +50,7 @@ func (m *GenerateKeyPairRequest) Reset()         { *m = GenerateKeyPairRequest{}
 func (m *GenerateKeyPairRequest) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairRequest) ProtoMessage()    {}
 func (*GenerateKeyPairRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_f3405305e933bdcd, []int{0}
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{0}
 }
 func (m *GenerateKeyPairRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairRequest.Unmarshal(m, b)
@@ -85,7 +85,7 @@ func (m *GenerateKeyPairResponse) Reset()         { *m = GenerateKeyPairResponse
 func (m *GenerateKeyPairResponse) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairResponse) ProtoMessage()    {}
 func (*GenerateKeyPairResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_f3405305e933bdcd, []int{1}
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{1}
 }
 func (m *GenerateKeyPairResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairResponse.Unmarshal(m, b)
@@ -119,6 +119,77 @@ func (m *GenerateKeyPairResponse) GetPrivateKey() []byte {
 	return nil
 }
 
+// * Represents a private key
+type StorePrivateKeyRequest struct {
+	// * Private key
+	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *StorePrivateKeyRequest) Reset()         { *m = StorePrivateKeyRequest{} }
+func (m *StorePrivateKeyRequest) String() string { return proto.CompactTextString(m) }
+func (*StorePrivateKeyRequest) ProtoMessage()    {}
+func (*StorePrivateKeyRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{2}
+}
+func (m *StorePrivateKeyRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorePrivateKeyRequest.Unmarshal(m, b)
+}
+func (m *StorePrivateKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorePrivateKeyRequest.Marshal(b, m, deterministic)
+}
+func (dst *StorePrivateKeyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyRequest.Merge(dst, src)
+}
+func (m *StorePrivateKeyRequest) XXX_Size() int {
+	return xxx_messageInfo_StorePrivateKeyRequest.Size(m)
+}
+func (m *StorePrivateKeyRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorePrivateKeyRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StorePrivateKeyRequest proto.InternalMessageInfo
+
+func (m *StorePrivateKeyRequest) GetPrivateKey() []byte {
+	if m != nil {
+		return m.PrivateKey
+	}
+	return nil
+}
+
+// * Represents an empty response
+type StorePrivateKeyResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *StorePrivateKeyResponse) Reset()         { *m = StorePrivateKeyResponse{} }
+func (m *StorePrivateKeyResponse) String() string { return proto.CompactTextString(m) }
+func (*StorePrivateKeyResponse) ProtoMessage()    {}
+func (*StorePrivateKeyResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{3}
+}
+func (m *StorePrivateKeyResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorePrivateKeyResponse.Unmarshal(m, b)
+}
+func (m *StorePrivateKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorePrivateKeyResponse.Marshal(b, m, deterministic)
+}
+func (dst *StorePrivateKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyResponse.Merge(dst, src)
+}
+func (m *StorePrivateKeyResponse) XXX_Size() int {
+	return xxx_messageInfo_StorePrivateKeyResponse.Size(m)
+}
+func (m *StorePrivateKeyResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorePrivateKeyResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_StorePrivateKeyResponse proto.InternalMessageInfo
+
 // * Represents an empty request
 type FetchPrivateKeyRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -130,7 +201,7 @@ func (m *FetchPrivateKeyRequest) Reset()         { *m = FetchPrivateKeyRequest{}
 func (m *FetchPrivateKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyRequest) ProtoMessage()    {}
 func (*FetchPrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_f3405305e933bdcd, []int{2}
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{4}
 }
 func (m *FetchPrivateKeyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Unmarshal(m, b)
@@ -152,7 +223,7 @@ var xxx_messageInfo_FetchPrivateKeyRequest proto.InternalMessageInfo
 
 // * Represents a private key
 type FetchPrivateKeyResponse struct {
-	// * Priavte key
+	// * Private key
 	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -163,7 +234,7 @@ func (m *FetchPrivateKeyResponse) Reset()         { *m = FetchPrivateKeyResponse
 func (m *FetchPrivateKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyResponse) ProtoMessage()    {}
 func (*FetchPrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_f3405305e933bdcd, []int{3}
+	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{5}
 }
 func (m *FetchPrivateKeyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Unmarshal(m, b)
@@ -193,6 +264,8 @@ func (m *FetchPrivateKeyResponse) GetPrivateKey() []byte {
 func init() {
 	proto.RegisterType((*GenerateKeyPairRequest)(nil), "spire.agent.keymanager.GenerateKeyPairRequest")
 	proto.RegisterType((*GenerateKeyPairResponse)(nil), "spire.agent.keymanager.GenerateKeyPairResponse")
+	proto.RegisterType((*StorePrivateKeyRequest)(nil), "spire.agent.keymanager.StorePrivateKeyRequest")
+	proto.RegisterType((*StorePrivateKeyResponse)(nil), "spire.agent.keymanager.StorePrivateKeyResponse")
 	proto.RegisterType((*FetchPrivateKeyRequest)(nil), "spire.agent.keymanager.FetchPrivateKeyRequest")
 	proto.RegisterType((*FetchPrivateKeyResponse)(nil), "spire.agent.keymanager.FetchPrivateKeyResponse")
 }
@@ -209,9 +282,11 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type KeyManagerClient interface {
-	// * Creates a key pair that is bound to hardware.
+	// * Creates a new key pair.
 	GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest, opts ...grpc.CallOption) (*GenerateKeyPairResponse, error)
-	// * Returns previously generated private key. For use after node restarts.
+	// * Persists a private key to the key manager's storage system.
+	StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest, opts ...grpc.CallOption) (*StorePrivateKeyResponse, error)
+	// * Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(ctx context.Context, in *FetchPrivateKeyRequest, opts ...grpc.CallOption) (*FetchPrivateKeyResponse, error)
 	// * Applies the plugin configuration and returns configuration errors.
 	Configure(ctx context.Context, in *plugin.ConfigureRequest, opts ...grpc.CallOption) (*plugin.ConfigureResponse, error)
@@ -230,6 +305,15 @@ func NewKeyManagerClient(cc *grpc.ClientConn) KeyManagerClient {
 func (c *keyManagerClient) GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest, opts ...grpc.CallOption) (*GenerateKeyPairResponse, error) {
 	out := new(GenerateKeyPairResponse)
 	err := c.cc.Invoke(ctx, "/spire.agent.keymanager.KeyManager/GenerateKeyPair", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *keyManagerClient) StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest, opts ...grpc.CallOption) (*StorePrivateKeyResponse, error) {
+	out := new(StorePrivateKeyResponse)
+	err := c.cc.Invoke(ctx, "/spire.agent.keymanager.KeyManager/StorePrivateKey", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -265,9 +349,11 @@ func (c *keyManagerClient) GetPluginInfo(ctx context.Context, in *plugin.GetPlug
 
 // KeyManagerServer is the server API for KeyManager service.
 type KeyManagerServer interface {
-	// * Creates a key pair that is bound to hardware.
+	// * Creates a new key pair.
 	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
-	// * Returns previously generated private key. For use after node restarts.
+	// * Persists a private key to the key manager's storage system.
+	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
+	// * Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
 	// * Applies the plugin configuration and returns configuration errors.
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
@@ -293,6 +379,24 @@ func _KeyManager_GenerateKeyPair_Handler(srv interface{}, ctx context.Context, d
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(KeyManagerServer).GenerateKeyPair(ctx, req.(*GenerateKeyPairRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KeyManager_StorePrivateKey_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StorePrivateKeyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KeyManagerServer).StorePrivateKey(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/spire.agent.keymanager.KeyManager/StorePrivateKey",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KeyManagerServer).StorePrivateKey(ctx, req.(*StorePrivateKeyRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -360,6 +464,10 @@ var _KeyManager_serviceDesc = grpc.ServiceDesc{
 			Handler:    _KeyManager_GenerateKeyPair_Handler,
 		},
 		{
+			MethodName: "StorePrivateKey",
+			Handler:    _KeyManager_StorePrivateKey_Handler,
+		},
+		{
 			MethodName: "FetchPrivateKey",
 			Handler:    _KeyManager_FetchPrivateKey_Handler,
 		},
@@ -376,28 +484,30 @@ var _KeyManager_serviceDesc = grpc.ServiceDesc{
 	Metadata: "keymanager.proto",
 }
 
-func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_keymanager_f3405305e933bdcd) }
+func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_keymanager_af4d8576fb78f72c) }
 
-var fileDescriptor_keymanager_f3405305e933bdcd = []byte{
-	// 311 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x92, 0x41, 0x4b, 0xc3, 0x40,
-	0x10, 0x85, 0x8d, 0x82, 0xd0, 0xa1, 0x52, 0xd9, 0x43, 0x1b, 0x8a, 0x88, 0x14, 0x14, 0xf5, 0xb0,
-	0x0b, 0x7a, 0xd1, 0xab, 0x82, 0x45, 0x82, 0x10, 0x7a, 0x11, 0x7a, 0x4b, 0xc2, 0x24, 0x5d, 0x6c,
-	0x76, 0xd7, 0xcd, 0x46, 0xc8, 0x3f, 0xf3, 0xe7, 0x89, 0xc9, 0xa6, 0xb1, 0x69, 0x82, 0x3d, 0x05,
-	0xe6, 0xbd, 0x99, 0x6f, 0xf6, 0x4d, 0xe0, 0xf4, 0x03, 0x8b, 0x34, 0x10, 0x41, 0x82, 0x9a, 0x2a,
-	0x2d, 0x8d, 0x24, 0xe3, 0x4c, 0x71, 0x8d, 0x34, 0x48, 0x50, 0x18, 0xda, 0xa8, 0xd3, 0x87, 0x84,
-	0x9b, 0x55, 0x1e, 0xd2, 0x48, 0xa6, 0x2c, 0x53, 0x3c, 0x8e, 0x91, 0x95, 0x4e, 0x56, 0xb6, 0xb1,
-	0x48, 0xa6, 0xa9, 0x14, 0x4c, 0xad, 0xf3, 0x84, 0xd7, 0x9f, 0x6a, 0xe2, 0xcc, 0x85, 0xf1, 0x1c,
-	0x05, 0xea, 0xc0, 0xa0, 0x87, 0x85, 0x1f, 0x70, 0xbd, 0xc0, 0xcf, 0x1c, 0x33, 0x33, 0x7b, 0x87,
-	0xc9, 0x8e, 0x92, 0x29, 0x29, 0x32, 0x24, 0x67, 0x30, 0x50, 0x79, 0xb8, 0xe6, 0x91, 0x87, 0x85,
-	0xeb, 0x5c, 0x38, 0xd7, 0xc3, 0x45, 0x53, 0x20, 0xe7, 0x00, 0x4a, 0xf3, 0xaf, 0xaa, 0xcf, 0x3d,
-	0x2c, 0xe5, 0x3f, 0x95, 0x5f, 0xe4, 0x0b, 0x9a, 0x68, 0xe5, 0x6f, 0x4a, 0x35, 0xf2, 0x11, 0x26,
-	0x3b, 0x8a, 0x45, 0x6e, 0x0f, 0x75, 0xda, 0x43, 0xef, 0xbe, 0x8f, 0x00, 0x3c, 0x2c, 0xde, 0xaa,
-	0x40, 0x88, 0x86, 0x51, 0x6b, 0x79, 0x42, 0x69, 0x77, 0x78, 0xb4, 0xfb, 0xfd, 0x53, 0xb6, 0xb7,
-	0xdf, 0xae, 0xa8, 0x61, 0xd4, 0xda, 0xbe, 0x9f, 0xd9, 0x1d, 0x40, 0x3f, 0xb3, 0x2f, 0x96, 0x25,
-	0x0c, 0x9e, 0xa5, 0x88, 0x79, 0x92, 0x6b, 0x24, 0x97, 0xb6, 0xbb, 0x3a, 0x37, 0xb5, 0x77, 0xde,
-	0xe8, 0x35, 0xe4, 0xea, 0x3f, 0x9b, 0x9d, 0x1d, 0xc3, 0xc9, 0x1c, 0x8d, 0x5f, 0xca, 0xaf, 0x22,
-	0x96, 0xe4, 0xa6, 0xb3, 0x71, 0xcb, 0x53, 0x33, 0x6e, 0xf7, 0xb1, 0x56, 0x9c, 0xa7, 0xe1, 0x12,
-	0x9a, 0x97, 0xfa, 0x07, 0xe1, 0x71, 0xf9, 0x67, 0xde, 0xff, 0x04, 0x00, 0x00, 0xff, 0xff, 0x7e,
-	0x36, 0x86, 0xac, 0xff, 0x02, 0x00, 0x00,
+var fileDescriptor_keymanager_af4d8576fb78f72c = []byte{
+	// 343 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x4b, 0xc3, 0x30,
+	0x14, 0xc6, 0x9d, 0x88, 0xb0, 0xc7, 0x64, 0x92, 0xc3, 0x36, 0x87, 0x88, 0x14, 0x14, 0xf5, 0x90,
+	0x82, 0x5e, 0xe6, 0x55, 0xc1, 0x21, 0x43, 0x28, 0xf3, 0x20, 0xec, 0xd6, 0x95, 0xd7, 0x2e, 0xb8,
+	0x26, 0x31, 0x4d, 0x85, 0xfe, 0x4f, 0xfe, 0x91, 0xb2, 0x26, 0xdb, 0xb4, 0x6d, 0xd8, 0x4e, 0x85,
+	0xf7, 0xbd, 0xef, 0xfd, 0xf2, 0xbe, 0xa4, 0x70, 0xfa, 0x89, 0x45, 0x1a, 0xf2, 0x30, 0x41, 0x45,
+	0xa5, 0x12, 0x5a, 0x90, 0x5e, 0x26, 0x99, 0x42, 0x1a, 0x26, 0xc8, 0x35, 0xdd, 0xaa, 0xc3, 0x51,
+	0xc2, 0xf4, 0x22, 0x9f, 0xd3, 0x48, 0xa4, 0x7e, 0x26, 0x59, 0x1c, 0xa3, 0x5f, 0x76, 0xfa, 0xa5,
+	0xcd, 0x8f, 0x44, 0x9a, 0x0a, 0xee, 0xcb, 0x65, 0x9e, 0xb0, 0xf5, 0xc7, 0x4c, 0xf4, 0x06, 0xd0,
+	0x1b, 0x23, 0x47, 0x15, 0x6a, 0x9c, 0x60, 0x11, 0x84, 0x4c, 0x4d, 0xf1, 0x2b, 0xc7, 0x4c, 0x7b,
+	0x1f, 0xd0, 0xaf, 0x29, 0x99, 0x14, 0x3c, 0x43, 0x72, 0x0e, 0x6d, 0x99, 0xcf, 0x97, 0x2c, 0x9a,
+	0x60, 0x31, 0x68, 0x5d, 0xb6, 0x6e, 0x3a, 0xd3, 0x6d, 0x81, 0x5c, 0x00, 0x48, 0xc5, 0xbe, 0x8d,
+	0x6f, 0x70, 0x58, 0xca, 0x7f, 0x2a, 0xde, 0x08, 0x7a, 0xef, 0x5a, 0x28, 0x0c, 0x36, 0x25, 0x8b,
+	0xac, 0x38, 0x5b, 0x35, 0xe7, 0x19, 0xf4, 0x6b, 0x4e, 0x73, 0xa4, 0xd5, 0x1e, 0x2f, 0xa8, 0xa3,
+	0x45, 0x6d, 0xa8, 0xf7, 0x08, 0xfd, 0x9a, 0x62, 0xf7, 0xd8, 0xc1, 0xbb, 0xff, 0x39, 0x02, 0x98,
+	0x60, 0xf1, 0x66, 0x52, 0x26, 0x0a, 0xba, 0x95, 0x44, 0x08, 0xa5, 0xcd, 0x37, 0x42, 0x9b, 0x43,
+	0x1d, 0xfa, 0x7b, 0xf7, 0xdb, 0x23, 0x2a, 0xe8, 0x56, 0x56, 0x76, 0x33, 0x9b, 0x53, 0x75, 0x33,
+	0x1d, 0x59, 0xae, 0x98, 0x95, 0xc4, 0xdc, 0xcc, 0xe6, 0xd0, 0xdd, 0x4c, 0xd7, 0x55, 0xcc, 0xa0,
+	0xfd, 0x2c, 0x78, 0xcc, 0x92, 0x5c, 0x21, 0xb9, 0xb2, 0x6e, 0xf3, 0x6e, 0xa9, 0x7d, 0xb0, 0x1b,
+	0x7d, 0x0d, 0xb9, 0xde, 0xd5, 0x66, 0x67, 0xc7, 0x70, 0x32, 0x46, 0x1d, 0x94, 0xf2, 0x2b, 0x8f,
+	0x05, 0xb9, 0x6d, 0x34, 0xfe, 0xeb, 0x59, 0x33, 0xee, 0xf6, 0x69, 0x35, 0x9c, 0xa7, 0xce, 0x0c,
+	0xb6, 0x9b, 0x06, 0x07, 0xf3, 0xe3, 0xf2, 0x17, 0x7b, 0xf8, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x5f,
+	0xc0, 0xc2, 0xe6, 0xc8, 0x03, 0x00, 0x00,
 }

--- a/proto/agent/keymanager/keymanager.pb.go
+++ b/proto/agent/keymanager/keymanager.pb.go
@@ -3,14 +3,13 @@
 
 package keymanager
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import plugin "github.com/spiffe/spire/proto/common/plugin"
-
 import (
-	context "golang.org/x/net/context"
+	context "context"
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
+	plugin "github.com/spiffe/spire/proto/common/plugin"
 	grpc "google.golang.org/grpc"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -22,12 +21,12 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 // ConfigureRequest from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type ConfigureRequest = plugin.ConfigureRequest
 
-// GlobalConfig from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
+// ConfigureRequest_GlobalConfig from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type ConfigureRequest_GlobalConfig = plugin.ConfigureRequest_GlobalConfig
 
 // ConfigureResponse from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
@@ -39,7 +38,7 @@ type GetPluginInfoRequest = plugin.GetPluginInfoRequest
 // GetPluginInfoResponse from public import github.com/spiffe/spire/proto/common/plugin/plugin.proto
 type GetPluginInfoResponse = plugin.GetPluginInfoResponse
 
-// * Represents an empty request
+//* Represents an empty request
 type GenerateKeyPairRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -50,16 +49,17 @@ func (m *GenerateKeyPairRequest) Reset()         { *m = GenerateKeyPairRequest{}
 func (m *GenerateKeyPairRequest) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairRequest) ProtoMessage()    {}
 func (*GenerateKeyPairRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{0}
+	return fileDescriptor_217d89b504f0b25a, []int{0}
 }
+
 func (m *GenerateKeyPairRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairRequest.Unmarshal(m, b)
 }
 func (m *GenerateKeyPairRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GenerateKeyPairRequest.Marshal(b, m, deterministic)
 }
-func (dst *GenerateKeyPairRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GenerateKeyPairRequest.Merge(dst, src)
+func (m *GenerateKeyPairRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GenerateKeyPairRequest.Merge(m, src)
 }
 func (m *GenerateKeyPairRequest) XXX_Size() int {
 	return xxx_messageInfo_GenerateKeyPairRequest.Size(m)
@@ -70,11 +70,11 @@ func (m *GenerateKeyPairRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_GenerateKeyPairRequest proto.InternalMessageInfo
 
-// * Represents a public and private key pair
+//* Represents a public and private key pair
 type GenerateKeyPairResponse struct {
-	// * Public key
+	//* Public key
 	PublicKey []byte `protobuf:"bytes,1,opt,name=publicKey,proto3" json:"publicKey,omitempty"`
-	// * Private key
+	//* Private key
 	PrivateKey           []byte   `protobuf:"bytes,2,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -85,16 +85,17 @@ func (m *GenerateKeyPairResponse) Reset()         { *m = GenerateKeyPairResponse
 func (m *GenerateKeyPairResponse) String() string { return proto.CompactTextString(m) }
 func (*GenerateKeyPairResponse) ProtoMessage()    {}
 func (*GenerateKeyPairResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{1}
+	return fileDescriptor_217d89b504f0b25a, []int{1}
 }
+
 func (m *GenerateKeyPairResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GenerateKeyPairResponse.Unmarshal(m, b)
 }
 func (m *GenerateKeyPairResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_GenerateKeyPairResponse.Marshal(b, m, deterministic)
 }
-func (dst *GenerateKeyPairResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_GenerateKeyPairResponse.Merge(dst, src)
+func (m *GenerateKeyPairResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GenerateKeyPairResponse.Merge(m, src)
 }
 func (m *GenerateKeyPairResponse) XXX_Size() int {
 	return xxx_messageInfo_GenerateKeyPairResponse.Size(m)
@@ -119,9 +120,9 @@ func (m *GenerateKeyPairResponse) GetPrivateKey() []byte {
 	return nil
 }
 
-// * Represents a private key
+//* Represents a private key
 type StorePrivateKeyRequest struct {
-	// * Private key
+	//* Private key
 	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -132,16 +133,17 @@ func (m *StorePrivateKeyRequest) Reset()         { *m = StorePrivateKeyRequest{}
 func (m *StorePrivateKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*StorePrivateKeyRequest) ProtoMessage()    {}
 func (*StorePrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{2}
+	return fileDescriptor_217d89b504f0b25a, []int{2}
 }
+
 func (m *StorePrivateKeyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorePrivateKeyRequest.Unmarshal(m, b)
 }
 func (m *StorePrivateKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StorePrivateKeyRequest.Marshal(b, m, deterministic)
 }
-func (dst *StorePrivateKeyRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StorePrivateKeyRequest.Merge(dst, src)
+func (m *StorePrivateKeyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyRequest.Merge(m, src)
 }
 func (m *StorePrivateKeyRequest) XXX_Size() int {
 	return xxx_messageInfo_StorePrivateKeyRequest.Size(m)
@@ -159,7 +161,7 @@ func (m *StorePrivateKeyRequest) GetPrivateKey() []byte {
 	return nil
 }
 
-// * Represents an empty response
+//* Represents an empty response
 type StorePrivateKeyResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -170,16 +172,17 @@ func (m *StorePrivateKeyResponse) Reset()         { *m = StorePrivateKeyResponse
 func (m *StorePrivateKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*StorePrivateKeyResponse) ProtoMessage()    {}
 func (*StorePrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{3}
+	return fileDescriptor_217d89b504f0b25a, []int{3}
 }
+
 func (m *StorePrivateKeyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorePrivateKeyResponse.Unmarshal(m, b)
 }
 func (m *StorePrivateKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_StorePrivateKeyResponse.Marshal(b, m, deterministic)
 }
-func (dst *StorePrivateKeyResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StorePrivateKeyResponse.Merge(dst, src)
+func (m *StorePrivateKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorePrivateKeyResponse.Merge(m, src)
 }
 func (m *StorePrivateKeyResponse) XXX_Size() int {
 	return xxx_messageInfo_StorePrivateKeyResponse.Size(m)
@@ -190,7 +193,7 @@ func (m *StorePrivateKeyResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_StorePrivateKeyResponse proto.InternalMessageInfo
 
-// * Represents an empty request
+//* Represents an empty request
 type FetchPrivateKeyRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -201,16 +204,17 @@ func (m *FetchPrivateKeyRequest) Reset()         { *m = FetchPrivateKeyRequest{}
 func (m *FetchPrivateKeyRequest) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyRequest) ProtoMessage()    {}
 func (*FetchPrivateKeyRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{4}
+	return fileDescriptor_217d89b504f0b25a, []int{4}
 }
+
 func (m *FetchPrivateKeyRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Unmarshal(m, b)
 }
 func (m *FetchPrivateKeyRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Marshal(b, m, deterministic)
 }
-func (dst *FetchPrivateKeyRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchPrivateKeyRequest.Merge(dst, src)
+func (m *FetchPrivateKeyRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchPrivateKeyRequest.Merge(m, src)
 }
 func (m *FetchPrivateKeyRequest) XXX_Size() int {
 	return xxx_messageInfo_FetchPrivateKeyRequest.Size(m)
@@ -221,9 +225,9 @@ func (m *FetchPrivateKeyRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_FetchPrivateKeyRequest proto.InternalMessageInfo
 
-// * Represents a private key
+//* Represents a private key
 type FetchPrivateKeyResponse struct {
-	// * Private key
+	//* Private key
 	PrivateKey           []byte   `protobuf:"bytes,1,opt,name=privateKey,proto3" json:"privateKey,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -234,16 +238,17 @@ func (m *FetchPrivateKeyResponse) Reset()         { *m = FetchPrivateKeyResponse
 func (m *FetchPrivateKeyResponse) String() string { return proto.CompactTextString(m) }
 func (*FetchPrivateKeyResponse) ProtoMessage()    {}
 func (*FetchPrivateKeyResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_keymanager_af4d8576fb78f72c, []int{5}
+	return fileDescriptor_217d89b504f0b25a, []int{5}
 }
+
 func (m *FetchPrivateKeyResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Unmarshal(m, b)
 }
 func (m *FetchPrivateKeyResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Marshal(b, m, deterministic)
 }
-func (dst *FetchPrivateKeyResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FetchPrivateKeyResponse.Merge(dst, src)
+func (m *FetchPrivateKeyResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FetchPrivateKeyResponse.Merge(m, src)
 }
 func (m *FetchPrivateKeyResponse) XXX_Size() int {
 	return xxx_messageInfo_FetchPrivateKeyResponse.Size(m)
@@ -270,6 +275,34 @@ func init() {
 	proto.RegisterType((*FetchPrivateKeyResponse)(nil), "spire.agent.keymanager.FetchPrivateKeyResponse")
 }
 
+func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_217d89b504f0b25a) }
+
+var fileDescriptor_217d89b504f0b25a = []byte{
+	// 343 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x4b, 0xc3, 0x30,
+	0x14, 0xc6, 0x9d, 0x88, 0xb0, 0xc7, 0x64, 0x92, 0xc3, 0x36, 0x87, 0x88, 0x14, 0x14, 0xf5, 0x90,
+	0x82, 0x5e, 0xe6, 0x55, 0xc1, 0x21, 0x43, 0x28, 0xf3, 0x20, 0xec, 0xd6, 0x95, 0xd7, 0x2e, 0xb8,
+	0x26, 0x31, 0x4d, 0x85, 0xfe, 0x4f, 0xfe, 0x91, 0xb2, 0x26, 0xdb, 0xb4, 0x6d, 0xd8, 0x4e, 0x85,
+	0xf7, 0xbd, 0xef, 0xfd, 0xf2, 0xbe, 0xa4, 0x70, 0xfa, 0x89, 0x45, 0x1a, 0xf2, 0x30, 0x41, 0x45,
+	0xa5, 0x12, 0x5a, 0x90, 0x5e, 0x26, 0x99, 0x42, 0x1a, 0x26, 0xc8, 0x35, 0xdd, 0xaa, 0xc3, 0x51,
+	0xc2, 0xf4, 0x22, 0x9f, 0xd3, 0x48, 0xa4, 0x7e, 0x26, 0x59, 0x1c, 0xa3, 0x5f, 0x76, 0xfa, 0xa5,
+	0xcd, 0x8f, 0x44, 0x9a, 0x0a, 0xee, 0xcb, 0x65, 0x9e, 0xb0, 0xf5, 0xc7, 0x4c, 0xf4, 0x06, 0xd0,
+	0x1b, 0x23, 0x47, 0x15, 0x6a, 0x9c, 0x60, 0x11, 0x84, 0x4c, 0x4d, 0xf1, 0x2b, 0xc7, 0x4c, 0x7b,
+	0x1f, 0xd0, 0xaf, 0x29, 0x99, 0x14, 0x3c, 0x43, 0x72, 0x0e, 0x6d, 0x99, 0xcf, 0x97, 0x2c, 0x9a,
+	0x60, 0x31, 0x68, 0x5d, 0xb6, 0x6e, 0x3a, 0xd3, 0x6d, 0x81, 0x5c, 0x00, 0x48, 0xc5, 0xbe, 0x8d,
+	0x6f, 0x70, 0x58, 0xca, 0x7f, 0x2a, 0xde, 0x08, 0x7a, 0xef, 0x5a, 0x28, 0x0c, 0x36, 0x25, 0x8b,
+	0xac, 0x38, 0x5b, 0x35, 0xe7, 0x19, 0xf4, 0x6b, 0x4e, 0x73, 0xa4, 0xd5, 0x1e, 0x2f, 0xa8, 0xa3,
+	0x45, 0x6d, 0xa8, 0xf7, 0x08, 0xfd, 0x9a, 0x62, 0xf7, 0xd8, 0xc1, 0xbb, 0xff, 0x39, 0x02, 0x98,
+	0x60, 0xf1, 0x66, 0x52, 0x26, 0x0a, 0xba, 0x95, 0x44, 0x08, 0xa5, 0xcd, 0x37, 0x42, 0x9b, 0x43,
+	0x1d, 0xfa, 0x7b, 0xf7, 0xdb, 0x23, 0x2a, 0xe8, 0x56, 0x56, 0x76, 0x33, 0x9b, 0x53, 0x75, 0x33,
+	0x1d, 0x59, 0xae, 0x98, 0x95, 0xc4, 0xdc, 0xcc, 0xe6, 0xd0, 0xdd, 0x4c, 0xd7, 0x55, 0xcc, 0xa0,
+	0xfd, 0x2c, 0x78, 0xcc, 0x92, 0x5c, 0x21, 0xb9, 0xb2, 0x6e, 0xf3, 0x6e, 0xa9, 0x7d, 0xb0, 0x1b,
+	0x7d, 0x0d, 0xb9, 0xde, 0xd5, 0x66, 0x67, 0xc7, 0x70, 0x32, 0x46, 0x1d, 0x94, 0xf2, 0x2b, 0x8f,
+	0x05, 0xb9, 0x6d, 0x34, 0xfe, 0xeb, 0x59, 0x33, 0xee, 0xf6, 0x69, 0x35, 0x9c, 0xa7, 0xce, 0x0c,
+	0xb6, 0x9b, 0x06, 0x07, 0xf3, 0xe3, 0xf2, 0x17, 0x7b, 0xf8, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x5f,
+	0xc0, 0xc2, 0xe6, 0xc8, 0x03, 0x00, 0x00,
+}
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn
@@ -282,15 +315,15 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type KeyManagerClient interface {
-	// * Creates a new key pair.
+	//* Creates a new key pair.
 	GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest, opts ...grpc.CallOption) (*GenerateKeyPairResponse, error)
-	// * Persists a private key to the key manager's storage system.
+	//* Persists a private key to the key manager's storage system.
 	StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest, opts ...grpc.CallOption) (*StorePrivateKeyResponse, error)
-	// * Returns the most recently stored private key. For use after node restarts.
+	//* Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(ctx context.Context, in *FetchPrivateKeyRequest, opts ...grpc.CallOption) (*FetchPrivateKeyResponse, error)
-	// * Applies the plugin configuration and returns configuration errors.
+	//* Applies the plugin configuration and returns configuration errors.
 	Configure(ctx context.Context, in *plugin.ConfigureRequest, opts ...grpc.CallOption) (*plugin.ConfigureResponse, error)
-	// * Returns the version and related metadata of the plugin.
+	//* Returns the version and related metadata of the plugin.
 	GetPluginInfo(ctx context.Context, in *plugin.GetPluginInfoRequest, opts ...grpc.CallOption) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -349,15 +382,15 @@ func (c *keyManagerClient) GetPluginInfo(ctx context.Context, in *plugin.GetPlug
 
 // KeyManagerServer is the server API for KeyManager service.
 type KeyManagerServer interface {
-	// * Creates a new key pair.
+	//* Creates a new key pair.
 	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
-	// * Persists a private key to the key manager's storage system.
+	//* Persists a private key to the key manager's storage system.
 	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
-	// * Returns the most recently stored private key. For use after node restarts.
+	//* Returns the most recently stored private key. For use after node restarts.
 	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
-	// * Applies the plugin configuration and returns configuration errors.
+	//* Applies the plugin configuration and returns configuration errors.
 	Configure(context.Context, *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error)
-	// * Returns the version and related metadata of the plugin.
+	//* Returns the version and related metadata of the plugin.
 	GetPluginInfo(context.Context, *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error)
 }
 
@@ -482,32 +515,4 @@ var _KeyManager_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "keymanager.proto",
-}
-
-func init() { proto.RegisterFile("keymanager.proto", fileDescriptor_keymanager_af4d8576fb78f72c) }
-
-var fileDescriptor_keymanager_af4d8576fb78f72c = []byte{
-	// 343 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x4b, 0xc3, 0x30,
-	0x14, 0xc6, 0x9d, 0x88, 0xb0, 0xc7, 0x64, 0x92, 0xc3, 0x36, 0x87, 0x88, 0x14, 0x14, 0xf5, 0x90,
-	0x82, 0x5e, 0xe6, 0x55, 0xc1, 0x21, 0x43, 0x28, 0xf3, 0x20, 0xec, 0xd6, 0x95, 0xd7, 0x2e, 0xb8,
-	0x26, 0x31, 0x4d, 0x85, 0xfe, 0x4f, 0xfe, 0x91, 0xb2, 0x26, 0xdb, 0xb4, 0x6d, 0xd8, 0x4e, 0x85,
-	0xf7, 0xbd, 0xef, 0xfd, 0xf2, 0xbe, 0xa4, 0x70, 0xfa, 0x89, 0x45, 0x1a, 0xf2, 0x30, 0x41, 0x45,
-	0xa5, 0x12, 0x5a, 0x90, 0x5e, 0x26, 0x99, 0x42, 0x1a, 0x26, 0xc8, 0x35, 0xdd, 0xaa, 0xc3, 0x51,
-	0xc2, 0xf4, 0x22, 0x9f, 0xd3, 0x48, 0xa4, 0x7e, 0x26, 0x59, 0x1c, 0xa3, 0x5f, 0x76, 0xfa, 0xa5,
-	0xcd, 0x8f, 0x44, 0x9a, 0x0a, 0xee, 0xcb, 0x65, 0x9e, 0xb0, 0xf5, 0xc7, 0x4c, 0xf4, 0x06, 0xd0,
-	0x1b, 0x23, 0x47, 0x15, 0x6a, 0x9c, 0x60, 0x11, 0x84, 0x4c, 0x4d, 0xf1, 0x2b, 0xc7, 0x4c, 0x7b,
-	0x1f, 0xd0, 0xaf, 0x29, 0x99, 0x14, 0x3c, 0x43, 0x72, 0x0e, 0x6d, 0x99, 0xcf, 0x97, 0x2c, 0x9a,
-	0x60, 0x31, 0x68, 0x5d, 0xb6, 0x6e, 0x3a, 0xd3, 0x6d, 0x81, 0x5c, 0x00, 0x48, 0xc5, 0xbe, 0x8d,
-	0x6f, 0x70, 0x58, 0xca, 0x7f, 0x2a, 0xde, 0x08, 0x7a, 0xef, 0x5a, 0x28, 0x0c, 0x36, 0x25, 0x8b,
-	0xac, 0x38, 0x5b, 0x35, 0xe7, 0x19, 0xf4, 0x6b, 0x4e, 0x73, 0xa4, 0xd5, 0x1e, 0x2f, 0xa8, 0xa3,
-	0x45, 0x6d, 0xa8, 0xf7, 0x08, 0xfd, 0x9a, 0x62, 0xf7, 0xd8, 0xc1, 0xbb, 0xff, 0x39, 0x02, 0x98,
-	0x60, 0xf1, 0x66, 0x52, 0x26, 0x0a, 0xba, 0x95, 0x44, 0x08, 0xa5, 0xcd, 0x37, 0x42, 0x9b, 0x43,
-	0x1d, 0xfa, 0x7b, 0xf7, 0xdb, 0x23, 0x2a, 0xe8, 0x56, 0x56, 0x76, 0x33, 0x9b, 0x53, 0x75, 0x33,
-	0x1d, 0x59, 0xae, 0x98, 0x95, 0xc4, 0xdc, 0xcc, 0xe6, 0xd0, 0xdd, 0x4c, 0xd7, 0x55, 0xcc, 0xa0,
-	0xfd, 0x2c, 0x78, 0xcc, 0x92, 0x5c, 0x21, 0xb9, 0xb2, 0x6e, 0xf3, 0x6e, 0xa9, 0x7d, 0xb0, 0x1b,
-	0x7d, 0x0d, 0xb9, 0xde, 0xd5, 0x66, 0x67, 0xc7, 0x70, 0x32, 0x46, 0x1d, 0x94, 0xf2, 0x2b, 0x8f,
-	0x05, 0xb9, 0x6d, 0x34, 0xfe, 0xeb, 0x59, 0x33, 0xee, 0xf6, 0x69, 0x35, 0x9c, 0xa7, 0xce, 0x0c,
-	0xb6, 0x9b, 0x06, 0x07, 0xf3, 0xe3, 0xf2, 0x17, 0x7b, 0xf8, 0x0d, 0x00, 0x00, 0xff, 0xff, 0x5f,
-	0xc0, 0xc2, 0xe6, 0xc8, 0x03, 0x00, 0x00,
 }

--- a/proto/agent/keymanager/keymanager.proto
+++ b/proto/agent/keymanager/keymanager.proto
@@ -20,20 +20,31 @@ message GenerateKeyPairResponse {
     bytes privateKey = 2;
 }
 
+/** Represents a private key */
+message StorePrivateKeyRequest {
+    /** Private key */
+    bytes privateKey = 1;
+}
+
+/** Represents an empty response */
+message StorePrivateKeyResponse {}
+
 /** Represents an empty request */
 message FetchPrivateKeyRequest {}
 
 /** Represents a private key */
 message FetchPrivateKeyResponse {
-    /** Priavte key */
+    /** Private key */
     bytes privateKey = 1;
 }
 
 
 service KeyManager {
-    /** Creates a key pair that is bound to hardware. */
+    /** Creates a new key pair. */
     rpc GenerateKeyPair(GenerateKeyPairRequest) returns (GenerateKeyPairResponse);
-    /** Returns previously generated private key. For use after node restarts. */
+    /** Persists a private key to the key manager's storage system. */
+    rpc StorePrivateKey(StorePrivateKeyRequest) returns (StorePrivateKeyResponse);
+    /** Returns the most recently stored private key. For use after node restarts. */
     rpc FetchPrivateKey(FetchPrivateKeyRequest) returns (FetchPrivateKeyResponse);
     /** Applies the plugin configuration and returns configuration errors. */
     rpc Configure(spire.common.plugin.ConfigureRequest) returns (spire.common.plugin.ConfigureResponse);

--- a/test/mock/proto/agent/keymanager/keymanager_mock.go
+++ b/test/mock/proto/agent/keymanager/keymanager_mock.go
@@ -61,6 +61,19 @@ func (mr *MockKeyManagerMockRecorder) GenerateKeyPair(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateKeyPair", reflect.TypeOf((*MockKeyManager)(nil).GenerateKeyPair), arg0, arg1)
 }
 
+// StorePrivateKey mocks base method
+func (m *MockKeyManager) StorePrivateKey(arg0 context.Context, arg1 *keymanager.StorePrivateKeyRequest) (*keymanager.StorePrivateKeyResponse, error) {
+	ret := m.ctrl.Call(m, "StorePrivateKey", arg0, arg1)
+	ret0, _ := ret[0].(*keymanager.StorePrivateKeyResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StorePrivateKey indicates an expected call of StorePrivateKey
+func (mr *MockKeyManagerMockRecorder) StorePrivateKey(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorePrivateKey", reflect.TypeOf((*MockKeyManager)(nil).StorePrivateKey), arg0, arg1)
+}
+
 // MockPlugin is a mock of Plugin interface
 type MockPlugin struct {
 	ctrl     *gomock.Controller
@@ -134,4 +147,17 @@ func (m *MockPlugin) GetPluginInfo(arg0 context.Context, arg1 *plugin.GetPluginI
 // GetPluginInfo indicates an expected call of GetPluginInfo
 func (mr *MockPluginMockRecorder) GetPluginInfo(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPluginInfo", reflect.TypeOf((*MockPlugin)(nil).GetPluginInfo), arg0, arg1)
+}
+
+// StorePrivateKey mocks base method
+func (m *MockPlugin) StorePrivateKey(arg0 context.Context, arg1 *keymanager.StorePrivateKeyRequest) (*keymanager.StorePrivateKeyResponse, error) {
+	ret := m.ctrl.Call(m, "StorePrivateKey", arg0, arg1)
+	ret0, _ := ret[0].(*keymanager.StorePrivateKeyResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StorePrivateKey indicates an expected call of StorePrivateKey
+func (mr *MockPluginMockRecorder) StorePrivateKey(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorePrivateKey", reflect.TypeOf((*MockPlugin)(nil).StorePrivateKey), arg0, arg1)
 }


### PR DESCRIPTION
This separates key generation from key storage in the keymanager plugin, which enables the application to handle cases when SVID renewal fails, and choose not to store the invalid private key (since it doesn't correspond to a valid SVID).

Fixes #613