### PR TITLE
Fix panic in signCSRs if no attested node record found

### DIFF
--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -218,7 +218,7 @@ func (h *Handler) FetchX509SVID(server node.Node_FetchX509SVIDServer) (err error
 		svids, err := h.signCSRs(ctx, peerCert, request.Csrs, regEntries)
 		if err != nil {
 			h.c.Log.Error(err)
-			return errors.New("Error trying sign CSRs")
+			return errors.New("Error trying to sign CSRs")
 		}
 
 		bundles, err := h.getBundlesForEntries(ctx, regEntries)
@@ -627,6 +627,9 @@ func (h *Handler) signCSRs(ctx context.Context,
 			)
 			if err != nil {
 				return nil, err
+			}
+			if res.Node == nil {
+				return nil, errors.New("no record of attested node")
 			}
 			if res.Node.CertSerialNumber != peerCert.SerialNumber.String() {
 				err := errors.New("SVID serial number does not match")


### PR DESCRIPTION
PR adds a check that there is an attested node entry before trying to use it while exercising signCSR to sign a a Node SVID.

Fixes #682 