### PR TITLE
centralization of metric names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
-	github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.4.0

--- a/pkg/agent/attestor/node/node.go
+++ b/pkg/agent/attestor/node/node.go
@@ -59,7 +59,7 @@ func New(config *Config) Attestor {
 }
 
 func (a *attestor) Attest(ctx context.Context) (res *AttestationResult, err error) {
-	defer telemetry.CountCall(a.c.Metrics, "node", "attest")(&err)
+	defer telemetry.CountCall(a.c.Metrics, telemetry.Node, telemetry.Attest)(&err)
 
 	bundle, err := a.loadBundle()
 	if err != nil {
@@ -188,7 +188,7 @@ func (a *attestor) readSVIDFromDisk() []*x509.Certificate {
 // newSVID obtains an agent svid for the given private key by performing node attesatation. The bundle is
 // necessary in order to validate the SPIRE server we are attesting to. Returns the SVID and an updated bundle.
 func (a *attestor) newSVID(ctx context.Context, key *ecdsa.PrivateKey, bundle *bundleutil.Bundle) (newSVID []*x509.Certificate, newBundle *bundleutil.Bundle, err error) {
-	counter := telemetry.StartCall(a.c.Metrics, "node", "attestor", "new_svid")
+	counter := telemetry.StartCall(a.c.Metrics, telemetry.Node, telemetry.Attestor, telemetry.NewSVID)
 	defer counter.Done(&err)
 
 	// make sure all of the streams are cancelled if something goes awry
@@ -262,7 +262,7 @@ func (a *attestor) newSVID(ctx context.Context, key *ecdsa.PrivateKey, bundle *b
 			break
 		}
 	}
-	counter.AddLabel("spiffe_id", spiffeID)
+	counter.AddLabel(telemetry.SPIFFEID, spiffeID)
 
 	if fetchStream != nil {
 		fetchStream.CloseSend()

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -33,10 +33,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const (
-	workloadApi = "workload_api"
-)
-
 // Handler implements the Workload API interface
 type Handler struct {
 	Manager manager.Manager
@@ -45,6 +41,7 @@ type Handler struct {
 	M       telemetry.Metrics
 }
 
+// FetchJWTSVID processes request for a JWT SVID
 func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest) (resp *workload.JWTSVIDResponse, err error) {
 	if len(req.Audience) == 0 {
 		return nil, errs.New("audience must be specified")
@@ -56,26 +53,26 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 	}
 	defer done()
 
-	counter := telemetry.StartCall(metrics, workloadApi, "fetch_jwt_svid")
+	counter := telemetry.StartCall(metrics, telemetry.WorkloadAPI, telemetry.FetchJWTSVID)
 	defer counter.Done(&err)
 
-	counter.AddLabel("svid_type", "jwt")
+	counter.AddLabel(telemetry.SVIDType, telemetry.JWT)
 
 	var spiffeIDs []string
 	entries := h.Manager.MatchingEntries(selectors)
 	if len(entries) == 0 {
-		counter.AddLabel("registered", "false")
+		counter.AddLabel(telemetry.Registered, "false")
 		return nil, status.Errorf(codes.PermissionDenied, "no identity issued")
 	}
 
-	counter.AddLabel("registered", "true")
+	counter.AddLabel(telemetry.Registered, "true")
 
 	for _, entry := range entries {
 		if req.SpiffeId != "" && entry.RegistrationEntry.SpiffeId != req.SpiffeId {
 			continue
 		}
 		spiffeIDs = append(spiffeIDs, entry.RegistrationEntry.SpiffeId)
-		counter.AddLabel("spiffe_id", entry.RegistrationEntry.SpiffeId)
+		counter.AddLabel(telemetry.SPIFFEID, entry.RegistrationEntry.SpiffeId)
 	}
 
 	resp = new(workload.JWTSVIDResponse)
@@ -92,16 +89,17 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 
 		ttl := time.Until(svid.ExpiresAt)
 		metrics.SetGaugeWithLabels(
-			[]string{workloadApi, "fetch_jwt_svid", "ttl"},
+			[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
 			float32(ttl.Seconds()),
 			[]telemetry.Label{
-				{Name: "spiffe_id", Value: spiffeID},
+				{Name: telemetry.SPIFFEID, Value: spiffeID},
 			})
 	}
 
 	return resp, nil
 }
 
+// FetchJWTBundles processes request for JWT bundles
 func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream workload.SpiffeWorkloadAPI_FetchJWTBundlesServer) error {
 	ctx := stream.Context()
 
@@ -111,7 +109,7 @@ func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream worklo
 	}
 	defer done()
 
-	metrics.IncrCounter([]string{workloadApi, "fetch_jwt_bundles"}, 1)
+	metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, 1)
 
 	subscriber := h.Manager.SubscribeToCacheChanges(selectors)
 	defer subscriber.Finish()
@@ -119,13 +117,13 @@ func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream worklo
 	for {
 		select {
 		case update := <-subscriber.Updates():
-			metrics.IncrCounter([]string{workloadApi, "bundles_update"}, 1)
+			metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate}, 1)
 			start := time.Now()
 			if err := h.sendJWTBundlesResponse(update, stream); err != nil {
 				return err
 			}
 
-			metrics.MeasureSince([]string{workloadApi, "send_jwt_bundle_latency"}, start)
+			metrics.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, start)
 			if time.Since(start) > (1 * time.Second) {
 				h.L.Warnf("Took %v seconds to send JWT bundle to PID %v", time.Since(start).Seconds, pid)
 			}
@@ -135,6 +133,7 @@ func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream worklo
 	}
 }
 
