### PR TITLE
add SQL DB metrics

### DIFF
--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -14,6 +14,10 @@ const (
 	// should be used with other tags to add clarity
 	Activate = "activate"
 
+	// Append functionality related to appending some element (such as part of a bundle);
+	// should be used with other tags to add clarity
+	Append = "append"
+
 	// Attest functionality related to attesting; should be used with other tags
 	// to add clarity
 	Attest = "attest"
@@ -45,6 +49,10 @@ const (
 	// Rotate functionality related to rotation of SVID; should be used with other tags
 	// to add clarity
 	Rotate = "rotate"
+
+	// Set functionality related to set/override/clobber of an entity, such as a bundle;
+	// should be used with other tags to add clarity
+	Set = "set"
 
 	// Sign functionality related to signing a token / cert; should be used with other tags
 	// to add clarity
@@ -137,6 +145,9 @@ const (
 
 	// Nonce tags some nonce for communication
 	Nonce = "nonce"
+
+	// ParentID tags parent ID for an entry
+	ParentID = "parent_id"
 
 	// Path declares some logic path, likely on the file system
 	Path = "path"
@@ -289,6 +300,9 @@ const (
 
 	// Catalog functionality related to plugin catalog
 	Catalog = "catalog"
+
+	// Datastore functionality related to datastore plugin
+	Datastore = "datastore"
 
 	// Endpoints functionality related to agent/server endpoints
 	Endpoints = "endpoints"

--- a/pkg/common/telemetry/server/datastore/bundle.go
+++ b/pkg/common/telemetry/server/datastore/bundle.go
@@ -1,0 +1,58 @@
+package datastore
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartAppendBundleCall return metric
+// for server's datastore, on sets the bundle.
+func StartAppendBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Append)
+}
+
+// StartCreateBundleCall return metric
+// for server's datastore, on creating a bundle.
+func StartCreateBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Create)
+}
+
+// StartDeleteBundleCall return metric
+// for server's datastore, on deleting a bundle.
+func StartDeleteBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Delete)
+}
+
+// StartFetchBundleCall return metric
+// for server's datastore, on fetching a bundle.
+func StartFetchBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Fetch)
+}
+
+// StartListBundleCall return metric
+// for server's datastore, on listing bundles.
+func StartListBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.List)
+}
+
+// StartPruneBundleCall return metric
+// for server's datastore, on pruning a bundle.
+func StartPruneBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Prune)
+}
+
+// StartSetBundleCall return metric
+// for server's datastore, on sets the bundle.
+func StartSetBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Set)
+}
+
+// StartUpdateBundleCall return metric
+// for server's datastore, on updating a bundle.
+func StartUpdateBundleCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Bundle, telemetry.Update)
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/server/datastore/join_token.go
+++ b/pkg/common/telemetry/server/datastore/join_token.go
@@ -1,0 +1,34 @@
+package datastore
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartCreateJoinTokenCall return metric
+// for server's datastore, on creating a join token.
+func StartCreateJoinTokenCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.JoinToken, telemetry.Create)
+}
+
+// StartDeleteJoinTokenCall return metric
+// for server's datastore, on deleting a join token.
+func StartDeleteJoinTokenCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.JoinToken, telemetry.Delete)
+}
+
+// StartFetchJoinTokenCall return metric
+// for server's datastore, on fetching a join token.
+func StartFetchJoinTokenCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.JoinToken, telemetry.Fetch)
+}
+
+// StartPruneJoinTokenCall return metric
+// for server's datastore, on pruning join tokens.
+func StartPruneJoinTokenCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.JoinToken, telemetry.Prune)
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/server/datastore/node.go
+++ b/pkg/common/telemetry/server/datastore/node.go
@@ -1,0 +1,52 @@
+package datastore
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartCreateNodeCall return metric
+// for server's datastore, on creating a node.
+func StartCreateNodeCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Create)
+}
+
+// StartDeleteNodeCall return metric
+// for server's datastore, on deleting a node.
+func StartDeleteNodeCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Delete)
+}
+
+// StartFetchNodeCall return metric
+// for server's datastore, on fetching a node.
+func StartFetchNodeCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Fetch)
+}
+
+// StartListNodeCall return metric
+// for server's datastore, on listing nodes.
+func StartListNodeCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.List)
+}
+
+// StartGetNodeSelectorsCall return metric
+// for server's datastore, on getting selectors for a node.
+func StartGetNodeSelectorsCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Selectors, telemetry.Fetch)
+}
+
+// StartSetNodeSelectorsCall return metric
+// for server's datastore, on setting selectors for a node.
+func StartSetNodeSelectorsCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Selectors, telemetry.Set)
+}
+
+// StartUpdateNodeCall return metric
+// for server's datastore, on updating a node.
+func StartUpdateNodeCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.Node, telemetry.Update)
+}
+
+// End Call Counters

