### PR TITLE
[agent/nodeattestor/gcp] Allow configuration of identity token host

### DIFF
--- a/doc/plugin_agent_nodeattestor_gcp_iit.md
+++ b/doc/plugin_agent_nodeattestor_gcp_iit.md
@@ -2,8 +2,20 @@
 
 *Must be used in conjunction with the server-side gcp_iit plugin*
 
-The `gcp_iit` plugin automatically attests instances using the [GCP Instance Identity Token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity). It also allows an operator to use GCP Instance IDs when defining SPIFFE ID attestation policies.  
+The `gcp_iit` plugin automatically attests instances using the [GCP Instance Identity Token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity). It also allows an operator to use GCP Instance IDs when defining SPIFFE ID attestation policies.
 
-| Configuration       | Description                                                       | Default |
-|---------------------|-------------------------------------------------------------------|---------|
 
+| Configuration         | Description                                                                                                                        | Default                    |
+| --------------------- | -----------------------------------------------------------------------------------------------------------------------------------| -------------------------- |
+| identity_token__host  |  Host where an [identity token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity) can be retrieved from | `metadata.google.internal` |
+| service_account       | The service account to fetch an identity token from                                                                                | `default`                  |
+
+A sample configuration:
+
+```
+    NodeAttestor "gcp_iit" {
+        plugin_data {
+            identity_token_host = "metadata.google.internal"
+            service_account = "XXX@developer.gserviceaccount.com"
+        }
+    }

--- a/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
@@ -128,7 +128,8 @@ func (s *Suite) TestSuccessfulIdentityTokenProcessingCustomPathTemplate() {
 		Configuration: fmt.Sprintf(`
 agent_path_template = "{{ .InstanceID }}"
 service_account = "%s"
-`, testServiceAccount),
+identity_token_host = "%s"
+`, testServiceAccount, s.server.Listener.Addr().String()),
 	})
 
 	resp, err := s.fetchAttestationData()
@@ -143,14 +144,14 @@ func (s *Suite) TestFailToSendOnStream() {
 	require := s.Require()
 
 	p := New()
-	p.tokenHost = s.server.Listener.Addr().String()
 	_, err := p.Configure(context.Background(), &plugin.ConfigureRequest{
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
 			TrustDomain: "example.org",
 		},
 		Configuration: fmt.Sprintf(`
 service_account = "%s"
-`, testServiceAccount),
+identity_token_host = "%s"
+`, testServiceAccount, s.server.Listener.Addr().String()),
 	})
 	require.NoError(err)
 
@@ -221,7 +222,6 @@ func (s *Suite) TestGetPluginInfo() {
 
 func (s *Suite) newPlugin() nodeattestor.Plugin {
 	p := New()
-	p.tokenHost = s.server.Listener.Addr().String()
 
 	var plugin nodeattestor.Plugin
 	s.LoadPlugin(builtin(p), &plugin)
@@ -235,7 +235,8 @@ func (s *Suite) configure() {
 		},
 		Configuration: fmt.Sprintf(`
 service_account = "%s"
-`, testServiceAccount),
+identity_token_host = "%s"
+`, testServiceAccount, s.server.Listener.Addr().String()),
 	})
 	s.Require().NoError(err)
 	s.status = http.StatusOK


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?


**Description of change**
This PR updates the agent GCP nodeattestor plugin to enable an operator to choose to have no dependency on a DNS lookup to fetch an identity token or possibly to force the plugin to fetch an
 identity token from another source.

An ancillary change is that a previously undocumented configuration option is now documented.