+// ValidateJWTSVID processes request for JWT SVID validation
 func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWTSVIDRequest) (*workload.ValidateJWTSVIDResponse, error) {
 	if req.Audience == "" {
 		return nil, status.Error(codes.InvalidArgument, "audience must be specified")
@@ -153,22 +152,22 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 
 	spiffeID, claims, err := jwtsvid.ValidateToken(ctx, req.Svid, keyStore, []string{req.Audience})
 	if err != nil {
-		metrics.IncrCounterWithLabels([]string{workloadApi, "validate_jwt_svid"}, 1, []telemetry.Label{
+		metrics.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
 			{
-				Name:  "error",
+				Name:  telemetry.Error,
 				Value: err.Error(),
 			},
 		})
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	metrics.IncrCounterWithLabels([]string{workloadApi, "validate_jwt_svid"}, 1, []telemetry.Label{
+	metrics.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
 		{
-			Name:  "subject",
+			Name:  telemetry.Subject,
 			Value: spiffeID,
 		},
 		{
-			Name:  "audience",
+			Name:  telemetry.Audience,
 			Value: req.Audience,
 		},
 	})
@@ -185,6 +184,7 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 
 }
 
+// FetchX509SVID processes request for an x509 SVID
 func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.SpiffeWorkloadAPI_FetchX509SVIDServer) error {
 	ctx := stream.Context()
 
@@ -209,7 +209,7 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 			// TODO: evaluate the possibility of removing the following metric at some point
 			// in the future because almost the same metric (with different labels and keys) is being
 			// taken by the CallCounter in sendX509SVIDResponse function.
-			metrics.MeasureSince([]string{workloadApi, "svid_response_latency"}, start)
+			metrics.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency}, start)
 			if time.Since(start) > (1 * time.Second) {
 				h.L.Warnf("Took %v seconds to send SVID response to PID %v", time.Since(start).Seconds, pid)
 			}
@@ -220,17 +220,17 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 }
 
 func (h *Handler) sendX509SVIDResponse(update *cache.WorkloadUpdate, stream workload.SpiffeWorkloadAPI_FetchX509SVIDServer, metrics telemetry.Metrics, selectors []*common.Selector) (err error) {
-	counter := telemetry.StartCall(metrics, workloadApi, "fetch_x509_svid")
+	counter := telemetry.StartCall(metrics, telemetry.WorkloadAPI, telemetry.FetchX509SVID)
 	defer counter.Done(&err)
 
-	counter.AddLabel("svid_type", "x509")
+	counter.AddLabel(telemetry.SVIDType, telemetry.X509)
 
 	if len(update.Entries) == 0 {
-		counter.AddLabel("registered", "false")
+		counter.AddLabel(telemetry.Registered, "false")
 		return status.Errorf(codes.PermissionDenied, "no identity issued")
 	}
 
-	counter.AddLabel("registered", "true")
+	counter.AddLabel(telemetry.Registered, "true")
 
 	resp, err := h.composeX509SVIDResponse(update)
 	if err != nil {
@@ -244,14 +244,14 @@ func (h *Handler) sendX509SVIDResponse(update *cache.WorkloadUpdate, stream work
 
 	// Add all the SPIFFE IDs to the labels array.
 	for i, svid := range resp.Svids {
-		counter.AddLabel("spiffe_id", svid.SpiffeId)
+		counter.AddLabel(telemetry.SPIFFEID, svid.SpiffeId)
 
 		ttl := time.Until(update.Entries[i].SVID[0].NotAfter)
 		metrics.SetGaugeWithLabels(
-			[]string{workloadApi, "fetch_x509_svid", "ttl"},
+			[]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.TTL},
 			float32(ttl.Seconds()),
 			[]telemetry.Label{
-				{Name: "spiffe_id", Value: svid.SpiffeId},
+				{Name: telemetry.SPIFFEID, Value: svid.SpiffeId},
 			})
 	}
 
@@ -338,7 +338,7 @@ func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, tel
 		return 0, nil, nil, nil, status.Errorf(codes.Internal, "Is this a supported system? Please report this bug: %v", err)
 	}
 
-	h.M.IncrCounter([]string{workloadApi, "connections"}, 1)
+	h.M.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, 1)
 
 	config := attestor.Config{
 		Catalog: h.Catalog,
@@ -356,10 +356,10 @@ func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, tel
 	}
 
 	metrics := telemetry.WithLabels(h.M, selectorsToLabels(selectors))
-	metrics.IncrCounter([]string{workloadApi, "connection"}, 1)
+	metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connection}, 1)
 
 	done := func() {
-		defer h.M.IncrCounter([]string{workloadApi, "connections"}, -1)
+		defer h.M.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, -1)
 	}
 
 	return watcher.PID(), selectors, metrics, done, nil
@@ -423,7 +423,7 @@ func structFromValues(values map[string]interface{}) (*structpb.Struct, error) {
 func selectorsToLabels(selectors []*common.Selector) (labels []telemetry.Label) {
 	for _, selector := range selectors {
 		labels = append(labels, telemetry.Label{
-			Name:  "selector",
+			Name:  telemetry.Selector,
 			Value: strings.Join([]string{selector.Type, selector.Value}, ":"),
 		})
 	}

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -116,19 +116,19 @@ func (s *HandlerTestSuite) TestFetchX509SVID() {
 	labels := selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
 	labelsSvidResponse := append(labels, []telemetry.Label{
-		{Name: "svid_type", Value: "x509"},
-		{Name: "registered", Value: "true"},
-		{Name: "spiffe_id", Value: "spiffe://example.org/foo"},
+		{Name: telemetry.SVIDType, Value: telemetry.X509},
+		{Name: telemetry.Registered, Value: "true"},
+		{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/foo"},
 	}...)
 	s.metrics.EXPECT().SetGaugeWithLabels(
-		[]string{workloadApi, "fetch_x509_svid", "ttl"},
+		[]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.TTL},
 		gomock.Any(),
 		append(labels, telemetry.Label{
-			Name: "spiffe_id", Value: "spiffe://example.org/foo",
+			Name: telemetry.SPIFFEID, Value: "spiffe://example.org/foo",
 		}))
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_x509_svid"}, float32(1), labelsSvidResponse)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_x509_svid", "elapsed_time"}, gomock.Any(), labelsSvidResponse)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "svid_response_latency"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID}, float32(1), labelsSvidResponse)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.ElapsedTime}, gomock.Any(), labelsSvidResponse)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency}, gomock.Any(), labels)
 
 	go func() { result <- s.h.FetchX509SVID(nil, stream) }()
 
