### PR TITLE
Update k8s examples to use SPIRE 0.8.0 image

### DIFF
--- a/examples/k8s/eks_sat/spire-agent.yaml
+++ b/examples/k8s/eks_sat/spire-agent.yaml
@@ -119,7 +119,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:unstable
+          image: gcr.io/spiffe-io/spire-agent:0.8.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/examples/k8s/eks_sat/spire-server.yaml
+++ b/examples/k8s/eks_sat/spire-server.yaml
@@ -149,7 +149,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:unstable
+          image: gcr.io/spiffe-io/spire-server:0.8.0
           args: ["-config", "/run/spire/config/server.conf"]
           ports:
             - containerPort: 8081

--- a/examples/k8s/simple_psat/spire-agent.yaml
+++ b/examples/k8s/simple_psat/spire-agent.yaml
@@ -120,7 +120,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.7.3
+          image: gcr.io/spiffe-io/spire-agent:0.8.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/examples/k8s/simple_psat/spire-server.yaml
+++ b/examples/k8s/simple_psat/spire-server.yaml
@@ -151,7 +151,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.7.3
+          image: gcr.io/spiffe-io/spire-server:0.8.0
           args: ["-config", "/run/spire/config/server.conf"]
           ports:
             - containerPort: 8081


### PR DESCRIPTION
Signed-off-by: Marcos G. Yedro <marcosyedro@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Kubernetes sample configuration files

**Description of change**
<!-- Please provide a description of the change -->
This PR updates the "simple_psat" and "eks_sat" example configurations to use the minimum required SPIRE version for those features:  v0.8.0