### PR TITLE
Run travis tests on multiple platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: required
-dist: xenial
 
 services:
   - docker
@@ -9,24 +8,54 @@ language: go
 cache:
   directories:
     - .cache
+    - $HOME/.build
     # cache the Go module cache
     - $HOME/gopath/pkg/mod
+    # cache `go install`-ed binaries across stages. build.sh unsets GOPATH
+    # so this is hitting the default go env of $HOME/go
+    - $HOME/go/bin
+
+stages:
+  - setup
+  - lint
+  - test
+  - build release
+  - publish images
 
 jobs:
   include:
-    - stage: lint
-      script:
-        - shellcheck build.sh
-    - stage: build release
+    - stage: setup
       script:
         - ./build.sh setup
         - ./build.sh utils
-        - ./build.sh protobuf_verify
+      os: macos
+    - stage: setup
+      script:
+        - ./build.sh setup
+        - ./build.sh utils
+      os: linux
+      dist: xenial
+    - stage: lint
+      script:
+        - shellcheck build.sh
+    - stage: test
+      script:
         - ./build.sh race-test
+      os: macos
+    - stage: test
+      script:
+        - ./build.sh race-test
+      os: linux
+      dist: xenial
+    - stage: build release
+      script:
+        - ./build.sh protobuf_verify
         - ./build.sh binaries
         - ./build.sh integration
         - ./build.sh artifact
         - ./build.sh release
+      os: linux
+      dist: xenial
       deploy:
         - provider: s3
           access_key_id: $AWS_ACCESS_KEY_ID
@@ -53,6 +82,8 @@ jobs:
       if: type = push AND (tag IS present OR branch = master)
       env:
         - CHANGE_MINIKUBE_NONE_USER=true
+      os: linux
+      dist: xenial
       before_script:
         # Decrypt credentials needed to log into gcr registry
         - openssl aes-256-cbc -K $encrypted_b48f9e852489_key -iv $encrypted_b48f9e852489_iv -in .travis/spire-travis-ci.json.enc -out .travis/spire-travis-ci.json -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,12 @@ jobs:
       dist: xenial
     - stage: lint
       script:
+        - ./build.sh protobuf_verify
         - shellcheck build.sh
+      # linting is OS agnostic but protobuf_verify needs utils to lets be explicit
+      # about its runtime environment
+      os: linux 
+      dist: xenial
     - stage: test
       script:
         - ./build.sh race-test
@@ -49,7 +54,6 @@ jobs:
       dist: xenial
     - stage: build release
       script:
-        - ./build.sh protobuf_verify
         - ./build.sh binaries
         - ./build.sh integration
         - ./build.sh artifact

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,11 @@
 set -o errexit
 [[ -n $DEBUG ]] && set -o xtrace
 
+if [[ -n $TRAVIS ]] ; then
+	unset GOPATH GOROOT
+	BUILD_ROOT=$HOME/.build
+fi
+
 ARTIFACT_DIRS="$(find cmd/* functional/* -maxdepth 0 -type d 2>/dev/null)"
 declare -r ARTIFACT_DIRS
 RELEASE_DIRS="$(find cmd/* -maxdepth 0 -type d 2>/dev/null)"
@@ -28,8 +33,9 @@ case $(uname -m) in
 			;;
 esac
 
-declare -r BUILD_DIR=${BUILD_DIR:-$PWD/.build-${OS1}-${ARCH1}}
-declare -r BUILD_CACHE=${BUILD_CACHE:-$PWD/.cache}
+declare -r BUILD_ROOT=${BUILD_ROOT:-$PWD}
+declare -r BUILD_DIR=${BUILD_DIR:-${BUILD_ROOT}/.build-${OS1}-${ARCH1}}
+declare -r BUILD_CACHE=${BUILD_CACHE:-${BUILD_ROOT}/.cache}
 
 # versioned binaries that we need for builds
 export GO111MODULE=on
@@ -39,8 +45,6 @@ declare -r GO_TGZ="go${GO_VERSION}.${OS1}-${ARCH2}.tar.gz"
 declare -r PROTOBUF_VERSION=${PROTOBUF_VERSION:-3.3.0}
 declare -r PROTOBUF_URL="https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}"
 declare -r PROTOBUF_TGZ="protoc-${PROTOBUF_VERSION}-${OS2}-${ARCH1}.zip"
-
-[[ -n $TRAVIS ]] && unset GOPATH GOROOT
 
 _exit_error() { echo "ERROR: $*" 1>&2; exit 1; }
 _log_info() { echo "INFO: $*"; }


### PR DESCRIPTION
Signed-off-by: Tyler Dixon <tylerd@uber.com>

There are some opinions in here about what should be cached to be shared across stages. Additionally, it separates some stuff out of the "release" stage.

I think I could make this change much smaller but I thought separating the stages made some sense and this gives consistency across platform where possible. For example, the test job for macos is the same as linux If the test logic was still in the "release" stage, that stage would differ across platform, rather than not existing for certain platforms.