### PR TITLE
Handle agent restarts in SDS handler

### DIFF
--- a/pkg/agent/endpoints/sds/handler.go
+++ b/pkg/agent/endpoints/sds/handler.go
@@ -102,7 +102,7 @@ func (h *Handler) StreamSecrets(stream discovery_v2.SecretDiscoveryService_Strea
 			// The nonce should be empty (if we've never sent a response) or
 			// match the last sent nonce, otherwise the request should be
 			// ignored.
-			if lastNonce != newReq.ResponseNonce {
+			if lastNonce != "" && lastNonce != newReq.ResponseNonce {
 				h.c.Log.Warnf("Received unexpected nonce %q (expected %q); ignoring request", newReq.ResponseNonce, lastNonce)
 				continue
 			}


### PR DESCRIPTION
Envoy will send the last known nonce when it reconnects to a restarted
agent. The agent should ignore the nonce unless it has sent one.

Fixes #813 