### PR TITLE
Server healthcheck

### DIFF
--- a/cmd/spire-server/cli/cli.go
+++ b/cmd/spire-server/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spiffe/spire/cmd/spire-server/cli/agent"
 	"github.com/spiffe/spire/cmd/spire-server/cli/bundle"
 	"github.com/spiffe/spire/cmd/spire-server/cli/entry"
+	"github.com/spiffe/spire/cmd/spire-server/cli/healthcheck"
 	"github.com/spiffe/spire/cmd/spire-server/cli/run"
 	"github.com/spiffe/spire/cmd/spire-server/cli/token"
 	"github.com/spiffe/spire/pkg/common/version"
@@ -60,6 +61,9 @@ func Run(args []string) int {
 		},
 		"token generate": func() (cli.Command, error) {
 			return &token.GenerateCLI{}, nil
+		},
+		"healthcheck": func() (cli.Command, error) {
+			return healthcheck.NewHealthCheckCommand(), nil
 		},
 	}
 

--- a/cmd/spire-server/cli/healthcheck/healthcheck.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck.go
@@ -1,0 +1,93 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"time"
+
+	"github.com/mitchellh/cli"
+	"github.com/spiffe/spire/cmd/spire-server/util"
+	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/proto/common"
+)
+
+func NewHealthCheckCommand() cli.Command {
+	return newHealthCheckCommand(common_cli.DefaultEnv)
+}
+
+func newHealthCheckCommand(env *common_cli.Env) *healthCheckCommand {
+	return &healthCheckCommand{
+		env:     env,
+		timeout: common_cli.DurationFlag(time.Second * 5),
+	}
+}
+
+type healthCheckCommand struct {
+	env *common_cli.Env
+
+	socketPath string
+	timeout    common_cli.DurationFlag
+	shallow    bool
+	verbose    bool
+}
+
+func (c *healthCheckCommand) Help() string {
+	c.parseFlags([]string{"-h"})
+	return ""
+}
+
+func (c *healthCheckCommand) Synopsis() string {
+	return "Determines server health status"
+}
+
+func (c *healthCheckCommand) Run(args []string) int {
+	if err := c.parseFlags(args); err != nil {
+		return 1
+	}
+	if err := c.run(args); err != nil {
+		c.env.ErrPrintf("Server is unhealthy: %v\n", err)
+		return 1
+	}
+	c.env.Println("Server is healthy.")
+	return 0
+}
+
+func (c *healthCheckCommand) parseFlags(args []string) error {
+	fs := flag.NewFlagSet("health", flag.ContinueOnError)
+	fs.SetOutput(c.env.Stderr)
+	fs.StringVar(&c.socketPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
+	fs.BoolVar(&c.shallow, "shallow", false, "Perform a less stringent health check")
+	fs.BoolVar(&c.verbose, "verbose", false, "Print verbose information")
+	return fs.Parse(args)
+}
+
+func (c *healthCheckCommand) run(args []string) error {
+	if c.verbose {
+		c.env.Println("Fetching bundle via Registration API...")
+	}
+
+	client, err := util.NewRegistrationClient(c.socketPath)
+	if err != nil {
+		if c.verbose {
+			c.env.ErrPrintf("Failed to create client: %v\n", err)
+		}
+		return errors.New("cannot create registration client")
+	}
+
+	// Currently using the ability to fetch a bundle as the health check. This
+	// **could** be problematic if the Upstream CA signing process is lengthy.
+	// As currently coded however, the registration API isn't served until after
+	// the server CA has been signed by upstream.
+	if _, err := client.FetchBundle(context.Background(), &common.Empty{}); err != nil {
+		if c.verbose {
+			c.env.ErrPrintf("Failed to fetch bundle: %v\n", err)
+		}
+		return errors.New("unable to fetch bundle")
+	}
+	if c.verbose {
+		c.env.Println("Successfully fetched bundle.")
+	}
+
+	return nil
+}

--- a/cmd/spire-server/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck_test.go
@@ -1,0 +1,142 @@
+package healthcheck
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/proto/api/registration"
+	"github.com/spiffe/spire/proto/common"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+func TestHealthCheck(t *testing.T) {
+	suite.Run(t, new(HealthCheckSuite))
+}
+
+type HealthCheckSuite struct {
+	suite.Suite
+
+	stdin  *bytes.Buffer
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+
+	cmd cli.Command
+}
+
+func (s *HealthCheckSuite) SetupTest() {
+	s.stdin = new(bytes.Buffer)
+	s.stdout = new(bytes.Buffer)
+	s.stderr = new(bytes.Buffer)
+
+	s.cmd = newHealthCheckCommand(&common_cli.Env{
+		Stdin:  s.stdin,
+		Stdout: s.stdout,
+		Stderr: s.stderr,
+	})
+}
+
+func (s *HealthCheckSuite) TestSynopsis() {
+	s.Equal("Determines server health status", s.cmd.Synopsis())
+}
+
+func (s *HealthCheckSuite) TestHelp() {
+	s.Equal("", s.cmd.Help())
+	s.Equal(`Usage of health:
+  -registrationUDSPath string
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
+  -shallow
+    	Perform a less stringent health check
+  -verbose
+    	Print verbose information
+`, s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) TestBadFlags() {
+	code := s.cmd.Run([]string{"-badflag"})
+	s.NotEqual(0, code, "exit code")
+	s.Equal("", s.stdout.String(), "stdout")
+	s.Equal(`flag provided but not defined: -badflag
+Usage of health:
+  -registrationUDSPath string
+    	Registration API UDS path (default "/tmp/spire-registration.sock")
+  -shallow
+    	Perform a less stringent health check
+  -verbose
+    	Print verbose information
+`, s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) TestFailsIfBundleCannotBeFetched() {
+	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock"})
+	s.NotEqual(0, code, "exit code")
+	s.Equal("", s.stdout.String(), "stdout")
+	s.Equal("Server is unhealthy: unable to fetch bundle\n", s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) TestFailsIfBundleCannotBeFetchedVerbose() {
+	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock", "--verbose"})
+	s.NotEqual(0, code, "exit code")
+	s.Equal(`Fetching bundle via Registration API...
+`, s.stdout.String(), "stdout")
+	s.Equal(`Failed to fetch bundle: rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing dial unix doesnotexist.sock: connect: no such file or directory"
+Server is unhealthy: unable to fetch bundle
+`, s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) TestSucceedsIfBundleFetched() {
+	socketPath, done := s.serveRegistrationAPI(withBundle{})
+	defer done()
+	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath})
+	s.Equal(0, code, "exit code")
+	s.Equal("Server is healthy.\n", s.stdout.String(), "stdout")
+	s.Equal("", s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) TestSucceedsIfBundleFetchedVerbose() {
+	socketPath, done := s.serveRegistrationAPI(withBundle{})
+	defer done()
+	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath, "--verbose"})
+	s.Equal(0, code, "exit code")
+	s.Equal(`Fetching bundle via Registration API...
+Successfully fetched bundle.
+Server is healthy.
+`, s.stdout.String(), "stdout")
+	s.Equal("", s.stderr.String(), "stderr")
+}
+
+func (s *HealthCheckSuite) serveRegistrationAPI(r registration.RegistrationServer) (string, func()) {
+	dir, err := ioutil.TempDir("", "server-healthcheck-test")
+	s.Require().NoError(err)
+
+	socketPath := filepath.Join(dir, "registration.sock")
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		os.RemoveAll(dir)
+		s.Require().NoError(err)
+	}
+
+	server := grpc.NewServer()
+	registration.RegisterRegistrationServer(server, r)
+	go server.Serve(listener)
+	return socketPath, func() {
+		server.Stop()
+		os.RemoveAll(dir)
+	}
+}
+
+type withBundle struct {
+	registration.RegistrationServer
+}
+
+func (withBundle) FetchBundle(context.Context, *common.Empty) (*registration.Bundle, error) {
+	return &registration.Bundle{}, nil
+}


### PR DESCRIPTION
Implements a simple server healthcheck that does a simple fetch of the trust bundle as outlined in #730.

The shallow flag is provided for use in liveliness tests, but currently has no effect.

Once we get a more flexible plugin/catalog system (i.e. #725) we can expand this to involve plugins in the health decision.

Fixes #731.