--- a/pkg/common/telemetry/server/datastore/registration.go
+++ b/pkg/common/telemetry/server/datastore/registration.go
@@ -1,0 +1,46 @@
+package datastore
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartCreateRegistrationCall return metric
+// for server's datastore, on creating a registration.
+func StartCreateRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.Create)
+}
+
+// StartDeleteRegistrationCall return metric
+// for server's datastore, on deleting a registration.
+func StartDeleteRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.Delete)
+}
+
+// StartFetchRegistrationCall return metric
+// for server's datastore, on creating a registration.
+func StartFetchRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.Fetch)
+}
+
+// StartListRegistrationCall return metric
+// for server's datastore, on listing registrations.
+func StartListRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.List)
+}
+
+// StartPruneRegistrationCall return metric
+// for server's datastore, on pruning registrations.
+func StartPruneRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.Prune)
+}
+
+// StartUpdateRegistrationCall return metric
+// for server's datastore, on updating a registration.
+func StartUpdateRegistrationCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntry, telemetry.Update)
+}
+
+// End Call Counters

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -10,30 +10,28 @@ import (
 	"sync"
 	"time"
 
-	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
-
-	"github.com/spiffe/spire/proto/spire/common/hostservices"
-
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/proto"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/jinzhu/gorm"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	// gorm sqlite dialect init registration
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/selector"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	ds_telemetry "github.com/spiffe/spire/pkg/common/telemetry/server/datastore"
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/proto/spire/common/hostservices"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/proto/spire/server/datastore"
 	"github.com/zeebo/errs"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -118,12 +118,11 @@ func (p *SQLPlugin) BrokerHostServices(broker catalog.HostServiceBroker) error {
 // CreateBundle stores the given bundle
 func (ds *SQLPlugin) CreateBundle(ctx context.Context, req *datastore.CreateBundleRequest) (resp *datastore.CreateBundleResponse, err error) {
 	callCounter := ds_telemetry.StartCreateBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.Bundle.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.Bundle.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -139,12 +138,11 @@ func (ds *SQLPlugin) CreateBundle(ctx context.Context, req *datastore.CreateBund
 // existing certificates.
 func (ds *SQLPlugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (resp *datastore.UpdateBundleResponse, err error) {
 	callCounter := ds_telemetry.StartUpdateBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.Bundle.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.Bundle.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -159,12 +157,11 @@ func (ds *SQLPlugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBund
 // SetBundle sets bundle contents. If no bundle exists for the trust domain, it is created.
 func (ds *SQLPlugin) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (resp *datastore.SetBundleResponse, err error) {
 	callCounter := ds_telemetry.StartSetBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.Bundle.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.Bundle.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -179,12 +176,11 @@ func (ds *SQLPlugin) SetBundle(ctx context.Context, req *datastore.SetBundleRequ
 // AppendBundle append bundle contents to the existing bundle (by trust domain). If no existing one is present, create it.
 func (ds *SQLPlugin) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (resp *datastore.AppendBundleResponse, err error) {
 	callCounter := ds_telemetry.StartAppendBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.Bundle.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.Bundle.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -199,12 +195,11 @@ func (ds *SQLPlugin) AppendBundle(ctx context.Context, req *datastore.AppendBund
 // DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
 func (ds *SQLPlugin) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleRequest) (resp *datastore.DeleteBundleResponse, err error) {
 	callCounter := ds_telemetry.StartDeleteBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -219,12 +214,11 @@ func (ds *SQLPlugin) DeleteBundle(ctx context.Context, req *datastore.DeleteBund
 // FetchBundle returns the bundle matching the specified Trust Domain.
 func (ds *SQLPlugin) FetchBundle(ctx context.Context, req *datastore.FetchBundleRequest) (resp *datastore.FetchBundleResponse, err error) {
 	callCounter := ds_telemetry.StartFetchBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.TrustDomainId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -238,7 +232,7 @@ func (ds *SQLPlugin) FetchBundle(ctx context.Context, req *datastore.FetchBundle
 
 // ListBundles can be used to fetch all existing bundles.
 func (ds *SQLPlugin) ListBundles(ctx context.Context, req *datastore.ListBundlesRequest) (resp *datastore.ListBundlesResponse, err error) {
-	callCounter := ds_telemetry.StartListBundleCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartListBundleCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -255,16 +249,11 @@ func (ds *SQLPlugin) ListBundles(ctx context.Context, req *datastore.ListBundles
 // PruneBundle removes expired certs and keys from a bundle
 func (ds *SQLPlugin) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (resp *datastore.PruneBundleResponse, err error) {
 	callCounter := ds_telemetry.StartPruneBundleCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.Bundle,
-				Value: req.TrustDomainId,
-			},
-			telemetry.Label{
-				Name:  telemetry.Expiration,
-				Value: strconv.FormatInt(req.ExpiresBefore, 10),
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.Bundle,
+			Value: req.TrustDomainId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -281,7 +270,7 @@ func (ds *SQLPlugin) PruneBundle(ctx context.Context, req *datastore.PruneBundle
 // CreateAttestedNode stores the given attested node
 func (ds *SQLPlugin) CreateAttestedNode(ctx context.Context,
 	req *datastore.CreateAttestedNodeRequest) (resp *datastore.CreateAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartCreateNodeCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartCreateNodeCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if req.Node == nil {
@@ -290,8 +279,6 @@ func (ds *SQLPlugin) CreateAttestedNode(ctx context.Context,
 
 	callCounter.AddLabel(telemetry.Attestor, req.Node.AttestationDataType)
 	callCounter.AddLabel(telemetry.SPIFFEID, req.Node.SpiffeId)
-	callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(req.Node.CertNotAfter, 10))
-	callCounter.AddLabel(telemetry.SerialNumber, req.Node.CertSerialNumber)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createAttestedNode(tx, req)
@@ -306,12 +293,11 @@ func (ds *SQLPlugin) CreateAttestedNode(ctx context.Context,
 func (ds *SQLPlugin) FetchAttestedNode(ctx context.Context,
 	req *datastore.FetchAttestedNodeRequest) (resp *datastore.FetchAttestedNodeResponse, err error) {
 	callCounter := ds_telemetry.StartFetchNodeCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.SPIFFEID,
-				Value: req.SpiffeId,
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.SPIFFEID,
+			Value: req.SpiffeId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -326,12 +312,8 @@ func (ds *SQLPlugin) FetchAttestedNode(ctx context.Context,
 // ListAttestedNodes lists all attested nodes (pagination available)
 func (ds *SQLPlugin) ListAttestedNodes(ctx context.Context,
 	req *datastore.ListAttestedNodesRequest) (resp *datastore.ListAttestedNodesResponse, err error) {
-	callCounter := ds_telemetry.StartListNodeCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartListNodeCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
-
-	if req.ByExpiresBefore != nil {
-		callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(req.ByExpiresBefore.GetValue(), 10))
-	}
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listAttestedNodes(tx, req)
@@ -348,20 +330,11 @@ func (ds *SQLPlugin) ListAttestedNodes(ctx context.Context,
 func (ds *SQLPlugin) UpdateAttestedNode(ctx context.Context,
 	req *datastore.UpdateAttestedNodeRequest) (resp *datastore.UpdateAttestedNodeResponse, err error) {
 	callCounter := ds_telemetry.StartUpdateNodeCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(
-			telemetry.Label{
-				Name:  telemetry.SPIFFEID,
-				Value: req.SpiffeId,
-			},
-			telemetry.Label{
-				Name:  telemetry.SerialNumber,
-				Value: req.CertSerialNumber,
-			},
-			telemetry.Label{
-				Name:  telemetry.Expiration,
-				Value: strconv.FormatInt(req.CertNotAfter, 10),
-			},
-		)...))
+		telemetry.Label{
+			Name:  telemetry.SPIFFEID,
+			Value: req.SpiffeId,
+		},
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -377,11 +350,11 @@ func (ds *SQLPlugin) UpdateAttestedNode(ctx context.Context,
 func (ds *SQLPlugin) DeleteAttestedNode(ctx context.Context,
 	req *datastore.DeleteAttestedNodeRequest) (resp *datastore.DeleteAttestedNodeResponse, err error) {
 	callCounter := ds_telemetry.StartDeleteNodeCall(ds.prepareMetricsForCall(ctx,
-		ds.addCommonLabels(telemetry.Label{
+		telemetry.Label{
 			Name:  telemetry.SPIFFEID,
 			Value: req.SpiffeId,
 		},
-		)...))
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -395,7 +368,7 @@ func (ds *SQLPlugin) DeleteAttestedNode(ctx context.Context,
 
 // SetNodeSelectors sets node (agent) selectors by SPIFFE ID, deleting old selectors first
 func (ds *SQLPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (resp *datastore.SetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartSetNodeSelectorsCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartSetNodeSelectorsCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if req.Selectors == nil {
@@ -417,12 +390,12 @@ func (ds *SQLPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNod
 // GetNodeSelectors gets node (agent) selectors by SPIFFE ID
 func (ds *SQLPlugin) GetNodeSelectors(ctx context.Context,
 	req *datastore.GetNodeSelectorsRequest) (resp *datastore.GetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
+	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall(ctx,
 		telemetry.Label{
 			Name:  telemetry.SPIFFEID,
 			Value: req.SpiffeId,
 		},
-	)...))
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -439,7 +412,7 @@ func (ds *SQLPlugin) GetNodeSelectors(ctx context.Context,
 // CreateRegistrationEntry stores the given registration entry
 func (ds *SQLPlugin) CreateRegistrationEntry(ctx context.Context,
 	req *datastore.CreateRegistrationEntryRequest) (resp *datastore.CreateRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartCreateRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartCreateRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	// TODO: Validations should be done in the ProtoBuf level [https://github.com/spiffe/spire/issues/44]
@@ -449,7 +422,6 @@ func (ds *SQLPlugin) CreateRegistrationEntry(ctx context.Context,
 
 	callCounter.AddLabel(telemetry.SPIFFEID, req.Entry.SpiffeId)
 	callCounter.AddLabel(telemetry.ParentID, req.Entry.ParentId)
-	callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(req.Entry.EntryExpiry, 10))
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createRegistrationEntry(tx, req)
@@ -463,12 +435,12 @@ func (ds *SQLPlugin) CreateRegistrationEntry(ctx context.Context,
 // FetchRegistrationEntry fetches an existing registration by entry ID
 func (ds *SQLPlugin) FetchRegistrationEntry(ctx context.Context,
 	req *datastore.FetchRegistrationEntryRequest) (resp *datastore.FetchRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartFetchRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
+	callCounter := ds_telemetry.StartFetchRegistrationCall(ds.prepareMetricsForCall(ctx,
 		telemetry.Label{
 			Name:  telemetry.Entry,
 			Value: req.EntryId,
 		},
-	)...))
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -483,7 +455,7 @@ func (ds *SQLPlugin) FetchRegistrationEntry(ctx context.Context,
 // ListRegistrationEntries lists all registrations (pagination available)
 func (ds *SQLPlugin) ListRegistrationEntries(ctx context.Context,
 	req *datastore.ListRegistrationEntriesRequest) (resp *datastore.ListRegistrationEntriesResponse, err error) {
-	callCounter := ds_telemetry.StartListRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartListRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if req.ByParentId != nil {
@@ -510,7 +482,7 @@ func (ds *SQLPlugin) ListRegistrationEntries(ctx context.Context,
 // UpdateRegistrationEntry updates an existing registration entry
 func (ds *SQLPlugin) UpdateRegistrationEntry(ctx context.Context,
 	req *datastore.UpdateRegistrationEntryRequest) (resp *datastore.UpdateRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartUpdateRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartUpdateRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = validateRegistrationEntry(req.Entry); err != nil {
@@ -520,7 +492,6 @@ func (ds *SQLPlugin) UpdateRegistrationEntry(ctx context.Context,
 	callCounter.AddLabel(telemetry.SPIFFEID, req.Entry.SpiffeId)
 	callCounter.AddLabel(telemetry.Entry, req.Entry.EntryId)
 	callCounter.AddLabel(telemetry.ParentID, req.Entry.ParentId)
-	callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(req.Entry.EntryExpiry, 10))
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = updateRegistrationEntry(tx, req)
@@ -534,12 +505,12 @@ func (ds *SQLPlugin) UpdateRegistrationEntry(ctx context.Context,
 // DeleteRegistrationEntry deletes the given registration
 func (ds *SQLPlugin) DeleteRegistrationEntry(ctx context.Context,
 	req *datastore.DeleteRegistrationEntryRequest) (resp *datastore.DeleteRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
+	callCounter := ds_telemetry.StartDeleteRegistrationCall(ds.prepareMetricsForCall(ctx,
 		telemetry.Label{
 			Name:  telemetry.Entry,
 			Value: req.EntryId,
 		},
-	)...))
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -554,12 +525,7 @@ func (ds *SQLPlugin) DeleteRegistrationEntry(ctx context.Context,
 // PruneRegistrationEntries takes a registration entry message, and deletes all entries which have expired
 // before the date in the message
 func (ds *SQLPlugin) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (resp *datastore.PruneRegistrationEntriesResponse, err error) {
-	callCounter := ds_telemetry.StartPruneRegistrationCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
-		telemetry.Label{
-			Name:  telemetry.Expiration,
-			Value: strconv.FormatInt(req.ExpiresBefore, 10),
-		},
-	)...))
+	callCounter := ds_telemetry.StartPruneRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -573,14 +539,12 @@ func (ds *SQLPlugin) PruneRegistrationEntries(ctx context.Context, req *datastor
 
 // CreateJoinToken takes a Token message and stores it
 func (ds *SQLPlugin) CreateJoinToken(ctx context.Context, req *datastore.CreateJoinTokenRequest) (resp *datastore.CreateJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartCreateJoinTokenCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartCreateJoinTokenCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if req.JoinToken == nil || req.JoinToken.Token == "" || req.JoinToken.Expiry == 0 {
 		return nil, errors.New("token and expiry are required")
 	}
-
-	callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(req.JoinToken.Expiry, 10))
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createJoinToken(tx, req)
@@ -594,7 +558,7 @@ func (ds *SQLPlugin) CreateJoinToken(ctx context.Context, req *datastore.CreateJ
 // FetchJoinToken takes a Token message and returns one, populating the fields
 // we have knowledge of
 func (ds *SQLPlugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTokenRequest) (resp *datastore.FetchJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartFetchJoinTokenCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels()...))
+	callCounter := ds_telemetry.StartFetchJoinTokenCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -604,20 +568,17 @@ func (ds *SQLPlugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoi
 		return nil, err
 	}
 
-	if resp.JoinToken != nil {
-		callCounter.AddLabel(telemetry.Expiration, strconv.FormatInt(resp.JoinToken.Expiry, 10))
-	}
 	return resp, nil
 }
 
 // DeleteJoinToken deletes the given join token
 func (ds *SQLPlugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (resp *datastore.DeleteJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteJoinTokenCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
+	callCounter := ds_telemetry.StartDeleteJoinTokenCall(ds.prepareMetricsForCall(ctx,
 		telemetry.Label{
 			Name:  telemetry.JoinToken,
 			Value: req.Token,
 		},
-	)...))
+	))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -632,12 +593,7 @@ func (ds *SQLPlugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJ
 // PruneJoinTokens takes a Token message, and deletes all tokens which have expired
 // before the date in the message
 func (ds *SQLPlugin) PruneJoinTokens(ctx context.Context, req *datastore.PruneJoinTokensRequest) (resp *datastore.PruneJoinTokensResponse, err error) {
-	callCounter := ds_telemetry.StartPruneJoinTokenCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
-		telemetry.Label{
-			Name:  telemetry.Expiration,
-			Value: strconv.FormatInt(req.ExpiresBefore, 10),
-		},
-	)...))
+	callCounter := ds_telemetry.StartPruneJoinTokenCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -766,12 +722,6 @@ func (ds *SQLPlugin) openDB(cfg *configuration) (*gorm.DB, error) {
 	}
 
 	return db, nil
-}
-
-// addCommonLabels append common labels for this entity to the input labels,
-// and return the result
-func (ds *SQLPlugin) addCommonLabels(labels ...telemetry.Label) []telemetry.Label {
-	return append(labels, telemetry.Label{Name: telemetry.DatabaseType, Value: ds.db.databaseType})
 }
 
 func (ds *SQLPlugin) prepareMetricsForCall(ctx context.Context, labels ...telemetry.Label) telemetry.Metrics {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -241,8 +241,6 @@ func (ds *SQLPlugin) ListBundles(ctx context.Context, req *datastore.ListBundles
 	}); err != nil {
 		return nil, err
 	}
-
-	callCounter.AddLabel(telemetry.Count, strconv.Itoa(len(resp.Bundles)))
 	return resp, nil
 }
 
@@ -277,9 +275,6 @@ func (ds *SQLPlugin) CreateAttestedNode(ctx context.Context,
 		return nil, sqlError.New("invalid request: missing attested node")
 	}
 
-	callCounter.AddLabel(telemetry.Attestor, req.Node.AttestationDataType)
-	callCounter.AddLabel(telemetry.SPIFFEID, req.Node.SpiffeId)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createAttestedNode(tx, req)
 		return err
@@ -292,12 +287,7 @@ func (ds *SQLPlugin) CreateAttestedNode(ctx context.Context,
 // FetchAttestedNode fetches an existing attested node by SPIFFE ID
 func (ds *SQLPlugin) FetchAttestedNode(ctx context.Context,
 	req *datastore.FetchAttestedNodeRequest) (resp *datastore.FetchAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartFetchNodeCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.SPIFFEID,
-			Value: req.SpiffeId,
-		},
-	))
+	callCounter := ds_telemetry.StartFetchNodeCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -321,20 +311,13 @@ func (ds *SQLPlugin) ListAttestedNodes(ctx context.Context,
 	}); err != nil {
 		return nil, err
 	}
-
-	callCounter.AddLabel(telemetry.Count, strconv.Itoa(len(resp.Nodes)))
 	return resp, nil
 }
 
 // UpdateAttestedNode updates the given node's cert serial and expiration.
 func (ds *SQLPlugin) UpdateAttestedNode(ctx context.Context,
 	req *datastore.UpdateAttestedNodeRequest) (resp *datastore.UpdateAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartUpdateNodeCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.SPIFFEID,
-			Value: req.SpiffeId,
-		},
-	))
+	callCounter := ds_telemetry.StartUpdateNodeCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -349,12 +332,7 @@ func (ds *SQLPlugin) UpdateAttestedNode(ctx context.Context,
 // DeleteAttestedNode deletes the given attested node
 func (ds *SQLPlugin) DeleteAttestedNode(ctx context.Context,
 	req *datastore.DeleteAttestedNodeRequest) (resp *datastore.DeleteAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteNodeCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.SPIFFEID,
-			Value: req.SpiffeId,
-		},
-	))
+	callCounter := ds_telemetry.StartDeleteNodeCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
@@ -375,9 +353,6 @@ func (ds *SQLPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNod
 		return nil, errors.New("invalid request: missing selectors")
 	}
 
-	callCounter.AddLabel(telemetry.SPIFFEID, req.Selectors.SpiffeId)
-	callCounter.AddLabel(telemetry.Count, strconv.Itoa(len(req.Selectors.Selectors)))
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = setNodeSelectors(tx, req)
 		return err
@@ -390,12 +365,7 @@ func (ds *SQLPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNod
 // GetNodeSelectors gets node (agent) selectors by SPIFFE ID
 func (ds *SQLPlugin) GetNodeSelectors(ctx context.Context,
 	req *datastore.GetNodeSelectorsRequest) (resp *datastore.GetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.SPIFFEID,
-			Value: req.SpiffeId,
-		},
-	))
+	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -404,8 +374,6 @@ func (ds *SQLPlugin) GetNodeSelectors(ctx context.Context,
 	}); err != nil {
 		return nil, err
 	}
-
-	callCounter.AddLabel(telemetry.Count, strconv.Itoa(len(resp.Selectors.Selectors)))
 	return resp, nil
 }
 
@@ -420,9 +388,6 @@ func (ds *SQLPlugin) CreateRegistrationEntry(ctx context.Context,
 		return nil, err
 	}
 
-	callCounter.AddLabel(telemetry.SPIFFEID, req.Entry.SpiffeId)
-	callCounter.AddLabel(telemetry.ParentID, req.Entry.ParentId)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createRegistrationEntry(tx, req)
 		return err
@@ -435,12 +400,7 @@ func (ds *SQLPlugin) CreateRegistrationEntry(ctx context.Context,
 // FetchRegistrationEntry fetches an existing registration by entry ID
 func (ds *SQLPlugin) FetchRegistrationEntry(ctx context.Context,
 	req *datastore.FetchRegistrationEntryRequest) (resp *datastore.FetchRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartFetchRegistrationCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.Entry,
-			Value: req.EntryId,
-		},
-	))
+	callCounter := ds_telemetry.StartFetchRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
@@ -458,24 +418,12 @@ func (ds *SQLPlugin) ListRegistrationEntries(ctx context.Context,
 	callCounter := ds_telemetry.StartListRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
-	if req.ByParentId != nil {
-		callCounter.AddLabel(telemetry.ParentID, req.ByParentId.Value)
-	}
-	if req.BySpiffeId != nil {
-		callCounter.AddLabel(telemetry.SPIFFEID, req.BySpiffeId.Value)
-	}
-	if req.BySelectors != nil {
-		callCounter.AddLabel(telemetry.Selectors, strconv.Itoa(len(req.BySelectors.Selectors)))
-	}
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listRegistrationEntries(tx, req)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-
-	callCounter.AddLabel(telemetry.Count, strconv.Itoa(len(resp.Entries)))
 	return resp, nil
 }
 
@@ -489,10 +437,6 @@ func (ds *SQLPlugin) UpdateRegistrationEntry(ctx context.Context,
 		return nil, err
 	}
 
-	callCounter.AddLabel(telemetry.SPIFFEID, req.Entry.SpiffeId)
-	callCounter.AddLabel(telemetry.Entry, req.Entry.EntryId)
-	callCounter.AddLabel(telemetry.ParentID, req.Entry.ParentId)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = updateRegistrationEntry(tx, req)
 		return err
@@ -505,12 +449,7 @@ func (ds *SQLPlugin) UpdateRegistrationEntry(ctx context.Context,
 // DeleteRegistrationEntry deletes the given registration
 func (ds *SQLPlugin) DeleteRegistrationEntry(ctx context.Context,
 	req *datastore.DeleteRegistrationEntryRequest) (resp *datastore.DeleteRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteRegistrationCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.Entry,
-			Value: req.EntryId,
-		},
-	))
+	callCounter := ds_telemetry.StartDeleteRegistrationCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -512,12 +512,7 @@ func (ds *SQLPlugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoi
 
 // DeleteJoinToken deletes the given join token
 func (ds *SQLPlugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (resp *datastore.DeleteJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteJoinTokenCall(ds.prepareMetricsForCall(ctx,
-		telemetry.Label{
-			Name:  telemetry.JoinToken,
-			Value: req.Token,
-		},
-	))
+	callCounter := ds_telemetry.StartDeleteJoinTokenCall(ds.prepareMetricsForCall(ctx))
 	defer callCounter.Done(&err)
 
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -768,15 +768,10 @@ func (ds *SQLPlugin) openDB(cfg *configuration) (*gorm.DB, error) {
 	return db, nil
 }
 
-// addCommonLabels append the input labels to an array of common labels for this entity,
+// addCommonLabels append common labels for this entity to the input labels,
 // and return the result
 func (ds *SQLPlugin) addCommonLabels(labels ...telemetry.Label) []telemetry.Label {
-	return append([]telemetry.Label{
-		{
-			Name:  telemetry.DatabaseType,
-			Value: ds.db.databaseType,
-		},
-	}, labels...)
+	return append(labels, telemetry.Label{Name: telemetry.DatabaseType, Value: ds.db.databaseType})
 }
 
 func (ds *SQLPlugin) prepareMetricsForCall(ctx context.Context, labels ...telemetry.Label) telemetry.Metrics {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -417,7 +417,7 @@ func (ds *SQLPlugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNod
 // GetNodeSelectors gets node (agent) selectors by SPIFFE ID
 func (ds *SQLPlugin) GetNodeSelectors(ctx context.Context,
 	req *datastore.GetNodeSelectorsRequest) (resp *datastore.GetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartSetNodeSelectorsCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
+	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall(ctx, ds.addCommonLabels(
 		telemetry.Label{
 			Name:  telemetry.SPIFFEID,
 			Value: req.SpiffeId,

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -49,9 +49,7 @@ type PluginSuite struct {
 	nextID int
 	ds     datastore.Plugin
 
-	m  *fakemetrics.FakeMetrics
-	ms proto_services.MetricsService
-
+	m               *fakemetrics.FakeMetrics
 	expectedMetrics *fakepluginmetrics.FakePluginMetrics
 }
 
@@ -85,12 +83,12 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 	)
 
 	s.m = fakemetrics.New()
-	s.ms = metricsservice.New(metricsservice.Config{
+	metricsService := metricsservice.New(metricsservice.Config{
 		Metrics: s.m,
 	})
 
 	s.LoadPlugin(builtin(p), &ds,
-		spiretest.HostService(proto_services.MetricsServiceHostServiceServer(s.ms)))
+		spiretest.HostService(proto_services.MetricsServiceHostServiceServer(metricsService)))
 
 	s.nextID++
 	dbPath := filepath.Join(s.dir, fmt.Sprintf("db%d.sqlite3", s.nextID))

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -1547,7 +1547,6 @@ func (s *PluginSuite) TestDeleteJoinToken() {
 	s.Require().NoError(err)
 
 	expectedCallCounter = ds_telemetry.StartDeleteJoinTokenCall(s.expectedMetrics)
-	expectedCallCounter.AddLabel(telemetry.JoinToken, joinToken1.Token)
 	_, err = s.ds.DeleteJoinToken(ctx, &datastore.DeleteJoinTokenRequest{
 		Token: joinToken1.Token,
 	})

--- a/test/fakes/fakepluginmetrics/fakepluginmetrics.go
+++ b/test/fakes/fakepluginmetrics/fakepluginmetrics.go
@@ -15,7 +15,7 @@ type FakePluginMetrics struct {
 }
 
 // New create new fake metrics wrapper for plugin test
-func New(labels []telemetry.Label) *FakePluginMetrics {
+func New(labels ...telemetry.Label) *FakePluginMetrics {
 	return &FakePluginMetrics{
 		fakeMetrics: fakemetrics.New(),
 		fixedLabels: labels,
@@ -28,10 +28,13 @@ func (m *FakePluginMetrics) AllMetrics() []fakemetrics.MetricItem {
 }
 
 func (m *FakePluginMetrics) SetGauge(key []string, val float32) {
-	m.SetGaugeWithLabels(key, val, nil)
+	m.SetGaugeWithLabels(key, val, []telemetry.Label{})
 }
 
 func (m *FakePluginMetrics) SetGaugeWithLabels(key []string, val float32, labels []telemetry.Label) {
+	if labels == nil {
+		labels = []telemetry.Label{}
+	}
 	m.fakeMetrics.SetGaugeWithLabels(key, val, append(labels, m.fixedLabels...))
 }
 
@@ -40,25 +43,34 @@ func (m *FakePluginMetrics) EmitKey(key []string, val float32) {
 }
 
 func (m *FakePluginMetrics) IncrCounter(key []string, val float32) {
-	m.IncrCounterWithLabels(key, val, nil)
+	m.IncrCounterWithLabels(key, val, []telemetry.Label{})
 }
 
 func (m *FakePluginMetrics) IncrCounterWithLabels(key []string, val float32, labels []telemetry.Label) {
+	if labels == nil {
+		labels = []telemetry.Label{}
+	}
 	m.fakeMetrics.IncrCounterWithLabels(key, val, append(labels, m.fixedLabels...))
 }
 
 func (m *FakePluginMetrics) AddSample(key []string, val float32) {
-	m.AddSampleWithLabels(key, val, nil)
+	m.AddSampleWithLabels(key, val, []telemetry.Label{})
 }
 
 func (m *FakePluginMetrics) AddSampleWithLabels(key []string, val float32, labels []telemetry.Label) {
+	if labels == nil {
+		labels = []telemetry.Label{}
+	}
 	m.fakeMetrics.AddSampleWithLabels(key, val, append(labels, m.fixedLabels...))
 }
 
 func (m *FakePluginMetrics) MeasureSince(key []string, start time.Time) {
-	m.MeasureSinceWithLabels(key, start, nil)
+	m.MeasureSinceWithLabels(key, start, []telemetry.Label{})
 }
 
 func (m *FakePluginMetrics) MeasureSinceWithLabels(key []string, start time.Time, labels []telemetry.Label) {
+	if labels == nil {
+		labels = []telemetry.Label{}
+	}
 	m.fakeMetrics.MeasureSinceWithLabels(key, start, append(labels, m.fixedLabels...))
 }

--- a/test/fakes/fakepluginmetrics/fakepluginmetrics.go
+++ b/test/fakes/fakepluginmetrics/fakepluginmetrics.go
@@ -1,0 +1,64 @@
+package fakepluginmetrics
+
+import (
+	"time"
+
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
+)
+
+// FakePluginMetrics mimics behavior of plugin metrics wrapper, delegates
+// behavior to FakeMetrics, appending fixed labels
+type FakePluginMetrics struct {
+	fakeMetrics *fakemetrics.FakeMetrics
+	fixedLabels []telemetry.Label
+}
+
+// New create new fake metrics wrapper for plugin test
+func New(labels []telemetry.Label) *FakePluginMetrics {
+	return &FakePluginMetrics{
+		fakeMetrics: fakemetrics.New(),
+		fixedLabels: labels,
+	}
+}
+
+// AllMetrics return all collected metrics
+func (m *FakePluginMetrics) AllMetrics() []fakemetrics.MetricItem {
+	return m.fakeMetrics.AllMetrics()
+}
+
+func (m *FakePluginMetrics) SetGauge(key []string, val float32) {
+	m.SetGaugeWithLabels(key, val, nil)
+}
+
+func (m *FakePluginMetrics) SetGaugeWithLabels(key []string, val float32, labels []telemetry.Label) {
+	m.fakeMetrics.SetGaugeWithLabels(key, val, append(labels, m.fixedLabels...))
+}
+
+func (m *FakePluginMetrics) EmitKey(key []string, val float32) {
+	m.fakeMetrics.EmitKey(key, val)
+}
+
+func (m *FakePluginMetrics) IncrCounter(key []string, val float32) {
+	m.IncrCounterWithLabels(key, val, nil)
+}
+
+func (m *FakePluginMetrics) IncrCounterWithLabels(key []string, val float32, labels []telemetry.Label) {
+	m.fakeMetrics.IncrCounterWithLabels(key, val, append(labels, m.fixedLabels...))
+}
+
+func (m *FakePluginMetrics) AddSample(key []string, val float32) {
+	m.AddSampleWithLabels(key, val, nil)
+}
+
+func (m *FakePluginMetrics) AddSampleWithLabels(key []string, val float32, labels []telemetry.Label) {
+	m.fakeMetrics.AddSampleWithLabels(key, val, append(labels, m.fixedLabels...))
+}
+
+func (m *FakePluginMetrics) MeasureSince(key []string, start time.Time) {
+	m.MeasureSinceWithLabels(key, start, nil)
+}
+
+func (m *FakePluginMetrics) MeasureSinceWithLabels(key []string, start time.Time, labels []telemetry.Label) {
+	m.fakeMetrics.MeasureSinceWithLabels(key, start, append(labels, m.fixedLabels...))
+}


### PR DESCRIPTION
Signed-off-by: Andrew Moore <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
No existing functionality changed

**Description of change**
SQL DB plugin now uses the `HostService` `metricsservice` and emits metrics for datastore API.

