### PR TITLE
Use the pared-down host service interface

### DIFF
--- a/pkg/common/catalog/test/fiximports.sh
+++ b/pkg/common/catalog/test/fiximports.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+sed -i.bak -e 's#"github.com/spiffe/spire/pkg/common/catalog"#catalog "github.com/spiffe/spire/pkg/common/catalog/internal"#g' *.go
+rm -f *.bak

--- a/pkg/common/catalog/test/generate.go
+++ b/pkg/common/catalog/test/generate.go
@@ -1,4 +1,5 @@
 //go:generate $GOPATH/bin/spire-plugingen -shared -mode plugin . TestPlugin
 //go:generate $GOPATH/bin/spire-plugingen -shared -mode service . TestService
 //go:generate $GOPATH/bin/spire-plugingen -shared -mode hostservice . TestHostService
+//go:generate ./fiximports.sh
 package test

--- a/pkg/common/catalog/test/testplugin.go
+++ b/pkg/common/catalog/test/testplugin.go
@@ -6,7 +6,7 @@ package test
 import (
 	"context"
 
-	"github.com/spiffe/spire/pkg/common/catalog/internal"
+	catalog "github.com/spiffe/spire/pkg/common/catalog/internal"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc"
 )
@@ -27,7 +27,7 @@ type TestPluginPlugin interface {
 }
 
 // TestPluginPluginServer returns a catalog PluginServer implementation for the TestPlugin plugin.
