### PR TITLE
datastore/sql: Add config for sql connection pools

### DIFF
--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -2,16 +2,16 @@
 
 The `sql` plugin implements a sql based storage option for the SPIRE server using SQLite, PostgreSQL or MySQL databases.
 
-| Configuration     | Description                                                |
-| ------------------| ---------------------------------------------------------- |
-| database_type     | database type                                              |
-| connection_string | connection string                                          |
-| root_ca_path      | Path to Root CA bundle (MySQL only)                        |
-| client_cert_path  | Path to client certificate (MySQL only)                    |
-| client_key_path   | Path to private key for client certificate (MySQL only)    |
-| max_open_conns    | The maximum number of open db connections                  |
-| max_idle_conns    | The maximum number of idle connections in the pool        |
-| conn_max_lifetime | The maximum amount of time a connection may be reused     |
+| Configuration     | Description                                                                |
+| ------------------| -------------------------------------------------------------------------- |
+| database_type     | database type                                                              |
+| connection_string | connection string                                                          |
+| root_ca_path      | Path to Root CA bundle (MySQL only)                                        |
+| client_cert_path  | Path to client certificate (MySQL only)                                    |
+| client_key_path   | Path to private key for client certificate (MySQL only)                    |
+| max_open_conns    | The maximum number of open db connections (default: unlimited)             |
+| max_idle_conns    | The maximum number of idle connections in the pool (default: 2)            |
+| conn_max_lifetime | The maximum amount of time a connection may be reused (default: unlimited) |
 
 The plugin defaults to an in-memory database and any information in the data store is lost on restart.
 

--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -9,8 +9,14 @@ The `sql` plugin implements a sql based storage option for the SPIRE server usin
 | root_ca_path      | Path to Root CA bundle (MySQL only)                        |
 | client_cert_path  | Path to client certificate (MySQL only)                    |
 | client_key_path   | Path to private key for client certificate (MySQL only)    |
+| max_open_conns    | The maximum number of open db connections                  |
+| max_idle_conns    | The maximum number of idle connections in the pool        |
+| conn_max_lifetime | The maximum amount of time a connection may be reused     |
 
 The plugin defaults to an in-memory database and any information in the data store is lost on restart.
+
+For more information on the `max_open_conns`, `max_idle_conns`, and `conn_max_lifetime`, refer to the
+documentation for the Go [`database/sql`](https://golang.org/pkg/database/sql/#DB) package.
 
 ## Database configurations
 

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"context"
 	"crypto/x509"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -1666,4 +1667,81 @@ func (s *PluginSuite) setNodeSelectors(spiffeID string, selectors []*common.Sele
 	})
 	s.Require().NoError(err)
 	s.RequireProtoEqual(&datastore.SetNodeSelectorsResponse{}, resp)
+}
+
+func (s *PluginSuite) TestConfigure() {
+	tests := []struct {
+		desc               string
+		giveDBConfig       string
+		expectMaxOpenConns int
+		expectIdle         int
+	}{
+
+		{
+			desc:               "defaults",
+			expectMaxOpenConns: 0,
+			// defined in database/sql
+			expectIdle: 2,
+		},
+		{
+			desc: "zero values",
+			giveDBConfig: `
+			max_open_conns = 0
+			max_idle_conns = 0
+			`,
+			expectMaxOpenConns: 0,
+			expectIdle:         0,
+		},
+		{
+			desc: "custom values",
+			giveDBConfig: `
+			max_open_conns = 1000
+			max_idle_conns = 50
+			conn_max_lifetime = "1ms"
+			`,
+			expectMaxOpenConns: 1000,
+			expectIdle:         50,
+		},
+	}
+
+	for _, tt := range tests {
+		s.T().Run(tt.desc, func(t *testing.T) {
+			p := New()
+
+			var ds datastore.Plugin
+			s.LoadPlugin(builtin(p), &ds)
+
+			dbPath := filepath.Join(s.dir, "test-datastore-configure.sqlite3")
+
+			_, err := ds.Configure(context.Background(), &spi.ConfigureRequest{
+				Configuration: fmt.Sprintf(`
+				database_type = "sqlite3"
+				log_sql = true
+				connection_string = "%s"
+				%s
+		`, dbPath, tt.giveDBConfig),
+			})
+			s.Require().NoError(err)
+
+			db := p.db.DB.DB()
+
+			s.Require().Equal(tt.expectMaxOpenConns, db.Stats().MaxOpenConnections)
+
+			// begin many queries simultaneously
+			numQueries := 100
+			var rowsList []*sql.Rows
+			for i := 0; i < numQueries; i++ {
+				rows, err := db.Query("SELECT * FROM bundles")
+				s.Require().NoError(err)
+				rowsList = append(rowsList, rows)
+			}
+
+			// close all open queries, which results in idle connections
+			for _, rows := range rowsList {
+				s.Require().NoError(rows.Close())
+			}
+			s.Require().Equal(tt.expectIdle, db.Stats().Idle)
+		})
+	}
+
 }


### PR DESCRIPTION
Currently, the number of open connections to a database is
unbounded, as is the number of idle connections and the amount
of time a connection may be reused. These characteristics can
have an adverse effect on database performance.

This commit adds configuration to the datastore/sql plugin
so that users can tune common connection configuration to their
liking.

max_open_conns:
  - description: The maximum number of open db connections
  - default: 0 (unlimited)

max_idle_conns:
  - use: The maximum number of idle connections in the pool
  - default: 2

conn_max_lifetime:
  - use: The maximum amount of time a connection may be reused
  - default: 0 (unlimited)
