### PR TITLE
Add health checking infrastructure to SPIRE Server

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -17,6 +17,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -34,9 +35,10 @@ const (
 
 // config contains all available configurables, arranged by section
 type config struct {
-	Server    *serverConfig               `hcl:"server"`
-	Plugins   *catalog.HCLPluginConfigMap `hcl:"plugins"`
-	Telemetry telemetry.FileConfig        `hcl:"telemetry"`
+	Server       *serverConfig               `hcl:"server"`
+	Plugins      *catalog.HCLPluginConfigMap `hcl:"plugins"`
+	Telemetry    telemetry.FileConfig        `hcl:"telemetry"`
+	HealthChecks health.Config               `hcl:"health_checks"`
 }
 
 type serverConfig struct {
@@ -312,6 +314,7 @@ func newServerConfig(c *config) (*server.Config, error) {
 
 	sc.PluginConfigs = *c.Plugins
 	sc.Telemetry = c.Telemetry
+	sc.HealthChecks = c.HealthChecks
 
 	return sc, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.1.0 // indirect
 	// version 1.14
 	github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190405210948-c70a36b8193f
+	github.com/InVisionApp/go-health v2.1.0+incompatible
+	github.com/InVisionApp/go-logger v1.0.1 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129

--- a/go.sum
+++ b/go.sum
@@ -39,13 +39,19 @@ github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190405210948-c70a36b8193f
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190405210948-c70a36b8193f/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190625211440-fa714b45b08a h1:Ko7s/GwoegnrmU93+erycrndRP4Oyz+Ug+i6axQkhAU=
 github.com/GoogleCloudPlatform/cloudsql-proxy v0.0.0-20190625211440-fa714b45b08a/go.mod h1:aJ4qN3TfrelA6NZ6AXsXRfmEVaYin3EDbSPJrKS8OXo=
+github.com/InVisionApp/go-health v2.1.0+incompatible h1:m5nRf/RKaMCkob7V5Vc3tuzlpqY2K9hL5awZomjzuCk=
+github.com/InVisionApp/go-health v2.1.0+incompatible/go.mod h1:/+Gv1o8JUsrjC6pi6MN6/CgKJo4OqZ6x77XAnImrzhg=
+github.com/InVisionApp/go-logger v1.0.1 h1:WFL19PViM1mHUmUWfsv5zMo379KSWj2MRmBlzMFDRiE=
+github.com/InVisionApp/go-logger v1.0.1/go.mod h1:+cGTDSn+P8105aZkeOfIhdd7vFO5X1afUHcjvanY0L8=
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
@@ -376,6 +382,7 @@ google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1 h1:j6XxA85m/6txkUCHvzlV5f+HBNl/1r5cZ2A/3IEFOO8=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/pkg/common/health/config.go
+++ b/pkg/common/health/config.go
@@ -1,0 +1,55 @@
+package health
+
+import (
+	"fmt"
+)
+
+type Config struct {
+	ListenerEnabled bool `hcl:"listener_enabled"`
+
+	// Address and port to listen on, defaulting to localhost:80
+	BindAddress string `hcl:"bind_address"`
+	BindPort    string `hcl:"bind_port"`
+
+	// Paths for /ready and /live
+	ReadyPath string `hcl:"ready_path"`
+	LivePath  string `hcl:"live_path"`
+}
+
+// getReadyPath returns the configured value or a default
+func (c *Config) getReadyPath() string {
+	if c.ReadyPath == "" {
+		return "/ready"
+	}
+
+	return c.ReadyPath
+}
+
+// getLivePath returns the configured value or a default
+func (c *Config) getLivePath() string {
+	if c.LivePath == "" {
+		return "/live"
+	}
+
+	return c.LivePath
+}
+
+// getAddress returns an address suitable for use as http.Server.Addr, or nil if not configured with
+// a port to listen on
+func (c *Config) getAddress() *string {
+	if c.ListenerEnabled {
+		host := "localhost"
+		if c.BindAddress != "" {
+			host = c.BindAddress
+		}
+
+		port := "80"
+		if c.BindPort != "" {
+			port = c.BindPort
+		}
+
+		address := fmt.Sprintf("%s:%s", host, port)
+		return &address
+	}
+	return nil
+}

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -1,0 +1,102 @@
+package health
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/InVisionApp/go-health"
+	"github.com/InVisionApp/go-health/handlers"
+	"github.com/sirupsen/logrus"
+)
+
+// health.Checker is responsible for running health checks and serving the healthcheck HTTP paths
+type Checker struct {
+	config Config
+
+	server *http.Server
+
+	hc    *health.Health
+	mutex sync.Mutex // Mutex protects non-threadsafe hc
+
+	log logrus.FieldLogger
+}
+
+func live(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+}
+
+func NewChecker(config Config, log logrus.FieldLogger) *Checker {
+	hc := health.New()
+
+	var server http.Server
+	// Start HTTP server if address is configured
+	address := config.getAddress()
+	if address != nil {
+		handler := http.NewServeMux()
+
+		handler.HandleFunc(config.getReadyPath(), handlers.NewJSONHandlerFunc(hc, nil))
+		handler.HandleFunc(config.getLivePath(), live)
+
+		server = http.Server{
+			Addr:    *address,
+			Handler: handler,
+		}
+	}
+
+	hc.StatusListener = &statusListener{}
+
+	return &Checker{config: config, server: &server, hc: hc, log: log}
+}
+
+func (c *Checker) AddCheck(name string, checker health.ICheckable, interval time.Duration) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	return c.hc.AddCheck(&health.Config{
+		Name:     name,
+		Checker:  checker,
+		Interval: interval,
+		Fatal:    true,
+	})
+}
+
+func (c *Checker) ListenAndServe(ctx context.Context) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if err := c.hc.Start(); err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	if c.server != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.log.WithField("address", c.config.getAddress()).Info("Serving health checks")
+			if err := c.server.ListenAndServe(); err != http.ErrServerClosed {
+				c.log.WithError(err).Warn("Error serving health checks")
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-ctx.Done()
+		if c.server != nil {
+			c.server.Close()
+		}
+	}()
+
+	wg.Wait()
+
+	if err := c.hc.Stop(); err != nil {
+		c.log.WithError(err).Warn("error stopping health checks")
+	}
+
+	return nil
+}

