### PR TITLE
metrics through common functions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ build_protobuf() {
 
 	# Generate protobufs in the proto/ and pkg/ subdirectories. README markdown
 	# will also be generated for protobufs in proto/. Unless an "_out" argument
-	# has been set the output will sit alongside the proto files. 
+	# has been set the output will sit alongside the proto files.
 	_proto_files="$(find proto pkg -name '*.proto' 2>/dev/null)"
 	for _protofile in ${_proto_files}; do
 		_srcdir="$(dirname "${_protofile}")"

--- a/pkg/agent/attestor/workload/workload.go
+++ b/pkg/agent/attestor/workload/workload.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_workload "github.com/spiffe/spire/pkg/common/telemetry/agent/workloadapi"
 	"github.com/spiffe/spire/proto/spire/agent/workloadattestor"
 	"github.com/spiffe/spire/proto/spire/common"
 )
@@ -37,7 +38,7 @@ type Config struct {
 // Attest invokes all workload attestor plugins against the provided PID. If an error
 // is encountered, it is logged and selectors from the failing plugin are discarded.
 func (wla *attestor) Attest(ctx context.Context, pid int32) []*common.Selector {
-	defer wla.c.M.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestationDuration}, time.Now())
+	defer telemetry_workload.MeasureAttestDuration(wla.c.M, time.Now())
 
 	plugins := wla.c.Catalog.GetWorkloadAttestors()
 	sChan := make(chan []*common.Selector)
@@ -64,15 +65,13 @@ func (wla *attestor) Attest(ctx context.Context, pid int32) []*common.Selector {
 		}
 	}
 
-	wla.c.M.AddSample([]string{telemetry.WorkloadAPI, telemetry.DiscoveredSelectors}, float32(len(selectors)))
+	telemetry_workload.AddDiscoveredSelectorsSample(wla.c.M, float32(len(selectors)))
 	wla.c.L.Debugf("PID %v attested to have selectors %v", pid, selectors)
 	return selectors
 }
 
 // invokeAttestor invokes attestation against the supplied plugin. Should be called from a goroutine.
 func (wla *attestor) invokeAttestor(ctx context.Context, a catalog.WorkloadAttestor, pid int32) ([]*common.Selector, error) {
-	tLabels := []telemetry.Label{{telemetry.AttestorName, a.Name()}}
-
 	req := &workloadattestor.AttestRequest{
 		Pid: pid,
 	}
@@ -81,7 +80,7 @@ func (wla *attestor) invokeAttestor(ctx context.Context, a catalog.WorkloadAttes
 	resp, err := a.Attest(ctx, req)
 
 	// Capture the attestor latency metrics regardless of whether an error condition was encountered or not
-	wla.c.M.MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestorLatency}, start, tLabels)
+	telemetry_workload.MeasureAttestorLatency(wla.c.M, start, a.Name())
 	if err != nil {
 		return nil, fmt.Errorf("workload attestor %q failed: %v", a.Name(), err)
 	}

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spiffe/spire/pkg/common/jwtsvid"
 	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_workload "github.com/spiffe/spire/pkg/common/telemetry/agent/workloadapi"
+	telemetry_common "github.com/spiffe/spire/pkg/common/telemetry/common"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/api/workload"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -53,26 +55,24 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 	}
 	defer done()
 
-	counter := telemetry.StartCall(metrics, telemetry.WorkloadAPI, telemetry.FetchJWTSVID)
+	counter := telemetry_workload.StartFetchJWTSVIDCall(metrics)
 	defer counter.Done(&err)
-
-	counter.AddLabel(telemetry.SVIDType, telemetry.JWT)
 
 	var spiffeIDs []string
 	identities := h.Manager.MatchingIdentities(selectors)
 	if len(identities) == 0 {
-		counter.AddLabel(telemetry.Registered, "false")
+		telemetry_common.AddRegistered(counter, false)
 		return nil, status.Errorf(codes.PermissionDenied, "no identity issued")
 	}
 
-	counter.AddLabel(telemetry.Registered, "true")
+	telemetry_common.AddRegistered(counter, true)
 
 	for _, identity := range identities {
 		if req.SpiffeId != "" && identity.Entry.SpiffeId != req.SpiffeId {
 			continue
 		}
 		spiffeIDs = append(spiffeIDs, identity.Entry.SpiffeId)
-		counter.AddLabel(telemetry.SPIFFEID, identity.Entry.SpiffeId)
+		telemetry_common.AddSPIFFEID(counter, identity.Entry.SpiffeId)
 	}
 
 	resp = new(workload.JWTSVIDResponse)
@@ -88,12 +88,7 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 		})
 
 		ttl := time.Until(svid.ExpiresAt)
-		metrics.SetGaugeWithLabels(
-			[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
-			float32(ttl.Seconds()),
-			[]telemetry.Label{
-				{Name: telemetry.SPIFFEID, Value: spiffeID},
-			})
+		telemetry_workload.SetFetchJWTSVIDTTLGauge(metrics, spiffeID, float32(ttl.Seconds()))
 	}
 
 	return resp, nil
@@ -109,7 +104,7 @@ func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream worklo
 	}
 	defer done()
 
-	metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, 1)
+	telemetry_workload.IncrFetchJWTBundlesCounter(metrics)
 
 	subscriber := h.Manager.SubscribeToCacheChanges(selectors)
 	defer subscriber.Finish()
@@ -117,13 +112,13 @@ func (h *Handler) FetchJWTBundles(req *workload.JWTBundlesRequest, stream worklo
 	for {
 		select {
 		case update := <-subscriber.Updates():
-			metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate}, 1)
+			telemetry_workload.IncrUpdateJWTBundlesCounter(metrics)
 			start := time.Now()
 			if err := h.sendJWTBundlesResponse(update, stream); err != nil {
 				return err
 			}
 
-			metrics.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, start)
+			telemetry_workload.MeasureSendJWTBundleLatency(metrics, start)
 			if time.Since(start) > (1 * time.Second) {
 				h.L.Warnf("Took %v seconds to send JWT bundle to PID %v", time.Since(start).Seconds, pid)
 			}
