### PR TITLE
Introduce --node helper flag in spire-server cli

### DIFF
--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -31,13 +31,17 @@ type CreateConfig struct {
 	SpiffeID string
 	Ttl      int
 
-	Downstream bool
-
 	// List of SPIFFE IDs of trust domains the registration entry is federated with
 	FederatesWith StringsFlag
 
 	// Whether or not the registration entry is for an "admin" workload
 	Admin bool
+
+	// Whether or not the entry is for a downstream SPIRE server
+	Downstream bool
+
+	// Whether or not the entry represents a node or group of nodes
+	Node bool
 }
 
 // Perform basic validation, even on fields that we
@@ -56,8 +60,12 @@ func (rc *CreateConfig) Validate() (err error) {
 		return errors.New("at least one selector is required")
 	}
 
-	if rc.ParentID == "" {
-		return errors.New("a parent ID is required")
+	if rc.Node && len(rc.FederatesWith) > 0 {
+		return errors.New("node entries can not federate")
+	}
+
+	if rc.ParentID == "" && !rc.Node {
+		return errors.New("a parent ID is required if the node flag is not set")
 	}
 
 	if rc.SpiffeID == "" {
@@ -147,6 +155,17 @@ func (c CreateCLI) parseConfig(config *CreateConfig) ([]*common.RegistrationEntr
 		Downstream: config.Downstream,
 	}
 
+	// If the node flag is set, then set the Parent ID to the server's expected SPIFFE ID
+	if config.Node {
+		id, err := idutil.ParseSpiffeID(e.SpiffeId, idutil.AllowAny())
+		if err != nil {
+			return nil, err
+		}
+
+		id.Path = "/spire/server"
+		e.ParentId = id.String()
+	}
+
 	selectors := []*common.Selector{}
 	for _, s := range config.Selectors {
 		cs, err := parseSelector(s)
@@ -206,9 +225,10 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 
 	f.Var(&c.Selectors, "selector", "A colon-delimeted type:value selector. Can be used more than once")
 	f.Var(&c.FederatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
-	f.BoolVar(&c.Downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 
-	f.BoolVar(&c.Admin, "admin", false, "If true, the SPIFFE ID in this entry will be granted access to the Registration API")
+	f.BoolVar(&c.Node, "node", false, "If set, this entry will be applied to matching nodes rather than workloas")
+	f.BoolVar(&c.Admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the Registration API")
+	f.BoolVar(&c.Downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 
 	return c, f.Parse(args)
 }

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -226,7 +226,7 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 	f.Var(&c.Selectors, "selector", "A colon-delimeted type:value selector. Can be used more than once")
 	f.Var(&c.FederatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
 
-	f.BoolVar(&c.Node, "node", false, "If set, this entry will be applied to matching nodes rather than workloas")
+	f.BoolVar(&c.Node, "node", false, "If set, this entry will be applied to matching nodes rather than workloads")
 	f.BoolVar(&c.Admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the Registration API")
 	f.BoolVar(&c.Downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -46,6 +46,32 @@ func TestCreateParseConfig(t *testing.T) {
 	assert.Equal(t, expectedEntries, entries)
 }
 
+func TestCreateNodeParseConfig(t *testing.T) {
+	c := &CreateConfig{
+		RegistrationUDSPath: cmdutil.DefaultSocketPath,
+		SpiffeID:            "spiffe://example.org/bar",
+		Node:                true,
+		Ttl:                 60,
+		Selectors:           StringsFlag{"aws:sg:sg-12345"},
+	}
+
+	entries, err := CreateCLI{}.parseConfig(c)
+	require.NoError(t, err)
+
+	expectedEntry := &common.RegistrationEntry{
+		ParentId: "spiffe://example.org/spire/server",
+		SpiffeId: "spiffe://example.org/bar",
+		Ttl:      60,
+		Selectors: []*common.Selector{
+			{Type: "aws", Value: "sg:sg-12345"},
+		},
+		Admin:    false,
+	}
+
+	expectedEntries := []*common.RegistrationEntry{expectedEntry}
+	assert.Equal(t, expectedEntries, entries)
+}
+
 func TestRegisterParseFile(t *testing.T) {
 	p := path.Join(util.ProjectRoot(), "test/fixture/registration/good.json")
 	entries, err := CreateCLI{}.parseFile(p)


### PR DESCRIPTION
Registration entries can apply to either nodes or workloads, but the
behavior is slightly different for each case. The distinction between
one and the other is made implicitly, and is difficult to understand
without learning about SPIRE authz internals. This leads to a confusing
experience, often to the point that users don't realize that
registration entries can apply to nodes too.

While this problem deserves a more robust solution, this commit puts in
place a quick win that will hopefully serve to disambiguate the uses
between now and the time that we refine the model.

It adds a `--node` flag to the `spire-server entry create` command,
which indicates that the entry being created should be assigned to
nodes rather than workloads. When set, a Parent ID is no longer required
from the operator. Instead, the utility will set the Parent ID equal to
the server's SPIFFE ID under the covers.

Signed-off-by: Evan Gilman <evan@scytale.io>