### PR TITLE
Some small fixes to build in other platforms

### DIFF
--- a/pkg/common/auth/uds_fallback.go
+++ b/pkg/common/auth/uds_fallback.go
@@ -6,6 +6,6 @@
 
 package auth
 
-func getPeerPID(fd int) (pid int, err error) {
+func getPeerPID(fd uintptr) (pid int32, err error) {
 	return 0, ErrUnsupportedPlatform
 }

--- a/pkg/common/cli/umask_posix.go
+++ b/pkg/common/cli/umask_posix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package cli
 
 import "syscall"


### PR DESCRIPTION
- FIx the `getPeerPID` func in uds_fallback.go to match the called types.
- Do not build umask_posix.go on Windows.
The umask_posix.go file name may suggest that the "posix" suffix is a GOOS name when it's not. We may consider a file name change.