@@ -152,25 +147,11 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 
 	spiffeID, claims, err := jwtsvid.ValidateToken(ctx, req.Svid, keyStore, []string{req.Audience})
 	if err != nil {
-		metrics.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
-			{
-				Name:  telemetry.Error,
-				Value: err.Error(),
-			},
-		})
+		telemetry_workload.IncrValidJWTSVIDErrCounter(metrics, err.Error())
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	metrics.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
-		{
-			Name:  telemetry.Subject,
-			Value: spiffeID,
-		},
-		{
-			Name:  telemetry.Audience,
-			Value: req.Audience,
-		},
-	})
+	telemetry_workload.IncrValidJWTSVIDCounter(metrics, spiffeID, req.Audience)
 
 	s, err := structFromValues(claims)
 	if err != nil {
@@ -209,7 +190,7 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 			// TODO: evaluate the possibility of removing the following metric at some point
 			// in the future because almost the same metric (with different labels and keys) is being
 			// taken by the CallCounter in sendX509SVIDResponse function.
-			metrics.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency}, start)
+			telemetry_workload.MeasureFetchX509SVIDLatency(metrics, start)
 			if time.Since(start) > (1 * time.Second) {
 				h.L.Warnf("Took %v seconds to send SVID response to PID %v", time.Since(start).Seconds, pid)
 			}
@@ -220,17 +201,15 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 }
 
 func (h *Handler) sendX509SVIDResponse(update *cache.WorkloadUpdate, stream workload.SpiffeWorkloadAPI_FetchX509SVIDServer, metrics telemetry.Metrics, selectors []*common.Selector) (err error) {
-	counter := telemetry.StartCall(metrics, telemetry.WorkloadAPI, telemetry.FetchX509SVID)
+	counter := telemetry_workload.StartFetchX509SVIDCall(metrics)
 	defer counter.Done(&err)
 
-	counter.AddLabel(telemetry.SVIDType, telemetry.X509)
-
 	if len(update.Identities) == 0 {
-		counter.AddLabel(telemetry.Registered, "false")
+		telemetry_common.AddRegistered(counter, false)
 		return status.Errorf(codes.PermissionDenied, "no identity issued")
 	}
 
-	counter.AddLabel(telemetry.Registered, "true")
+	telemetry_common.AddRegistered(counter, true)
 
 	resp, err := h.composeX509SVIDResponse(update)
 	if err != nil {
@@ -244,15 +223,10 @@ func (h *Handler) sendX509SVIDResponse(update *cache.WorkloadUpdate, stream work
 
 	// Add all the SPIFFE IDs to the labels array.
 	for i, svid := range resp.Svids {
-		counter.AddLabel(telemetry.SPIFFEID, svid.SpiffeId)
+		telemetry_common.AddSPIFFEID(counter, svid.SpiffeId)
 
 		ttl := time.Until(update.Identities[i].SVID[0].NotAfter)
-		metrics.SetGaugeWithLabels(
-			[]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.TTL},
-			float32(ttl.Seconds()),
-			[]telemetry.Label{
-				{Name: telemetry.SPIFFEID, Value: svid.SpiffeId},
-			})
+		telemetry_workload.SetFetchX509SVIDTTLGauge(metrics, svid.SpiffeId, float32(ttl.Seconds()))
 	}
 
 	return nil
@@ -327,6 +301,9 @@ func (h *Handler) composeJWTBundlesResponse(update *cache.WorkloadUpdate) (*work
 	}, nil
 }
 
+// From context, parse out peer watcher PID and selectors. Attest against the PID. Add selectors as labels to
+// to a new metrics object. Return this information to the caller so it can emit further metrics.
+// If no error, callers must call the output func() to decrement current connections count.
 func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, telemetry.Metrics, func(), error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok || len(md["workload.spiffe.io"]) != 1 || md["workload.spiffe.io"][0] != "true" {
@@ -338,7 +315,8 @@ func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, tel
 		return 0, nil, nil, nil, status.Errorf(codes.Internal, "Is this a supported system? Please report this bug: %v", err)
 	}
 
-	h.M.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, 1)
+	// add to count of current
+	telemetry_workload.IncrConnectionTotalCounter(h.M)
 
 	config := attestor.Config{
 		Catalog: h.Catalog,
@@ -352,14 +330,17 @@ func (h *Handler) startCall(ctx context.Context) (int32, []*common.Selector, tel
 	// attest some other process that happened to be assigned the original PID
 	err = watcher.IsAlive()
 	if err != nil {
+		// error, decrement count of current connections
+		telemetry_workload.DecrConnectionTotalCounter(h.M)
 		return 0, nil, nil, nil, status.Errorf(codes.Unauthenticated, "Could not verify existence of the original caller: %v", err)
 	}
 
 	metrics := telemetry.WithLabels(h.M, selectorsToLabels(selectors))
-	metrics.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connection}, 1)
+	telemetry_workload.IncrConnectionCounter(metrics)
 
 	done := func() {
-		defer h.M.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, -1)
+		// rely on caller to decrement count of current connections
+		telemetry_workload.DecrConnectionTotalCounter(h.M)
 	}
 
 	return watcher.PID(), selectors, metrics, done, nil

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -126,7 +126,7 @@ func (s *HandlerTestSuite) TestFetchX509SVID() {
 		}))
 	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID}, float32(1), labelsSvidResponse)
 	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.ElapsedTime}, gomock.Any(), labelsSvidResponse)
-	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency}, gomock.Any(), labels)
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency, telemetry.Fetch}, gomock.Any(), labels)
 
 	go func() { result <- s.h.FetchX509SVID(nil, stream) }()
 
@@ -352,7 +352,7 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 }
 
 func setupMetricsCommonExpectations(metrics *mock_telemetry.MockMetrics, selectorsLabels []telemetry.Label, pid int32) {
-	attestorLabels := []telemetry.Label{{telemetry.AttestorName, "fake"}}
+	attestorLabels := []telemetry.Label{{telemetry.Attestor, "fake"}}
 
 	metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestorLatency}, gomock.Any(), attestorLabels)
 	metrics.EXPECT().AddSample([]string{telemetry.WorkloadAPI, telemetry.DiscoveredSelectors}, float32(len(selectorsLabels)))
