### PR TITLE
Return codes.AlreadyExists if an entry already exists

### DIFF
--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) CreateEntry(
 	}
 
 	if !unique {
-		err = errors.New("Entry already exists")
+		err = status.Error(codes.AlreadyExists, "entry already exists")
 		h.Log.Error(err)
 		return nil, err
 	}

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -343,7 +343,7 @@ func (s *HandlerSuite) TestCreateEntry() {
 				SpiffeId:  "spiffe://example.org/child",
 				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
 			},
-			Err: "Entry already exists",
+			Err: status.Error(codes.AlreadyExists, "entry already exists").Error(),
 		},
 	}
 


### PR DESCRIPTION
This will enable checking on the client side if a create failed because the entry already exists. This will allow a caller to avoid first calling ListBySpiffeID to check if the entry already exists.
