### PR TITLE
Use k8s.io canonical import which dep enfores but go mod doesnt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	github.com/jinzhu/now v0.0.0-20181116074157-8ec929ed50c3 // indirect
 	github.com/json-iterator/go v1.1.5 // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
-	github.com/kubernetes/client-go v10.0.0+incompatible
 	github.com/lib/pq v1.0.0 // indirect
 	github.com/lyft/protoc-gen-validate v0.0.12 // indirect
 	github.com/mattn/go-sqlite3 v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,6 @@ github.com/json-iterator/go v1.1.5 h1:gL2yXlmiIo4+t+y32d4WGwOjKGYcGOuyrg46vadswD
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/kubernetes/client-go v10.0.0+incompatible h1:JyUQ2lK3g7vKdhEswzIYwJ7EkJ0J3A+uXbuRNAXhtbk=
-github.com/kubernetes/client-go v10.0.0+incompatible/go.mod h1:kszVi2i+FeqECZHhjpkV5h5zM0GnURfJv897YzgoAQ8=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lyft/protoc-gen-validate v0.0.12 h1:4yfI8PSMdUqdTrQqjNIgjTJ7Vl3zFNqtgBGXsB7QJiw=

--- a/pkg/common/plugin/k8s/client/client.go
+++ b/pkg/common/plugin/k8s/client/client.go
@@ -1,8 +1,8 @@
 package client
 
 import (
-	"github.com/kubernetes/client-go/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
https://github.com/golang/go/issues/26367#issuecomment-405666468

That said, this does clean up the potential for the two different
versions of the same code imported in the same file to diverge.


