### PR TITLE
datastore/sql: Make database operations context-aware

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -485,9 +485,7 @@ func (ds *SQLPlugin) withTx(ctx context.Context, op func(tx *gorm.DB) error, rea
 		defer db.opMu.Unlock()
 	}
 
-	// TODO: as soon as GORM supports it, attach the context
-	// https://github.com/jinzhu/gorm/issues/1231
-	tx := db.Begin()
+	tx := db.BeginTx(ctx, nil /* opts *sql.TxOptions */)
 	if err := tx.Error; err != nil {
 		return sqlError.Wrap(err)
 	}


### PR DESCRIPTION
Support for BeginTx() with a context was added in gorm v1.9.9
with: https://github.com/jinzhu/gorm/pull/2227

Since go.mod already pins gorm v1.9.9, no dependency updates
are needed.
