### PR TITLE
Fix k8s test tool flags

### DIFF
--- a/tools/k8s-test/attestation.go
+++ b/tools/k8s-test/attestation.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	reSignedX509 = regexp.MustCompile(`\"Signed X509 SVID\"\s.+spiffe_id=\"(spiffe://[^/]+/spire/agent/[^"]+)\"`)
+	reSignedX509 = regexp.MustCompile(`\"Signed [xX]509 SVID.*\".*(spiffe://[^/]+/spire/agent/[^"]+)\"`)
 )
 
 func WaitForNodeAttestation(ctx context.Context, server Object, count int) error {

--- a/tools/k8s-test/main.go
+++ b/tools/k8s-test/main.go
@@ -74,7 +74,7 @@ func main() {
 			runCmd(WaitForDeploymentCmd(ctx, args[0], interval))
 		},
 	}
-	waitDeploymentCmd.LocalFlags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for deployment status")
+	waitDeploymentCmd.Flags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for deployment status")
 	waitCmd.AddCommand(waitDeploymentCmd)
 
 	waitDaemonSetCmd := &cobra.Command{
@@ -86,7 +86,7 @@ func main() {
 			runCmd(WaitForDaemonSetCmd(ctx, args[0], interval))
 		},
 	}
-	waitDaemonSetCmd.LocalFlags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for daemon set status")
+	waitDaemonSetCmd.Flags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for daemon set status")
 	waitCmd.AddCommand(waitDaemonSetCmd)
 
 	waitNodeAttestationCmd := &cobra.Command{
@@ -98,7 +98,7 @@ func main() {
 			runCmd(WaitForNodeAttestationCmd(ctx, args[0], count))
 		},
 	}
-	waitNodeAttestationCmd.LocalFlags().IntVarP(&count, "count", "c", 1, "number of nodes expected to attest")
+	waitNodeAttestationCmd.Flags().IntVarP(&count, "count", "c", 1, "number of nodes expected to attest")
 	waitCmd.AddCommand(waitNodeAttestationCmd)
 
 	applyCmd := &cobra.Command{
@@ -108,9 +108,9 @@ func main() {
 			runCmd(ApplyConfigCmd(ctx, args, !noWait, !noLocal, interval))
 		},
 	}
-	applyCmd.LocalFlags().BoolVarP(&noWait, "no-wait", "", false, "don't wait for all objects after applying")
-	applyCmd.LocalFlags().BoolVarP(&noLocal, "no-local", "", false, "don't use locally built SPIRE images")
-	applyCmd.LocalFlags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for object status")
+	applyCmd.Flags().BoolVarP(&noWait, "no-wait", "", false, "don't wait for all objects after applying")
+	applyCmd.Flags().BoolVarP(&noLocal, "no-local", "", false, "don't use locally built SPIRE images")
+	applyCmd.Flags().DurationVarP(&interval, "interval", "i", defaultInterval, "polling interval for object status")
 	root.AddCommand(applyCmd)
 
 	root.Execute()


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Kubernetes test tool

**Description of change**
<!-- Please provide a description of the change -->
This PR:

- Changes the method `LocalFlags()` to `Flags()` to set the local flags of the `k8s-test` command.

- Relaxes the regular expression used by the kubernetes test tool to detect node attestations. In this way, it will also detect attestation from older SPIRE releases where the string is slightly different:

_SPIRE v0.8.0:_
```
time="2019-08-14T19:48:44Z" level=debug msg="Signed X509 SVID" expires_at="2019-08-14T20:48:44Z" spiffe_id="spiffe://example.org/spire/agent/k8s_psat/demo-cluster/c2122240-6b66-11e9-9bf9-0800278af9c5" subsystem_name=ca
```

_SPIRE v0.7.3:_
```
time="2019-08-14T19:42:27Z" level=debug msg="Signed x509 SVID \"spiffe://example.org/spire/agent/k8s_sat/demo-cluster/02801fbf-cf9d-45e0-9388-5e38de480a10\" (expires 2019-08-14T20:42:27Z)" subsystem_name=ca_manager
```

The above item is due to the interest in pinning Kubernetes examples to particular SPIRE versions. 
Related PR: https://github.com/spiffe/spire-workload-integrations/pull/1