### PR TITLE
(DO NOT MERGE) Figuring out why Travis CI is causing a node test to fail with EOF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,21 @@ test: ## Run tests
 	$(docker) go test github.com/spiffe/spire/...
 
 race-test: ## Run race tests
-	$(docker) go test -race github.com/spiffe/spire/...
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
+	$(docker) (cd pkg/server/endpoints/node && go test -race -testify.m Stale)
 
 integration: ## Run integration tests
 	$(docker) script/e2e_test.sh

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -930,11 +930,17 @@ func (s *HandlerSuite) requireFetchX509SVIDSuccess(req *node.FetchX509SVIDReques
 }
 
 func (s *HandlerSuite) requireFetchX509SVIDFailure(req *node.FetchX509SVIDRequest, errorCode codes.Code, errorContains string) {
+	fmt.Println("Opening FetchX509SVID stream")
 	stream, err := s.attestedClient.FetchX509SVID(context.Background())
 	s.Require().NoError(err)
-	s.Require().NoError(stream.Send(req))
+	fmt.Println("Sending request over FetchX509SVID stream")
+	err = stream.Send(req)
+	fmt.Println("Done request over FetchX509SVID stream", err)
+	s.Require().NoError(err)
 	stream.CloseSend()
+	fmt.Println("Receiving request over FetchX509SVID stream")
 	resp, err := stream.Recv()
+	fmt.Println("Done receiving request over FetchX509SVID stream", err)
 	s.Require().Contains(errorContains, status.Convert(err).Message())
 	s.Require().Equal(errorCode, status.Code(err))
 	s.Require().Nil(resp)


### PR DESCRIPTION
We've got a flaky test in the node handler that fails on Travis CI. The code doesn't seem to depend on any timing so I'm adding a bunch of print's to see if i can narrow down what is happening.