@@ -398,7 +398,7 @@ func (s *HandlerTestSuite) TestFetchJWTBundles() {
 	labels := selectorsToLabels(selectors)
 	setupMetricsCommonExpectations(s.metrics, labels, 1)
 	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, float32(1), labels)
-	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate}, float32(1), labels)
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate, telemetry.JWT}, float32(1), labels)
 	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, gomock.Any(), labels)
 
 	go func() { result <- s.h.FetchJWTBundles(&workload.JWTBundlesRequest{}, stream) }()

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -11,7 +11,7 @@ import (
 	"github.com/andres-erbsen/clock"
 	observer "github.com/imkira/go-observer"
 	"github.com/spiffe/spire/pkg/agent/client"
-	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_agent "github.com/spiffe/spire/pkg/common/telemetry/agent"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/spire/agent/keymanager"
 	"github.com/spiffe/spire/proto/spire/api/node"
@@ -87,10 +87,9 @@ func (r *rotator) shouldRotate() bool {
 
 // rotateSVID asks SPIRE's server for a new agent's SVID.
 func (r *rotator) rotateSVID(ctx context.Context) (err error) {
-	counter := telemetry.StartCall(r.c.Metrics, telemetry.AgentSVID, telemetry.Rotate)
+	counter := telemetry_agent.StartRotateAgentSVIDCall(r.c.Metrics, r.c.SpiffeID)
 	defer counter.Done(&err)
 
-	counter.AddLabel(telemetry.SPIFFEID, r.c.SpiffeID)
 	r.c.Log.Debug("Rotating agent SVID")
 
 	key, err := r.newKey(ctx)

--- a/pkg/common/telemetry/agent/manager.go
+++ b/pkg/common/telemetry/agent/manager.go
@@ -1,0 +1,25 @@
+package agent
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartManagerFetchUpdatesCall returns metric for when agent's
+// synchronization manager fetching latest SVID information
+// from server
+func StartManagerFetchUpdatesCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Manager, telemetry.Sync, telemetry.FetchUpdates)
+}
+
+// End Call Counters
+
+// Add Samples (metric on count of some object, entries, event...)
+
+// AddCacheManagerExpiredSVIDsSample count of expiring SVIDs according to
+// agent cache manager
+func AddCacheManagerExpiredSVIDsSample(m telemetry.Metrics, count float32) {
+	m.AddSample([]string{telemetry.CacheManager, telemetry.ExpiringSVIDs}, count)
+}
+
+// End Add Samples

--- a/pkg/common/telemetry/agent/node.go
+++ b/pkg/common/telemetry/agent/node.go
@@ -1,0 +1,21 @@
+package agent
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartNodeAttestCall return metric for
+// an agent's call for Node Attestation
+func StartNodeAttestCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Node, telemetry.Attest)
+}
+
+// StartNodeAttestorNewSVIDCall return metric
+// for agent node attestor call to get new SVID
+// for the agent
+func StartNodeAttestorNewSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Node, telemetry.Attestor, telemetry.NewSVID)
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/agent/rotate.go
+++ b/pkg/common/telemetry/agent/rotate.go
@@ -1,0 +1,19 @@
+package agent
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/common/telemetry/common"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartRotateAgentSVIDCall return metric for Agent's SVID
+// Rotation. Takes the agent's spiffe ID as a label.
+func StartRotateAgentSVIDCall(m telemetry.Metrics, id string) *telemetry.CallCounter {
+	cc := telemetry.StartCall(m, telemetry.AgentSVID, telemetry.Rotate)
+	common.AddSPIFFEID(cc, id)
+	return cc
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/agent/sdsapi.go
+++ b/pkg/common/telemetry/agent/sdsapi.go
@@ -1,0 +1,25 @@
+package agent
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Counters (literal increments, not call counters)
+
+// IncrSDSAPIConnectionCounter indicate SDS
+// API connection (some connection is made, running total count)
+func IncrSDSAPIConnectionCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.SDSAPI, telemetry.Connection}, 1)
+}
+
+// DecrSDSAPIConnectionTotalCounter indicate one less
+// SDS API active connection (active in that moment)
+func DecrSDSAPIConnectionTotalCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.SDSAPI, telemetry.Connections}, -1)
+}
+
+// IncrSDSAPIConnectionTotalCounter indicate one more
+// SDS API active connections (active in that moment)
+func IncrSDSAPIConnectionTotalCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.SDSAPI, telemetry.Connections}, 1)
+}
+
+// End Counters

