### PR TITLE
Updating telemetry plugin config examples

### DIFF
--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -84,17 +84,14 @@ telemetry {
                 port = 9988
         }
 
-        DogStatsd {
-                address = "localhost:8125"
-        }
+        DogStatsd = [
+            { address = "localhost:8125" },
+        ]
 
-        Statsd {
-                address = "localhost:1337"
-        }
-
-        Statsd {
-                address = "collector.example.org:8125"
-        }
+        Statsd = [
+            { address = "localhost:1337" },
+            { address = "collector.example.org:8125" },
+        ]
 }
 ```
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -98,17 +98,14 @@ telemetry {
                 port = 9988
         }
 
-        DogStatsd {
-                address = "localhost:8125"
-        }
+        DogStatsd = [
+            { address = "localhost:8125" },
+        ]
 
-        Statsd {
-                address = "localhost:1337"
-        }
-
-        Statsd {
-                address = "collector.example.org:8125"
-        }
+        Statsd = [
+            { address = "localhost:1337" },
+            { address = "collector.example.org:8125" },
+        ]
 }
 ```
 


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
None

**Description of change**
The syntax in the existing examples for statsd and dogstatsd config
is not valid if additional properties are added to the config objects.
The hcl unmarshaller will ignore all but the first property for an array
of objects when they are specified as follows:

```
telemetry {
    Statsd {
        address = "localhost:1337"
        new_property = "foo"
    }
    Statsd {
        address = "collector.example.org:8125"
        new_property = "bar"
    }
}
```

In the above example, "new_property" will be silently ignored by the hcl
parser and the corresponding values in the Go config objects will be empty.

The proper way to specify an array of objects in hcl appears to be as follows:

```
telemetry {
    Statsd = [
        { address = "localhost:1337" new_property = "foo" },
        { address = "collector.example.org:8125" new_property = "bar" },
    ]
}
```

This limitation of the array syntax definition is unfortunately not very clearly documented anywhere, and there is an open issue on the GitHub page requesting clarification of this syntax:
https://github.com/hashicorp/hcl/issues/276

Updating the documentation to be more future-proof in case new properties are added to statsd and dogstatsd plugin configuration.

Signed-off-by: Ryan Turner <turner@uber.com>

