### PR TITLE
[datastore/sql] Close DB after each test

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -583,6 +583,12 @@ func (ds *SQLPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (
 	return &spi.ConfigureResponse{}, nil
 }
 
+func (p *SQLPlugin) closeDB() {
+	if p.db != nil {
+		p.db.Close()
+	}
+}
+
 // GetPluginInfo returns the sql plugin
 func (*SQLPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &pluginInfo, nil

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -69,7 +69,7 @@ func (s *PluginSuite) SetupTest() {
 	s.ds = s.newPlugin()
 }
 
-func (s *PluginSuite) AfterTest(_, testName string) {
+func (s *PluginSuite) TearDownTest() {
 	s.sqlPlugin.closeDB()
 }
 

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -45,9 +45,10 @@ type PluginSuite struct {
 	cert   *x509.Certificate
 	cacert *x509.Certificate
 
-	dir    string
-	nextID int
-	ds     datastore.Plugin
+	dir       string
+	nextID    int
+	ds        datastore.Plugin
+	sqlPlugin *SQLPlugin
 
 	m               *fakemetrics.FakeMetrics
 	expectedMetrics *fakepluginmetrics.FakePluginMetrics
@@ -60,6 +61,7 @@ func (s *PluginSuite) SetupSuite() {
 
 	s.cacert, _, err = testutil.LoadCAFixture()
 	s.Require().NoError(err)
+
 }
 
 func (s *PluginSuite) SetupTest() {
@@ -67,8 +69,13 @@ func (s *PluginSuite) SetupTest() {
 	s.ds = s.newPlugin()
 }
 
+func (s *PluginSuite) AfterTest(_, testName string) {
+	s.sqlPlugin.closeDB()
+}
+
 func (s *PluginSuite) newPlugin() datastore.Plugin {
 	p := New()
+	s.sqlPlugin = p
 
 	var ds datastore.Plugin
 

--- a/test/util/race.go
+++ b/test/util/race.go
@@ -18,14 +18,19 @@ func init() {
 }
 
 func RaceTest(t *testing.T, fn func(*testing.T)) {
-	for i := 0; i < raceTestNumThreads; i++ {
-		t.Run(fmt.Sprintf("thread %v", i), func(t *testing.T) {
-			t.Parallel()
-			for i := 0; i < raceTestNumLoops; i++ {
-				fn(t)
-			}
-		})
-	}
+	// wrap in a top level group to ensure all subtests
+	// complete before this method returns. All subtests
+	// will be run in parallel
+	t.Run("group", func(t *testing.T) {
+		for i := 0; i < raceTestNumThreads; i++ {
+			t.Run(fmt.Sprintf("thread %v", i), func(t *testing.T) {
+				t.Parallel()
+				for i := 0; i < raceTestNumLoops; i++ {
+					fn(t)
+				}
+			})
+		}
+	})
 }
 
 func getEnvInt(name string, fallback int) int {


### PR DESCRIPTION
On OSX the datastore/sql suite now fails as it has too
many files open. This change ensures that the open DB
files are closed after each test.