--- a/pkg/common/telemetry/agent/workloadapi/workload.go
+++ b/pkg/common/telemetry/agent/workloadapi/workload.go
@@ -1,0 +1,153 @@
+package workloadapi
+
+import (
+	"time"
+
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartFetchJWTSVIDCall return metric
+// for agent's Workload API, on fetching the workload's JWT SVID
+func StartFetchJWTSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	cc := telemetry.StartCall(m, telemetry.WorkloadAPI, telemetry.FetchJWTSVID)
+	cc.AddLabel(telemetry.SVIDType, telemetry.JWT)
+	return cc
+}
+
+// StartFetchX509SVIDCall return metric
+// for agent's Workload API, on fetching the workload's X509 SVID
+func StartFetchX509SVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	cc := telemetry.StartCall(m, telemetry.WorkloadAPI, telemetry.FetchX509SVID)
+	cc.AddLabel(telemetry.SVIDType, telemetry.X509)
+	return cc
+}
+
+// End Call Counters
+
+// Counters (literal increments, not call counters)
+
+// IncrConnectionCounter indicate Workload
+// API connection (some connection is made, running total count)
+func IncrConnectionCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connection}, 1)
+}
+
+// DecrConnectionTotalCounter indicate one less
+// Workload API active connection (active in that moment)
+func DecrConnectionTotalCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, -1)
+}
+
+// IncrConnectionTotalCounter indicate one more
+// Workload API active connection (active in that moment)
+func IncrConnectionTotalCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, 1)
+}
+
+// IncrFetchJWTBundlesCounter indicate call to Workload
+// API, on fetching JWT bundles.
+func IncrFetchJWTBundlesCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, 1)
+}
+
+// IncrUpdateJWTBundlesCounter indicate call to Workload
+// API, on updating JWT bundles
+func IncrUpdateJWTBundlesCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate, telemetry.JWT}, 1)
+}
+
+// IncrValidJWTSVIDCounter indicate call to Workload
+// API, on validating JWT SVID. Takes SVID SPIFFE ID and request audience
+func IncrValidJWTSVIDCounter(m telemetry.Metrics, id string, aud string) {
+	m.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
+		{
+			Name:  telemetry.Subject,
+			Value: id,
+		},
+		{
+			Name:  telemetry.Audience,
+			Value: aud,
+		},
+	})
+}
+
+// IncrValidJWTSVIDErrCounter indicate call to Workload
+// API, on error validating JWT SVID. Takes error string.
+func IncrValidJWTSVIDErrCounter(m telemetry.Metrics, err string) {
+	m.IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.ValidateJWTSVID}, 1, []telemetry.Label{
+		{
+			Name:  telemetry.Error,
+			Value: err,
+		},
+	})
+}
+
+// End Counters
+
+// Gauge (remember previous value set)
+
+// SetFetchJWTSVIDTTLGauge set gauge for agent Workload API,
+// TTL of fetching JWT SVID for a specific SPIFFE ID
+func SetFetchJWTSVIDTTLGauge(m telemetry.Metrics, id string, val float32) {
+	m.SetGaugeWithLabels(
+		[]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.TTL},
+		val,
+		[]telemetry.Label{
+			{Name: telemetry.SPIFFEID, Value: id},
+		})
+}
+
+// SetFetchX509SVIDTTLGauge set gauge for agent Workload API,
+// TTL of fetching X509 SVID for a specific SPIFFE ID
+func SetFetchX509SVIDTTLGauge(m telemetry.Metrics, id string, val float32) {
+	m.SetGaugeWithLabels(
+		[]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.TTL},
+		val,
+		[]telemetry.Label{
+			{Name: telemetry.SPIFFEID, Value: id},
+		})
+}
+
+// End Gauge
+
+// Measure Since (metric on time passed since some given time)
+
+// MeasureAttestDuration emit metric on agent Workload API Attestor latency
+// for no specific attestor (the entire attest process)
+func MeasureAttestDuration(m telemetry.Metrics, t time.Time) {
+	m.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestationDuration}, t)
+}
+
+// MeasureAttestorLatency emit metric on agent Workload API Attestor latency
+// for a specific attestor
+func MeasureAttestorLatency(m telemetry.Metrics, t time.Time, aType string) {
+	m.MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestorLatency}, t,
+		[]telemetry.Label{{Name: telemetry.Attestor, Value: aType}})
+}
+
+// MeasureSendJWTBundleLatency emit metric on agent Workload API,
+// latency of sending JWT Bundle to workload
+func MeasureSendJWTBundleLatency(m telemetry.Metrics, t time.Time) {
+	m.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, t)
+}
+
+// MeasureFetchX509SVIDLatency emit metric on agent Workload API,
+// latency of fetching X509SVID
+func MeasureFetchX509SVIDLatency(m telemetry.Metrics, t time.Time) {
+	m.MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SVIDResponseLatency, telemetry.Fetch}, t)
+}
+
+// End Measure Since
+
+// Add Samples (metric on count of some object, entries, event...)
+
+// AddDiscoveredSelectorsSample count of discovered selectors
+// during an agent Workload Attest call
+func AddDiscoveredSelectorsSample(m telemetry.Metrics, count float32) {
+	m.AddSample([]string{telemetry.WorkloadAPI, telemetry.DiscoveredSelectors}, count)
+}
+
+// End Add Samples

--- a/pkg/common/telemetry/call.go
+++ b/pkg/common/telemetry/call.go
@@ -64,8 +64,3 @@ func (c *CallCounter) Done(errp *error) {
 	c.metrics.IncrCounterWithLabels(key, 1, c.labels)
 	c.metrics.MeasureSinceWithLabels(append(key, ElapsedTime), c.start, c.labels)
 }
-
-func CountCall(metrics Metrics, key string, keyn ...string) func(*error) {
-	counter := StartCall(metrics, key, keyn...)
-	return counter.Done
-}

--- a/pkg/common/telemetry/common/label_adders.go
+++ b/pkg/common/telemetry/common/label_adders.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"strconv"
+
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// AddAttestorType add Attestor type label to the given counter
+// from the given attestor type
+func AddAttestorType(cc *telemetry.CallCounter, aType string) {
+	cc.AddLabel(telemetry.Attestor, aType)
+}
+
+// AddAudience add the Audience label(s) to the given counter
+// from the given audience(s)
+func AddAudience(cc *telemetry.CallCounter, auds ...string) {
+	for _, aud := range auds {
+		cc.AddLabel(telemetry.Audience, aud)
+	}
+}
+
+// AddCallerID add the CallerID label to the given counter
+// from the given ID
+func AddCallerID(cc *telemetry.CallCounter, id string) {
+	cc.AddLabel(telemetry.CallerID, id)
+}
+
+// AddRegistered add the Registered label to the given
+// counter, from given boolean
+func AddRegistered(cc *telemetry.CallCounter, reg bool) {
+	cc.AddLabel(telemetry.Registered, strconv.FormatBool(reg))
+}
+
+// AddSPIFFEID add SPIFFE ID label to the given counter
+// from the given ID
+func AddSPIFFEID(cc *telemetry.CallCounter, id string) {
+	cc.AddLabel(telemetry.SPIFFEID, id)
+}

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -2,27 +2,154 @@ package telemetry
 
 // Constants for metric keys and labels. Helps with enforcement of non-conflicting usage of same or similar names.
 // Additionally, importers of this package can get an idea of metric tags to look for.
+// While these constants are exported, it is preferable to use the functions defined in subpackages, or
+// define new such functions there
 
