### PR TITLE
Fix --node entry creation

### DIFF
--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -81,10 +81,14 @@ func (rc *CreateConfig) Validate() (err error) {
 	if err != nil {
 		return err
 	}
-	rc.ParentID, err = idutil.NormalizeSpiffeID(rc.ParentID, idutil.AllowAny())
-	if err != nil {
-		return err
+
+	if rc.ParentID != "" {
+		rc.ParentID, err = idutil.NormalizeSpiffeID(rc.ParentID, idutil.AllowAny())
+		if err != nil {
+			return err
+		}
 	}
+
 	for i := range rc.FederatesWith {
 		rc.FederatesWith[i], err = idutil.NormalizeSpiffeID(rc.FederatesWith[i], idutil.AllowAny())
 		if err != nil {


### PR DESCRIPTION
Parent ID become optional with the --node flag but a validation check
was missed that fails the command when trying to parse an empty parent
ID.

This commit only does the validation of the Parent ID if it is set.

Fixes #713 