### PR TITLE
Enable fetching Instance Tags for Agent Template String

### DIFF
--- a/pkg/common/plugin/aws/iid.go
+++ b/pkg/common/plugin/aws/iid.go
@@ -29,6 +29,7 @@ type agentPathTemplateData struct {
 	InstanceIdentityDocument
 	PluginName  string
 	TrustDomain string
+	Tags        InstanceTags
 }
 
 // SessionConfig is a common config for AWS session config.
@@ -50,17 +51,20 @@ type IIDAttestationData struct {
 	Signature string `json:"signature"`
 }
 
+type InstanceTags map[string]string
+
 // AttestationStepError error with attestation
 func AttestationStepError(step string, cause error) error {
 	return fmt.Errorf("Attempted AWS IID attestation but an error occurred %s: %s", step, cause)
 }
 
 // MakeSpiffeID create spiffe ID from IID data
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc InstanceIdentityDocument) (*url.URL, error) {
+func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc InstanceIdentityDocument, tags InstanceTags) (*url.URL, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
 		InstanceIdentityDocument: doc,
 		PluginName:               PluginName,
+		Tags:                     tags,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This diff adds the ability to [ conditionally ] fetch Instance Tags
from the EC2 api to e.g. fetch more metadata about the instance that
might be needed for selectors or further attestation.

Signed-off-by: Will Salisbury <willsalz@users.noreply.github.com>

**Pull Request check list**

- [✅] Commit conforms to CONTRIBUTING.md?
- [🚧] Proper tests/regressions included?
- [🚧] Documentation updated?

**Affected functionality**
- AWS node attestation

**Description of change**
This diff adds the ability to [ conditionally ] fetch Instance Tags
from the EC2 api to e.g. fetch more metadata about the instance that
might be needed for selectors or further attestation.

**Which issue this PR fixes**
NA