### PR TITLE
Fix k8s system tests

### DIFF
--- a/examples/k8s/simple_psat/spire-server.yaml
+++ b/examples/k8s/simple_psat/spire-server.yaml
@@ -38,6 +38,7 @@ data:
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
       svid_ttl = "1h"
+      upstream_bundle = true
       ca_subject = {
         Country = ["US"],
         Organization = ["SPIFFE"],

--- a/examples/k8s/simple_sat/spire-server.yaml
+++ b/examples/k8s/simple_sat/spire-server.yaml
@@ -38,6 +38,7 @@ data:
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
       svid_ttl = "1h"
+      upstream_bundle = true
       ca_subject = {
         Country = ["US"],
         Organization = ["SPIFFE"],


### PR DESCRIPTION
The simple_sat and simple_psat examples were misconfigured to not set
upstream_bundle=true, even though they relied on the dummy upstream cert
for bootstrapping. This configuration still worked until recently as
SPIRE server presented the server CA certificate (which is signed by
upstream) along with the server certificate during the TLS handshake,
for compatability with old agents that didn't handle SVID intermediates
appropriately. This behavior was recently removed, thus breaking
bootstrapping. Fixing the systems tests to set upstream_bundle=true.
