### PR TITLE
Remove old plugin_dir conf

### DIFF
--- a/conf/agent/ha-postgres.conf
+++ b/conf/agent/ha-postgres.conf
@@ -1,7 +1,6 @@
 agent {
     data_dir = "./.data"
     log_level = "DEBUG"
-    plugin_dir = "./conf/agent/plugin"
     server_address = "spire-server"
     server_port = "8081"
     socket_path ="/tmp/agent.sock"

--- a/conf/server/ha-postgres.conf
+++ b/conf/server/ha-postgres.conf
@@ -4,7 +4,6 @@ server {
     registration_uds_path ="/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "./.data"
-    plugin_dir = "./conf/server/plugin"
     log_level = "DEBUG"
     umask = ""
     upstream_bundle = true

--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -4,7 +4,6 @@ server {
     registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "./.data"
-    plugin_dir = "./conf/server/plugin"
     log_level = "DEBUG"
     upstream_bundle = true
     svid_ttl = "1h"

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -79,7 +79,6 @@ server {
         bind_port = "8081"
         registration_uds_path ="/tmp/spire-registration.sock"
         trust_domain = "example.org"
-        plugin_dir = "conf/server/plugin"
         log_level = "DEBUG"
         base_svid_ttl = 999999
         server_svid_ttl = 999999

--- a/test/configs/server/postgres.conf
+++ b/test/configs/server/postgres.conf
@@ -4,7 +4,6 @@ server {
     registration_uds_path ="/tmp/spire-registration.sock"
     trust_domain = "example.org"
 	data_dir = "./.data"
-    plugin_dir = "./conf/server/plugin"
     log_level = "DEBUG"
     umask = ""
     upstream_bundle = true

--- a/test/fixture/config/agent_good.conf
+++ b/test/fixture/config/agent_good.conf
@@ -3,7 +3,6 @@ agent {
     bind_port = "8088"
     data_dir = "."
     log_level = "INFO"
-    plugin_dir = "conf/agent/plugin"
     server_address = "127.0.0.1"
     server_port = "8081"
     socket_path ="/tmp/agent.sock"

--- a/test/fixture/config/server_good.conf
+++ b/test/fixture/config/server_good.conf
@@ -3,7 +3,6 @@ server {
     bind_port = "8081"
     registration_uds_path ="/tmp/server.sock"
     trust_domain = "example.org"
-    plugin_dir = "conf/server/plugin"
     log_level = "INFO"
     base_svid_ttl = 999999
     server_svid_ttl = 999999


### PR DESCRIPTION
Removes the `plugin_dir` configurable which been unused for some time now but remains inside of sample configuration files.