### PR TITLE
[spire-agent] use roundrobin grpc balancer

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -214,7 +214,8 @@ func newAgentConfig(c *config) (*agent.Config, error) {
 		return nil, err
 	}
 
-	ac.ServerAddress = net.JoinHostPort(c.Agent.ServerAddress, strconv.Itoa(c.Agent.ServerPort))
+	serverHostPort := net.JoinHostPort(c.Agent.ServerAddress, strconv.Itoa(c.Agent.ServerPort))
+	ac.ServerAddress = fmt.Sprintf("dns:///%s", serverHostPort)
 
 	td, err := idutil.ParseSpiffeID("spiffe://"+c.Agent.TrustDomain, idutil.AllowAnyTrustDomain())
 	if err != nil {

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -513,7 +513,7 @@ func TestNewAgentConfig(t *testing.T) {
 				c.Agent.ServerPort = 1337
 			},
 			test: func(t *testing.T, c *agent.Config) {
-				require.Equal(t, "192.168.1.1:1337", c.ServerAddress)
+				require.Equal(t, "dns:///192.168.1.1:1337", c.ServerAddress)
 			},
 		},
 		{

--- a/pkg/agent/client/dial.go
+++ b/pkg/agent/client/dial.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spiffe/go-spiffe/spiffe"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/roundrobin"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -65,6 +66,7 @@ func DialServer(ctx context.Context, config DialServerConfig) (*grpc.ClientConn,
 	}
 
 	return grpc.DialContext(ctx, config.Address,
+		grpc.WithBalancerName(roundrobin.Name),
 		grpc.FailOnNonTempDialError(true),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
 	)


### PR DESCRIPTION
This change will ensure that agent->server communication
using the roundrobin grpc balancer. If the server address
resolves to more than one record this will ensure that
each agent will balance its traffic across all available
servers. If the server address resolves to a single record
the agent will continue sending all traffic to that server.

We need to force the grpc target to have a resolver scheme
since passthrough (the default resolver) doesn't seem to use
anything other than pick_first.