-func TestPluginPluginServer(server TestPluginServer) internal.PluginServer {
+func TestPluginPluginServer(server TestPluginServer) catalog.PluginServer {
 	return &testPluginPluginServer{
 		server: server,
 	}
@@ -41,7 +41,7 @@ func (s testPluginPluginServer) PluginType() string {
 	return TestPluginType
 }
 
-func (s testPluginPluginServer) PluginClient() internal.PluginClient {
+func (s testPluginPluginServer) PluginClient() catalog.PluginClient {
 	return TestPluginPluginClient
 }
 
@@ -51,7 +51,7 @@ func (s testPluginPluginServer) RegisterPluginServer(server *grpc.Server) interf
 }
 
 // TestPluginPluginClient is a catalog PluginClient implementation for the TestPlugin plugin.
-var TestPluginPluginClient internal.PluginClient = testPluginPluginClient{}
+var TestPluginPluginClient catalog.PluginClient = testPluginPluginClient{}
 
 type testPluginPluginClient struct{}
 
@@ -60,10 +60,10 @@ func (testPluginPluginClient) PluginType() string {
 }
 
 func (testPluginPluginClient) NewPluginClient(conn *grpc.ClientConn) interface{} {
-	return AdaptPluginClientTestPlugin(NewTestPluginClient(conn))
+	return AdaptTestPluginPluginClient(NewTestPluginClient(conn))
 }
 
-func AdaptPluginClientTestPlugin(client TestPluginClient) TestPlugin {
+func AdaptTestPluginPluginClient(client TestPluginClient) TestPlugin {
 	return testPluginPluginClientAdapter{client: client}
 }
 

--- a/pkg/common/catalog/test/testpluginimpl.go
+++ b/pkg/common/catalog/test/testpluginimpl.go
@@ -17,7 +17,7 @@ func NewTestPlugin() TestPluginPlugin {
 
 type testPlugin struct {
 	log hclog.Logger
-	hs  TestHostServiceClient
+	hs  TestHostService
 }
 
 func (s *testPlugin) SetLogger(log hclog.Logger) {

--- a/pkg/common/catalog/test/testservice.go
+++ b/pkg/common/catalog/test/testservice.go
@@ -6,7 +6,7 @@ package test
 import (
 	"context"
 
-	"github.com/spiffe/spire/pkg/common/catalog/internal"
+	catalog "github.com/spiffe/spire/pkg/common/catalog/internal"
 	"google.golang.org/grpc"
 )
 
@@ -20,7 +20,7 @@ type TestService interface {
 }
 
 // TestServiceServiceServer returns a catalog ServiceServer implementation for the TestService plugin.
-func TestServiceServiceServer(server TestServiceServer) internal.ServiceServer {
+func TestServiceServiceServer(server TestServiceServer) catalog.ServiceServer {
 	return &testServiceServiceServer{
 		server: server,
 	}
@@ -34,7 +34,7 @@ func (s testServiceServiceServer) ServiceType() string {
 	return TestServiceType
 }
 
-func (s testServiceServiceServer) ServiceClient() internal.ServiceClient {
+func (s testServiceServiceServer) ServiceClient() catalog.ServiceClient {
 	return TestServiceServiceClient
 }
 
@@ -44,7 +44,7 @@ func (s testServiceServiceServer) RegisterServiceServer(server *grpc.Server) int
 }
 
 // TestServiceServiceClient is a catalog ServiceClient implementation for the TestService plugin.
-var TestServiceServiceClient internal.ServiceClient = testServiceServiceClient{}
+var TestServiceServiceClient catalog.ServiceClient = testServiceServiceClient{}
 
 type testServiceServiceClient struct{}
 
@@ -53,10 +53,10 @@ func (testServiceServiceClient) ServiceType() string {
 }
 
 func (testServiceServiceClient) NewServiceClient(conn *grpc.ClientConn) interface{} {
-	return AdaptServiceClientTestService(NewTestServiceClient(conn))
+	return AdaptTestServiceServiceClient(NewTestServiceClient(conn))
 }
 
-func AdaptServiceClientTestService(client TestServiceClient) TestService {
+func AdaptTestServiceServiceClient(client TestServiceClient) TestService {
 	return testServiceServiceClientAdapter{client: client}
 }
 

--- a/pkg/common/catalog/test/testserviceimpl.go
+++ b/pkg/common/catalog/test/testserviceimpl.go
@@ -14,7 +14,7 @@ func NewTestService() TestService {
 
 type testService struct {
 	log hclog.Logger
-	hs  TestHostServiceClient
+	hs  TestHostService
 }
 
 func (s *testService) SetLogger(log hclog.Logger) {

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -57,7 +57,7 @@ type Plugin struct {
 	mu               sync.RWMutex
 	log              hclog.Logger
 	config           *pluginConfig
-	identityProvider hostservices.IdentityProviderClient
+	identityProvider hostservices.IdentityProvider
 
 	hooks struct {
 		newKubeClient func(configPath string) (kubeClient, error)

--- a/proto/spire/server/hostservices/identityprovider.go
+++ b/proto/spire/server/hostservices/identityprovider.go
@@ -39,14 +39,14 @@ func (s identityProviderHostServiceServer) RegisterHostServiceServer(server *grp
 }
 
 // IdentityProviderHostServiceServer returns a catalog HostServiceServer implementation for the IdentityProvider plugin.
-func IdentityProviderHostServiceClient(client *IdentityProviderClient) catalog.HostServiceClient {
+func IdentityProviderHostServiceClient(client *IdentityProvider) catalog.HostServiceClient {
 	return &identityProviderHostServiceClient{
 		client: client,
 	}
 }
 
 type identityProviderHostServiceClient struct {
-	client *IdentityProviderClient
+	client *IdentityProvider
 }
 
 func (c *identityProviderHostServiceClient) HostServiceType() string {
@@ -54,5 +54,17 @@ func (c *identityProviderHostServiceClient) HostServiceType() string {
 }
 
 func (c *identityProviderHostServiceClient) InitHostServiceClient(conn *grpc.ClientConn) {
-	*c.client = NewIdentityProviderClient(conn)
+	*c.client = AdaptIdentityProviderHostServiceClient(NewIdentityProviderClient(conn))
+}
+
+func AdaptIdentityProviderHostServiceClient(client IdentityProviderClient) IdentityProvider {
+	return identityProviderHostServiceClientAdapter{client: client}
+}
+
+type identityProviderHostServiceClientAdapter struct {
+	client IdentityProviderClient
+}
+
+func (a identityProviderHostServiceClientAdapter) FetchX509Identity(ctx context.Context, in *FetchX509IdentityRequest) (*FetchX509IdentityResponse, error) {
+	return a.client.FetchX509Identity(ctx, in)
 }

--- a/tools/spire-plugingen/main.go
+++ b/tools/spire-plugingen/main.go
@@ -346,12 +346,12 @@ func dumpLined(w io.Writer, r io.Reader) {
 	}
 }
 
-func mkexpname(prefix, name string) string {
-	return prefix + name
+func mkexpname(parts ...string) string {
+	return strings.Join(parts, "")
 }
 
-func mkname(prefix, name string) string {
-	s := mkexpname(prefix, name)
+func mkname(parts ...string) string {
+	s := mkexpname(parts...)
 	if len(s) == 0 {
 		return s
 	}


### PR DESCRIPTION
Codegen for plugins, services, and host services provides a pared-down client interface with the gRPC call options argument removed so the call options cannot be abused by callers. The plugin and service codegen provides the pared-down interface as the client interface but the host service code does not.

This change updates the host service codegen to properly use the pared-down interface as the client interface.

It also updates the codegen for the catalog test package to automatically fix up imports (only necessary for testing).