### PR TITLE
[datastore/sql] modify fixtures

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -23,6 +23,7 @@ import (
 	proto_services "github.com/spiffe/spire/proto/spire/common/hostservices"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/proto/spire/server/datastore"
+	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakemetrics"
 	"github.com/spiffe/spire/test/fakes/fakepluginmetrics"
 	"github.com/spiffe/spire/test/spiretest"
@@ -33,6 +34,13 @@ import (
 
 var (
 	ctx = context.Background()
+)
+
+const (
+	_ttl                   = time.Duration(time.Hour)
+	_expiredNotAfterString = "2018-01-10T01:34:00+00:00"
+	_validNotAfterString   = "2018-01-10T01:36:00+00:00"
+	_middleTimeString      = "2018-01-10T01:35:00+00:00"
 )
 
 func TestPlugin(t *testing.T) {
@@ -55,13 +63,33 @@ type PluginSuite struct {
 }
 
 func (s *PluginSuite) SetupSuite() {
-	var err error
-	s.cert, _, err = testutil.LoadSVIDFixture()
+	clk := clock.New()
+
+	expiredNotAfterTime, err := time.Parse(time.RFC3339, _expiredNotAfterString)
+	s.Require().NoError(err)
+	validNotAfterTime, err := time.Parse(time.RFC3339, _validNotAfterString)
 	s.Require().NoError(err)
 
-	s.cacert, _, err = testutil.LoadCAFixture()
+	caTemplate, err := testutil.NewCATemplate(clk, "foo")
 	s.Require().NoError(err)
 
+	caTemplate.NotAfter = expiredNotAfterTime
+	caTemplate.NotBefore = expiredNotAfterTime.Add(-_ttl)
+
+	cacert, cakey, err := testutil.SelfSign(caTemplate)
+	s.Require().NoError(err)
+
+	svidTemplate, err := testutil.NewSVIDTemplate(clk, "spiffe://foo/id1")
+	s.Require().NoError(err)
+
+	svidTemplate.NotAfter = validNotAfterTime
+	svidTemplate.NotBefore = validNotAfterTime.Add(-_ttl)
+
+	cert, _, err := testutil.Sign(svidTemplate, cacert, cakey)
+	s.Require().NoError(err)
+
+	s.cacert = cacert
+	s.cert = cert
 }
 
 func (s *PluginSuite) SetupTest() {
@@ -304,14 +332,14 @@ func (s *PluginSuite) TestBundlePrune() {
 	bundle := bundleutil.BundleProtoFromRootCAs("spiffe://foo", []*x509.Certificate{s.cert, s.cacert})
 
 	// Add two JWT signing keys (one valid and one expired)
-	expiredKeyTime, err := time.Parse(time.RFC3339, "2018-01-10T01:35:00+00:00")
+	expiredKeyTime, err := time.Parse(time.RFC3339, _expiredNotAfterString)
 	s.Require().NoError(err)
 
-	nonExpiredKeyTime, err := time.Parse(time.RFC3339, "2018-03-10T01:35:00+00:00")
+	nonExpiredKeyTime, err := time.Parse(time.RFC3339, _validNotAfterString)
 	s.Require().NoError(err)
 
 	// middleTime is a point between the two certs expiration time
-	middleTime, err := time.Parse(time.RFC3339, "2018-02-10T01:35:00+00:00")
+	middleTime, err := time.Parse(time.RFC3339, _middleTimeString)
 	s.Require().NoError(err)
 
 	bundle.JwtSigningKeys = []*common.PublicKey{
@@ -1254,7 +1282,8 @@ func (s *PluginSuite) TestDeleteRegistrationEntry() {
 }
 
 func (s *PluginSuite) TestListParentIDEntries() {
-	allEntries := testutil.GetRegistrationEntries("entries.json")
+	allEntries := make([]*common.RegistrationEntry, 0)
+	s.getTestDataFromJSONFile(filepath.Join("testdata", "entries.json"), &allEntries)
 	tests := []struct {
 		name                string
 		registrationEntries []*common.RegistrationEntry
@@ -1290,14 +1319,15 @@ func (s *PluginSuite) TestListParentIDEntries() {
 					Value: test.parentID,
 				},
 			})
-			s.Require().NoError(err)
-			s.RequireProtoListEqual(test.expectedList, result.Entries)
+			require.NoError(t, err)
+			spiretest.RequireProtoListEqual(t, test.expectedList, result.Entries)
 		})
 	}
 }
 
 func (s *PluginSuite) TestListSelectorEntries() {
-	allEntries := testutil.GetRegistrationEntries("entries.json")
+	allEntries := make([]*common.RegistrationEntry, 0)
+	s.getTestDataFromJSONFile(filepath.Join("testdata", "entries.json"), &allEntries)
 	tests := []struct {
 		name                string
 		registrationEntries []*common.RegistrationEntry
@@ -1345,7 +1375,8 @@ func (s *PluginSuite) TestListSelectorEntries() {
 }
 
 func (s *PluginSuite) TestListMatchingEntries() {
-	allEntries := testutil.GetRegistrationEntries("entries.json")
+	allEntries := make([]*common.RegistrationEntry, 0)
+	s.getTestDataFromJSONFile(filepath.Join("testdata", "entries.json"), &allEntries)
 	tests := []struct {
 		name                string
 		registrationEntries []*common.RegistrationEntry
@@ -1380,7 +1411,6 @@ func (s *PluginSuite) TestListMatchingEntries() {
 			ds := s.newPlugin()
 			for _, entry := range test.registrationEntries {
 				r, err := ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{Entry: entry})
-				s.Require().NoError(err)
 				require.NoError(t, err)
 				require.NotNil(t, r)
 				require.NotNil(t, r.Entry)
@@ -1392,7 +1422,7 @@ func (s *PluginSuite) TestListMatchingEntries() {
 					Match:     datastore.BySelectors_MATCH_SUBSET,
 				},
 			})
-			s.Require().NoError(err)
+			require.NoError(t, err)
 			util.SortRegistrationEntries(test.expectedList)
 			util.SortRegistrationEntries(result.Entries)
 			s.RequireProtoListEqual(test.expectedList, result.Entries)
@@ -1843,10 +1873,10 @@ func (s *PluginSuite) TestBindVar() {
 }
 
 func (s *PluginSuite) getTestDataFromJSONFile(filePath string, jsonValue interface{}) {
-	invalidRegistrationEntriesJSON, err := ioutil.ReadFile(filePath)
+	entriesJSON, err := ioutil.ReadFile(filePath)
 	s.Require().NoError(err)
 
-	err = json.Unmarshal(invalidRegistrationEntriesJSON, &jsonValue)
+	err = json.Unmarshal(entriesJSON, &jsonValue)
 	s.Require().NoError(err)
 }
 

--- a/pkg/server/plugin/datastore/sql/testdata/entries.json
+++ b/pkg/server/plugin/datastore/sql/testdata/entries.json
@@ -1,0 +1,94 @@
+[
+    {
+        "selectors": [
+            {
+                "type": "a",
+                "value": "1"
+            },
+            {
+                "type": "b",
+                "value": "2"
+            },
+            {
+                "type": "c",
+                "value": "3"
+            }
+        ],
+        "spiffe_id": "spiffe://id1",
+        "parent_id": "spiffe://parent",
+        "ttl": 200,
+        "federates_with": ["spiffe://otherdomain.org"]
+    },
+    {
+        "selectors": [
+            {
+                "type": "a",
+                "value": "1"
+            },
+            {
+                "type": "b",
+                "value": "2"
+            }
+        ],
+        "spiffe_id": "spiffe://id2",
+        "parent_id": "spiffe://parent",
+        "ttl": 200
+    },
+    {
+        "selectors": [
+            {
+                "type": "b",
+                "value": "2"
+            },
+            {
+                "type": "c",
+                "value": "3"
+            }
+        ],
+        "spiffe_id": "spiffe://id3",
+        "parent_id": "spiffe://parent2",
+        "ttl": 200
+    },
+    {
+        "selectors": [
+            {
+                "type": "a",
+                "value": "1"
+            },
+            {
+                "type": "b",
+                "value": "2"
+            },
+            {
+                "type": "c",
+                "value": "3"
+            },
+            {
+                "type": "d",
+                "value": "4"
+            }
+        ],
+        "spiffe_id": "spiffe://id4",
+        "parent_id": "spiffe://parent2",
+        "ttl": 200
+    },
+    {
+        "selectors": [
+            {
+                "type": "b",
+                "value": "2"
+            },
+            {
+                "type": "c",
+                "value": "3"
+            },
+            {
+                "type": "d",
+                "value": "4"
+            }
+        ],
+        "spiffe_id": "spiffe://id5",
+        "parent_id": "spiffe://parent2",
+        "ttl": 200
+    }
+]

--- a/pkg/server/plugin/datastore/sql/testdata/entries.json
+++ b/pkg/server/plugin/datastore/sql/testdata/entries.json
@@ -16,8 +16,7 @@
         ],
         "spiffe_id": "spiffe://id1",
         "parent_id": "spiffe://parent",
-        "ttl": 200,
-        "federates_with": ["spiffe://otherdomain.org"]
+        "ttl": 200
     },
     {
         "selectors": [


### PR DESCRIPTION
This removes a dependency on fixtures read relative to the "project root"
and either creates the data in memory, or depends on a local testdata directory

Signed-off-by: Tyler Dixon <tylerd@uber.com>