--- a/pkg/common/health/logger.go
+++ b/pkg/common/health/logger.go
@@ -1,0 +1,32 @@
+package health
+
+import (
+	"github.com/InVisionApp/go-health"
+	"github.com/sirupsen/logrus"
+)
+
+// statusListener logs
+type statusListener struct {
+	log logrus.FieldLogger
+}
+
+// Assert statusListener implements IStatusListener
+var _ health.IStatusListener = &statusListener{}
+
+// HealthCheckFailed is triggered when a health check fails the first time
+func (sl *statusListener) HealthCheckFailed(entry *health.State) {
+	sl.log.WithField("check", entry.Name).
+		WithField("details", entry.Details).
+		WithField("error", entry.Err).
+		Warn("Health check failed")
+}
+
+// HealthCheckRecovered is triggered when a health check recovers
+func (sl *statusListener) HealthCheckRecovered(entry *health.State, recordedFailures int64, failureDurationSeconds float64) {
+	sl.log.WithField("check", entry.Name).
+		WithField("details", entry.Details).
+		WithField("error", entry.Err).
+		WithField("failures", recordedFailures).
+		WithField("duration", failureDurationSeconds).
+		Info("Health check recovered")
+}


### PR DESCRIPTION
We add a new common health package which is a SPIRE-flavored wrapper around
github.com/InVisionApp/go-health

This doesn't actually check anything yet.  I started looking at how to have something that called a Status method on plugins if they exposed it, but I got hung up in the weeds figuring out how the catalog worked.  So I thought it was better to start small and get some early feedback if this approach seems reasonable.