### PR TITLE
Insure k8s tests have a runnable test-all.sh

### DIFF
--- a/examples/k8s/test-all.sh
+++ b/examples/k8s/test-all.sh
@@ -27,10 +27,10 @@ export PATH
 
 echo "${bold}Running all tests...${norm}"
 for testdir in "${DIR}"/*; do
-	if [ -d "${testdir}" ]; then
+	if [[ -x "${testdir}/test.sh" ]]; then
 		testname=$(basename "$testdir")
 		echo "${bold}Running \"$testname\" test...${norm}"
-		if LOGPREFIX=$testname "$testdir"/test.sh; then
+		if LOGPREFIX=$testname "${testdir}/test.sh"; then
 			echo "${green}\"$testname\" test succeeded${norm}"
 		else
 			echo "${red}\"$testname\" test failed${norm}"


### PR DESCRIPTION
Instead of relying on existence of subdirectories (which may or may not contain a test driver), use existence of a test driver for running tests. Also canonicalize bash syntax a bit.

Signed-off-by: Scott Emmons <scott@scytale.io>