### PR TITLE
add error class metrics to agent workload API

### DIFF
--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -160,6 +160,7 @@ func (s *HandlerTestSuite) TestSendX509Response() {
 	labels := []telemetry.Label{
 		{Name: telemetry.SVIDType, Value: telemetry.X509},
 		{Name: telemetry.Registered, Value: "false"},
+		{Name: telemetry.Error, Value: codes.PermissionDenied.String()},
 	}
 	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.Error}, float32(1), labels)
 	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchX509SVID, telemetry.Error, telemetry.ElapsedTime}, gomock.Any(), labels)
@@ -243,6 +244,7 @@ func (s *HandlerTestSuite) TestFetchJWTSVID() {
 	labels := []telemetry.Label{
 		{Name: telemetry.SVIDType, Value: telemetry.JWT},
 		{Name: telemetry.Registered, Value: "false"},
+		{Name: telemetry.Error, Value: codes.PermissionDenied.String()},
 	}
 	setupMetricsCommonExpectations(s.metrics, len(selectors))
 	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTSVID, telemetry.Error}, float32(1), labels)
@@ -402,6 +404,12 @@ func (s *HandlerTestSuite) TestFetchJWTBundles() {
 	setupMetricsCommonExpectations(s.metrics, len(selectors))
 	s.metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, float32(1))
 	s.metrics.EXPECT().IncrCounter([]string{telemetry.WorkloadAPI, telemetry.BundlesUpdate, telemetry.JWT}, float32(1))
+	s.metrics.EXPECT().IncrCounterWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles}, gomock.Any(), []telemetry.Label{
+		{Name: telemetry.SVIDType, Value: telemetry.JWT},
+	})
+	s.metrics.EXPECT().MeasureSinceWithLabels([]string{telemetry.WorkloadAPI, telemetry.FetchJWTBundles, telemetry.ElapsedTime}, gomock.Any(), []telemetry.Label{
+		{Name: telemetry.SVIDType, Value: telemetry.JWT},
+	})
 	s.metrics.EXPECT().MeasureSince([]string{telemetry.WorkloadAPI, telemetry.SendJWTBundleLatency}, gomock.Any())
 
 	go func() { result <- s.h.FetchJWTBundles(&workload.JWTBundlesRequest{}, stream) }()

--- a/pkg/common/telemetry/agent/workloadapi/workload.go
+++ b/pkg/common/telemetry/agent/workloadapi/workload.go
@@ -9,7 +9,7 @@ import (
 // Call Counters (timing and success metrics)
 // Allows adding labels in-code
 
-// StartAttestorCall return metric
+// StartAttestorLatencyCall return metric
 // for agent's Workload API Attestor latency for a specific attestor
 func StartAttestorLatencyCall(m telemetry.Metrics, aType string) *telemetry.CallCounter {
 	cc := telemetry.StartCall(m, telemetry.WorkloadAPI, telemetry.WorkloadAttestorLatency)
@@ -21,6 +21,14 @@ func StartAttestorLatencyCall(m telemetry.Metrics, aType string) *telemetry.Call
 // for agent's Workload API, on fetching the workload's JWT SVID
 func StartFetchJWTSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
 	cc := telemetry.StartCall(m, telemetry.WorkloadAPI, telemetry.FetchJWTSVID)
+	cc.AddLabel(telemetry.SVIDType, telemetry.JWT)
+	return cc
+}
+
+// StartFetchJWTBundlesCall return metric
+// for agent's Workload API, on fetching the workload's JWT Bundles
+func StartFetchJWTBundlesCall(m telemetry.Metrics) *telemetry.CallCounter {
+	cc := telemetry.StartCall(m, telemetry.WorkloadAPI, telemetry.FetchJWTBundles)
 	cc.AddLabel(telemetry.SVIDType, telemetry.JWT)
 	return cc
 }


### PR DESCRIPTION
Signed-off-by: Andrew Moore <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Agent workload API metrics.

**Description of change**
Add error classes to agent workload API metrics. Add `FetchJWTBundles` call counter metric.

