### PR TITLE
Server gcp_iit nodeattestor support for templated base SVID

### DIFF
--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	spiffe_tls "github.com/spiffe/go-spiffe/tls"
 	"github.com/spiffe/spire/pkg/common/grpcutil"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/api/node"
 	"github.com/spiffe/spire/proto/common"
@@ -72,7 +73,7 @@ func (c *client) credsFunc() (credentials.TransportCredentials, error) {
 
 	svid, key, bundle := c.c.KeysAndBundle()
 	spiffePeer := &spiffe_tls.TLSPeer{
-		SpiffeIDs:  []string{"spiffe://" + c.c.TrustDomain.Host + "/spire/server"},
+		SpiffeIDs:  []string{idutil.ServerID(c.c.TrustDomain.Host)},
 		TrustRoots: util.NewCertPool(bundle...),
 	}
 	tlsCert := tls.Certificate{PrivateKey: key}

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/api/node"
@@ -1008,7 +1009,7 @@ func newMockNodeAPIHandler(config *mockNodeAPIHandlerConfig) *mockNodeAPIHandler
 		c:        config,
 		bundle:   bundleutil.BundleFromRootCA("spiffe://"+config.trustDomain, ca),
 		cakey:    cakey,
-		serverID: "spiffe://" + config.trustDomain + "/spire/server",
+		serverID: idutil.ServerID(config.trustDomain),
 	}
 
 	h.svid, h.svidKey = h.newSVID(h.serverID, 1*time.Hour)

--- a/pkg/agent/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit.go
@@ -112,11 +112,14 @@ func (p *IITAttestorPlugin) buildAttestationResponse(trustDomain string, identit
 		Data: identityTokenBytes,
 	}
 
-	spiffeID := gcp.MakeSpiffeID(trustDomain, identityToken.Google.ComputeEngine.ProjectID, identityToken.Google.ComputeEngine.InstanceID)
+	spiffeID, err := gcp.MakeSpiffeID(trustDomain, gcp.DefaultAgentPathTemplate, identityToken.Google.ComputeEngine)
+	if err != nil {
+		return nil, newErrorf("failed to make agent id: %v", err)
+	}
 
 	resp := &nodeattestor.FetchAttestationDataResponse{
 		AttestationData: data,
-		SpiffeId:        spiffeID,
+		SpiffeId:        spiffeID.String(),
 	}
 	return resp, nil
 }

--- a/pkg/common/idutil/spiffeid.go
+++ b/pkg/common/idutil/spiffeid.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -284,4 +285,24 @@ func normalizeSpiffeIDURL(u *url.URL) *url.URL {
 	// SPIFFE ID's can't contain ports so don't bother handling that here.
 	c.Host = strings.ToLower(u.Hostname())
 	return &c
+}
+
+func AgentURI(trustDomain, p string) *url.URL {
+	return &url.URL{
+		Scheme: "spiffe",
+		Host:   trustDomain,
+		Path:   path.Join("spire", "agent", p),
+	}
+}
+
+func ServerID(trustDomain string) string {
+	return ServerURI(trustDomain).String()
+}
+
+func ServerURI(trustDomain string) *url.URL {
+	return &url.URL{
+		Scheme: "spiffe",
+		Host:   trustDomain,
+		Path:   path.Join("spire", "server"),
+	}
 }

--- a/pkg/common/idutil/spiffeid.go
+++ b/pkg/common/idutil/spiffeid.go
@@ -287,6 +287,8 @@ func normalizeSpiffeIDURL(u *url.URL) *url.URL {
 	return &c
 }
 
