### PR TITLE
Fix log formatting in sql migration code

### DIFF
--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -46,7 +46,7 @@ func migrateDB(db *gorm.DB, dbType string, log hclog.Logger) (err error) {
 		return nil
 	}
 
-	log.Info("running migrations...")
+	log.Info("Running migrations...")
 	for version < codeVersion {
 		tx := db.Begin()
 		if err := tx.Error; err != nil {
@@ -62,12 +62,12 @@ func migrateDB(db *gorm.DB, dbType string, log hclog.Logger) (err error) {
 		}
 	}
 
-	log.Info("done running migrations.")
+	log.Info("Done running migrations.")
 	return nil
 }
 
 func initDB(db *gorm.DB, dbType string, log hclog.Logger) (err error) {
-	log.Info("initializing database.")
+	log.Info("Initializing database.")
 	tx := db.Begin()
 	if err := tx.Error; err != nil {
 		return sqlError.Wrap(err)
@@ -112,7 +112,7 @@ func tableOptionsForDialect(tx *gorm.DB, dbType string) *gorm.DB {
 }
 
 func migrateVersion(tx *gorm.DB, version int, log hclog.Logger) (versionOut int, err error) {
-	log.Info("migrating from version %d", version)
+	log.Info(fmt.Sprintf("Migrating from version %d", version))
 
 	// When a new version is added an entry must be included here that knows
 	// how to bring the previous version up. The migrations are run


### PR DESCRIPTION
Plugins moved to logging via hclog interface recently, but this
interface does not include formatter functions like `Infof`. It also
treats all arguments following the first string as key/value labels, so
when we moved away from logrus `Infof` we lost the formatting we had
previously (and introduced some malformed labels).

This commit corrects the formatting, and updates a couple other log line
instances to conform with our capitalization conventions.

Signed-off-by: Evan Gilman <evan@scytale.io>