@@ -160,11 +160,11 @@ func (s *HandlerTestSuite) TestSendX509Response() {
 	stream.EXPECT().Send(gomock.Any()).Times(0)
 
 	labels := []telemetry.Label{
-		{Name: "svid_type", Value: "x509"},
-		{Name: "registered", Value: "false"},
+		{Name: telemetry.SVIDType, Value: telemetry.X509},
+		{Name: telemetry.Registered, Value: "false"},
 	}
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_x509_svid", "error"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_x509_svid", "error", "elapsed_time"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.Error}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.Error, telemetry.ElapsedTime}, gomock.Any(), labels)
 
 	err := s.h.sendX509SVIDResponse(emptyUpdate, stream, s.h.M, []*common.Selector{})
 	s.Assert().Error(err)
@@ -174,18 +174,18 @@ func (s *HandlerTestSuite) TestSendX509Response() {
 	stream.EXPECT().Send(resp)
 
 	labels = []telemetry.Label{
-		{Name: "svid_type", Value: "x509"},
-		{Name: "registered", Value: "true"},
-		{Name: "spiffe_id", Value: "spiffe://example.org/foo"},
+		{Name: telemetry.SVIDType, Value: telemetry.X509},
+		{Name: telemetry.Registered, Value: "true"},
+		{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/foo"},
 	}
 	s.metrics.EXPECT().SetGaugeWithLabels(
-		[]string{workloadApi, "fetch_x509_svid", "ttl"},
+		[]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.TTL},
 		gomock.Any(),
 		[]telemetry.Label{
-			{Name: "spiffe_id", Value: "spiffe://example.org/foo"},
+			{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/foo"},
 		})
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_x509_svid"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_x509_svid", "elapsed_time"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.ElapsedTime}, gomock.Any(), labels)
 
 	err = s.h.sendX509SVIDResponse(s.workloadUpdate(), stream, s.h.M, []*common.Selector{})
 	s.Assert().NoError(err)
@@ -244,12 +244,12 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 
 	selectorsLabels := selectorsToLabels(selectors)
 	labels := append(selectorsLabels, []telemetry.Label{
-		{Name: "svid_type", Value: "jwt"},
-		{Name: "registered", Value: "false"},
+		{Name: telemetry.SVIDType, Value: telemetry.JWT},
+		{Name: telemetry.Registered, Value: "false"},
 	}...)
 	setupMetricsCommonExpectations(s.metrics, selectorsLabels, 1)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_jwt_svid", "error"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_jwt_svid", "error", "elapsed_time"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.Error}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.Error, telemetry.ElapsedTime}, gomock.Any(), labels)
 
 	resp, err = s.h.FetchJWTSVID(makeContext(1), &workload.JWTSVIDRequest{
 		Audience: audience,
@@ -279,26 +279,26 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 
 	setupMetricsCommonExpectations(s.metrics, selectorsLabels, 1)
 	labels = append(selectorsLabels, []telemetry.Label{
-		{Name: "svid_type", Value: "jwt"},
-		{Name: "registered", Value: "true"},
-		{Name: "spiffe_id", Value: "spiffe://example.org/one"},
-		{Name: "spiffe_id", Value: "spiffe://example.org/two"},
+		{Name: telemetry.SVIDType, Value: telemetry.JWT},
+		{Name: telemetry.Registered, Value: "true"},
+		{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/one"},
+		{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/two"},
 	}...)
 
 	s.metrics.EXPECT().SetGaugeWithLabels(
-		[]string{workloadApi, "fetch_jwt_svid", "ttl"},
+		[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
 		gomock.Any(),
 		append(selectorsLabels, telemetry.Label{
-			Name: "spiffe_id", Value: "spiffe://example.org/one",
+			Name: telemetry.SPIFFEID, Value: "spiffe://example.org/one",
 		}))
 	s.metrics.EXPECT().SetGaugeWithLabels(
-		[]string{workloadApi, "fetch_jwt_svid", "ttl"},
+		[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
 		gomock.Any(),
 		append(selectorsLabels, telemetry.Label{
-			Name: "spiffe_id", Value: "spiffe://example.org/two",
+			Name: telemetry.SPIFFEID, Value: "spiffe://example.org/two",
 		}))
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_jwt_svid"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_jwt_svid", "elapsed_time"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.ElapsedTime}, gomock.Any(), labels)
 
 	resp, err = s.h.FetchJWTSVID(makeContext(1), &workload.JWTSVIDRequest{
 		Audience: audience,
@@ -325,18 +325,18 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 	selectorsLabels = selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, selectorsLabels, 1)
 	labels = append(selectorsLabels, []telemetry.Label{
-		{Name: "svid_type", Value: "jwt"},
-		{Name: "registered", Value: "true"},
-		{Name: "spiffe_id", Value: "spiffe://example.org/two"},
+		{Name: telemetry.SVIDType, Value: telemetry.JWT},
+		{Name: telemetry.Registered, Value: "true"},
+		{Name: telemetry.SPIFFEID, Value: "spiffe://example.org/two"},
 	}...)
 	s.metrics.EXPECT().SetGaugeWithLabels(
-		[]string{workloadApi, "fetch_jwt_svid", "ttl"},
+		[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
 		gomock.Any(),
 		append(selectorsLabels, telemetry.Label{
-			Name: "spiffe_id", Value: "spiffe://example.org/two",
+			Name: telemetry.SPIFFEID, Value: "spiffe://example.org/two",
 		}))
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_jwt_svid"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "fetch_jwt_svid", "elapsed_time"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.ElapsedTime}, gomock.Any(), labels)
 
 	resp, err = s.h.FetchJWTSVID(makeContext(1), &workload.JWTSVIDRequest{
 		SpiffeId: "spiffe://example.org/two",
@@ -354,15 +354,15 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 }
 
 func setupMetricsCommonExpectations(metrics *mock_telemetry.MockMetrics, selectorsLabels []telemetry.Label, pid int32) {
-	attestorLabels := []telemetry.Label{{"attestor_name", "fake"}}
+	attestorLabels := []telemetry.Label{{telemetry.AttestorName, "fake"}}
 
-	metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "workload_attestor_latency"}, gomock.Any(), attestorLabels)
-	metrics.EXPECT().AddSample([]string{workloadApi, "discovered_selectors"}, float32(len(selectorsLabels)))
-	metrics.EXPECT().MeasureSince([]string{workloadApi, "workload_attestation_duration"}, gomock.Any())
+	metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestorLatency}, gomock.Any(), attestorLabels)
+	metrics.EXPECT().AddSample([]string{telemetry.WorkloadAPI, telemetry.DiscoveredSelectors}, float32(len(selectorsLabels)))
+	metrics.EXPECT().MeasureSince([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestationDuration}, gomock.Any())
 
-	metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "connection"}, float32(1), selectorsLabels)
-	metrics.EXPECT().IncrCounter([]string{workloadApi, "connections"}, float32(1))
-	metrics.EXPECT().IncrCounter([]string{workloadApi, "connections"}, float32(-1))
+	metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.Connection}, float32(1), selectorsLabels)
+	metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(1))
+	metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(-1))
 }
 
 func (s *HandlerTestSuite) TestFetchJWTBundles() {
@@ -399,9 +399,9 @@ func (s *HandlerTestSuite) TestFetchJWTBundles() {
 
 	labels := selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "fetch_jwt_bundles"}, float32(1), labels)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "bundles_update"}, float32(1), labels)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{workloadApi, "send_jwt_bundle_latency"}, gomock.Any(), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, float32(1), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate}, float32(1), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, gomock.Any(), labels)
 
 	go func() { result <- s.h.FetchJWTBundles(&workload.JWTBundlesRequest{}, stream) }()
 
