### PR TITLE
add logic for negative workload_size_limit to disable unix sha function

### DIFF
--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -5,7 +5,7 @@ The `unix` plugin generates unix-based selectors for workloads calling the agent
 | Configuration | Description | Default |
 | ------------- | ----------- | ------- |
 | `discover_workload_path` | If true, the workload path will be discovered by the plugin and used to provide additional selectors | false |
-| `workload_size_limit` | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. | 0 |
+| `workload_size_limit` | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash. | 0 |
 
 If configured with `discover_workload_path = true`, the plugin will discover
 the workload path to provide additional selectors. If the plugin cannot
@@ -37,12 +37,13 @@ Security Considerations:
 
 Malicious workloads could cause the SPIRE agent to do expensive work
 calculating a sha256 for large workload binaries, causing a denial-of-service.
-This plugin includes a configuration value that can be used to mitigate such an
-attack (i.e. `workload_size_limit`) by enforcing a limit on the binary size the
-plugin is willing to hash. The same attack could be performed by spawning a
-bunch of processes under the limit. The workload API does not yet support rate
-limiting, but when it does, this attack can be mitigated by using rate limiting
-in conjunction with `workload_size_limit`.
+Defenses against this are:
+- disabling calculation entirely by setting `workload_size_limit` to a negative value
+- use `workload_size_limit` to enforce a limit on the binary size the
+plugin is willing to hash. However, the same attack could be performed by spawning a
+bunch of processes under the limit.
+The workload API does not yet support rate limiting, but when it does, this attack can
+be mitigated by using rate limiting in conjunction with non-negative `workload_size_limit`.
 
 A sample configuration:
 

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -107,12 +107,16 @@ func (p *UnixPlugin) Attest(ctx context.Context, req *workloadattestor.AttestReq
 		if err != nil {
 			return nil, err
 		}
-		sha256Digest, err := getSHA256Digest(processPath, config.WorkloadSizeLimit)
-		if err != nil {
-			return nil, err
-		}
 		selectors = append(selectors, makeSelector("path", processPath))
-		selectors = append(selectors, makeSelector("sha256", sha256Digest))
+
+		if config.WorkloadSizeLimit >= 0 {
+			sha256Digest, err := getSHA256Digest(processPath, config.WorkloadSizeLimit)
+			if err != nil {
+				return nil, err
+			}
+
+			selectors = append(selectors, makeSelector("sha256", sha256Digest))
+		}
 	}
 
 	return &workloadattestor.AttestResponse{

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -8,12 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-
 	"github.com/spiffe/spire/proto/spire/agent/workloadattestor"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 var (
@@ -140,6 +139,31 @@ func (s *Suite) TestAttest() {
 				"group:g2000",
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
 				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
+			},
+		},
+		{
+			name:   "success getting path and hashing process binary",
+			pid:    12,
+			config: "discover_workload_path = true",
+			selectors: []string{
+				"uid:1000",
+				"user:u1000",
+				"gid:2000",
+				"group:g2000",
+				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
+				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
+			},
+		},
+		{
+			name:   "success getting path, disabled hashing process binary",
+			pid:    12,
+			config: "discover_workload_path = true\nworkload_size_limit = -1",
+			selectors: []string{
+				"uid:1000",
+				"user:u1000",
+				"gid:2000",
+				"group:g2000",
+				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Andrew Moore <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Agent Unix Workload Attestor plugin SHA calculation.

**Description of change**
Add ability to disable agent Unix workload attestor SHA calculation if workload_size_limit is set to negative, since 0 implies not set implies no size limit.

The alternative of no change + simply setting a very low value for size limit was tried out. It still results in large amounts of processing in aggregate, and is still not resistant to a DoS as noted in the plugin's doc.

**Which issue this PR fixes**
fixes #1076

