### PR TITLE
agent/nodeattestor/gcp: Use FQDN to find metadata server

### DIFF
--- a/pkg/agent/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	identityTokenURLHost  = "metadata"
+	identityTokenURLHost  = "metadata.google.internal"
 	identityTokenURLPath  = "/computeMetadata/v1/instance/service-accounts/default/identity"
 	identityTokenAudience = "spire-gcp-node-attestor"
 )


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
This change removes the dependency on `/etc/resolv.conf` by querying the
GCP metadata server using its FQDN `metadata.google.internal`.

**Description of change**
In GCP node attestation, we request the instance identity token using
the `metadata` DNS record. This uses `/etc/resolv.conf` to expand into
`metadata.google.internal`; however, this means that node attestation
has a dependency on GCP's default resolution, which makes it difficult
for consumers with custom DNS resolvers.

```
$ cat /etc/resolv.conf
domain foo.internal
search foo.internal. google.internal.
nameserver 169.254.169.254
```