### PR TITLE
Minor doc typo

### DIFF
--- a/doc/plugin_agent_nodeattestor_gcp_iit.md
+++ b/doc/plugin_agent_nodeattestor_gcp_iit.md
@@ -7,7 +7,7 @@ The `gcp_iit` plugin automatically attests instances using the [GCP Instance Ide
 
 | Configuration         | Description                                                                                                                        | Default                    |
 | --------------------- | -----------------------------------------------------------------------------------------------------------------------------------| -------------------------- |
-| identity_token__host  |  Host where an [identity token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity) can be retrieved from | `metadata.google.internal` |
+| identity_token_host  |  Host where an [identity token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity) can be retrieved from | `metadata.google.internal` |
 | service_account       | The service account to fetch an identity token from                                                                                | `default`                  |
 
 A sample configuration:


### PR DESCRIPTION
There is an extra underscore in a config param in the docs, this removes the extra underscore; whoops!