+// AgentURI creates an agent spiffe URI given a trust domain and a path.
+// The /spire/agent prefix in the path is implied.
 func AgentURI(trustDomain, p string) *url.URL {
 	return &url.URL{
 		Scheme: "spiffe",
@@ -295,10 +297,12 @@ func AgentURI(trustDomain, p string) *url.URL {
 	}
 }
 
+// ServerID creates a server spiffe ID string given a trustDomain.
 func ServerID(trustDomain string) string {
 	return ServerURI(trustDomain).String()
 }
 
+// ServerURI creates a server spiffe URI given a trustDomain.
 func ServerURI(trustDomain string) *url.URL {
 	return &url.URL{
 		Scheme: "spiffe",

--- a/pkg/common/plugin/gcp/iit.go
+++ b/pkg/common/plugin/gcp/iit.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"bytes"
 	"net/url"
-	"path"
 	"text/template"
 
 	jwt "github.com/dgrijalva/jwt-go"

--- a/pkg/common/plugin/gcp/iit.go
+++ b/pkg/common/plugin/gcp/iit.go
@@ -1,15 +1,21 @@
 package gcp
 
 import (
+	"bytes"
 	"net/url"
 	"path"
+	"text/template"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
 const (
 	PluginName = "gcp_iit"
 )
+
+// DefaultAgentPathTemplate is the default text/template
+var DefaultAgentPathTemplate = template.Must(template.New("agent-path").Parse("{{ .PluginName }}/{{ .ProjectID }}/{{ .InstanceID }}"))
 
 type IdentityToken struct {
 	jwt.StandardClaims
@@ -31,12 +37,19 @@ type ComputeEngine struct {
 	InstanceCreationTimestamp int64  `json:"instance_creation_timestamp"`
 }
 
-func MakeSpiffeID(trustDomain, gcpAccountID, gcpInstanceID string) string {
-	spiffePath := path.Join("spire", "agent", PluginName, gcpAccountID, gcpInstanceID)
-	id := &url.URL{
-		Scheme: "spiffe",
-		Host:   trustDomain,
-		Path:   spiffePath,
+type agentPathTemplateData struct {
+	ComputeEngine
+	PluginName string
+}
+
+func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, computeEngine ComputeEngine) (*url.URL, error) {
+	var agentPath bytes.Buffer
+	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
+		ComputeEngine: computeEngine,
+		PluginName:    PluginName,
+	}); err != nil {
+		return nil, err
 	}
-	return id.String()
+
+	return idutil.AgentURI(trustDomain, agentPath.String()), nil
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit.go
@@ -22,7 +22,7 @@ const (
 	svidPrefix    = "spiffe://{{ .TrustDomain }}/spire/agent"
 )
 
-var _defaultAgentSVIDTemplate = template.Must(template.New("agent-svid").Parse(fmt.Sprintf("%s/{{ .PluginName}}/{{ .ProjectID }}/{{ .InstanceID }}", svidPrefix)))
+var defaultAgentSVIDTemplate = template.Must(template.New("agent-svid").Parse(fmt.Sprintf("%s/{{ .PluginName}}/{{ .ProjectID }}/{{ .InstanceID }}", svidPrefix)))
 
 type tokenKeyRetriever interface {
 	retrieveKey(token *jwt.Token) (interface{}, error)
@@ -46,7 +46,7 @@ type IITAttestorConfig struct {
 // NewIITAttestorPlugin creates a new IITAttestorPlugin.
 func NewIITAttestorPlugin() *IITAttestorPlugin {
 	return &IITAttestorPlugin{
-		svidTemplate:      _defaultAgentSVIDTemplate,
+		svidTemplate:      defaultAgentSVIDTemplate,
 		tokenKeyRetriever: newGooglePublicKeyRetriever(googleCertURL),
 	}
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -270,7 +270,7 @@ func (s *IITAttestorSuite) TestGetPluginInfo() {
 
 func (s *IITAttestorSuite) TestFailToRecvStream() {
 	p := NewIITAttestorPlugin()
-	_, err := p.ValidateIdentityAndExtractMetadata(&recvFailStream{}, gcp.PluginName)
+	_, err := p.ValidateAttestationAndExtractIdentityMetadata(&recvFailStream{}, gcp.PluginName)
 	s.Require().EqualError(err, "failed to recv from stream")
 }
 

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -204,11 +204,11 @@ func (s *IITAttestorSuite) TestErrorOnBadSVIDTemplate() {
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
 projectid_whitelist = ["project-123"]
-agent_svid_template = "{{ .InstanceID "
+agent_path_template = "{{ .InstanceID "
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
-	s.requireErrorContains(err, "failed to parse agent svid template")
+	s.requireErrorContains(err, "failed to parse agent path template")
 }
 
 func (s *IITAttestorSuite) TestSuccesfullyProcessAttestationRequest() {
@@ -230,7 +230,7 @@ func (s *IITAttestorSuite) TestSuccesfullyProcessAttestationRequestCustomSVID() 
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
 projectid_whitelist = ["project-123"]
-agent_svid_template = "{{ .InstanceID }}"
+agent_path_template = "{{ .InstanceID }}"
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -307,7 +307,7 @@ func (s *IITAttestorSuite) TestGetPluginInfo() {
 
 func (s *IITAttestorSuite) TestFailToRecvStream() {
 	p := NewIITAttestorPlugin()
-	_, err := p.validateAttestationAndExtractIdentityMetadata(&recvFailStream{}, gcp.PluginName)
+	_, err := validateAttestationAndExtractIdentityMetadata(&recvFailStream{}, gcp.PluginName, p.tokenKeyRetriever)
 	s.Require().EqualError(err, "failed to recv from stream")
 }
 

--- a/pkg/server/plugin/upstreamca/spire/spire_node.go
+++ b/pkg/server/plugin/upstreamca/spire/spire_node.go
@@ -13,6 +13,7 @@ import (
 
 	spiffe_tls "github.com/spiffe/go-spiffe/tls"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/api/node"
 )
@@ -117,7 +118,7 @@ func (m *spirePlugin) getGrpcTransportCreds(wCert []byte, wKey []byte, wBundle [
 	}
 
 	spiffePeer := &spiffe_tls.TLSPeer{
-		SpiffeIDs:  []string{m.trustDomain.String() + "/spire/server"},
+		SpiffeIDs:  []string{idutil.ServerID(m.trustDomain.Host)},
 		TrustRoots: util.NewCertPool(bundle...),
 	}
 

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -6,11 +6,10 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
-	"net/url"
-	"path"
 	"time"
 
 	"github.com/imkira/go-observer"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/util"
 )
@@ -93,11 +92,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	defer telemetry.CountCall(r.c.Metrics, "svid", "rotate")(&err)
 	r.c.Log.Debug("Rotating server SVID")
 
-	id := &url.URL{
-		Scheme: "spiffe",
-		Host:   r.c.TrustDomain.Host,
-		Path:   path.Join("spire", "server"),
-	}
+	id := idutil.ServerURI(r.c.TrustDomain.Host)
 
 	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Tyler Dixon <tylerd@uber.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
The GCP iit server plugin has an undocumented option added to use a provided text/template to format the agent base svid.

**Description of change**
A bit of refactoring was done and an undocumented feature was added that enables the agent svid to be configured by a text/template.

Additionally, this change bumps the test coverage up and the package now passes golint.