### PR TITLE
Bumping assumerole duration to 900s

### DIFF
--- a/pkg/server/plugin/upstreamca/awssecret/awslib.go
+++ b/pkg/server/plugin/upstreamca/awssecret/awslib.go
@@ -52,7 +52,7 @@ func newSecretsManagerClient(config *AWSSecretConfiguration, region string) (sec
 		awsConfig.Credentials = credentials.NewCredentials(&stscreds.AssumeRoleProvider{
 			Client:   sts.New(staticsess),
 			RoleARN:  config.AssumeRoleARN,
-			Duration: 5 * time.Minute,
+			Duration: 15 * time.Minute,
 		})
 	}
 


### PR DESCRIPTION
AWS rejects assumerole if it is < 900 seconds

https://docs.aws.amazon.com/sdk-for-go/v1/api/service.sts.AssumeRoleInput.html

Signed-off-by: Michael Weissbacher <mweissbacher@squareup.com>