@@ -515,9 +515,9 @@ func (s *HandlerTestSuite) TestValidateJWTSVID() {
 	labels := selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
 	labels = append(labels, []telemetry.Label{
-		{Name: "error", Value: "token contains an invalid number of segments"},
+		{Name: telemetry.Error, Value: "token contains an invalid number of segments"},
 	}...)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "validate_jwt_svid"}, float32(1), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, float32(1), labels)
 
 	resp, err = s.h.ValidateJWTSVID(makeContext(1), &workload.ValidateJWTSVIDRequest{
 		Audience: "audience",
@@ -560,10 +560,10 @@ func (s *HandlerTestSuite) TestValidateJWTSVID() {
 	labels = selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
 	labels = append(labels, []telemetry.Label{
-		{Name: "subject", Value: "spiffe://example.org/blog"},
-		{Name: "audience", Value: "audience"},
+		{Name: telemetry.Subject, Value: "spiffe://example.org/blog"},
+		{Name: telemetry.Audience, Value: "audience"},
 	}...)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "validate_jwt_svid"}, float32(1), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, float32(1), labels)
 
 	// token validated by bundle
 	s.manager.EXPECT().FetchWorkloadUpdate(selectors).Return(&cache.WorkloadUpdate{
@@ -589,10 +589,10 @@ func (s *HandlerTestSuite) TestValidateJWTSVID() {
 	labels = selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
 	labels = append(labels, []telemetry.Label{
-		{Name: "subject", Value: "spiffe://example.org/blog"},
-		{Name: "audience", Value: "audience"},
+		{Name: telemetry.Subject, Value: "spiffe://example.org/blog"},
+		{Name: telemetry.Audience, Value: "audience"},
 	}...)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{workloadApi, "validate_jwt_svid"}, float32(1), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, float32(1), labels)
 
 	resp, err = s.h.ValidateJWTSVID(makeContext(1), &workload.ValidateJWTSVIDRequest{
 		Audience: "audience",

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -48,14 +48,14 @@ func (m *manager) synchronize(ctx context.Context) (err error) {
 }
 
 func (m *manager) fetchUpdates(ctx context.Context, entryRequests map[string]*entryRequest) (entries map[string]*common.RegistrationEntry, svids map[string]*node.X509SVID, err error) {
-	counter := telemetry.StartCall(m.c.Metrics, "manager", "sync", "fetch_updates")
+	counter := telemetry.StartCall(m.c.Metrics, telemetry.Manager, telemetry.Sync, telemetry.FetchUpdates)
 	defer counter.Done(&err)
 	// Put all the CSRs in an array to make just one call with all the CSRs.
 	csrs := [][]byte{}
 	if entryRequests != nil {
 		for _, entryRequest := range entryRequests {
 			m.c.Log.Debugf("Requesting SVID for %v", entryRequest.entry.RegistrationEntry.SpiffeId)
-			counter.AddLabel("spiffe_id", entryRequest.entry.RegistrationEntry.SpiffeId)
+			counter.AddLabel(telemetry.SPIFFEID, entryRequest.entry.RegistrationEntry.SpiffeId)
 			csrs = append(csrs, entryRequest.CSR)
 		}
 	}
@@ -129,7 +129,7 @@ func (m *manager) clearStaleCacheEntries(regEntries map[string]*common.Registrat
 
 func (m *manager) checkExpiredCacheEntries(cEntryRequests entryRequests) error {
 	now := m.clk.Now()
-	defer m.c.Metrics.MeasureSince([]string{"cache_manager", "expiry_check_duration"}, now)
+	defer m.c.Metrics.MeasureSince([]string{telemetry.CacheManager, telemetry.ExpiryCheckDuration}, now)
 
 	for _, entry := range m.cache.Entries() {
 		ttl := entry.SVID[0].NotAfter.Sub(now)
@@ -152,7 +152,7 @@ func (m *manager) checkExpiredCacheEntries(cEntryRequests entryRequests) error {
 		}
 	}
 
-	m.c.Metrics.AddSample([]string{"cache_manager", "expiring_svids"}, float32(len(cEntryRequests)))
+	m.c.Metrics.AddSample([]string{telemetry.CacheManager, telemetry.ExpiringSVIDs}, float32(len(cEntryRequests)))
 	return nil
 }
 

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -87,10 +87,10 @@ func (r *rotator) shouldRotate() bool {
 
 // rotateSVID asks SPIRE's server for a new agent's SVID.
 func (r *rotator) rotateSVID(ctx context.Context) (err error) {
-	counter := telemetry.StartCall(r.c.Metrics, "agent_svid", "rotate")
+	counter := telemetry.StartCall(r.c.Metrics, telemetry.AgentSVID, telemetry.Rotate)
 	defer counter.Done(&err)
 
-	counter.AddLabel("spiffe_id", r.c.SpiffeID)
+	counter.AddLabel(telemetry.SPIFFEID, r.c.SpiffeID)
 	r.c.Log.Debug("Rotating agent SVID")
 
 	key, err := r.newKey(ctx)

--- a/pkg/common/telemetry/call.go
+++ b/pkg/common/telemetry/call.go
@@ -62,7 +62,7 @@ func (c *CallCounter) Done(errp *error) {
 		key = append(key, "error")
 	}
 	c.metrics.IncrCounterWithLabels(key, 1, c.labels)
-	c.metrics.MeasureSinceWithLabels(append(key, "elapsed_time"), c.start, c.labels)
+	c.metrics.MeasureSinceWithLabels(append(key, ElapsedTime), c.start, c.labels)
 }
 
 func CountCall(metrics Metrics, key string, keyn ...string) func(*error) {

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -1,0 +1,242 @@
+package telemetry
+
+// Constants for metric keys and labels. Helps with enforcement of non-conflicting usage of same or similar names.
+// Additionally, importers of this package can get an idea of metric tags to look for.
+
+const (
+	// Activate functionality related to activating some element (such as X509 CA manager);
+	// should be used with other tags to add clarity
+	Activate = "activate"
+
+	// AgentSVID tag a node (agent) SVID
+	AgentSVID = "agent_svid"
+
+	// Attest functionality related to attesting; should be used with other tags
+	// to add clarity
+	Attest = "attest"
+
+	// Attestor tags an attestor type (eg. gcp, aws...)
+	Attestor = "attestor"
+
+	// AttestorName tags an attestor name
+	AttestorName = "attestor_name"
+
+	// Audience tags some audience for a token
+	Audience = "audience"
+
+	// Bundle functionality related to a bundle; should be used with other tags
+	// to add clarity
+	Bundle = "bundle"
+
+	// BundlesUpdate functionality related to updating bundles
+	BundlesUpdate = "bundles_update"
+
+	// CA functionality related to some CA; should be used with other tags
+	// to add clarity
+	CA = "ca"
+
+	// CacheManager functionality related to a cache manager
+	CacheManager = "cache_manager"
+
+	// CallerID tags an API caller; should be used with other tags
+	// to add clarity
+	CallerID = "caller_id"
+
+	// Connection functionality related to some connection; should be used with other tags
+	// to add clarity
+	Connection = "connection"
+
+	// Connections functionality related to some group of connections; should be used with other tags
+	// to add clarity
+	Connections = "connections"
+
+	// Create functionality related to creating some entity; should be used with other tags
+	// to add clarity
+	Create = "create"
+
+	// Delete functionality related to deleting some entity; should be used with other tags
+	// to add clarity
+	Delete = "delete"
+
+	// DiscoveredSelectors tags selectors for some registration
+	DiscoveredSelectors = "discovered_selectors"
+
+	// ElapsedTime tags some duration of time; should be used with other tags to add clarity
+	ElapsedTime = "elapsed_time"
+
+	// Entry tag for some stored entry; should be used with other tags such as RegistrationAPI
+	// to add clarity
+	Entry = "entry"
+
+	// Error tag for some error that occurred
+	Error = "error"
+
+	// ExpiringSVIDs tags expiring SVID count/list
+	ExpiringSVIDs = "expiring_svids"
+
+	// ExpiryCheckDuration tags duration for an expiry check; should be used with other tags
+	// to add clarity
+	ExpiryCheckDuration = "expiry_check_duration"
+
+	// FederatedBundle functionality related to a federated bundle; should be used
+	// with other tags to add clarity
+	FederatedBundle = "federated_bundle"
+
+	// Fetch functionality related to fetching some entity; should be used with other tags
+	// to add clarity
+	Fetch = "fetch"
+
+	// FetchJWTSVID functionality related to fetching a JWT SVID
+	FetchJWTSVID = "fetch_jwt_svid"
+
+	// FetchJWTBundles functionality related to fetching JWT bundles
+	FetchJWTBundles = "fetch_jwt_bundles"
+
+	// FetchUpdates functionality related to fetching updates; should be used
+	// with other tags to add clarity
+	FetchUpdates = "fetch_updates"
+
+	// FetchX509SVID functionality related to fetching an X509 SVID
+	FetchX509SVID = "fetch_x509_svid"
+
+	// JoinToken functionality related to a join token; should be used
+	// with other tags to add clarity
+	JoinToken = "join_token"
+
+	// JWT declares JWT SVID type, clarifying metrics
+	JWT = "jwt"
+
+	// JWTKey functionality related to a JWT key; should be used with other tags
+	// to add clarity
+	JWTKey = "jwt_key"
+
+	// JWTSVID functionality related to a JWT SVID; should be used with other tags
+	// to add clarity
+	JWTSVID = "jwt_svid"
+
+	// List functionality related to listing some objects; should be used
+	// with other tags to add clarity
+	List = "list"
+
+	// Manager functionality related to a manager (such as CA manager); should be
+	// used with other tags to add clarity
+	Manager = "manager"
+
+	// NewSVID functionality related to creation of a new SVID
+	NewSVID = "new_svid"
+
+	// Node functionality related to a node entity or type; should be used with other tags
+	// to add clarity
+	Node = "node"
+
+	// NodeAPI functionality related to attested/attesting nodes (agents)
+	NodeAPI = "node_api"
+
+	// Prepare functionality related to preparation of some entity; should be used with other tags
+	// to add clarity
+	Prepare = "prepare"
+
+	// Prune functionality related to pruning some entity(ies); should be used with other tags
+	// to add clarity
+	Prune = "prune"
+
+	// Pruned flagging something has been pruned
+	Pruned = "pruned"
+
+	// Registered flags whether some entity is registered or not; should be
+	// either true or false
+	Registered = "registered"
+
+	// RegistrationAPI functionality related to the registration api; should be used
+	// with other tags to add clarity
+	RegistrationAPI = "registration_api"
+
+	// Rotate functionality related to rotation of SVID; should be used with other tags
+	// to add clarity
+	Rotate = "rotate"
+
+	// SDSAPI functionality related to SDS; should be used with other tags
+	// to add clarity
+	SDSAPI = "sds_api"
+
+	// SDSPID tags an SDS PID
+	SDSPID = "sds_pid"
+
+	// Selector tags some registration selector
+	Selector = "selector"
+
+	// SendJWTBundleLatency tags latency for sending JWT bundle
+	SendJWTBundleLatency = "send_jwt_bundle_latency"
+
+	// ServerCA functionality related to a server CA; should be used with other tags
+	// to add clarity
+	ServerCA = "server_ca"
+
+	// Sign functionality related to signing a token / cert; should be used with other tags
+	// to add clarity
+	Sign = "sign"
+
+	// SPIFFEID tags a SPIFFE ID
+	SPIFFEID = "spiffe_id"
+
+	// Subject tags some subject (likely a SPIFFE ID, and likely for a token); should be used
+	// with other tags to add clarity
+	Subject = "subject"
+
+	// SVID functionality related to a SVID; should be used with other tags
+	// to add clarity
+	SVID = "svid"
+
+	// SVIDResponseLatency tags latency for SVID response
+	SVIDResponseLatency = "svid_response_latency"
+
+	// SVIDType tags some type of SVID (eg. X509, JWT)
+	SVIDType = "svid_type"
+
+	// Sync functionality for syncing (such as CA manager updates). Should
+	// be used with other tags to add clarity
+	Sync = "sync"
+
+	// TTL functionality related to a time-to-live field; should be used
+	// with other tags to add clarity
+	TTL = "ttl"
+
+	// TrustDomainID tags some trust domain ID
+	TrustDomainID = "trust_domain_id"
+
+	// Update functionality related to updating some entity; should be used
+	// with other tags to add clarity
+	Update = "update"
+
+	// Updated tags some entity as updated; should be used
+	// with other tags to add clarity
+	Updated = "updated"
+
+	// ValidateJWTSVID functionality related validating a JWT SVID
+	ValidateJWTSVID = "validate_jwt_svid"
+
+	// WorkloadAPI flagging usage of workload API; should be used with other tags
+	// to add clarity
+	WorkloadAPI = "workload_api"
+
+	// WorkloadAttestationDuration tags duration of workload attestation
+	WorkloadAttestationDuration = "workload_attestation_duration"
+
+	// WorkloadAttestorLatency tags latency of a workload attestor
+	WorkloadAttestorLatency = "workload_attestor_latency"
+
+	// X509 declared X509 SVID type, clarifying metrics
+	X509 = "x509"
+
+	// X509CA functionality related to an x509 CA; should be used with other tags
+	// to add clarity
+	X509CA = "x509_ca"
+
+	// X509CASVID functionality related to an x509 CA SVID; should be used with other tags
+	// to add clarity
+	X509CASVID = "x509_ca_svid"
+
+	// X509SVID functionality related to an x509 SVID; should be used with other tags
+	// to add clarity
+	X509SVID = "x509_svid"
+)

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -171,9 +171,9 @@ func (ca *CA) SignX509SVID(ctx context.Context, csrDER []byte, params X509Params
 		"expires_at": cert.NotAfter.Format(time.RFC3339),
 	}).Debug("Signed X509 SVID")
 
-	ca.c.Metrics.IncrCounterWithLabels([]string{"ca", "sign", "x509_svid"}, 1, []telemetry.Label{
+	ca.c.Metrics.IncrCounterWithLabels([]string{telemetry.CA, telemetry.Sign, telemetry.X509SVID}, 1, []telemetry.Label{
 		{
-			Name:  "spiffe_id",
+			Name:  telemetry.SPIFFEID,
 			Value: spiffeID,
 		},
 	})
@@ -214,9 +214,9 @@ func (ca *CA) SignX509CASVID(ctx context.Context, csrDER []byte, params X509Para
 		"expires_at": cert.NotAfter.Format(time.RFC3339),
 	}).Debug("Signed X509 CA SVID")
 
-	ca.c.Metrics.IncrCounterWithLabels([]string{"ca", "sign", "x509_ca_svid"}, 1, []telemetry.Label{
+	ca.c.Metrics.IncrCounterWithLabels([]string{telemetry.CA, telemetry.Sign, telemetry.X509CASVID}, 1, []telemetry.Label{
 		{
-			Name:  "spiffe_id",
+			Name:  telemetry.SPIFFEID,
 			Value: spiffeID,
 		},
 	})
@@ -247,17 +247,17 @@ func (ca *CA) SignJWTSVID(ctx context.Context, jsr *node.JSR) (string, error) {
 
 	labels := []telemetry.Label{
 		{
-			Name:  "spiffe_id",
+			Name:  telemetry.SPIFFEID,
 			Value: jsr.SpiffeId,
 		},
 	}
 	for _, audience := range jsr.Audience {
 		labels = append(labels, telemetry.Label{
-			Name:  "audience",
+			Name:  telemetry.Audience,
 			Value: audience,
 		})
 	}
-	ca.c.Metrics.IncrCounterWithLabels([]string{"server_ca", "sign", "jwt_svid"}, 1, labels)
+	ca.c.Metrics.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.JWTSVID}, 1, labels)
 
 	return token, nil
 }

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -167,7 +167,7 @@ func (m *Manager) rotateX509CA(ctx context.Context) error {
 }
 
 func (m *Manager) prepareX509CA(ctx context.Context, slot *x509CASlot) (err error) {
-	defer telemetry.CountCall(m.c.Metrics, "manager", "x509_ca", "prepare")(&err)
+	defer telemetry.CountCall(m.c.Metrics, telemetry.Manager, telemetry.X509CA, telemetry.Prepare)(&err)
 
 	log := m.c.Log.WithField("slot", slot.id)
 	log.Debug("Preparing X509 CA")
@@ -222,7 +222,7 @@ func (m *Manager) activateX509CA() {
 		"issued_at": timeField(m.currentX509CA.issuedAt),
 		"not_after": timeField(m.currentX509CA.x509CA.Certificate.NotAfter),
 	}).Info("X509 CA activated")
-	m.c.Metrics.IncrCounter([]string{"manager", "x509_ca", "activate"}, 1)
+	m.c.Metrics.IncrCounter([]string{telemetry.Manager, telemetry.X509CA, telemetry.Activate}, 1)
 	m.c.CA.SetX509CA(m.currentX509CA.x509CA)
 }
 
@@ -255,7 +255,7 @@ func (m *Manager) rotateJWTKey(ctx context.Context) error {
 }
 
 func (m *Manager) prepareJWTKey(ctx context.Context, slot *jwtKeySlot) (err error) {
-	defer telemetry.CountCall(m.c.Metrics, "manager", "jwt_key", "prepare")(&err)
+	defer telemetry.CountCall(m.c.Metrics, telemetry.Manager, telemetry.JWTKey, telemetry.Prepare)(&err)
 
 	log := m.c.Log.WithField("slot", slot.id)
 	log.Debug("Preparing JWT key")
@@ -306,7 +306,7 @@ func (m *Manager) activateJWTKey() {
 		"issued_at": timeField(m.currentJWTKey.issuedAt),
 		"not_after": timeField(m.currentJWTKey.jwtKey.NotAfter),
 	}).Info("JWT key activated")
-	m.c.Metrics.IncrCounter([]string{"manager", "jwt_key", "activate"}, 1)
+	m.c.Metrics.IncrCounter([]string{telemetry.Manager, telemetry.JWTKey, telemetry.Activate}, 1)
 	m.c.CA.SetJWTKey(m.currentJWTKey.jwtKey)
 }
 
@@ -327,7 +327,7 @@ func (m *Manager) pruneBundleEvery(ctx context.Context, interval time.Duration) 
 }
 
 func (m *Manager) pruneBundle(ctx context.Context) (err error) {
-	defer telemetry.CountCall(m.c.Metrics, "manager", "bundle", "prune")(&err)
+	defer telemetry.CountCall(m.c.Metrics, telemetry.Manager, telemetry.Bundle, telemetry.Prune)(&err)
 	ds := m.c.Catalog.GetDataStore()
 
 	now := m.c.Clock.Now().Add(-safetyThreshold)
@@ -384,7 +384,7 @@ pruneRootCA:
 	}
 
 	if changed {
-		m.c.Metrics.IncrCounter([]string{"manager", "bundle", "pruned"}, 1)
+		m.c.Metrics.IncrCounter([]string{telemetry.Manager, telemetry.Bundle, telemetry.Pruned}, 1)
 		_, err := ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
 			Bundle: newBundle,
 		})

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Config is a configuration for endpoints
 type Config struct {
 	// Addresses to bind the servers to
 	TCPAddr *net.TCPAddr
@@ -41,6 +42,7 @@ type Config struct {
 	Metrics telemetry.Metrics
 }
 
+// New creates new endpoints struct
 func New(c *Config) *endpoints {
 	return &endpoints{
 		c:   c,

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -179,8 +179,6 @@ func (e *endpoints) runUDSServer(ctx context.Context, server *grpc.Server) error
 		e.c.Log.Info("UDS server has stopped.")
 		return nil
 	}
-
-	return nil
 }
 
 func (e *endpoints) runSVIDObserver(ctx context.Context) error {

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -45,7 +45,7 @@ func (h *Handler) CreateEntry(
 	ctx context.Context, request *common.RegistrationEntry) (
 	response *registration.RegistrationEntryID, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "create")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Create)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (h *Handler) DeleteEntry(
 	ctx context.Context, request *registration.RegistrationEntryID) (
 	response *common.RegistrationEntry, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "delete")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Delete)
 	if err != nil {
 		return nil, err
 	}
@@ -104,12 +104,12 @@ func (h *Handler) DeleteEntry(
 	return resp.Entry, nil
 }
 
-//Retrieves a specific registered entry
+//FetchEntry Retrieves a specific registered entry
 func (h *Handler) FetchEntry(
 	ctx context.Context, request *registration.RegistrationEntryID) (
 	response *common.RegistrationEntry, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "fetch")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Fetch)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (h *Handler) FetchEntries(
 	ctx context.Context, request *common.Empty) (
 	response *common.RegistrationEntries, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "list")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.List)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (h *Handler) UpdateEntry(
 	ctx context.Context, request *registration.UpdateEntryRequest) (
 	response *common.RegistrationEntry, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "update")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Update)
 	if err != nil {
 		return nil, err
 	}
@@ -179,17 +179,17 @@ func (h *Handler) UpdateEntry(
 		return nil, fmt.Errorf("Failed to update registration entry: %v", err)
 	}
 
-	h.Metrics.IncrCounter([]string{"registration_api", "entry", "updated"}, 1)
+	h.Metrics.IncrCounter([]string{telemetry.RegistrationAPI, telemetry.Entry, telemetry.Updated}, 1)
 
 	return resp.Entry, nil
 }
 
-//Returns all the Entries associated with the ParentID value
+//ListByParentID Returns all the Entries associated with the ParentID value
 func (h *Handler) ListByParentID(
 	ctx context.Context, request *registration.ParentID) (
 	response *common.RegistrationEntries, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "list")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.List)
 	if err != nil {
 		return nil, err
 	}
