### PR TITLE
gcp_iit: add instance metadata and label selectors

### DIFF
--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -8,10 +8,12 @@ This plugin requires a whitelist of ProjectID from which nodes can be attested. 
 
 ## Configuration
 
-| Configuration           | Description                                                                                        | Default                                    |
-|-------------------------|----------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `projectid_whitelist`   | List of whitelisted ProjectIDs from which nodes can be attested.  |         |
-| `use_instance_metadata` | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false |
+| Configuration             | Description                                                                                        | Default                                    |
+|---------------------------|----------------------------------------------------------------------------------------------------|--------------------------------------------|
+| `projectid_whitelist`     | List of whitelisted ProjectIDs from which nodes can be attested.  |         |
+| `use_instance_metadata`   | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false |
+| `allowed_metadata_keys`   | Instance metadata keys considered for selectors | |
+| `max_metadata_value_size` | Sets the maximum metadata value size considered by the plugin for selectors | 128 |
 
 A sample configuration:
 
@@ -39,6 +41,14 @@ If `use_instance_metadata` is true, then the Google Compute Engine API is querie
 | -------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------|
 | `gcp_iit:tag`              | `gcp_iit:tag:blog-server`                                    | Instance tag (one selector per)
 | `gcp_iit:sa`               | `gcp_iit:sa:123456789-compute@developer.gserviceaccount.com` | Service account (one selector per) 
+| `gcp_iit:metadata`         | `gcp_iit:metadata:key:value`                                 | Instance metadata (see caveat below)
+| `gcp_iit:label`            | `gcp_iit:label:key:value`                                    | Instance label
+
+Instance metadata can hold large values up to 256KiB. Since not all metadata would be useful for node selection, and to prevent pushing potentially large amounts
+of data into the datastore, only metadata values with keys in the `allowed_metadata_keys` configurable are considered. Additionally, any metadata value larger than the
+`max_metadata_value_size` configurable is skipped.
+
+Metadata and label values are optional. If the value isn't present, the corresponding selector will still have a trailing colon (i.e. `gcp_iit:label:<key>:`, `gcp_iit:metadata:<key>:`)
 
 ## Authenticating with the Google Compute Engine API
 

--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -12,6 +12,7 @@ This plugin requires a whitelist of ProjectID from which nodes can be attested. 
 |---------------------------|----------------------------------------------------------------------------------------------------|--------------------------------------------|
 | `projectid_whitelist`     | List of whitelisted ProjectIDs from which nodes can be attested.  |         |
 | `use_instance_metadata`   | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false |
+| `allowed_label_keys`      | Instance label keys considered for selectors | |
 | `allowed_metadata_keys`   | Instance metadata keys considered for selectors | |
 | `max_metadata_value_size` | Sets the maximum metadata value size considered by the plugin for selectors | 128 |
 
@@ -41,14 +42,23 @@ If `use_instance_metadata` is true, then the Google Compute Engine API is querie
 | -------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------|
 | `gcp_iit:tag`              | `gcp_iit:tag:blog-server`                                    | Instance tag (one selector per)
 | `gcp_iit:sa`               | `gcp_iit:sa:123456789-compute@developer.gserviceaccount.com` | Service account (one selector per) 
-| `gcp_iit:metadata`         | `gcp_iit:metadata:key:value`                                 | Instance metadata (see caveat below)
 | `gcp_iit:label`            | `gcp_iit:label:key:value`                                    | Instance label
+| `gcp_iit:metadata`         | `gcp_iit:metadata:key:value`                                 | Instance metadata (see caveat below)
 
-Instance metadata can hold large values up to 256KiB. Since not all metadata would be useful for node selection, and to prevent pushing potentially large amounts
-of data into the datastore, only metadata values with keys in the `allowed_metadata_keys` configurable are considered. Additionally, any metadata value larger than the
-`max_metadata_value_size` configurable is skipped.
+Not all instance label and metadata values are useful for node selection. To
+prevent the creation of large amounts of useless selectors, labels and metadata
+are not used by default. To opt-in to use a specific label or metadata value,
+specify the key in the `allowed_label_keys` or `allowed_metadata_keys`
+configurable.
 
-Metadata and label values are optional. If the value isn't present, the corresponding selector will still have a trailing colon (i.e. `gcp_iit:label:<key>:`, `gcp_iit:metadata:<key>:`)
+Instance metadata can hold large values up to 256KiB. To prevent pushing large amounts
+of data into the datastore, a maximum metadata value size limit is enforced. If
+an allowed (i.e. key specified in `allowed_metadata_keys`) metadata value is
+encountered that exceeds the limit then attestation will fail.
+
+Metadata and label values are optional. If the value isn't present, the
+corresponding selector will still have a trailing colon (i.e.
+`gcp_iit:label:<key>:`, `gcp_iit:metadata:<key>:`)
 
 ## Authenticating with the Google Compute Engine API
 


### PR DESCRIPTION
This PR enhances the GCP IIT node attestor to gather instance metadata and labels into selectors.

The plugin uses an opt-in strategy for metadata keys it will consider since metadata values can be quite large and not all metadata necessarily useful for node selection. Also, a configurable upper bound on metadata values is also enforced. Metadata that exceeds the limit is ignored.

All labels are added as selectors. 

Fixes #1001 