### PR TITLE
Prevent evicted/expired agents from fetching SVIDs

### DIFF
--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -337,8 +337,14 @@ func (h *Handler) AuthorizeCall(ctx context.Context, fullMethod string) (context
 		peerCert, err := getPeerCertificateFromRequestContext(ctx)
 		if err != nil {
 			h.c.Log.Error(err)
-			return nil, errors.New("client SVID is required for this request")
+			return nil, errors.New("agent SVID is required for this request")
 		}
+
+		if err := h.validateAgentSVID(ctx, peerCert); err != nil {
+			h.c.Log.Error(err)
+			return nil, errors.New("agent is not attested or no longer valid")
+		}
+
 		ctx = withPeerCertificate(ctx, peerCert)
 
 	// method not handled
@@ -367,6 +373,44 @@ func (h *Handler) isAttested(ctx context.Context, baseSpiffeID string) (bool, er
 	}
 
 	return false, nil
+}
+
+func (h *Handler) validateAgentSVID(ctx context.Context, cert *x509.Certificate) error {
+	dataStore := h.c.Catalog.DataStores()[0]
+
+	agentID, err := getSpiffeIDFromCert(cert)
+	if err != nil {
+		return err
+	}
+
+	// agent SVIDs must be unexpired and a belong to the attested nodes.
+	// NOTE: gRPC will reuse connections from agents and therefore, we can't
+	// rely on TLS handshakes to verify certificate validity since the
+	// certificate on the connection could have expired after the initial
+	// handshake.
+	if h.hooks.now().After(cert.NotAfter) {
+		return fmt.Errorf("agent %s SVID has expired", agentID)
+	}
+
+	resp, err := dataStore.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{
+		SpiffeId: agentID,
+	})
+	if err != nil {
+		return err
+	}
+
+	node := resp.Node
+	if node == nil {
+		return fmt.Errorf("agent %s is not attested", agentID)
+	}
+	if node.CertSerialNumber != cert.SerialNumber.String() {
+		return fmt.Errorf("agent %s SVID does not match expected serial number", agentID)
+	}
+	if node.CertNotAfter != cert.NotAfter.Unix() {
+		return fmt.Errorf("agent %s SVID does not match expected expiration", agentID)
+	}
+
+	return nil
 }
 
 func (h *Handler) doAttestChallengeResponse(ctx context.Context,

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -406,9 +406,6 @@ func (h *Handler) validateAgentSVID(ctx context.Context, cert *x509.Certificate)
 	if node.CertSerialNumber != cert.SerialNumber.String() {
 		return fmt.Errorf("agent %s SVID does not match expected serial number", agentID)
 	}
-	if node.CertNotAfter != cert.NotAfter.Unix() {
-		return fmt.Errorf("agent %s SVID does not match expected expiration", agentID)
-	}
 
 	return nil
 }

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -390,21 +390,6 @@ func testAuthorizeCallForCallsRequiringAgentSVID(t *testing.T, method string) {
 	require.Nil(t, ctx)
 	now = peerCert.NotAfter
 	peerCert.SerialNumber.Add(peerCert.SerialNumber, big.NewInt(-1))
-
-	// expiration does not match
-	_, err = ds.UpdateAttestedNode(context.Background(), &datastore.UpdateAttestedNodeRequest{
-		SpiffeId:         "spiffe://example.org/spire/agent/join_token/token",
-		CertSerialNumber: peerCert.SerialNumber.String(),
-		CertNotAfter:     peerCert.NotAfter.Unix() + 1,
-	})
-	peerCert.NotAfter = peerCert.NotAfter.Add(time.Second)
-	ctx, err = handler.AuthorizeCall(peerCtx, fullMethod)
-	require.EqualError(t, err, "agent is not attested or no longer valid")
-	require.Equal(t, "agent spiffe://example.org/spire/agent/join_token/token SVID does not match expected expiration", logHook.LastEntry().Message)
-	require.Nil(t, ctx)
-	now = peerCert.NotAfter
-	peerCert.NotAfter = peerCert.NotAfter.Add(-time.Second)
-
 }
 
 func loadCertFromPEM(fileName string) *x509.Certificate {


### PR DESCRIPTION
Recent eviction feature exposed a bug where evicted agents can still ask
for SVIDs since there is no check against the attested node data set.

Also, due to gRPC connection reuse, agent SVIDs used for an initial
connection that afterwards expire can still be used to fetch SVIDs.

This PR plugs the security hole by checking the client certificate
for validity every time it is used to make a call. Valid agent SVIDs are
unexpired and match an entry in the attested node data set.