### PR TITLE
Wire up mock clock in ca tests

### DIFF
--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -88,6 +88,7 @@ func (s *CATestSuite) SetupTest() {
 			Country:      []string{"TEST"},
 			Organization: []string{"TEST"},
 		},
+		Clock: s.clock,
 	})
 	s.ca.setKeypairSet(keypairSet{
 		slot: "FOO",


### PR DESCRIPTION
Previous work introduced the mock clock but it was never wired up during
tests, causing spurious test failures.