+// Action metric tags or labels that are typically a specific action
 const (
 	// Activate functionality related to activating some element (such as X509 CA manager);
 	// should be used with other tags to add clarity
 	Activate = "activate"
 
-	// AgentSVID tag a node (agent) SVID
-	AgentSVID = "agent_svid"
-
 	// Attest functionality related to attesting; should be used with other tags
 	// to add clarity
 	Attest = "attest"
 
-	// Attestor tags an attestor type (eg. gcp, aws...)
-	Attestor = "attestor"
+	// Create functionality related to creating some entity; should be used with other tags
+	// to add clarity
+	Create = "create"
 
-	// AttestorName tags an attestor name
-	AttestorName = "attestor_name"
+	// Delete functionality related to deleting some entity; should be used with other tags
+	// to add clarity
+	Delete = "delete"
 
+	// Fetch functionality related to fetching some entity; should be used with other tags
+	// to add clarity
+	Fetch = "fetch"
+
+	// List functionality related to listing some objects; should be used
+	// with other tags to add clarity
+	List = "list"
+
+	// Prepare functionality related to preparation of some entity; should be used with other tags
+	// to add clarity
+	Prepare = "prepare"
+
+	// Prune functionality related to pruning some entity(ies); should be used with other tags
+	// to add clarity
+	Prune = "prune"
+
+	// Rotate functionality related to rotation of SVID; should be used with other tags
+	// to add clarity
+	Rotate = "rotate"
+
+	// Sign functionality related to signing a token / cert; should be used with other tags
+	// to add clarity
+	Sign = "sign"
+
+	// Sync functionality for syncing (such as CA manager updates). Should
+	// be used with other tags to add clarity
+	Sync = "sync"
+
+	// Update functionality related to updating some entity; should be used
+	// with other tags to add clarity
+	Update = "update"
+)
+
+// Attribute metric tags or labels that are typically an attribute of a
+// larger entity or logic path
+const (
 	// Audience tags some audience for a token
 	Audience = "audience"
+
+	// CallerID tags an API caller; should be used with other tags
+	// to add clarity
+	CallerID = "caller_id"
+
+	// Connection functionality related to some connection; should be used with other tags
+	// to add clarity
+	Connection = "connection"
+
+	// Connections functionality related to some group of connections; should be used with other tags
+	// to add clarity
+	Connections = "connections"
+
+	// DiscoveredSelectors tags selectors for some registration
+	DiscoveredSelectors = "discovered_selectors"
+
+	// ElapsedTime tags some duration of time. Reserved for use in telemetry package on
+	// call counters. Exported for tests only.
+	ElapsedTime = "elapsed_time"
+
+	// Error tag for some error that occurred
+	Error = "error"
+
+	// ExpiryCheckDuration tags duration for an expiry check; should be used with other tags
+	// to add clarity
+	ExpiryCheckDuration = "expiry_check_duration"
+
+	// JWT declares JWT SVID type, clarifying metrics
+	JWT = "jwt"
+
+	// Pruned flagging something has been pruned
+	Pruned = "pruned"
+
+	// Registered flags whether some entity is registered or not; should be
+	// either true or false
+	Registered = "registered"
+
+	// Selector tags some registration selector
+	Selector = "selector"
+
+	// SendJWTBundleLatency tags latency for sending JWT bundle
+	SendJWTBundleLatency = "send_jwt_bundle_latency"
+
+	// SDSPID tags an SDS PID
+	SDSPID = "sds_pid"
+
+	// SPIFFEID tags a SPIFFE ID
+	SPIFFEID = "spiffe_id"
+
+	// Subject tags some subject (likely a SPIFFE ID, and likely for a token); should be used
+	// with other tags to add clarity
+	Subject = "subject"
+
+	// SVIDResponseLatency tags latency for SVID response
+	SVIDResponseLatency = "svid_response_latency"
+
+	// SVIDType tags some type of SVID (eg. X509, JWT)
+	SVIDType = "svid_type"
+
+	// TTL functionality related to a time-to-live field; should be used
+	// with other tags to add clarity
+	TTL = "ttl"
+
+	// TrustDomainID tags some trust domain ID
+	TrustDomainID = "trust_domain_id"
+
+	// Updated tags some entity as updated; should be used
+	// with other tags to add clarity
+	Updated = "updated"
+
+	// WorkloadAttestationDuration tags duration of workload attestation
+	WorkloadAttestationDuration = "workload_attestation_duration"
+
+	// WorkloadAttestorLatency tags latency of a workload attestor
+	WorkloadAttestorLatency = "workload_attestor_latency"
+
+	// X509 declared X509 SVID type, clarifying metrics
+	X509 = "x509"
+)
+
+// Entity metric tags or labels that are typically an entity or
+// module in their own right, rather than descriptive of other
+// entities or modules
+const (
+	// AgentSVID tag a node (agent) SVID
+	AgentSVID = "agent_svid"
+
+	// Attestor tags an attestor plugin/type (eg. gcp, aws...)
+	Attestor = "attestor"
 
 	// Bundle functionality related to a bundle; should be used with other tags
 	// to add clarity
@@ -38,54 +165,64 @@ const (
 	// CacheManager functionality related to a cache manager
 	CacheManager = "cache_manager"
 
-	// CallerID tags an API caller; should be used with other tags
-	// to add clarity
-	CallerID = "caller_id"
-
-	// Connection functionality related to some connection; should be used with other tags
-	// to add clarity
-	Connection = "connection"
-
-	// Connections functionality related to some group of connections; should be used with other tags
-	// to add clarity
-	Connections = "connections"
-
-	// Create functionality related to creating some entity; should be used with other tags
-	// to add clarity
-	Create = "create"
-
-	// Delete functionality related to deleting some entity; should be used with other tags
-	// to add clarity
-	Delete = "delete"
-
-	// DiscoveredSelectors tags selectors for some registration
-	DiscoveredSelectors = "discovered_selectors"
-
-	// ElapsedTime tags some duration of time; should be used with other tags to add clarity
-	ElapsedTime = "elapsed_time"
-
 	// Entry tag for some stored entry; should be used with other tags such as RegistrationAPI
 	// to add clarity
 	Entry = "entry"
 
-	// Error tag for some error that occurred
-	Error = "error"
-
 	// ExpiringSVIDs tags expiring SVID count/list
 	ExpiringSVIDs = "expiring_svids"
-
-	// ExpiryCheckDuration tags duration for an expiry check; should be used with other tags
-	// to add clarity
-	ExpiryCheckDuration = "expiry_check_duration"
 
 	// FederatedBundle functionality related to a federated bundle; should be used
 	// with other tags to add clarity
 	FederatedBundle = "federated_bundle"
 
-	// Fetch functionality related to fetching some entity; should be used with other tags
-	// to add clarity
-	Fetch = "fetch"
+	// JoinToken functionality related to a join token; should be used
+	// with other tags to add clarity
+	JoinToken = "join_token"
 
+	// JWTKey functionality related to a JWT key; should be used with other tags
+	// to add clarity
+	JWTKey = "jwt_key"
+
+	// JWTSVID functionality related to a JWT SVID; should be used with other tags
+	// to add clarity
+	JWTSVID = "jwt_svid"
+
+	// Manager functionality related to a manager (such as CA manager); should be
+	// used with other tags to add clarity
+	Manager = "manager"
+
+	// NewSVID functionality related to creation of a new SVID
+	NewSVID = "new_svid"
+
+	// Node functionality related to a node entity or type; should be used with other tags
+	// to add clarity
+	Node = "node"
+
+	// ServerCA functionality related to a server CA; should be used with other tags
+	// to add clarity
+	ServerCA = "server_ca"
+
+	// SVID functionality related to a SVID; should be used with other tags
+	// to add clarity
+	SVID = "svid"
+
+	// X509CA functionality related to an x509 CA; should be used with other tags
+	// to add clarity
+	X509CA = "x509_ca"
+
+	// X509CASVID functionality related to an x509 CA SVID; should be used with other tags
+	// to add clarity
+	X509CASVID = "x509_ca_svid"
+
+	// X509SVID functionality related to an x509 SVID; should be used with other tags
+	// to add clarity
+	X509SVID = "x509_svid"
+)
+
+// Operation metric tags or labels that are typically a specific
+// operation or API
+const (
 	// FetchJWTSVID functionality related to fetching a JWT SVID
 	FetchJWTSVID = "fetch_jwt_svid"
 
@@ -99,118 +236,16 @@ const (
 	// FetchX509SVID functionality related to fetching an X509 SVID
 	FetchX509SVID = "fetch_x509_svid"
 
-	// JoinToken functionality related to a join token; should be used
-	// with other tags to add clarity
-	JoinToken = "join_token"
-
-	// JWT declares JWT SVID type, clarifying metrics
-	JWT = "jwt"
-
-	// JWTKey functionality related to a JWT key; should be used with other tags
-	// to add clarity
-	JWTKey = "jwt_key"
-
-	// JWTSVID functionality related to a JWT SVID; should be used with other tags
-	// to add clarity
-	JWTSVID = "jwt_svid"
-
-	// List functionality related to listing some objects; should be used
-	// with other tags to add clarity
-	List = "list"
-
-	// Manager functionality related to a manager (such as CA manager); should be
-	// used with other tags to add clarity
-	Manager = "manager"
-
-	// NewSVID functionality related to creation of a new SVID
-	NewSVID = "new_svid"
-
-	// Node functionality related to a node entity or type; should be used with other tags
-	// to add clarity
-	Node = "node"
-
 	// NodeAPI functionality related to attested/attesting nodes (agents)
 	NodeAPI = "node_api"
-
-	// Prepare functionality related to preparation of some entity; should be used with other tags
-	// to add clarity
-	Prepare = "prepare"
-
-	// Prune functionality related to pruning some entity(ies); should be used with other tags
-	// to add clarity
-	Prune = "prune"
-
-	// Pruned flagging something has been pruned
-	Pruned = "pruned"
-
-	// Registered flags whether some entity is registered or not; should be
-	// either true or false
-	Registered = "registered"
 
 	// RegistrationAPI functionality related to the registration api; should be used
 	// with other tags to add clarity
 	RegistrationAPI = "registration_api"
 
-	// Rotate functionality related to rotation of SVID; should be used with other tags
-	// to add clarity
-	Rotate = "rotate"
-
 	// SDSAPI functionality related to SDS; should be used with other tags
 	// to add clarity
 	SDSAPI = "sds_api"
-
-	// SDSPID tags an SDS PID
-	SDSPID = "sds_pid"
-
-	// Selector tags some registration selector
-	Selector = "selector"
-
-	// SendJWTBundleLatency tags latency for sending JWT bundle
-	SendJWTBundleLatency = "send_jwt_bundle_latency"
-
-	// ServerCA functionality related to a server CA; should be used with other tags
-	// to add clarity
-	ServerCA = "server_ca"
-
-	// Sign functionality related to signing a token / cert; should be used with other tags
-	// to add clarity
-	Sign = "sign"
-
-	// SPIFFEID tags a SPIFFE ID
-	SPIFFEID = "spiffe_id"
-
-	// Subject tags some subject (likely a SPIFFE ID, and likely for a token); should be used
-	// with other tags to add clarity
-	Subject = "subject"
-
-	// SVID functionality related to a SVID; should be used with other tags
-	// to add clarity
-	SVID = "svid"
-
-	// SVIDResponseLatency tags latency for SVID response
-	SVIDResponseLatency = "svid_response_latency"
-
-	// SVIDType tags some type of SVID (eg. X509, JWT)
-	SVIDType = "svid_type"
-
-	// Sync functionality for syncing (such as CA manager updates). Should
-	// be used with other tags to add clarity
-	Sync = "sync"
-
-	// TTL functionality related to a time-to-live field; should be used
-	// with other tags to add clarity
-	TTL = "ttl"
-
-	// TrustDomainID tags some trust domain ID
-	TrustDomainID = "trust_domain_id"
-
-	// Update functionality related to updating some entity; should be used
-	// with other tags to add clarity
-	Update = "update"
-
-	// Updated tags some entity as updated; should be used
-	// with other tags to add clarity
-	Updated = "updated"
 
 	// ValidateJWTSVID functionality related validating a JWT SVID
 	ValidateJWTSVID = "validate_jwt_svid"
@@ -218,25 +253,4 @@ const (
 	// WorkloadAPI flagging usage of workload API; should be used with other tags
 	// to add clarity
 	WorkloadAPI = "workload_api"
-
-	// WorkloadAttestationDuration tags duration of workload attestation
-	WorkloadAttestationDuration = "workload_attestation_duration"
-
-	// WorkloadAttestorLatency tags latency of a workload attestor
-	WorkloadAttestorLatency = "workload_attestor_latency"
-
-	// X509 declared X509 SVID type, clarifying metrics
-	X509 = "x509"
-
-	// X509CA functionality related to an x509 CA; should be used with other tags
-	// to add clarity
-	X509CA = "x509_ca"
-
-	// X509CASVID functionality related to an x509 CA SVID; should be used with other tags
-	// to add clarity
-	X509CASVID = "x509_ca_svid"
-
-	// X509SVID functionality related to an x509 SVID; should be used with other tags
-	// to add clarity
-	X509SVID = "x509_svid"
 )

--- a/pkg/common/telemetry/server/ca_manager.go
+++ b/pkg/common/telemetry/server/ca_manager.go
@@ -1,0 +1,88 @@
+package server
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartCAManagerPruneBundleCall returns metric for
+// for server CA manager bundle pruning
+func StartCAManagerPruneBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.CA, telemetry.Manager, telemetry.Bundle, telemetry.Prune)
+}
+
+// StartServerCAManagerPrepareJWTKeyCall return metric for
+// Server CA Manager preparing a JWT Key
+func StartServerCAManagerPrepareJWTKeyCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.CA, telemetry.Manager, telemetry.JWTKey, telemetry.Prepare)
+}
+
+// StartServerCAManagerPrepareX509CACall return metric for
+// Server CA Manager preparing an X509 CA
+func StartServerCAManagerPrepareX509CACall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.CA, telemetry.Manager, telemetry.X509CA, telemetry.Prepare)
+}
+
+// End Call Counters
+
+// Counters (literal increments, not call counters)
+
+// IncrActivateJWTKeyManagerCounter indicate activation
+// of JWT Key manager
+func IncrActivateJWTKeyManagerCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.Manager, telemetry.JWTKey, telemetry.Activate}, 1)
+}
+
+// IncrActivateX509CAManagerCounter indicate activation
+// of X509 CA manager
+func IncrActivateX509CAManagerCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.CA, telemetry.Manager, telemetry.X509CA, telemetry.Activate}, 1)
+}
+
+// IncrManagerPrunedBundleCounter indicate manager
+// having pruned a bundle
+func IncrManagerPrunedBundleCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.CA, telemetry.Manager, telemetry.Bundle, telemetry.Pruned}, 1)
+}
+
+// IncrServerCASignJWTSVIDCounter indicate Server CA
+// signed a JWT SVID. Takes SVID's SPIFFE ID and audience(s)
+func IncrServerCASignJWTSVIDCounter(m telemetry.Metrics, id string, auds ...string) {
+	labels := []telemetry.Label{
+		{
+			Name:  telemetry.SPIFFEID,
+			Value: id,
+		},
+	}
+	for _, audience := range auds {
+		labels = append(labels, telemetry.Label{
+			Name:  telemetry.Audience,
+			Value: audience,
+		})
+	}
+	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.JWTSVID}, 1, labels)
+}
+
+// IncrServerCASignX509CACounter indicate Server CA
+// signed an X509 CA SVID. Takes SVID's SPIFFE ID
+func IncrServerCASignX509CACounter(m telemetry.Metrics, id string) {
+	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509CASVID}, 1, []telemetry.Label{
+		{
+			Name:  telemetry.SPIFFEID,
+			Value: id,
+		},
+	})
+}
+
+// IncrServerCASignX509Counter indicate Server CA
+// signed an X509 SVID. Takes SVID's SPIFFE ID
+func IncrServerCASignX509Counter(m telemetry.Metrics, id string) {
+	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509SVID}, 1, []telemetry.Label{
+		{
+			Name:  telemetry.SPIFFEID,
+			Value: id,
+		},
+	})
+}
+
+// End Counters

