### PR TITLE
Agent gcp_iit nodeattestor support for templated base SVID

### DIFF
--- a/pkg/agent/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit.go
@@ -19,15 +19,14 @@ import (
 )
 
 const (
-	identityTokenURLHost  = "metadata.google.internal"
-	identityTokenURLPath  = "/computeMetadata/v1/instance/service-accounts/default/identity"
-	identityTokenAudience = "spire-gcp-node-attestor"
+	identityTokenURLHost         = "metadata.google.internal"
+	identityTokenURLPathTemplate = "/computeMetadata/v1/instance/service-accounts/%s/identity"
+	identityTokenAudience        = "spire-gcp-node-attestor"
+
+	defaultServiceAccount = "default"
 )
 
-type IITAttestorConfig struct {
-	trustDomain string
-}
-
+// IITAttestorPlugin implements GCP nodeattestation in the agent.
 type IITAttestorPlugin struct {
 	tokenHost string
 
@@ -35,17 +34,130 @@ type IITAttestorPlugin struct {
 	config *IITAttestorConfig
 }
 
-func identityTokenURL(host string) string {
+// IITAttestorConfig configures a IITAttestorPlugin.
+type IITAttestorConfig struct {
+	trustDomain    string
+	ServiceAccount string `hcl:"service_account"`
+}
+
+// NewIITAttestorPlugin creates a new IITAttestorPlugin.
+func NewIITAttestorPlugin() *IITAttestorPlugin {
+	return &IITAttestorPlugin{
+		tokenHost: identityTokenURLHost,
+	}
+}
+
+// FetchAttestationData fetches attestation data from the GCP metadata server and sends an attestation response
+// on given stream.
+func (p *IITAttestorPlugin) FetchAttestationData(stream nodeattestor.FetchAttestationData_PluginStream) error {
+	c, err := p.getConfig()
+	if err != nil {
+		return err
+	}
+
+	identityToken, identityTokenBytes, err := RetrieveValidInstanceIdentityToken(IdentityTokenURL(p.tokenHost, c.ServiceAccount))
+	if err != nil {
+		return newErrorf("unable to retrieve valid identity token: %v", err)
+	}
+
+	spiffeID := gcp.MakeSpiffeID(p.config.trustDomain, identityToken.Google.ComputeEngine.ProjectID, identityToken.Google.ComputeEngine.InstanceID)
+	resp := BuildAttestationResponse(spiffeID, gcp.PluginName, identityTokenBytes)
+
+	if err := stream.Send(resp); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *IITAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	config := &IITAttestorConfig{}
+	if err := hcl.Decode(config, req.Configuration); err != nil {
+		return nil, newErrorf("unable to decode configuration: %v", err)
+	}
+
+	if req.GlobalConfig == nil {
+		return nil, newError("global configuration is required")
+	}
+	if req.GlobalConfig.TrustDomain == "" {
+		return nil, newError("trust_domain is required")
+	}
+	config.trustDomain = req.GlobalConfig.TrustDomain
+
+	if config.ServiceAccount == "" {
+		config.ServiceAccount = defaultServiceAccount
+	}
+
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	p.config = config
+
+	return &spi.ConfigureResponse{}, nil
+}
+
+// GetPluginInfo returns the version and other metadata of the plugin.
+func (*IITAttestorPlugin) GetPluginInfo(ctx context.Context, req *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p *IITAttestorPlugin) getConfig() (*IITAttestorConfig, error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	if p.config == nil {
+		return nil, newError("not configured")
+	}
+	return p.config, nil
+}
+
+// BuildAttestationResponse creates an attestation response given a spiffe ID, the plugin name, and the raw bytes of the
+// GCP identity document.
+func BuildAttestationResponse(spiffeID string, pluginName string, identityTokenBytes []byte) *nodeattestor.FetchAttestationDataResponse {
+	data := &common.AttestationData{
+		Type: pluginName,
+		Data: identityTokenBytes,
+	}
+
+	resp := &nodeattestor.FetchAttestationDataResponse{
+		AttestationData: data,
+		SpiffeId:        spiffeID,
+	}
+	return resp
+}
+
+// IdentityTokenURL creates the URL to find an instance identity document given the
+// host of the GCP metadata server and the service account the instance is running as.
+func IdentityTokenURL(host, serviceAccount string) string {
 	query := url.Values{}
 	query.Set("audience", identityTokenAudience)
 	query.Set("format", "full")
 	url := &url.URL{
 		Scheme:   "http",
 		Host:     host,
-		Path:     identityTokenURLPath,
+		Path:     fmt.Sprintf(identityTokenURLPathTemplate, serviceAccount),
 		RawQuery: query.Encode(),
 	}
 	return url.String()
+}
+
+// RetrieveValidInstanceIdentityToken retrieves and validates a GCP identity token from
+// the given URL.
+func RetrieveValidInstanceIdentityToken(url string) (*gcp.IdentityToken, []byte, error) {
+	identityTokenBytes, err := retrieveInstanceIdentityToken(url)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	identityToken := &gcp.IdentityToken{}
+	if _, _, err := new(jwt.Parser).ParseUnverified(string(identityTokenBytes), identityToken); err != nil {
+		return nil, nil, newErrorf("unable to parse identity token: %v", err)
+	}
+
+	if identityToken.Google == (gcp.Google{}) {
+		return nil, nil, newError("identity token is missing google claims")
+	}
+
+	return identityToken, identityTokenBytes, nil
 }
 
 func retrieveInstanceIdentityToken(url string) ([]byte, error) {
@@ -71,98 +183,6 @@ func retrieveInstanceIdentityToken(url string) ([]byte, error) {
 		return nil, err
 	}
 	return bytes, nil
-}
-
-func (p *IITAttestorPlugin) FetchAttestationData(stream nodeattestor.FetchAttestationData_PluginStream) error {
-	c, err := p.getConfig()
-	if err != nil {
-		return err
-	}
-
-	docBytes, err := retrieveInstanceIdentityToken(identityTokenURL(p.tokenHost))
-	if err != nil {
-		return newErrorf("unable to retrieve identity token: %v", err)
-	}
-
-	resp, err := p.buildAttestationResponse(c.trustDomain, docBytes)
-	if err != nil {
-		return err
-	}
-
-	if err := stream.Send(resp); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (p *IITAttestorPlugin) buildAttestationResponse(trustDomain string, identityTokenBytes []byte) (*nodeattestor.FetchAttestationDataResponse, error) {
-	identityToken := &gcp.IdentityToken{}
-	_, _, err := new(jwt.Parser).ParseUnverified(string(identityTokenBytes), identityToken)
-	if err != nil {
-		return nil, newErrorf("unable to parse identity token: %v", err)
-	}
-
-	if identityToken.Google == (gcp.Google{}) {
-		return nil, newError("identity token is missing google claims")
-	}
-
-	data := &common.AttestationData{
-		Type: gcp.PluginName,
-		Data: identityTokenBytes,
-	}
-
-	spiffeID, err := gcp.MakeSpiffeID(trustDomain, gcp.DefaultAgentPathTemplate, identityToken.Google.ComputeEngine)
-	if err != nil {
-		return nil, newErrorf("failed to make agent id: %v", err)
-	}
-
-	resp := &nodeattestor.FetchAttestationDataResponse{
-		AttestationData: data,
-		SpiffeId:        spiffeID.String(),
-	}
-	return resp, nil
-}
-
-func (p *IITAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	config := &IITAttestorConfig{}
-	if err := hcl.Decode(config, req.Configuration); err != nil {
-		return nil, newErrorf("unable to decode configuration: %v", err)
-	}
-
-	if req.GlobalConfig == nil {
-		return nil, newError("global configuration is required")
-	}
-	if req.GlobalConfig.TrustDomain == "" {
-		return nil, newError("trust_domain is required")
-	}
-
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-	config.trustDomain = req.GlobalConfig.TrustDomain
-	p.config = config
-
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (*IITAttestorPlugin) GetPluginInfo(ctx context.Context, req *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
-}
-
-func NewIITAttestorPlugin() *IITAttestorPlugin {
-	return &IITAttestorPlugin{
-		tokenHost: identityTokenURLHost,
-	}
-}
-
-func (p *IITAttestorPlugin) getConfig() (*IITAttestorConfig, error) {
-	p.mtx.Lock()
-	defer p.mtx.Unlock()
-
-	if p.config == nil {
-		return nil, newError("gcp-iit: not configured")
-	}
-	return p.config, nil
 }
 
 func newError(msg string) error {

--- a/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
@@ -2,6 +2,8 @@ package gcp
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,8 +12,11 @@ import (
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
 	"github.com/spiffe/spire/proto/agent/nodeattestor"
 	"github.com/spiffe/spire/proto/common/plugin"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
+
+const testServiceAccount = "test-service-account"
 
 func TestIITAttestorPlugin(t *testing.T) {
 	suite.Run(t, new(Suite))
@@ -27,12 +32,14 @@ type Suite struct {
 }
 
 func (s *Suite) SetupTest() {
+	serviceAccount := "test-service-account"
+
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.Header.Get("Metadata-Flavor") != "Google" {
 			http.Error(w, "unexpected flavor", http.StatusInternalServerError)
 			return
 		}
-		if req.URL.Path != identityTokenURLPath {
+		if req.URL.Path != fmt.Sprintf(identityTokenURLPathTemplate, serviceAccount) {
 			http.Error(w, "unexpected path", http.StatusInternalServerError)
 			return
 		}
@@ -56,6 +63,9 @@ func (s *Suite) SetupTest() {
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
 			TrustDomain: "example.org",
 		},
+		Configuration: fmt.Sprintf(`
+service_account = "%s"
+`, testServiceAccount),
 	})
 	s.Require().NoError(err)
 	s.status = http.StatusOK
@@ -78,7 +88,7 @@ func (s *Suite) TestUnexpectedStatus() {
 	s.status = http.StatusBadGateway
 	s.body = ""
 	_, err := s.fetchAttestationData()
-	s.requireErrorContains(err, "gcp-iit: unable to retrieve identity token: unexpected status code: 502")
+	s.requireErrorContains(err, "gcp-iit: unable to retrieve valid identity token: unexpected status code: 502")
 }
 
 func (s *Suite) TestErrorOnInvalidToken() {
@@ -111,6 +121,34 @@ func (s *Suite) TestSuccessfulIdentityTokenProcessing() {
 	require.Equal("spiffe://example.org/spire/agent/gcp_iit/project-123/instance-123", resp.SpiffeId)
 	require.Equal(gcp.PluginName, resp.AttestationData.Type)
 	require.Equal(s.body, string(resp.AttestationData.Data))
+}
+
+func (s *Suite) TestFailToSendOnStream() {
+	require := s.Require()
+
+	p := NewIITAttestorPlugin()
+	p.tokenHost = s.server.Listener.Addr().String()
+	_, err := p.Configure(context.Background(), &plugin.ConfigureRequest{
+		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
+			TrustDomain: "example.org",
+		},
+		Configuration: fmt.Sprintf(`
+service_account = "%s"
+`, testServiceAccount),
+	})
+	require.NoError(err)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"google": gcp.Google{
+			ComputeEngine: gcp.ComputeEngine{
+				ProjectID:  "project-123",
+				InstanceID: "instance-123",
+			},
+		},
+	})
+	s.body = s.signToken(token)
+	err = p.FetchAttestationData(&failSendStream{})
+	require.EqualError(err, "failed to send to stream")
 }
 
 func (s *Suite) TestConfigure() {
@@ -169,4 +207,56 @@ func (s *Suite) signToken(token *jwt.Token) string {
 func (s *Suite) requireErrorContains(err error, substring string) {
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), substring)
+}
+
+func TestRetrieveIdentity(t *testing.T) {
+	tests := []struct {
+		msg               string
+		url               string
+		handleFunc        func(w http.ResponseWriter, req *http.Request)
+		expectErrContains string
+	}{
+		{
+			msg:               "bad url",
+			url:               "::",
+			expectErrContains: "missing protocol scheme",
+		},
+		{
+			msg:               "invalid port",
+			url:               "http://0.0.0.0:70000",
+			expectErrContains: "invalid port",
+		},
+		{
+			msg: "fail to read body",
+			handleFunc: func(w http.ResponseWriter, req *http.Request) {
+				// Set a content length but don't write a body
+				w.Header().Set("Content-Length", "40")
+				w.WriteHeader(http.StatusOK)
+			},
+			expectErrContains: "unexpected EOF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			url := tt.url
+			if tt.handleFunc != nil {
+				server := httptest.NewServer(http.HandlerFunc(tt.handleFunc))
+				url = server.URL
+				defer server.Close()
+			}
+
+			_, err := retrieveInstanceIdentityToken(url)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectErrContains)
+		})
+	}
+}
+
+type failSendStream struct {
+	nodeattestor.FetchAttestationData_PluginStream
+}
+
+func (s *failSendStream) Send(*nodeattestor.FetchAttestationDataResponse) error {
+	return errors.New("failed to send to stream")
 }

--- a/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
@@ -121,7 +121,7 @@ func (s *Suite) TestSuccessfulIdentityTokenProcessing() {
 	require.Equal(s.body, string(resp.AttestationData.Data))
 }
 
-func (s *Suite) TestSuccessfulIdentityTokenProcessingCustomSVIDTemplate() {
+func (s *Suite) TestSuccessfulIdentityTokenProcessingCustomPathTemplate() {
 	require := s.Require()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"google": gcp.Google{
@@ -138,7 +138,7 @@ func (s *Suite) TestSuccessfulIdentityTokenProcessingCustomSVIDTemplate() {
 			TrustDomain: "example.org",
 		},
 		Configuration: fmt.Sprintf(`
-agent_svid_template = "{{ .InstanceID }}"
+agent_path_template = "{{ .InstanceID }}"
 service_account = "%s"
 `, testServiceAccount),
 	})
@@ -200,16 +200,16 @@ func (s *Suite) TestConfigure() {
 	s.requireErrorContains(err, "gcp-iit: trust_domain is required")
 	require.Nil(resp)
 
-	// bad svid template
+	// bad path template
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
 			TrustDomain: "example.org",
 		},
 		Configuration: `
-agent_svid_template = "{{"
+agent_path_template = "{{"
 `,
 	})
-	s.requireErrorContains(err, "failed to parse agent svid template")
+	s.requireErrorContains(err, "failed to parse agent path template")
 	require.Nil(resp)
 
 	// success

--- a/pkg/common/plugin/gcp/iit.go
+++ b/pkg/common/plugin/gcp/iit.go
@@ -41,6 +41,9 @@ type agentPathTemplateData struct {
 	PluginName string
 }
 
+// MakeSpiffeID makes an agent spiffe ID. The ID always has a host value equal to the given trust domain,
+// the path is created using the given agentPathTemplate which is given access to a fully populated
+// ComputeEngine object.
 func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, computeEngine ComputeEngine) (*url.URL, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{


### PR DESCRIPTION
Signed-off-by: Tyler Dixon <tylerd@uber.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
The gcp iit agent plugin now has an undocumented configuration option that allows a text/template to be provided for the agent base svid. This template must match the configuration on the SPIRE server side.

**Description of change**
Refactors the gcp iit agent plugin a bit and adds a new configuration option. Additionally, this change bumps the test coverage up and the package now passes golint.


