### PR TITLE
Run `golangci-lint --enable-all --fix` to tidy up

### DIFF
--- a/api/workload/x509_client_test.go
+++ b/api/workload/x509_client_test.go
@@ -23,7 +23,7 @@ const (
 	// something is broken is through failure to receive on channels. Using the
 	// following timeout to prevent having to wait for the default go test
 	// timeout (10 minutes) if this happens. The timeout should be large enough
-	// by a comfortable margin to accomodate for slower running platforms, like
+	// by a comfortable margin to accommodate for slower running platforms, like
 	// Travis CI.
 	testTimeout = time.Minute
 )

--- a/cmd/spire-server/cli/agent/evict_test.go
+++ b/cmd/spire-server/cli/agent/evict_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/api/registration"
 
 	"github.com/golang/mock/gomock"
-	"github.com/spiffe/spire/test/mock/proto/api/registration"
+	mock_registration "github.com/spiffe/spire/test/mock/proto/api/registration"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/cmd/spire-server/cli/agent/list_test.go
+++ b/cmd/spire-server/cli/agent/list_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/spiffe/spire/proto/spire/api/registration"
 	"github.com/spiffe/spire/proto/spire/common"
-	"github.com/spiffe/spire/test/mock/proto/api/registration"
+	mock_registration "github.com/spiffe/spire/test/mock/proto/api/registration"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,7 +38,7 @@ func (s *ListTestSuite) TestRun() {
 	req := &registration.ListAgentsRequest{}
 	resp := &registration.ListAgentsResponse{
 		Nodes: []*common.AttestedNode{
-			&common.AttestedNode{SpiffeId: "spiffe://example.org/spire/agent/join_token/token_a"},
+			{SpiffeId: "spiffe://example.org/spire/agent/join_token/token_a"},
 		},
 	}
 	s.mockClient.EXPECT().ListAgents(gomock.Any(), req).Return(resp, nil)

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -233,7 +233,7 @@ func newServerConfig(c *config) (*server.Config, error) {
 
 	ip := net.ParseIP(c.Server.BindAddress)
 	if ip == nil {
-		return nil, fmt.Errorf("could not parse bind_adress %q", c.Server.BindAddress)
+		return nil, fmt.Errorf("could not parse bind_address %q", c.Server.BindAddress)
 	}
 	sc.BindAddress = &net.TCPAddr{
 		IP:   ip,

--- a/cmd/spire-server/cli/token/generate_test.go
+++ b/cmd/spire-server/cli/token/generate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/spiffe/spire/proto/spire/api/registration"
 	"github.com/spiffe/spire/proto/spire/common"
-	"github.com/spiffe/spire/test/mock/proto/api/registration"
+	mock_registration "github.com/spiffe/spire/test/mock/proto/api/registration"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"

--- a/functional/tools/stresstest/createusers.go
+++ b/functional/tools/stresstest/createusers.go
@@ -74,7 +74,7 @@ func (*CreateUsers) Run(args []string) int {
 			entry := &common.RegistrationEntry{
 				ParentId: parentID,
 				Selectors: []*common.Selector{
-					&common.Selector{
+					{
 						Type:  "unix",
 						Value: selectorValue,
 					},

--- a/pkg/agent/attestor/node/fake_node_api_test.go
+++ b/pkg/agent/attestor/node/fake_node_api_test.go
@@ -130,12 +130,12 @@ func (n *fakeNodeAPI) createAttestResponse(csr *x509.CertificateRequest, agentID
 
 	svidUpdate := &node.X509SVIDUpdate{
 		Svids: map[string]*node.X509SVID{
-			agentID: &node.X509SVID{
+			agentID: {
 				CertChain: certDER,
 			},
 		},
 		Bundles: map[string]*common.Bundle{
-			"spiffe://domain.test": &common.Bundle{
+			"spiffe://domain.test": {
 				TrustDomainId: "spiffe://domain.test",
 				RootCas: []*common.Certificate{
 					{DerBytes: n.c.CACert.Raw},

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -52,7 +52,7 @@ func TestFetchUpdates(t *testing.T) {
 func newTestFetchX509SVIDRequest() *node.FetchX509SVIDRequest {
 	return &node.FetchX509SVIDRequest{
 		Csrs: map[string][]byte{
-			"entry-id": []byte{1, 2, 3, 4}},
+			"entry-id": {1, 2, 3, 4}},
 	}
 }
 

--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -84,7 +84,7 @@ type X509SVID struct {
 // memory. For maximal safety, the objects should be cloned both coming in and
 // leaving the cache. However, during global updates (e.g. trust bundle is
 // updated for the agent trust domain) in particular, cloning all of the
-// revelant objects for each subscriber causes HUGE amounts of memory pressure
+// relevant objects for each subscriber causes HUGE amounts of memory pressure
 // which adds non-trivial amounts of latency and causes a giant memory spike
 // that could OOM the agent on smaller VMs. For this reason, the cache is
 // presumed to own ALL data passing in and out of the cache. Producers and

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -236,8 +236,8 @@ func (m *manager) storePrivateKey(ctx context.Context, key *ecdsa.PrivateKey) er
 		m.c.Log.WithError(err).Error("could not store new agent key pair")
 		m.c.Log.Warn("Error encountered while storing new agent key pair. Is your KeyManager plugin is up-to-date?")
 
-		// This error is not returned, to preserve backwards-compability with KeyManagers that were built against the old interface.
-		// If the StorePrivateKey() method isn't avaiable on the plugin, we get a "not implemented" error, which we
+		// This error is not returned, to preserve backwards-compatibility with KeyManagers that were built against the old interface.
+		// If the StorePrivateKey() method isn't available on the plugin, we get a "not implemented" error, which we
 		// should ignore for now, but log an error and warning.
 		// return fmt.Errorf("store key pair: %v", err)
 	}

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -121,7 +121,7 @@ func TestStoreBundleOnStartup(t *testing.T) {
 		t.Fatal("manager was expected to fail during initialization")
 	}
 
-	// Althought start failed, the Bundle should have been saved, because it should be
+	// Although start failed, the Bundle should have been saved, because it should be
 	// one of the first thing the manager does at initialization.
 	bundle, err := ReadBundle(c.BundleCachePath)
 	if err != nil {
@@ -170,7 +170,7 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 		t.Fatal("manager was expected to fail during initialization")
 	}
 
-	// Althought start failed, the SVID should have been saved, because it should be
+	// Although start failed, the SVID should have been saved, because it should be
 	// one of the first thing the manager does at initialization.
 	svid, err := ReadSVID(c.SVIDCachePath)
 	if err != nil {
@@ -225,7 +225,7 @@ func TestStoreKeyOnStartup(t *testing.T) {
 		t.Fatal("manager was expected to fail during initialization")
 	}
 
-	// Althought start failed, the SVID key should have been saved, because it should be
+	// Although start failed, the SVID key should have been saved, because it should be
 	// one of the first thing the manager does at initialization.
 	kresp, err = km.FetchPrivateKey(context.Background(), &keymanager.FetchPrivateKeyRequest{})
 	if err != nil {

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -289,10 +289,10 @@ func (s *K8sAttestorSuite) TestAttestReachingKubeletViaNodeName() {
 	`)
 	s.requireAttestSuccessWithPod()
 
-	// pick up the node name from the overriden env value
-	s.env["OVERRIDEN_NODE_NAME"] = "localhost"
+	// pick up the node name from the overridden env value
+	s.env["OVERRIDDEN_NODE_NAME"] = "localhost"
 	s.configureSecure(`
-		node_name_env = "OVERRIDEN_NODE_NAME"
+		node_name_env = "OVERRIDDEN_NODE_NAME"
 	`)
 	s.requireAttestSuccessWithPod()
 
@@ -438,7 +438,7 @@ func (s *K8sAttestorSuite) TestConfigure() {
 			err: "cannot use both the read-only and secure port",
 		},
 		{
-			name: "non-existant kubelet ca",
+			name: "non-existent kubelet ca",
 			hcl: `
 				kubelet_ca_path = "no-such-file"
 			`,
@@ -452,7 +452,7 @@ func (s *K8sAttestorSuite) TestConfigure() {
 			err: "unable to parse kubelet CA",
 		},
 		{
-			name: "non-existant token",
+			name: "non-existent token",
 			hcl: `
 				skip_kubelet_verification = true
 				token_path = "no-such-file"

--- a/pkg/common/catalog/internal/interfaces.go
+++ b/pkg/common/catalog/internal/interfaces.go
@@ -4,7 +4,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// PluginServer is the interface for both the primary interface and auxilliary
+// PluginServer is the interface for both the primary interface and auxiliary
 // services served by the plugin.
 type PluginServer interface {
 	// PluginType returns the plugin type
@@ -14,7 +14,7 @@ type PluginServer interface {
 	PluginClient() PluginClient
 
 	// Registers the implementation against the provided gRPC server and
-	// retuns the implementation. The implementation is used to wire up
+	// returns the implementation. The implementation is used to wire up
 	// logging and host services.
 	RegisterPluginServer(server *grpc.Server) interface{}
 }
@@ -27,7 +27,7 @@ type PluginClient interface {
 	NewPluginClient(*grpc.ClientConn) interface{}
 }
 
-// ServiceServer is the interface for both the primary interface and auxilliary
+// ServiceServer is the interface for both the primary interface and auxiliary
 // services served by the plugin.
 type ServiceServer interface {
 	// ServiceType returns the service type
@@ -37,7 +37,7 @@ type ServiceServer interface {
 	ServiceClient() ServiceClient
 
 	// Registers the implementation against the provided gRPC server and
-	// retuns the implementation. The implementation is used to wire up
+	// returns the implementation. The implementation is used to wire up
 	// logging and host services.
 	RegisterServiceServer(server *grpc.Server) interface{}
 }

--- a/pkg/common/jwtsvid/method.go
+++ b/pkg/common/jwtsvid/method.go
@@ -17,7 +17,7 @@ var (
 )
 
 // signingMethodECDSA is a copy of the implementation of the JWT package
-// modified to accomodate both an *ecdsa.PrivateKey and a crypto.Signer based
+// modified to accommodate both an *ecdsa.PrivateKey and a crypto.Signer based
 // key. It can be thrown away as soon as
 // https://github.com/dgrijalva/jwt-go/pull/236 is merged.
 type signingMethodECDSA struct {

--- a/pkg/common/peertracker/tracker_bsd.go
+++ b/pkg/common/peertracker/tracker_bsd.go
@@ -186,7 +186,7 @@ func (b *bsdWatcher) IsAlive() error {
 	// system for exit detection. Delays can be incurred on either side: in our
 	// kevent consumer or in the kernel. Typically, IsAlive() is called following
 	// workload attestation which can take hundreds of milliseconds, so in practice
-	// we will probably have been notified of an exit by now if it occured prior to
+	// we will probably have been notified of an exit by now if it occurred prior to
 	// or during the attestation process.
 	//
 	// As an extra safety precaution, artificially delay our answer to IsAlive() in

--- a/pkg/common/plugin/sshpop/sshpop.go
+++ b/pkg/common/plugin/sshpop/sshpop.go
@@ -1,4 +1,4 @@
-// Package sshpop implements ssh proof of posession based node attestation.
+// Package sshpop implements ssh proof of possession based node attestation.
 package sshpop
 
 import (

--- a/pkg/common/telemetry/dogstatsd_test.go
+++ b/pkg/common/telemetry/dogstatsd_test.go
@@ -60,7 +60,7 @@ func testDogStatsdConfig() *MetricsConfig {
 		ServiceName: "foo",
 		FileConfig: FileConfig{
 			DogStatsd: []DogStatsdConfig{
-				DogStatsdConfig{
+				{
 					Address: "localhost:8125",
 				},
 			},

--- a/pkg/common/telemetry/statsd_test.go
+++ b/pkg/common/telemetry/statsd_test.go
@@ -60,7 +60,7 @@ func testStatsdConfig() *MetricsConfig {
 		ServiceName: "foo",
 		FileConfig: FileConfig{
 			Statsd: []StatsdConfig{
-				StatsdConfig{
+				{
 					Address: "localhost:8125",
 				},
 			},

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// attemptsPerRefreshHint is the number of attemps within the returned
+	// attemptsPerRefreshHint is the number of attempts within the returned
 	// refresh hint period that the manager will attempt to refresh the
 	// bundle. It is important to try more than once within a refresh hint
 	// period so we can be resilient to temporary downtime or failures.

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -229,7 +229,7 @@ func (ca *CA) signX509SVID(ctx context.Context, params X509SVIDParams, x509CA *X
 	if err != nil {
 		return nil, err
 	}
-	// Explicity set the AKI on the signed certificate, otherwise it won't be
+	// Explicitly set the AKI on the signed certificate, otherwise it won't be
 	// added if the subject and issuer match name match (however unlikely).
 	template.AuthorityKeyId = x509CA.Certificate.SubjectKeyId
 
@@ -283,7 +283,7 @@ func (ca *CA) SignX509CASVID(ctx context.Context, params X509CASVIDParams) ([]*x
 	if err != nil {
 		return nil, err
 	}
-	// Explicity set the AKI on the signed certificate, otherwise it won't be
+	// Explicitly set the AKI on the signed certificate, otherwise it won't be
 	// added if the subject and issuer match name matches (unlikely due to the
 	// OU override below, but just to be safe).
 	template.AuthorityKeyId = x509CA.Certificate.SubjectKeyId

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -374,7 +374,7 @@ func (s *CATestSuite) createCACertificate(cn string, parent *x509.Certificate) *
 		Subject: pkix.Name{
 			CommonName: cn,
 		},
-		IsCA: true,
+		IsCA:                  true,
 		BasicConstraintsValid: true,
 		NotAfter:              s.clock.Now().Add(10 * time.Minute),
 		SubjectKeyId:          keyID,

--- a/pkg/server/endpoints/bundle/server.go
+++ b/pkg/server/endpoints/bundle/server.go
@@ -57,7 +57,7 @@ func NewServer(config ServerConfig) *Server {
 }
 
 func (s *Server) Run(ctx context.Context) error {
-	// create the listener explicity instead of using ListenAndServeTLS since
+	// create the listener explicitly instead of using ListenAndServeTLS since
 	// it gives us the ability to use/inspect an ephemeral port during testing.
 	listener, err := s.c.listen("tcp", s.c.Address)
 	if err != nil {

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -565,7 +565,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithCurrentAndLegacyCSRs() {
 
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		Csrs:           map[string][]byte{"an-entry-id": []byte("MALFORMED")},
-		DEPRECATEDCsrs: [][]byte{[]byte{1, 2, 3}},
+		DEPRECATEDCsrs: [][]byte{{1, 2, 3}},
 	}, codes.InvalidArgument, "cannot use 'Csrs' and 'DeprecatedCsrs' on the same 'FetchX509Request'")
 }
 
@@ -581,7 +581,7 @@ func (s *HandlerSuite) TestFetchX509SVIDLimits() {
 	// Test with 5 CSRs (5 count should be added)
 	s.limiter.setNextError(errors.New("limit exceeded"))
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{Csrs: map[string][]byte{
-		"foo": []byte{1}, "bar": []byte{2}, "boo": []byte{3}, "far": []byte{4}, "bor": []byte{5}},
+		"foo": {1}, "bar": {2}, "boo": {3}, "far": {4}, "bor": {5}},
 	}, codes.ResourceExhausted, "limit exceeded")
 	s.Equal(5, s.limiter.callsFor(CSRMsg))
 }

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -134,7 +134,7 @@ func (s *PluginSuite) TestInvalidMySQLConfiguration() {
 func (s *PluginSuite) TestBundleCRUD() {
 	bundle := bundleutil.BundleProtoFromRootCA("spiffe://foo", s.cert)
 
-	// fetch non-existant
+	// fetch non-existent
 	expectedCallCounter := ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	expectedCallCounter.AddLabel(telemetry.Bundle, "spiffe://foo")
 	fresp, err := s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{TrustDomainId: "spiffe://foo"})
@@ -143,7 +143,7 @@ func (s *PluginSuite) TestBundleCRUD() {
 	s.Require().NotNil(fresp)
 	s.Require().Nil(fresp.Bundle)
 
-	// update non-existant
+	// update non-existent
 	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	expectedCallCounter.AddLabel(telemetry.Bundle, bundle.TrustDomainId)
 	_, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{Bundle: bundle})
@@ -151,7 +151,7 @@ func (s *PluginSuite) TestBundleCRUD() {
 	expectedCallCounter.Done(&expectedErr)
 	s.RequireGRPCStatus(err, codes.NotFound, expectedErr.Error())
 
-	// delete non-existant
+	// delete non-existent
 	expectedCallCounter = ds_telemetry.StartDeleteBundleCall(s.expectedMetrics)
 	expectedCallCounter.AddLabel(telemetry.Bundle, "spiffe://foo")
 	_, err = s.ds.DeleteBundle(ctx, &datastore.DeleteBundleRequest{TrustDomainId: "spiffe://foo"})

--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -37,7 +37,7 @@ func embellishSQLite3ConnString(connectionString string) (string, error) {
 	switch {
 	case u.Scheme == "":
 		// connection string is a path. move the path section into the
-		// opaque section so it renders propertly for sqlite3, for example:
+		// opaque section so it renders property for sqlite3, for example:
 		// data.db = file:data.db
 		// ./data.db = file:./data.db
 		// /data.db = file:/data.db

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -467,11 +467,11 @@ func (s *IIDAttestorSuite) configure() {
 func getDefaultDescribeInstancesOutput() ec2.DescribeInstancesOutput {
 	return ec2.DescribeInstancesOutput{
 		Reservations: []*ec2.Reservation{
-			&ec2.Reservation{
+			{
 				Instances: []*ec2.Instance{
-					&ec2.Instance{
+					{
 						NetworkInterfaces: []*ec2.InstanceNetworkInterface{
-							&ec2.InstanceNetworkInterface{
+							{
 								Attachment: &ec2.InstanceNetworkInterfaceAttachment{},
 							},
 						},

--- a/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
@@ -44,7 +44,7 @@ type AttestorConfig struct {
 // ClusterConfig holds a single cluster configuration
 type ClusterConfig struct {
 	// Array of whitelisted service accounts names
-	// Attestation is denied if comming from a service account that is not in the list
+	// Attestation is denied if coming from a service account that is not in the list
 	ServiceAccountWhitelist []string `hcl:"service_account_whitelist"`
 
 	// Audience for PSAT token validation

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -101,7 +101,7 @@ func (m *Mock) WaitForSleep(timeout time.Duration, format string, args ...interf
 	}
 }
 
-// Timer creates a new Timer containing a channel taht will send the time with a period specified by the duration argument.
+// Timer creates a new Timer containing a channel that will send the time with a period specified by the duration argument.
 func (m *Mock) Timer(d time.Duration) *clock.Timer {
 	c := m.Mock.Timer(d)
 	select {

--- a/test/fixture/nodeattestor/x509pop/generate.go
+++ b/test/fixture/nodeattestor/x509pop/generate.go
@@ -27,8 +27,8 @@ func main() {
 	rootCert := createRootCertificate(rootKey, &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		BasicConstraintsValid: true,
-		IsCA:     true,
-		NotAfter: neverExpires,
+		IsCA:                  true,
+		NotAfter:              neverExpires,
 	})
 
 	intermediateKey := generateRSAKey()
@@ -36,8 +36,8 @@ func main() {
 	intermediateCert := createCertificate(intermediateKey, &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		BasicConstraintsValid: true,
-		IsCA:     true,
-		NotAfter: neverExpires,
+		IsCA:                  true,
+		NotAfter:              neverExpires,
 	}, rootKey, rootCert)
 
 	leafKey := generateRSAKey()


### PR DESCRIPTION
This fixes a number of small issues, around spelling, codestyle, and
formatting.

No functionality should be affected.  There's one case where an environment variable name is changed to be spelled properly, but I don't see any use of it in this repo or docs, so I think it's just for manual testing.

