### PR TITLE
Add support for fetching tags in AWS node attestor plugin

### DIFF
--- a/pkg/common/plugin/aws/iid.go
+++ b/pkg/common/plugin/aws/iid.go
@@ -29,6 +29,7 @@ type agentPathTemplateData struct {
 	InstanceIdentityDocument
 	PluginName  string
 	TrustDomain string
+	Tags        InstanceTags
 }
 
 // SessionConfig is a common config for AWS session config.
@@ -50,17 +51,20 @@ type IIDAttestationData struct {
 	Signature string `json:"signature"`
 }
 
+type InstanceTags map[string]string
+
 // AttestationStepError error with attestation
 func AttestationStepError(step string, cause error) error {
 	return fmt.Errorf("Attempted AWS IID attestation but an error occurred %s: %s", step, cause)
 }
 
 // MakeSpiffeID create spiffe ID from IID data
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc InstanceIdentityDocument) (*url.URL, error) {
+func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc InstanceIdentityDocument, tags InstanceTags) (*url.URL, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
 		InstanceIdentityDocument: doc,
 		PluginName:               PluginName,
+		Tags:                     tags,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
🚧 WORK IN PROGRESS🚧

This diff adds the ability to [ unconditionally ] fetch Instance Tags
from the EC2 api to e.g. fetch more metadata about the instance that
might be needed for selectors or further attestation.

**Pull Request check list**

- [✅ ] Commit conforms to CONTRIBUTING.md?
- [ 🚧] Proper tests/regressions included?
- [ 🚧] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->