### PR TITLE
Add TLS options for MySQL

### DIFF
--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -2,10 +2,13 @@
 
 The `sql` plugin implements a sql based storage option for the SPIRE server using SQLite, PostgreSQL or MySQL databases.
 
-| Configuration     | Description                                |
-| ------------------| ------------------------------------------ |
-| database_type     | database type                              |
-| connection_string | connection string                          |
+| Configuration     | Description                                                |
+| ------------------| ---------------------------------------------------------- |
+| database_type     | database type                                              |
+| connection_string | connection string                                          |
+| root_ca_path      | Path to Root CA bundle (MySQL only)                        |
+| client_cert_path  | Path to client certificate (MySQL only)                    |
+| client_key_path   | Path to private key for client certificate (MySQL only)    |
 
 The plugin defaults to an in-memory database and any information in the data store is lost on restart.
 
@@ -79,4 +82,4 @@ Read MySQL driver for more `connection_string` options [here](https://github.com
 * address - The host to connect to. Values that start with / are for unix
   domain sockets. (default is localhost)
 
-You can configure SSL/TLS mode via [tls](https://github.com/go-sql-driver/mysql#tls) params
+If you need to use custom Root CA, just specify `root_ca_path` in the plugin config. Similarly, if you need to use client certificates, specify `client_key_path` and `client_cert_path`. Other options can be configured via [tls](https://github.com/go-sql-driver/mysql#tls) params in the `connection_string` options.

--- a/pkg/server/plugin/datastore/sql/mysql.go
+++ b/pkg/server/plugin/datastore/sql/mysql.go
@@ -1,7 +1,10 @@
 package sql
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
+	"io/ioutil"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
@@ -12,12 +15,77 @@ import (
 
 type mysql struct{}
 
-func (my mysql) connect(connectionString string) (*gorm.DB, error) {
-	db, err := gorm.Open("mysql", connectionString)
+const (
+	tlsConfigName = "spireCustomTLS"
+)
+
+func (my mysql) connect(cfg *configuration) (*gorm.DB, error) {
+	connString, err := configureConnection(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := gorm.Open("mysql", connString)
 	if err != nil {
 		return nil, err
 	}
 	return db, nil
+}
+
+// configureConnection modifies the connection string to support features that
+// normally require code changes, like custom Root CAs or client certificates
+func configureConnection(cfg *configuration) (string, error) {
+	if !hasTLSConfig(cfg) {
+		// connection string doesn't have to be modified
+		return cfg.ConnectionString, nil
+	}
+
+	tlsConf := tls.Config{}
+
+	opts, err := mysqldriver.ParseDSN(cfg.ConnectionString)
+	if err != nil {
+		// the connection string should have already been validated by now
+		// (in validateMySQLConfig)
+		return "", sqlError.Wrap(err)
+	}
+
+	// load and configure Root CA if it exists
+	if len(cfg.RootCAPath) > 0 {
+		rootCertPool := x509.NewCertPool()
+		pem, err := ioutil.ReadFile(cfg.RootCAPath)
+
+		if err != nil {
+			return "", sqlError.Wrap(errors.New("invalid mysql config: cannot find Root CA defined in root_ca_path"))
+		}
+
+		if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
+			return "", sqlError.Wrap(errors.New("invalid mysql config: failed to parse Root CA defined in root_ca_path"))
+		}
+		tlsConf.RootCAs = rootCertPool
+	}
+
+	// load and configure client certificate if it exists
+	if len(cfg.ClientCertPath) > 0 && len(cfg.ClientKeyPath) > 0 {
+		clientCert := make([]tls.Certificate, 0, 1)
+		certs, err := tls.LoadX509KeyPair(cfg.ClientCertPath, cfg.ClientKeyPath)
+		if err != nil {
+			return "", sqlError.Wrap(errors.New("invalid mysql config: failed to load client certificate defined in client_cert_path and client_key_path"))
+		}
+		clientCert = append(clientCert, certs)
+		tlsConf.Certificates = clientCert
+	}
+
+	// register a custom TLS config that uses custom Root CAs with the MySQL driver
+	mysqldriver.RegisterTLSConfig(tlsConfigName, &tlsConf)
+
+	// instruct MySQL driver to use the custom TLS config
+	opts.TLSConfig = tlsConfigName
+
+	return opts.FormatDSN(), nil
+}
+
+func hasTLSConfig(cfg *configuration) bool {
+	return len(cfg.RootCAPath) > 0 || len(cfg.ClientCertPath) > 0 && len(cfg.ClientKeyPath) > 0
 }
 
 func validateMySQLConfig(cfg *configuration) error {

--- a/pkg/server/plugin/datastore/sql/postgres.go
+++ b/pkg/server/plugin/datastore/sql/postgres.go
@@ -8,8 +8,8 @@ import (
 
 type postgres struct{}
 
-func (p postgres) connect(connectionString string) (*gorm.DB, error) {
-	db, err := gorm.Open("postgres", connectionString)
+func (p postgres) connect(cfg *configuration) (*gorm.DB, error) {
+	db, err := gorm.Open("postgres", cfg.ConnectionString)
 	if err != nil {
 		return nil, sqlError.Wrap(err)
 	}

--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -10,8 +10,8 @@ import (
 
 type sqlite struct{}
 
-func (s sqlite) connect(connectionString string) (*gorm.DB, error) {
-	embellished, err := embellishSQLite3ConnString(connectionString)
+func (s sqlite) connect(cfg *configuration) (*gorm.DB, error) {
+	embellished, err := embellishSQLite3ConnString(cfg.ConnectionString)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
None, adds functionality to datastore/sql plugin for MySQL.

**Description of change**
Allows users to specify custom Root CAs and client certificate for the TLS connection to the MySQL server. As an example, [AWS RDS MySQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html#MySQL.Concepts.SSLSupport) requires the client to use RDS root certificate for verification.

Unfortunately, [MySQL Go driver](https://github.com/go-sql-driver/mysql#tls) only allows to specify Root CAs and client certificates via a custom TLS Config (and not via a connection string options). This change allows for conditional configuration of the connection string, by simply specifying `root_ca_path` or `client_key_path` and `client_cert_path` in the plugin's config.

PostgreSQL doesn't need these config options, because they can be set via a connection string. Adding this to the datastore/sql plugin config might be somewhat misleading, so I've updated the documentation accordingly.

**Which issue this PR fixes**
None.

