### PR TITLE
Clean up peertracker code related to CR comments

### DIFF
--- a/pkg/common/peertracker/conn.go
+++ b/pkg/common/peertracker/conn.go
@@ -2,45 +2,14 @@ package peertracker
 
 import (
 	"net"
-	"time"
 )
 
-var _ net.Conn = &Conn{}
-
 type Conn struct {
-	c    net.Conn
+	net.Conn
 	Info AuthInfo
-}
-
-func (c *Conn) Read(b []byte) (int, error) {
-	return c.c.Read(b)
-}
-
-func (c *Conn) Write(b []byte) (int, error) {
-	return c.c.Write(b)
 }
 
 func (c *Conn) Close() error {
 	c.Info.Watcher.Close()
-	return c.c.Close()
-}
-
-func (c *Conn) LocalAddr() net.Addr {
-	return c.c.LocalAddr()
-}
-
-func (c *Conn) RemoteAddr() net.Addr {
-	return c.c.RemoteAddr()
-}
-
-func (c *Conn) SetDeadline(t time.Time) error {
-	return c.c.SetDeadline(t)
-}
-
-func (c *Conn) SetReadDeadline(t time.Time) error {
-	return c.c.SetReadDeadline(t)
-}
-
-func (c *Conn) SetWriteDeadline(t time.Time) error {
-	return c.c.SetReadDeadline(t)
+	return c.Conn.Close()
 }

--- a/pkg/common/peertracker/listener.go
+++ b/pkg/common/peertracker/listener.go
@@ -61,7 +61,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 	}
 
 	wrappedConn := &Conn{
-		c: conn,
+		Conn: conn,
 		Info: AuthInfo{
 			Caller:  caller,
 			Watcher: watcher,

--- a/pkg/common/peertracker/peertracker_test_child.go
+++ b/pkg/common/peertracker/peertracker_test_child.go
@@ -14,33 +14,13 @@ import (
 )
 
 func main() {
-	var descriptor int
 	var socketPath string
-	flag.IntVar(&descriptor, "descriptor", 0, "send a bit of data on the fd and then block forever")
 	flag.StringVar(&socketPath, "socketPath", "", "path to peertracker socket")
 	flag.Parse()
 
 	// We are a grandchild - send a sign then sleep forever
-	if descriptor != 0 {
-		fd := uintptr(descriptor)
-		fh := os.NewFile(fd, "socket")
-		if fh == nil {
-			fmt.Fprintf(os.Stderr, "could not open descriptor")
-			os.Exit(1)
-		}
-
-		conn, err := net.FileConn(fh)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not get conn from descriptor: %v", err)
-			os.Exit(2)
-		}
-
-		theSign := []byte("i'm alive!")
-		_, err = conn.Write(theSign)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not write to conn: %v", err)
-			os.Exit(3)
-		}
+	if socketPath == "" {
+		fmt.Fprintf(os.Stdout, "i'm alive!")
 
 		select {}
 	}
@@ -71,11 +51,11 @@ func main() {
 	procattr := &syscall.ProcAttr{
 		Files: []uintptr{
 			os.Stdin.Fd(),
-			fd.Fd(), // descriptor 1
+			fd.Fd(),
 		},
 	}
 
-	pid, err := syscall.ForkExec(os.Args[0], []string{os.Args[0], "-descriptor", "1"}, procattr)
+	pid, err := syscall.ForkExec(os.Args[0], []string{os.Args[0]}, procattr)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to produce grandchild: %v", err)
 		os.Exit(7)


### PR DESCRIPTION
* Move to embedded net.Conn
* Make grandchild UDS socket stdout for simplicity

Signed-off-by: Evan Gilman <evan@scytale.io>
