### PR TITLE
Fix k8s system test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: true
-dist: trusty
+sudo: required
+dist: xenial
 
 services:
   - docker
@@ -46,10 +46,30 @@ jobs:
 
     - stage: publish images
       if: type = push AND (tag IS present OR branch = master)
+      env:
+        - CHANGE_MINIKUBE_NONE_USER=true
       before_script:
+        # Decrypt credentials needed to log into gcr registry
         - openssl aes-256-cbc -K $encrypted_b48f9e852489_key -iv $encrypted_b48f9e852489_iv -in .travis/spire-travis-ci.json.enc -out .travis/spire-travis-ci.json -d
+        # Download stable kubectl
+        - curl -s -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        # Download latest minikube
+        - curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+        # Start up minikube
+        - sudo minikube start --vm-driver=none
+        # Make sure kubectl configuration is up to date
+        - sudo chown -R $USER.$USER ~/.kube
+        - sudo chown -R $USER.$USER ~/.minikube
+        - minikube update-context
+        # Wait for stuff to become ready
+        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       script:
-        - .travis/publish-images.sh
+        # Build spire images
+        - eval $(minikube docker-env) && make spire-images
+        # Run systems tests
+        - examples/k8s/test-all.sh
+        # Publish images
+        - eval $(minikube docker-env) && .travis/publish-images.sh
 
 notifications:
     slack:

--- a/.travis/publish-images.sh
+++ b/.travis/publish-images.sh
@@ -10,25 +10,11 @@ echo "Travis Branch : ${TRAVIS_BRANCH}"
 echo "Travis Tag    : ${TRAVIS_TAG}"
 echo "Travis Commit : ${TRAVIS_COMMIT}"
 
-if [ x"${TRAVIS_EVENT_TYPE}" != x"push" ]; then
-	echo "Skipping; only push builds are published"
-	exit 0
-fi
-
-if [ -z "${TRAVIS_TAG}" ] && [ x"${TRAVIS_BRANCH}" != x"master" ]; then
-	echo "Skipping; only tagged builds or builds off master are published"
-	exit 0
-fi
-
 # Log in to gcr.io using a key file for the Travis CI service account. The key
 # file is NOT stored plaintext and is decrypted by Travis CI before this script
 # is run.
 echo "Logging into gcr.io..."
 cat "${DIR}/spire-travis-ci.json" | docker login -u _json_key --password-stdin https://gcr.io
-
-# Build the SPIRE server and agent images
-echo "Building images..."
-make -C ${REPODIR} spire-images
 
 # Tag and push latest build by Git hash
 docker tag spire-server gcr.io/spiffe-io/spire-server:${TRAVIS_COMMIT}


### PR DESCRIPTION
- starts up minikube before building images
- runs systems tests before publishing images
- removes some unnecessary checks from publishing script (.travis.yml already checks these constraints)
- test-all.sh now exits with non-zero status if a test fails