### PR TITLE
Improve CI times

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -2,8 +2,13 @@
 ARG goversion
 FROM golang:${goversion}-alpine as builder
 RUN apk add build-base git mercurial
+# Download modules in a separate step for quicker builds when deps haven't changed
+ADD go.mod /spire/go.mod
+ADD go.sum /spire/go.sum
+RUN cd /spire && go mod download
+# Build spire-agent
 ADD . /spire
-RUN cd /spire && make test && make build
+RUN cd /spire && make test && make cmd/spire-agent
 
 # Image stage
 FROM alpine

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,8 +2,13 @@
 ARG goversion
 FROM golang:${goversion}-alpine as builder
 RUN apk add build-base git mercurial
+# Download modules in a separate step for quicker builds when deps haven't changed
+ADD go.mod /spire/go.mod
+ADD go.sum /spire/go.sum
+RUN cd /spire && go mod download
+# Build spire-server
 ADD . /spire
-RUN cd /spire && make test && make build
+RUN cd /spire && make test && make cmd/spire-server
 
 # Image stage
 FROM alpine

--- a/script/e2e_test.sh
+++ b/script/e2e_test.sh
@@ -101,9 +101,11 @@ run_e2e_test "conf/server/server.conf"
 run_docker_test "test/configs/server/postgres.conf" "-e POSTGRES_PASSWORD=password -p 10864:5432 -d postgres"
 run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:8.0.15"
 
-# Run these extra tests when running under Travis on the master branch or on a tagged commit
-if [ -n "$TRAVIS_TAG" ] || [ x"${TRAVIS_BRANCH}" = x"master" ]; then
-    run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.5.62"
-    run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.6.43"
-    run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.7.25"
+# Run these extra tests when Travis pushes on the master branch or on a tagged commit
+if [ x"${TRAVIS_EVENT_TYPE}" = x"push" ]; then
+	if [ -n "$TRAVIS_TAG" ] || [ x"${TRAVIS_BRANCH}" = x"master" ]; then
+		run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.5.62"
+		run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.6.43"
+		run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:5.7.25"
+	fi
 fi


### PR DESCRIPTION
- only execute MySQL end-to-end testing on old versions after a PR has been merged.
- download Go modules in a separate docker step so the results can be cached between agent/server image builds
- don't build unrelated binaries when building spire-server/spire-agent images