### PR TITLE
Change cert serial number generation

### DIFF
--- a/pkg/common/x509svid/upstreamca.go
+++ b/pkg/common/x509svid/upstreamca.go
@@ -80,7 +80,7 @@ func (ca *UpstreamCA) SignCSR(ctx context.Context, csrDER []byte) (*x509.Certifi
 			x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
-		IsCA: true,
+		IsCA:                  true,
 	}
 
 	certDER, err := ca.keypair.CreateCertificate(ctx, template, csr.PublicKey)

--- a/pkg/common/x509svid/upstreamca.go
+++ b/pkg/common/x509svid/upstreamca.go
@@ -15,9 +15,8 @@ const (
 )
 
 type UpstreamCAOptions struct {
-	Backdate     time.Duration
-	TTL          time.Duration
-	SerialNumber x509util.SerialNumber
+	Backdate time.Duration
+	TTL      time.Duration
 }
 
 type UpstreamCA struct {
@@ -32,9 +31,6 @@ func NewUpstreamCA(keypair x509util.Keypair, trustDomain string, options Upstrea
 	}
 	if options.TTL <= 0 {
 		options.TTL = DefaultUpstreamCATTL
-	}
-	if options.SerialNumber == nil {
-		options.SerialNumber = x509util.NewSerialNumber()
 	}
 
 	return &UpstreamCA{
@@ -68,7 +64,7 @@ func (ca *UpstreamCA) SignCSR(ctx context.Context, csrDER []byte) (*x509.Certifi
 		notAfter = caCert.NotAfter
 	}
 
-	serialNumber, err := ca.options.SerialNumber.NextNumber(ctx)
+	serialNumber, err := x509util.NewSerialNumber()
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +80,7 @@ func (ca *UpstreamCA) SignCSR(ctx context.Context, csrDER []byte) (*x509.Certifi
 			x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
-		IsCA:                  true,
+		IsCA: true,
 	}
 
 	certDER, err := ca.keypair.CreateCertificate(ctx, template, csr.PublicKey)

--- a/pkg/common/x509util/serialnumber.go
+++ b/pkg/common/x509util/serialnumber.go
@@ -3,13 +3,12 @@ package x509util
 import (
 	"crypto/rand"
 	"fmt"
-	"math"
 	"math/big"
 )
 
 var (
-	maxUint64 = new(big.Int).SetUint64(math.MaxUint64)
-	one       = big.NewInt(1)
+	maxUint128, ok = new(big.Int).SetString("340282366920938463463374607431768211455", 10) //(2^128 − 1)
+	one            = big.NewInt(1)
 )
 
 // NewSerialNumber creates a random certificate serial number according to CA/Browser forum spec
@@ -17,12 +16,16 @@ var (
 //   "Effective September 30, 2016, CAs SHALL generate non-sequential Certificate serial numbers greater than
 //   zero (0) containing at least 64 bits of output from a CSPRNG"
 func NewSerialNumber() (*big.Int, error) {
-	// Creates random integer in range [0,MaxUint64)
-	s, err := rand.Int(rand.Reader, maxUint64)
+	if !ok {
+		return nil, fmt.Errorf("cannot parse value for max unsigned int 128")
+	}
+
+	// Creates random integer in range [0,MaxUint128)
+	s, err := rand.Int(rand.Reader, maxUint128)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create random number: %v", err)
 	}
 
-	// Adds 1 to return serial number [1,MaxUint64]
+	// Adds 1 to return serial number [1,MaxUint128]
 	return s.Add(s, one), nil
 }

--- a/pkg/common/x509util/serialnumber.go
+++ b/pkg/common/x509util/serialnumber.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	maxUint128, ok = new(big.Int).SetString("340282366920938463463374607431768211455", 10) //(2^128 − 1)
-	one            = big.NewInt(1)
+	maxUint128 = getMaxUint128()
+	one        = big.NewInt(1)
 )
 
 // NewSerialNumber creates a random certificate serial number according to CA/Browser forum spec
@@ -16,10 +16,6 @@ var (
 //   "Effective September 30, 2016, CAs SHALL generate non-sequential Certificate serial numbers greater than
 //   zero (0) containing at least 64 bits of output from a CSPRNG"
 func NewSerialNumber() (*big.Int, error) {
-	if !ok {
-		return nil, fmt.Errorf("cannot parse value for max unsigned int 128")
-	}
-
 	// Creates random integer in range [0,MaxUint128)
 	s, err := rand.Int(rand.Reader, maxUint128)
 	if err != nil {
@@ -28,4 +24,12 @@ func NewSerialNumber() (*big.Int, error) {
 
 	// Adds 1 to return serial number [1,MaxUint128]
 	return s.Add(s, one), nil
+}
+
+func getMaxUint128() *big.Int {
+	max, ok := new(big.Int).SetString("340282366920938463463374607431768211455", 10) //(2^128 − 1)
+	if !ok {
+		panic("cannot parse value for max unsigned int 128")
+	}
+	return max
 }

--- a/pkg/common/x509util/serialnumber.go
+++ b/pkg/common/x509util/serialnumber.go
@@ -7,22 +7,22 @@ import (
 	"math/big"
 )
 
+var (
+	maxUint64 = new(big.Int).SetUint64(math.MaxUint64)
+	one       = big.NewInt(1)
+)
+
 // NewSerialNumber creates a random certificate serial number according to CA/Browser forum spec
 // Section 7.1:
 //   "Effective September 30, 2016, CAs SHALL generate non-sequential Certificate serial numbers greater than
 //   zero (0) containing at least 64 bits of output from a CSPRNG"
 func NewSerialNumber() (*big.Int, error) {
-	// Get MaxUint64 as big.Int
-	maxUInt64 := new(big.Int)
-	maxUInt64 = maxUInt64.SetUint64(math.MaxUint64)
-
 	// Creates random integer in range [0,MaxUint64)
-	s, err := rand.Int(rand.Reader, maxUInt64)
+	s, err := rand.Int(rand.Reader, maxUint64)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create random number: %v", err)
 	}
 
 	// Adds 1 to return serial number [1,MaxUint64]
-	s.Add(s, big.NewInt(1))
-	return s, nil
+	return s.Add(s, one), nil
 }

--- a/pkg/common/x509util/serialnumber.go
+++ b/pkg/common/x509util/serialnumber.go
@@ -1,23 +1,28 @@
 package x509util
 
 import (
-	"context"
+	"crypto/rand"
+	"fmt"
+	"math"
 	"math/big"
-	"sync/atomic"
 )
 
-type SerialNumber interface {
-	NextNumber(context.Context) (*big.Int, error)
-}
+// NewSerialNumber creates a random certificate serial number according to CA/Browser forum spec
+// Section 7.1:
+//   "Effective September 30, 2016, CAs SHALL generate non-sequential Certificate serial numbers greater than
+//   zero (0) containing at least 64 bits of output from a CSPRNG"
+func NewSerialNumber() (*big.Int, error) {
+	// Get MaxUint64 as big.Int
+	maxUInt64 := new(big.Int)
+	maxUInt64 = maxUInt64.SetUint64(math.MaxUint64)
 
-type serialNumber struct {
-	next int64
-}
+	// Creates random integer in range [0,MaxUint64)
+	s, err := rand.Int(rand.Reader, maxUInt64)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create random number: %v", err)
+	}
 
-func NewSerialNumber() SerialNumber {
-	return &serialNumber{}
-}
-
-func (m *serialNumber) NextNumber(ctx context.Context) (*big.Int, error) {
-	return big.NewInt(atomic.AddInt64(&m.next, 1)), nil
+	// Adds 1 to return serial number [1,MaxUint64]
+	s.Add(s, big.NewInt(1))
+	return s, nil
 }

--- a/pkg/common/x509util/serialnumber_test.go
+++ b/pkg/common/x509util/serialnumber_test.go
@@ -1,0 +1,18 @@
+package x509util
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSerialNumber(t *testing.T) {
+	number1, err := NewSerialNumber()
+	assert.NoError(t, err)
+	assert.NotEqual(t, big.NewInt(0), number1, "Serial numbers must not be zero")
+
+	number2, err := NewSerialNumber()
+	assert.NotEqual(t, number1, number2, "Successive serial numbers must be different")
+	assert.NotEqual(t, number1, number2.Add(number2, big.NewInt(-1)), "Serial numbers must not be sequential")
+}

--- a/pkg/common/x509util/serialnumber_test.go
+++ b/pkg/common/x509util/serialnumber_test.go
@@ -16,3 +16,8 @@ func TestNewSerialNumber(t *testing.T) {
 	assert.NotEqual(t, number1, number2, "Successive serial numbers must be different")
 	assert.NotEqual(t, number1, number2.Add(number2, big.NewInt(-1)), "Serial numbers must not be sequential")
 }
+
+func TestMaxUint128IsMaxValueRepresentableWith128bits(t *testing.T) {
+	assert.Equal(t, 128, maxUint128.BitLen())
+	assert.Equal(t, 129, maxUint128.Add(maxUint128, one).BitLen())
+}

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -208,15 +208,14 @@ func (s *CATestSuite) TestSignX509SVIDValidatesTrustDomain() {
 	s.Require().EqualError(err, `"spiffe://foo.com/workload" does not belong to trust domain "example.org"`)
 }
 
-func (s *CATestSuite) TestSignX509SVIDIncrementsSerialNumber() {
+func (s *CATestSuite) TestSignX509SVIDChangesSerialNumber() {
 	svid1, err := s.ca.SignX509SVID(ctx, s.createX509SVIDParams())
 	s.Require().NoError(err)
 	s.Require().Len(svid1, 1)
-	s.Require().Equal(0, svid1[0].SerialNumber.Cmp(big.NewInt(1)))
 	svid2, err := s.ca.SignX509SVID(ctx, s.createX509SVIDParams())
 	s.Require().NoError(err)
 	s.Require().Len(svid2, 1)
-	s.Require().Equal(0, svid2[0].SerialNumber.Cmp(big.NewInt(2)))
+	s.Require().NotEqual(0, svid2[0].SerialNumber.Cmp(svid1[0].SerialNumber))
 }
 
 func (s *CATestSuite) TestNoJWTKeySet() {
@@ -375,7 +374,7 @@ func (s *CATestSuite) createCACertificate(cn string, parent *x509.Certificate) *
 		Subject: pkix.Name{
 			CommonName: cn,
 		},
-		IsCA:                  true,
+		IsCA: true,
 		BasicConstraintsValid: true,
 		NotAfter:              s.clock.Now().Add(10 * time.Minute),
 		SubjectKeyId:          keyID,

--- a/pkg/server/plugin/upstreamca/awssecret/awssecret.go
+++ b/pkg/server/plugin/upstreamca/awssecret/awssecret.go
@@ -46,8 +46,6 @@ type AWSSecretConfiguration struct {
 }
 
 type AWSSecretPlugin struct {
-	serialNumber x509util.SerialNumber
-
 	mtx        sync.RWMutex
 	cert       *x509.Certificate
 	upstreamCA *x509svid.UpstreamCA
@@ -63,9 +61,7 @@ func New() *AWSSecretPlugin {
 }
 
 func newPlugin(newClient func(config *AWSSecretConfiguration, region string) (secretsManagerClient, error)) *AWSSecretPlugin {
-	p := &AWSSecretPlugin{
-		serialNumber: x509util.NewSerialNumber(),
-	}
+	p := &AWSSecretPlugin{}
 	p.hooks.getenv = os.Getenv
 	p.hooks.newClient = newClient
 	return p
@@ -99,8 +95,7 @@ func (m *AWSSecretPlugin) Configure(ctx context.Context, req *spi.ConfigureReque
 		x509util.NewMemoryKeypair(cert, key),
 		req.GlobalConfig.TrustDomain,
 		x509svid.UpstreamCAOptions{
-			SerialNumber: m.serialNumber,
-			TTL:          ttl,
+			TTL: ttl,
 		})
 
 	return &spi.ConfigureResponse{}, nil

--- a/pkg/server/plugin/upstreamca/disk/disk.go
+++ b/pkg/server/plugin/upstreamca/disk/disk.go
@@ -39,7 +39,6 @@ type Configuration struct {
 }
 
 type DiskPlugin struct {
-	serialNumber          x509util.SerialNumber
 	_testOnlyShouldVerify bool
 
 	mtx        sync.Mutex
@@ -55,7 +54,6 @@ type caCerts struct {
 
 func New() *DiskPlugin {
 	return &DiskPlugin{
-		serialNumber:          x509util.NewSerialNumber(),
 		_testOnlyShouldVerify: true,
 	}
 }
@@ -215,8 +213,7 @@ func (p *DiskPlugin) loadUpstreamCAAndCerts(config *Configuration) (*x509svid.Up
 		x509util.NewMemoryKeypair(caCert, key),
 		config.trustDomain,
 		x509svid.UpstreamCAOptions{
-			SerialNumber: p.serialNumber,
-			TTL:          config.ttl,
+			TTL: config.ttl,
 		},
 	), caCerts, nil
 }

--- a/pkg/server/plugin/upstreamca/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamca/spire/spire_test.go
@@ -183,8 +183,7 @@ func (h *handler) FetchX509CASVID(ctx context.Context, req *node.FetchX509CASVID
 		x509util.NewMemoryKeypair(caCert, caKey),
 		"localhost",
 		x509svid.UpstreamCAOptions{
-			SerialNumber: x509util.NewSerialNumber(),
-			TTL:          30 * time.Minute,
+			TTL: 30 * time.Minute,
 		})
 
 	cert, err := ca.SignCSR(ctx, req.Csr)


### PR DESCRIPTION
- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Certificates serial numbers generation

**Description of change**
Currently, the certificate's serial numbers are generated sequentially. This PR makes those numbers to be generated randomly according to the CA/B forum considerations:

_(Section 7.1)_

> Effective September 30, 2016, CAs SHALL generate non-sequential Certificate serial numbers greater than zero (0) containing at least 64 bits of output from a CSPRNG


**Which issue this PR fixes**
Fixes: #962 

