### PR TITLE
Increase agent manager test timeout

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -389,7 +389,7 @@ func TestSynchronization(t *testing.T) {
 		}
 	})
 
-	util.RunWithTimeout(t, 2*m.c.SyncInterval, func() {
+	util.RunWithTimeout(t, 3*m.c.SyncInterval, func() {
 		// There should be 3 updates after sync, because we are subcribed to selectors that
 		// matches with 3 entries that were renewed on the cache.
 		updates := sub.Updates()


### PR DESCRIPTION
This test is triggering failure when the tests are running under Docker in
Travis CI, which are quite slow.

This is a short term fix. Ideally the agent manager tests are refactored
to be more deterministic.