--- a/pkg/common/telemetry/server/node_api.go
+++ b/pkg/common/telemetry/server/node_api.go
@@ -1,0 +1,23 @@
+package server
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// StartNodeAPIAttestCall return metric for
+// the server's Node API, Attestation of a node.
+func StartNodeAPIAttestCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.NodeAPI, telemetry.Attest)
+}
+
+// StartNodeAPIFetchJWTSVIDCall return metric for
+// the server's Node API, Fetch JWT SVID for node.
+func StartNodeAPIFetchJWTSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.NodeAPI, telemetry.JWTSVID, telemetry.Fetch)
+}
+
+// StartNodeAPIFetchX509SVIDCall return metric for
+// the server's Node API, Fetch X509 SVID for node.
+func StartNodeAPIFetchX509SVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.NodeAPI, telemetry.X509SVID, telemetry.Fetch)
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/server/registrationapi/registrationapi.go
+++ b/pkg/common/telemetry/server/registrationapi/registrationapi.go
@@ -1,0 +1,90 @@
+package registrationapi
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartCreateEntryCall return metric
+// for server's registration API, on creating an entry.
+func StartCreateEntryCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Create)
+}
+
+// StartCreateFedBundleCall return metric
+// for server's registration API, on creating a federated bundle
+func StartCreateFedBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Create)
+}
+
+// StartCreateJoinTokenCall return metric
+// for server's registration API, on creating a join token
+func StartCreateJoinTokenCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.JoinToken, telemetry.Create)
+}
+
+// StartDeleteEntryCall return metric
+// for server's registration API, on deleting an entry
+func StartDeleteEntryCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Delete)
+}
+
+// StartDeleteFedBundleCall return metric
+// for server's registration API, on deleting a federated bundle
+func StartDeleteFedBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Delete)
+}
+
+// StartFetchBundleCall return metric
+// for server's registration API, on fetching a bundle
+func StartFetchBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Bundle, telemetry.Fetch)
+}
+
+// StartFetchEntryCall return metric
+// for server's registration API, on fetching an entry
+func StartFetchEntryCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Fetch)
+}
+
+// StartFetchFedBundleCall return metric
+// for server's registration API, on fetching a federated bundle
+func StartFetchFedBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Fetch)
+}
+
+// StartListEntriesCall return metric
+// for server's registration API, on listing entries
+func StartListEntriesCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Entry, telemetry.List)
+}
+
+// StartListFedBundlesCall return metric
+// for server's registration API, on listing federated bundles
+func StartListFedBundlesCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.List)
+}
+
+// StartUpdateEntryCall return metric
+// for server's registration API, on updating an entry
+func StartUpdateEntryCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.Entry, telemetry.Update)
+}
+
+// StartUpdateFedBundleCall return metric
+// for server's registration API, on updating a federated bundle
+func StartUpdateFedBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.RegistrationAPI, telemetry.FederatedBundle, telemetry.Update)
+}
+
+// End Call Counters
+
+// Counters (literal increments, not call counters)
+
+// IncrRegistrationAPIUpdatedEntryCounter indicate
+// Registration API successfully updating an entry
+func IncrRegistrationAPIUpdatedEntryCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.RegistrationAPI, telemetry.Entry, telemetry.Updated}, 1)
+}
+
+// End Counters

