### PR TITLE
add constant labels to metrics wrapper for plugins

### DIFF
--- a/pkg/common/hostservices/metricsservice/plugin_metrics.go
+++ b/pkg/common/hostservices/metricsservice/plugin_metrics.go
@@ -10,10 +10,10 @@ import (
 )
 
 type pluginMetrics struct {
-	ctx            context.Context
-	m              hostservices.MetricsService
-	log            hclog.Logger
-	constantLabels []*hostservices.Label
+	ctx         context.Context
+	m           hostservices.MetricsService
+	log         hclog.Logger
+	fixedLabels []*hostservices.Label
 }
 
 // WrapPluginMetricsForContext returns a Metrics implementation that wraps the Metrics Host Service
@@ -23,10 +23,10 @@ type pluginMetrics struct {
 // Any errors are logged, but not returned.
 func WrapPluginMetricsForContext(ctx context.Context, m hostservices.MetricsService, log hclog.Logger, labels ...telemetry.Label) telemetry.Metrics {
 	return pluginMetrics{
-		ctx:            ctx,
-		m:              m,
-		log:            log,
-		constantLabels: convertToRPCLabels(labels),
+		ctx:         ctx,
+		m:           m,
+		log:         log,
+		fixedLabels: convertToRPCLabels(labels),
 	}
 }
 
@@ -39,7 +39,7 @@ func (p pluginMetrics) SetGaugeWithLabels(key []string, val float32, labels []te
 	_, err := p.m.SetGauge(p.ctx, &hostservices.SetGaugeRequest{
 		Key:    key,
 		Val:    val,
-		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
+		Labels: append(convertToRPCLabels(labels), p.fixedLabels...),
 	})
 
 	if err != nil {
@@ -68,7 +68,7 @@ func (p pluginMetrics) IncrCounterWithLabels(key []string, val float32, labels [
 	_, err := p.m.IncrCounter(p.ctx, &hostservices.IncrCounterRequest{
 		Key:    key,
 		Val:    val,
-		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
+		Labels: append(convertToRPCLabels(labels), p.fixedLabels...),
 	})
 
 	if err != nil {
@@ -85,7 +85,7 @@ func (p pluginMetrics) AddSampleWithLabels(key []string, val float32, labels []t
 	_, err := p.m.AddSample(p.ctx, &hostservices.AddSampleRequest{
 		Key:    key,
 		Val:    val,
-		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
+		Labels: append(convertToRPCLabels(labels), p.fixedLabels...),
 	})
 
 	if err != nil {
@@ -102,7 +102,7 @@ func (p pluginMetrics) MeasureSinceWithLabels(key []string, start time.Time, lab
 	_, err := p.m.MeasureSince(p.ctx, &hostservices.MeasureSinceRequest{
 		Key:    key,
 		Time:   start.UnixNano(),
-		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
+		Labels: append(convertToRPCLabels(labels), p.fixedLabels...),
 	})
 
 	if err != nil {

--- a/pkg/common/hostservices/metricsservice/plugin_metrics.go
+++ b/pkg/common/hostservices/metricsservice/plugin_metrics.go
@@ -10,19 +10,23 @@ import (
 )
 
 type pluginMetrics struct {
-	ctx context.Context
-	m   hostservices.MetricsService
-	log hclog.Logger
+	ctx            context.Context
+	m              hostservices.MetricsService
+	log            hclog.Logger
+	constantLabels []*hostservices.Label
 }
 
 // WrapPluginMetricsForContext returns a Metrics implementation that wraps the Metrics Host Service
-// and passes in the given context to that service. This enables usage of common functionality related to
-// the Metrics interface from a plugin. Any errors are logged, but not returned.
-func WrapPluginMetricsForContext(ctx context.Context, m hostservices.MetricsService, log hclog.Logger) telemetry.Metrics {
+// and passes in the given context to that service. Additionally, labels common to the plugin/function
+// can also be set, and will be added to all resulting metrics calls.
+// This enables usage of common functionality related to the Metrics interface from a plugin.
+// Any errors are logged, but not returned.
+func WrapPluginMetricsForContext(ctx context.Context, m hostservices.MetricsService, log hclog.Logger, labels ...telemetry.Label) telemetry.Metrics {
 	return pluginMetrics{
-		ctx: ctx,
-		m:   m,
-		log: log,
+		ctx:            ctx,
+		m:              m,
+		log:            log,
+		constantLabels: convertToRPCLabels(labels),
 	}
 }
 
@@ -35,7 +39,7 @@ func (p pluginMetrics) SetGaugeWithLabels(key []string, val float32, labels []te
 	_, err := p.m.SetGauge(p.ctx, &hostservices.SetGaugeRequest{
 		Key:    key,
 		Val:    val,
-		Labels: convertToRPCLabels(labels),
+		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
 	})
 
 	if err != nil {
@@ -64,7 +68,7 @@ func (p pluginMetrics) IncrCounterWithLabels(key []string, val float32, labels [
 	_, err := p.m.IncrCounter(p.ctx, &hostservices.IncrCounterRequest{
 		Key:    key,
 		Val:    val,
-		Labels: convertToRPCLabels(labels),
+		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
 	})
 
 	if err != nil {
@@ -81,7 +85,7 @@ func (p pluginMetrics) AddSampleWithLabels(key []string, val float32, labels []t
 	_, err := p.m.AddSample(p.ctx, &hostservices.AddSampleRequest{
 		Key:    key,
 		Val:    val,
-		Labels: convertToRPCLabels(labels),
+		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
 	})
 
 	if err != nil {
@@ -98,7 +102,7 @@ func (p pluginMetrics) MeasureSinceWithLabels(key []string, start time.Time, lab
 	_, err := p.m.MeasureSince(p.ctx, &hostservices.MeasureSinceRequest{
 		Key:    key,
 		Time:   start.UnixNano(),
-		Labels: convertToRPCLabels(labels),
+		Labels: append(convertToRPCLabels(labels), p.constantLabels...),
 	})
 
 	if err != nil {

--- a/pkg/common/hostservices/metricsservice/plugin_metrics.go
+++ b/pkg/common/hostservices/metricsservice/plugin_metrics.go
@@ -17,7 +17,7 @@ type pluginMetrics struct {
 }
 
 // WrapPluginMetricsForContext returns a Metrics implementation that wraps the Metrics Host Service
-// and passes in the given context to that service. Additionally, labels common to the plugin/function
+// and passes in the given context to that service. Additionally, labels common to the context
 // can also be set, and will be added to all resulting metrics calls.
 // This enables usage of common functionality related to the Metrics interface from a plugin.
 // Any errors are logged, but not returned.

--- a/pkg/common/hostservices/metricsservice/plugin_metrics_test.go
+++ b/pkg/common/hostservices/metricsservice/plugin_metrics_test.go
@@ -40,7 +40,7 @@ func TestWrapPluginMetricsForContext(t *testing.T) {
 		{
 			Name:  "name2",
 			Value: "val2",
-		}}, pMetrics.constantLabels)
+		}}, pMetrics.fixedLabels)
 }
 
 func TestWrapEmitKey(t *testing.T) {
@@ -78,11 +78,11 @@ func TestWrapEmitKey(t *testing.T) {
 
 func TestWrapSetGaugeWithLabels(t *testing.T) {
 	tests := []struct {
-		desc           string
-		inKey          []string
-		inVal          float32
-		inLabels       []telemetry.Label
-		constantLabels []telemetry.Label
+		desc        string
+		inKey       []string
+		inVal       float32
+		inLabels    []telemetry.Label
+		fixedLabels []telemetry.Label
 	}{
 		{
 			desc:  "no labels",
@@ -110,7 +110,7 @@ func TestWrapSetGaugeWithLabels(t *testing.T) {
 					Value: "val1",
 				},
 			},
-			constantLabels: []telemetry.Label{
+			fixedLabels: []telemetry.Label{
 				{
 					Name:  "constLabel1",
 					Value: "constVal1",
@@ -131,10 +131,10 @@ func TestWrapSetGaugeWithLabels(t *testing.T) {
 			mockMetricsService.EXPECT().SetGauge(ctx, &hostservices.SetGaugeRequest{
 				Key:    tt.inKey,
 				Val:    tt.inVal,
-				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.constantLabels)...),
+				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.fixedLabels)...),
 			}).Return(&hostservices.SetGaugeResponse{}, nil)
 
-			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.constantLabels...)
+			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.fixedLabels...)
 			metricsWrapper.SetGaugeWithLabels(tt.inKey, tt.inVal, tt.inLabels)
 		})
 	}
@@ -142,11 +142,11 @@ func TestWrapSetGaugeWithLabels(t *testing.T) {
 
 func TestWrapIncrCounterWithLabels(t *testing.T) {
 	tests := []struct {
-		desc           string
-		inKey          []string
-		inVal          float32
-		inLabels       []telemetry.Label
-		constantLabels []telemetry.Label
+		desc        string
+		inKey       []string
+		inVal       float32
+		inLabels    []telemetry.Label
+		fixedLabels []telemetry.Label
 	}{
 		{
 			desc:  "no labels",
@@ -174,7 +174,7 @@ func TestWrapIncrCounterWithLabels(t *testing.T) {
 					Value: "val1",
 				},
 			},
-			constantLabels: []telemetry.Label{
+			fixedLabels: []telemetry.Label{
 				{
 					Name:  "constLabel1",
 					Value: "constVal1",
@@ -195,10 +195,10 @@ func TestWrapIncrCounterWithLabels(t *testing.T) {
 			mockMetricsService.EXPECT().IncrCounter(ctx, &hostservices.IncrCounterRequest{
 				Key:    tt.inKey,
 				Val:    tt.inVal,
-				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.constantLabels)...),
+				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.fixedLabels)...),
 			}).Return(&hostservices.IncrCounterResponse{}, nil)
 
-			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.constantLabels...)
+			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.fixedLabels...)
 			metricsWrapper.IncrCounterWithLabels(tt.inKey, tt.inVal, tt.inLabels)
 		})
 	}
@@ -206,11 +206,11 @@ func TestWrapIncrCounterWithLabels(t *testing.T) {
 
 func TestWrapAddSampleWithLabels(t *testing.T) {
 	tests := []struct {
-		desc           string
-		inKey          []string
-		inVal          float32
-		inLabels       []telemetry.Label
-		constantLabels []telemetry.Label
+		desc        string
+		inKey       []string
+		inVal       float32
+		inLabels    []telemetry.Label
+		fixedLabels []telemetry.Label
 	}{
 		{
 			desc:  "no labels",
@@ -238,7 +238,7 @@ func TestWrapAddSampleWithLabels(t *testing.T) {
 					Value: "val1",
 				},
 			},
-			constantLabels: []telemetry.Label{
+			fixedLabels: []telemetry.Label{
 				{
 					Name:  "constLabel1",
 					Value: "constVal1",
@@ -259,10 +259,10 @@ func TestWrapAddSampleWithLabels(t *testing.T) {
 			mockMetricsService.EXPECT().AddSample(ctx, &hostservices.AddSampleRequest{
 				Key:    tt.inKey,
 				Val:    tt.inVal,
-				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.constantLabels)...),
+				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.fixedLabels)...),
 			}).Return(&hostservices.AddSampleResponse{}, nil)
 
-			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.constantLabels...)
+			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.fixedLabels...)
 			metricsWrapper.AddSampleWithLabels(tt.inKey, tt.inVal, tt.inLabels)
 		})
 	}
@@ -270,11 +270,11 @@ func TestWrapAddSampleWithLabels(t *testing.T) {
 
 func TestWrapMeasureSinceWithLabels(t *testing.T) {
 	tests := []struct {
-		desc           string
-		inKey          []string
-		inTime         time.Time
-		inLabels       []telemetry.Label
-		constantLabels []telemetry.Label
+		desc        string
+		inKey       []string
+		inTime      time.Time
+		inLabels    []telemetry.Label
+		fixedLabels []telemetry.Label
 	}{
 		{
 			desc:   "no labels",
@@ -302,7 +302,7 @@ func TestWrapMeasureSinceWithLabels(t *testing.T) {
 					Value: "val1",
 				},
 			},
-			constantLabels: []telemetry.Label{
+			fixedLabels: []telemetry.Label{
 				{
 					Name:  "constLabel1",
 					Value: "constVal1",
@@ -323,10 +323,10 @@ func TestWrapMeasureSinceWithLabels(t *testing.T) {
 			mockMetricsService.EXPECT().MeasureSince(ctx, &hostservices.MeasureSinceRequest{
 				Key:    tt.inKey,
 				Time:   tt.inTime.UnixNano(),
-				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.constantLabels)...),
+				Labels: append(convertToRPCLabels(tt.inLabels), convertToRPCLabels(tt.fixedLabels)...),
 			}).Return(&hostservices.MeasureSinceResponse{}, nil)
 
-			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.constantLabels...)
+			metricsWrapper := setupPluginMetricsWrapper(ctx, mockMetricsService, hclog.NewNullLogger(), tt.fixedLabels...)
 			metricsWrapper.MeasureSinceWithLabels(tt.inKey, tt.inTime, tt.inLabels)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Andrew Moore <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Non-breaking API change to plugin metrics wrapper.

**Description of change**
Add ability to put in telemetry `label`s that should be common to all calls for metrics in a plugin using `WrapPluginMetricsForContext`. This saves on calls to the plugin metrics' API if the same `label`(s) are anticipated to be used repeatedly for the same context.

