### PR TITLE
Support autocreating directory of Agent plugin: KeyManager "disk"

### DIFF
--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -124,7 +124,13 @@ func (d *DiskPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (
 
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
+
+	// Create directory in which to store the private key if not exists
+	if err := os.MkdirAll(config.Directory, 0755); err != nil {
+		return nil, err
+	}
 	d.dir = config.Directory
+
 	return &spi.ConfigureResponse{}, nil
 }
 

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,15 +62,20 @@ func TestDisk_FetchPrivateKey(t *testing.T) {
 }
 
 func TestDisk_Configure(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "km-disk-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	keysDir := filepath.Join(tempDir, "keys")
+
 	plugin := New()
-	tmpdir := os.TempDir()
 	cReq := &spi.ConfigureRequest{
-		Configuration: fmt.Sprintf("directory = \"%s\"", tmpdir),
+		Configuration: fmt.Sprintf("directory = \"%s\"", keysDir),
 	}
 	_, e := plugin.Configure(ctx, cReq)
 	assert.NoError(t, e)
-	assert.Equal(t, tmpdir, plugin.dir)
-	assert.DirExists(t, tmpdir)
+	assert.Equal(t, keysDir, plugin.dir)
+	assert.DirExists(t, keysDir)
 }
 
 func TestDisk_GetPluginInfo(t *testing.T) {

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -61,14 +62,14 @@ func TestDisk_FetchPrivateKey(t *testing.T) {
 
 func TestDisk_Configure(t *testing.T) {
 	plugin := New()
+	tmpdir := os.TempDir()
 	cReq := &spi.ConfigureRequest{
-		Configuration: "directory = \"foo/bar\"",
+		Configuration: fmt.Sprintf("directory = \"%s\"", tmpdir),
 	}
 	_, e := plugin.Configure(ctx, cReq)
 	assert.NoError(t, e)
-	assert.Equal(t, "foo/bar", plugin.dir)
-	assert.DirExists(t, "foo/bar")
-	os.RemoveAll("foo")
+	assert.Equal(t, tmpdir, plugin.dir)
+	assert.DirExists(t, tmpdir)
 }
 
 func TestDisk_GetPluginInfo(t *testing.T) {

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -67,6 +67,8 @@ func TestDisk_Configure(t *testing.T) {
 	_, e := plugin.Configure(ctx, cReq)
 	assert.NoError(t, e)
 	assert.Equal(t, "foo/bar", plugin.dir)
+	assert.DirExists(t, "foo/bar")
+	os.RemoveAll("foo")
 }
 
 func TestDisk_GetPluginInfo(t *testing.T) {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

As the title says, This PR affects the functionality of [Agent plugin: KeyManager "disk"](https://github.com/spiffe/spire/blob/master/doc/plugin_agent_keymanager_disk.md) .

**Description of change**
<!-- Please provide a description of the change -->

The changes are below.

- Support autocreating directory of Agent plugin: KeyManager "disk"
- Fix test of Agent plugin: KeyManager "disk"

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

This PR fixes https://github.com/spiffe/spire/issues/894 .

