### PR TITLE
Fix the UpstreamCA bootstrap use case

### DIFF
--- a/conf/server/server-upstream-false.conf
+++ b/conf/server/server-upstream-false.conf
@@ -1,0 +1,44 @@
+server {
+    bind_address = "127.0.0.1"
+    bind_port = "8081"
+    registration_uds_path = "/tmp/spire-registration.sock"
+    trust_domain = "example.org"
+    data_dir = "./.data"
+    log_level = "DEBUG"
+    svid_ttl = "1h"
+    ca_subject = {
+        Country = ["US"],
+        Organization = ["SPIFFE"],
+        CommonName = "",
+    }
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "./.data/datastore.sqlite3"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {
+        }
+    }
+
+    NodeResolver "noop" {
+        plugin_data {}
+    }
+
+    KeyManager "memory" {
+        plugin_data = {}
+    }
+
+    UpstreamCA "disk" {
+        plugin_data {
+            ttl = "1h"
+            key_file_path = "./conf/server/dummy_upstream_ca.key"
+            cert_file_path = "./conf/server/dummy_upstream_ca.crt"
+        }
+    }
+}

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -81,6 +81,14 @@ func (s *CATestSuite) TestNoX509CASet() {
 	s.Require().EqualError(err, "X509 CA is not available for signing")
 }
 
+func (s *CATestSuite) TestSignServerX509SVID() {
+	svidChain, err := s.ca.SignServerX509SVID(ctx, s.generateCSR(), X509Params{})
+	s.Require().NoError(err)
+	s.Require().Len(svidChain, 2)
+
+	s.Equal(s.ca.x509CA.Certificate, svidChain[1])
+}
+
 func (s *CATestSuite) TestSignX509SVID() {
 	svidChain, err := s.ca.SignX509SVID(ctx, s.generateCSR(), X509Params{})
 	s.Require().NoError(err)

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -102,7 +102,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	}
 
 	// Sign the CSR
-	svid, err := r.c.ServerCA.SignX509SVID(ctx, csr, ca.X509Params{})
+	svid, err := r.c.ServerCA.SignServerX509SVID(ctx, csr, ca.X509Params{})
 	if err != nil {
 		return err
 	}

--- a/pkg/server/svid/rotator_test.go
+++ b/pkg/server/svid/rotator_test.go
@@ -103,7 +103,7 @@ func (s *RotatorTestSuite) requireNewCert(stream observer.Stream, serialNumber i
 	select {
 	case <-stream.Changes():
 		state := stream.Next().(State)
-		s.Require().Len(state.SVID, 1)
+		s.Require().Len(state.SVID, 2)
 		s.Require().Equal(0, state.SVID[0].SerialNumber.Cmp(big.NewInt(serialNumber)))
 		return state.SVID[0]
 	case <-timer.C:

--- a/script/e2e_test.sh
+++ b/script/e2e_test.sh
@@ -43,6 +43,7 @@ run_test() {
     rm -f .data/datastore.sqlite3
     rm -f .data/datastore.sqlite3-shm
     rm -f .data/datastore.sqlite3-wal
+    rm -f .data/journal.pem
     rm -f .data/agent_svid.der
     rm -f .data/bundle.der
     rm -f .data/svid.key
@@ -100,6 +101,7 @@ run_test() {
 }
 
 run_e2e_test "conf/server/server.conf"
+run_e2e_test "conf/server/server-upstream-false.conf"
 run_docker_test "test/configs/server/postgres.conf" "-e POSTGRES_PASSWORD=password -p 10864:5432 -d postgres"
 run_docker_test "test/configs/server/mysql.conf" "-e MYSQL_PASSWORD=password -e MYSQL_DATABASE=mysql -e MYSQL_USER=mysql -e MYSQL_RANDOM_ROOT_PASSWORD=yes -p 6612:3306 -d mysql:8.0.15"
 


### PR DESCRIPTION
In some cases, SPIRE users rely on an UpstreamCA to provide a stable
root, but do not set upstream_bundle to true because they want the trust
domain to be isolated from the upstream PKI. The stable root allows
agents to be bootstrapped without having to obtain an up-to-date SPIRE
bundle.

This use case broke with a recent CA refactor because the SPIRE server
TLS certificate does not serve a chain (i.e. it only serves the leaf)
when upstream_bundle is false. While this is the correct behavior under
normal conditions, it prevents the above stated use case from succeeding
because on first boot, agents don't have the CA certificate that the
server is managing - they only have the root that signed it.

I am not certain that we want to continue supporting this in the long
run. We should probably think through that. The default value of
upstream_bundle should also be switched to `true` in the near future as
well, since 1) it is surprising behavior to configure an UpstreamCA but
then not actually join the upstream PKI, 2) simply omitting higher
order certificates from the bundle is not a reliable isolation
mechanism, and 3) few X.509 validators will successfully validate a leaf
when the chain terminates with a non-self-signed root in the default
configuration (see openssl partial_chain).

This commit:
* Fixes the above stated use case by always including the server CA cert
as the second element when answering TLS requests
* Adds a functional test to ensure that this use case doesn't break in
the future
* Does NOT support this use case for any UpstreamCA where the signer is
not the root