### PR TITLE
Fixed agent hang on shutdown closing UDS gRPC server

### DIFF
--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -56,7 +56,6 @@ func (e *endpoints) ListenAndServe(ctx context.Context) error {
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping workload API")
 		server.Stop()
-		l.Close()
 		<-errChan
 		return nil
 	}

--- a/pkg/common/auth/uds.go
+++ b/pkg/common/auth/uds.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"net"
+	"syscall"
+)
+
+func FromUDSConn(conn net.Conn) CallerInfo {
+	var info CallerInfo
+
+	sysconn, ok := conn.(syscall.Conn)
+	if !ok {
+		info.Err = ErrInvalidConnection
+		return info
+	}
+
+	rawconn, err := sysconn.SyscallConn()
+	if err != nil {
+		info.Err = ErrInvalidConnection
+		return info
+	}
+
+	var result int32
+	controlErr := rawconn.Control(func(fd uintptr) {
+		result, err = getPeerPID(fd)
+	})
+
+	if controlErr != nil || err != nil {
+		info.Err = ErrInvalidConnection
+		return info
+	}
+
+	info.Addr = conn.RemoteAddr()
+	info.PID = result
+	return info
+}

--- a/pkg/common/auth/uds_bsd.go
+++ b/pkg/common/auth/uds_bsd.go
@@ -3,34 +3,13 @@
 package auth
 
 import (
-	"net"
-
 	"golang.org/x/sys/unix"
 )
 
-func FromUDSConn(conn net.Conn) CallerInfo {
-	var info CallerInfo
-
-	uconn, ok := conn.(*net.UnixConn)
-	if !ok {
-		info.Err = ErrInvalidConnection
-		return info
-	}
-
-	file, err := uconn.File()
+func getPeerPID(fd uintptr) (pid int32, err error) {
+	result, err := unix.GetsockoptInt(int(fd), 0, 0x002) //getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID)
 	if err != nil {
-		info.Err = err
-		return info
+		return 0, err
 	}
-	defer file.Close()
-
-	result, err := unix.GetsockoptInt(int(file.Fd()), 0, 0x002) //getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID)
-	if err != nil {
-		info.Err = err
-		return info
-	}
-
-	info.Addr = uconn.RemoteAddr()
-	info.PID = int32(result)
-	return info
+	return int32(result), nil
 }

--- a/pkg/common/auth/uds_fallback.go
+++ b/pkg/common/auth/uds_fallback.go
@@ -6,10 +6,6 @@
 
 package auth
 
-import "net"
-
-func FromUDSConn(conn net.Conn) CallerInfo {
-	var info CallerInfo
-	info.Err = ErrUnsupportedPlatform
-	return info
+func getPeerPID(fd int) (pid int, err error) {
+	return 0, ErrUnsupportedPlatform
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -139,7 +139,6 @@ func (e *endpoints) runTCPServer(ctx context.Context, server *grpc.Server) error
 		return err
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping TCP server")
-		l.Close()
 		server.Stop()
 		<-errChan
 		e.c.Log.Info("TCP server has stopped.")
@@ -172,7 +171,6 @@ func (e *endpoints) runUDSServer(ctx context.Context, server *grpc.Server) error
 		return err
 	case <-ctx.Done():
 		e.c.Log.Info("Stopping UDS server")
-		l.Close()
 		server.Stop()
 		<-errChan
 		e.c.Log.Info("UDS server has stopped.")


### PR DESCRIPTION
The UDS gRPC server credentials pull the peer PID off of the UDS. Obtaining the FD for the connection was via the File() method. Unfortunately, File() switches the underlying FD into blocking mode, which prevents gRPC from closing the conns appropriately.

This changes up the credentials to instead obtain the FD (and do the control call) via the syscall.RawConn. Doing so allows gRPC to close down the connections appropriately, fixing the hang on (*grpc.Server).Close().

Refactored the code a bit to share more implementation between unix and linux.

Also removed the unnecessary call to close listeners, since the gRPC server does that for us.

Fixes #787