@@ -224,13 +224,13 @@ func (h *Handler) ListBySelector(
 	ctx context.Context, request *common.Selector) (
 	response *common.RegistrationEntries, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "list")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.List)
 	if err != nil {
 		return nil, err
 	}
 	defer counter.Done(&err)
 
-	counter.AddLabel("selector", fmt.Sprintf("%s:%s", request.Type, request.Value))
+	counter.AddLabel(telemetry.Selector, fmt.Sprintf("%s:%s", request.Type, request.Value))
 
 	ds := h.getDataStore()
 	req := &datastore.ListRegistrationEntriesRequest{
@@ -252,7 +252,7 @@ func (h *Handler) ListBySpiffeID(
 	ctx context.Context, request *registration.SpiffeID) (
 	response *common.RegistrationEntries, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "entry", "list")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Entry, telemetry.List)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +264,7 @@ func (h *Handler) ListBySpiffeID(
 		return nil, err
 	}
 
-	counter.AddLabel("spiffe_id", request.Id)
+	counter.AddLabel(telemetry.SPIFFEID, request.Id)
 
 	ds := h.getDataStore()
 	req := &datastore.ListRegistrationEntriesRequest{
@@ -286,7 +286,7 @@ func (h *Handler) CreateFederatedBundle(
 	ctx context.Context, request *registration.FederatedBundle) (
 	response *common.Empty, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "federated_bundle", "create")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Create)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (h *Handler) CreateFederatedBundle(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	counter.AddLabel("trust_domain_id", bundle.TrustDomainId)
+	counter.AddLabel(telemetry.TrustDomainID, bundle.TrustDomainId)
 
 	if bundle.TrustDomainId == h.TrustDomain.String() {
 		return nil, status.Error(codes.InvalidArgument, "federated bundle id cannot match server trust domain")
@@ -321,7 +321,7 @@ func (h *Handler) FetchFederatedBundle(
 	ctx context.Context, request *registration.FederatedBundleID) (
 	response *registration.FederatedBundle, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "federated_bundle", "fetch")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Fetch)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (h *Handler) FetchFederatedBundle(
 }
 
 func (h *Handler) ListFederatedBundles(request *common.Empty, stream registration.Registration_ListFederatedBundlesServer) (err error) {
-	counter, err := h.startCall(stream.Context(), "registration_api", "federated_bundle", "list")
+	counter, err := h.startCall(stream.Context(), telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.List)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (h *Handler) UpdateFederatedBundle(
 	ctx context.Context, request *registration.FederatedBundle) (
 	response *common.Empty, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "federated_bundle", "update")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Update)
 	if err != nil {
 		return nil, err
 	}
@@ -398,7 +398,7 @@ func (h *Handler) UpdateFederatedBundle(
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	counter.AddLabel("trust_domain_id", bundle.TrustDomainId)
+	counter.AddLabel(telemetry.TrustDomainID, bundle.TrustDomainId)
 
 	if bundle.TrustDomainId == h.TrustDomain.String() {
 		return nil, status.Error(codes.InvalidArgument, "federated bundle id cannot match server trust domain")
@@ -418,7 +418,7 @@ func (h *Handler) DeleteFederatedBundle(
 	ctx context.Context, request *registration.DeleteFederatedBundleRequest) (
 	response *common.Empty, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "federated_bundle", "delete")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Delete)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +429,7 @@ func (h *Handler) DeleteFederatedBundle(
 		return nil, err
 	}
 
-	counter.AddLabel("trust_domain_id", request.Id)
+	counter.AddLabel(telemetry.TrustDomainID, request.Id)
 
 	if request.Id == h.TrustDomain.String() {
 		return nil, errors.New("federated bundle id cannot match server trust domain")
@@ -455,7 +455,7 @@ func (h *Handler) CreateJoinToken(
 	ctx context.Context, request *registration.JoinToken) (
 	token *registration.JoinToken, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "join_token", "create")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.JoinToken, telemetry.Create)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (h *Handler) FetchBundle(
 	ctx context.Context, request *common.Empty) (
 	response *registration.Bundle, err error) {
 
-	counter, err := h.startCall(ctx, "registration_api", "bundle", "fetch")
+	counter, err := h.startCall(ctx, telemetry.RegistrationAPI, telemetry.Bundle, telemetry.Fetch)
 	if err != nil {
 		return nil, err
 	}
@@ -624,7 +624,7 @@ func (h *Handler) prepareRegistrationEntry(entry *common.RegistrationEntry, forU
 func (h *Handler) startCall(ctx context.Context, key string, keyn ...string) (*telemetry.CallCounter, error) {
 	counter := telemetry.StartCall(h.Metrics, key, keyn...)
 	if callerID := getCallerID(ctx); callerID != "" {
-		counter.AddLabel("caller_id", callerID)
+		counter.AddLabel(telemetry.CallerID, callerID)
 	}
 	return counter, nil
 }

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -85,7 +85,7 @@ func (r *rotator) shouldRotate() bool {
 // rotateSVID cuts a new server SVID from the CA plugin and installs
 // it on the endpoints struct. Also updates the CA certificates.
 func (r *rotator) rotateSVID(ctx context.Context) (err error) {
-	defer telemetry.CountCall(r.c.Metrics, "svid", "rotate")(&err)
+	defer telemetry.CountCall(r.c.Metrics, telemetry.SVID, telemetry.Rotate)(&err)
 	r.c.Log.Debug("Rotating server SVID")
 
 	id := idutil.ServerURI(r.c.TrustDomain.Host)


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
N/A

**Description of change**
Move all metrics names and labels to common location for consistency and searchability.
A conversation should be had here, in #822, or in a new issue about reducing possibly redundant metric names.
Minor lints fixed.

**Which issue this PR fixes**
Addresses, but does not fully close spirit of, #822. A conversation needs to be had about paring down possibly redundant metric names.

