### PR TITLE
Use a gauge instead of a counter for connection total

### DIFF
--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -360,8 +360,8 @@ func setupMetricsCommonExpectations(metrics *mock_telemetry.MockMetrics, selecto
 	metrics.EXPECT().MeasureSince([]string{telemetry.WorkloadAPI, telemetry.WorkloadAttestationDuration}, gomock.Any())
 
 	metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.Connection}, float32(1), selectorsLabels)
-	metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(1))
-	metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(-1))
+	metrics.EXPECT().SetGauge([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(1))
+	metrics.EXPECT().SetGauge([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(0))
 }
 
 func (s *HandlerTestSuite) TestFetchJWTBundles() {

--- a/pkg/common/telemetry/agent/workloadapi/workload.go
+++ b/pkg/common/telemetry/agent/workloadapi/workload.go
@@ -43,16 +43,9 @@ func IncrConnectionCounter(m telemetry.Metrics) {
 	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connection}, 1)
 }
 
-// DecrConnectionTotalCounter indicate one less
-// Workload API active connection (active in that moment)
-func DecrConnectionTotalCounter(m telemetry.Metrics) {
-	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, -1)
-}
-
-// IncrConnectionTotalCounter indicate one more
-// Workload API active connection (active in that moment)
-func IncrConnectionTotalCounter(m telemetry.Metrics) {
-	m.IncrCounter([]string{telemetry.WorkloadAPI, telemetry.Connections}, 1)
+// SetConnectionTotalGauge sets the number of active Workload API connections
+func SetConnectionTotalGauge(m telemetry.Metrics, connections int32) {
+	m.SetGauge([]string{telemetry.WorkloadAPI, telemetry.Connections}, float32(connections))
 }
 
 // IncrFetchJWTBundlesCounter indicate call to Workload


### PR DESCRIPTION
Counter's are intended for values can only grow, never shrink. The total connection count fluctuates 
with the number of outstanding connections and is therefore more appropriately measured with a gauge.

Fixes #937 