--- a/pkg/common/telemetry/server/rotate.go
+++ b/pkg/common/telemetry/server/rotate.go
@@ -1,0 +1,14 @@
+package server
+
+import "github.com/spiffe/spire/pkg/common/telemetry"
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartRotateServerSVIDCall return metric for
+// Server's SVID Rotation.
+func StartRotateServerSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.SVID, telemetry.Rotate)
+}
+
+// End Call Counters

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -17,6 +17,8 @@ import (
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/jwtsvid"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_common "github.com/spiffe/spire/pkg/common/telemetry/common"
+	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/catalog"
 	"github.com/spiffe/spire/pkg/server/util/regentryutil"
@@ -61,7 +63,7 @@ func NewHandler(config HandlerConfig) *Handler {
 
 //Attest attests the node and gets the base node SVID.
 func (h *Handler) Attest(stream node.Node_AttestServer) (err error) {
-	counter := telemetry.StartCall(h.c.Metrics, telemetry.NodeAPI, telemetry.Attest)
+	counter := telemetry_server.StartNodeAPIAttestCall(h.c.Metrics)
 	defer counter.Done(&err)
 
 	// make sure node attestor stream will be cancelled if things go awry
@@ -94,7 +96,7 @@ func (h *Handler) Attest(stream node.Node_AttestServer) (err error) {
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "request CSR is invalid: %v", err)
 	}
-	counter.AddLabel(telemetry.SPIFFEID, agentID)
+	telemetry_common.AddSPIFFEID(counter, agentID)
 
 	attestedBefore, err := h.isAttested(ctx, agentID)
 	if err != nil {
@@ -190,7 +192,7 @@ func (h *Handler) getNodeAttestationValidationMode() idutil.ValidationMode {
 //Also used for rotation Base Node SVID or the Registered Node SVID used for this call.
 //List can be empty to allow Node Agent cache refresh).
 func (h *Handler) FetchX509SVID(server node.Node_FetchX509SVIDServer) (err error) {
-	counter := telemetry.StartCall(h.c.Metrics, telemetry.NodeAPI, telemetry.X509SVID, telemetry.Fetch)
+	counter := telemetry_server.StartNodeAPIFetchX509SVIDCall(h.c.Metrics)
 	defer counter.Done(&err)
 
 	peerCert, ok := getPeerCertificate(server.Context())
@@ -239,7 +241,7 @@ func (h *Handler) FetchX509SVID(server node.Node_FetchX509SVIDServer) (err error
 		}
 
 		for spiffeID := range svids {
-			counter.AddLabel(telemetry.SPIFFEID, spiffeID)
+			telemetry_common.AddSPIFFEID(counter, spiffeID)
 		}
 
 		err = server.Send(&node.FetchX509SVIDResponse{
@@ -310,7 +312,7 @@ func (h *Handler) FetchX509CASVID(ctx context.Context, req *node.FetchX509CASVID
 }
 
 func (h *Handler) FetchJWTSVID(ctx context.Context, req *node.FetchJWTSVIDRequest) (resp *node.FetchJWTSVIDResponse, err error) {
-	counter := telemetry.StartCall(h.c.Metrics, telemetry.NodeAPI, telemetry.JWTSVID, telemetry.Fetch)
+	counter := telemetry_server.StartNodeAPIFetchJWTSVIDCall(h.c.Metrics)
 	defer counter.Done(&err)
 
 	if err := h.limiter.Limit(ctx, JSRMsg, 1); err != nil {
@@ -332,7 +334,7 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *node.FetchJWTSVIDReques
 		return nil, status.Error(codes.InvalidArgument, "request missing audience")
 	}
 
-	counter.AddLabel(telemetry.SPIFFEID, req.Jsr.SpiffeId)
+	telemetry_common.AddSPIFFEID(counter, req.Jsr.SpiffeId)
 
 	agentID, err := getSpiffeIDFromCert(peerCert)
 	if err != nil {
@@ -370,9 +372,7 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *node.FetchJWTSVIDReques
 		return nil, err
 	}
 
-	for _, audience := range req.Jsr.Audience {
-		counter.AddLabel(telemetry.Audience, audience)
-	}
+	telemetry_common.AddAudience(counter, req.Jsr.Audience...)
 
 	return &node.FetchJWTSVIDResponse{
 		Svid: &node.JWTSVID{

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/imkira/go-observer"
 	"github.com/spiffe/spire/pkg/common/idutil"
-	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/ca"
 )
@@ -85,7 +85,8 @@ func (r *rotator) shouldRotate() bool {
 // rotateSVID cuts a new server SVID from the CA plugin and installs
 // it on the endpoints struct. Also updates the CA certificates.
 func (r *rotator) rotateSVID(ctx context.Context) (err error) {
-	defer telemetry.CountCall(r.c.Metrics, telemetry.SVID, telemetry.Rotate)(&err)
+	counter := telemetry_server.StartRotateServerSVIDCall(r.c.Metrics)
+	defer counter.Done(&err)
 	r.c.Log.Debug("Rotating server SVID")
 
 	id := idutil.ServerURI(r.c.TrustDomain.Host)


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Refactor. Also, for `connections` metric decrement, fix spotted bug where an error would not result in the count being decremented as is expected for caller to do when there is not an error.
Remove shortcut `CountCall` function from metrics, so all metrics have ability to get additional labels later without a refactor.

**Description of change**
Metrics usage is primarily through well-defined functions. Remove `CountCall` function from metrics package.

**Which issue this PR fixes**
Fixes #822

