### PR TITLE
[spire-server] use DefaultServeMux for profiling

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/http/pprof"
+	_ "net/http/pprof" // import registers routes on DefaultServeMux
 	"net/url"
 	"os"
 	"runtime"
@@ -258,7 +258,7 @@ func (s *Server) setupProfiling(ctx context.Context) (stop func()) {
 
 		server := http.Server{
 			Addr:    fmt.Sprintf("localhost:%d", s.config.ProfilingPort),
-			Handler: http.HandlerFunc(pprof.Index),
+			Handler: http.DefaultServeMux,
 		}
 
 		// kick off a goroutine to serve the pprof endpoints and one to


### PR DESCRIPTION
`net/http/pprof.Index` only supports named profiles, which does not
include `profile`. https://golang.org/src/net/http/pprof/pprof.go#L229

However, as an import side effect, `net/http/pprof` does register
[Profile](https://golang.org/src/net/http/pprof/pprof.go#L116) on
`net/http.DefaultServerMux`. This is the handler that `go tool pprof`
uses so ensure it is supported is pretty important.
