### PR TITLE
Don't read from errchan if Stop was called

### DIFF
--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -56,8 +56,6 @@ func (e *endpoints) ListenAndServe(ctx context.Context) error {
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping workload API")
 		server.Stop()
-		l.Close()
-		<-errChan
 		return nil
 	}
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -139,9 +139,7 @@ func (e *endpoints) runTCPServer(ctx context.Context, server *grpc.Server) error
 		return err
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping TCP server")
-		l.Close()
 		server.Stop()
-		<-errChan
 		e.c.Log.Info("TCP server has stopped.")
 		return nil
 	}
@@ -172,9 +170,7 @@ func (e *endpoints) runUDSServer(ctx context.Context, server *grpc.Server) error
 		return err
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping UDS server")
-		l.Close()
 		server.Stop()
-		<-errChan
 		e.c.Log.Info("UDS server has stopped.")
 		return nil
 	}


### PR DESCRIPTION
https://godoc.org/google.golang.org/grpc#Server.Serve
"Serve will return a non-nil error unless Stop or GracefulStop is called."
"lis will be closed when this method returns."

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

