### PR TITLE
Fix incorrect container id selection in k8s agent workload attestor

### DIFF
--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -336,7 +336,11 @@ func (p *K8SPlugin) getContainerIDFromCGroups(pid int32) (string, error) {
 				continue
 			}
 			id := strings.TrimSuffix(parts[4], ".scope")
-			id = strings.TrimPrefix(id, "docker-")
+			// Trim the id of any container runtime prefixes.  Ex "docker-" or "crio-"
+			dash := strings.Index(id, "-")
+			if dash > -1 {
+				id = id[dash+1:]
+			}
 			return id, nil
 		}
 	}

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -335,7 +335,9 @@ func (p *K8SPlugin) getContainerIDFromCGroups(pid int32) (string, error) {
 				log.Printf("Kube pod entry found, but without container id: %v", substring)
 				continue
 			}
-			return parts[4], nil
+			id := strings.TrimSuffix(parts[4], ".scope")
+			id = strings.TrimPrefix(id, "docker-")
+			return id, nil
 		}
 	}
 

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -37,6 +37,7 @@ const (
 	cgPidInPodFilePath        = "testdata/cgroups_pid_in_pod.txt"
 	cgInitPidInPodFilePath    = "testdata/cgroups_init_pid_in_pod.txt"
 	cgPidNotInPodFilePath     = "testdata/cgroups_pid_not_in_pod.txt"
+	cgSystemdPidInPodFilePath = "testdata/systemd_cgroups_pid_in_pod.txt"
 
 	certPath = "cert.pem"
 	keyPath  = "key.pem"
@@ -137,6 +138,13 @@ func (s *K8sAttestorSuite) TestAttestWithPidInPod() {
 	s.configureInsecure()
 
 	s.requireAttestSuccessWithPod()
+}
+
+func (s *K8sAttestorSuite) TestAttestWithPidInPodSystemdCgroups() {
+	s.startInsecureKubelet()
+	s.configureInsecure()
+
+	s.requireAttestSuccessWithPodSystemdCgroups()
 }
 
 func (s *K8sAttestorSuite) TestAttestWithInitPidInPod() {
@@ -747,6 +755,12 @@ func (s *K8sAttestorSuite) writeKey(path string, key *ecdsa.PrivateKey) {
 func (s *K8sAttestorSuite) requireAttestSuccessWithPod() {
 	s.addPodListResponse(podListFilePath)
 	s.addCgroupsResponse(cgPidInPodFilePath)
+	s.requireAttestSuccess(testPodSelectors)
+}
+
+func (s *K8sAttestorSuite) requireAttestSuccessWithPodSystemdCgroups() {
+	s.addPodListResponse(podListFilePath)
+	s.addCgroupsResponse(cgSystemdPidInPodFilePath)
 	s.requireAttestSuccess(testPodSelectors)
 }
 

--- a/pkg/agent/plugin/workloadattestor/k8s/testdata/systemd_cgroups_pid_in_pod.txt
+++ b/pkg/agent/plugin/workloadattestor/k8s/testdata/systemd_cgroups_pid_in_pod.txt
@@ -1,0 +1,11 @@
+11:hugetlb:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+10:devices:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+9:pids:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+8:perf_event:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+7:net_cls,net_prio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+6:cpuset:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+5:memory:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+4:cpu,cpuacct:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+3:freezer:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+2:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope
+1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2c48913c-b29f-11e7-9350-020968147796.slice/docker-9bca8d63d5fa610783847915bcff0ecac1273e5b4bed3f6fa1b07350e0135961.scope


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
This fixes k8s agent workload attestor container id selection bug.  #949 

**Description of change**
Strip any container runtime prefix and ".scope" from container id in `/proc/<pid>/cgroup`

**Which issue this PR fixes**
#949 

