### PR TITLE
Prevent races on agent SVID rotator

### DIFF
--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -38,7 +39,7 @@ func TestFetchUpdates(t *testing.T) {
 	nodeFsc.EXPECT().Recv().Return(res, nil)
 	nodeFsc.EXPECT().Recv().Return(nil, io.EOF)
 
-	update, err := client.FetchUpdates(context.Background(), req)
+	update, err := client.FetchUpdates(context.Background(), req, false)
 	require.Nil(t, err)
 
 	assert.Equal(t, res.SvidUpdate.Bundles, update.Bundles)
@@ -104,7 +105,7 @@ func TestFetchReleaseWaitsForFetchUpdatesToFinish(t *testing.T) {
 	nodeFsc.EXPECT().Recv().Return(res, nil)
 	nodeFsc.EXPECT().Recv().Return(nil, io.EOF)
 
-	update, err := client.FetchUpdates(context.Background(), req)
+	update, err := client.FetchUpdates(context.Background(), req, false)
 	require.Nil(t, err)
 
 	assert.Equal(t, res.SvidUpdate.Bundles, update.Bundles)
@@ -154,7 +155,7 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToFetchX509SVID(t *testing.T) {
 	nodeClient.EXPECT().FetchX509SVID(gomock.Any()).Return(nil, errors.New("an error"))
 	client := createClient(t, nodeClient)
 
-	update, err := client.FetchUpdates(context.Background(), &node.FetchX509SVIDRequest{})
+	update, err := client.FetchUpdates(context.Background(), &node.FetchX509SVIDRequest{}, false)
 	assert.Nil(t, update)
 	assert.Error(t, err)
 	assertNodeConnIsNil(t, client)
@@ -171,7 +172,7 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToSendRequest(t *testing.T) {
 	nodeClient.EXPECT().FetchX509SVID(gomock.Any()).Return(nodeFsc, nil)
 	client := createClient(t, nodeClient)
 
-	update, err := client.FetchUpdates(context.Background(), req)
+	update, err := client.FetchUpdates(context.Background(), req, false)
 	assert.Nil(t, update)
 	assert.Error(t, err)
 	assertNodeConnIsNil(t, client)
@@ -189,7 +190,7 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToReceiveResponse(t *testing.T) {
 	nodeClient.EXPECT().FetchX509SVID(gomock.Any()).Return(nodeFsc, nil)
 	client := createClient(t, nodeClient)
 
-	update, err := client.FetchUpdates(context.Background(), req)
+	update, err := client.FetchUpdates(context.Background(), req, false)
 	assert.Nil(t, update)
 	assert.Error(t, err)
 	assertNodeConnIsNil(t, client)
@@ -200,6 +201,7 @@ func createClient(t *testing.T, nodeClient *mock_node.MockNodeClient) *client {
 	client := New(&Config{
 		Log:           log,
 		KeysAndBundle: keysAndBundle,
+		RotMtx:        new(sync.RWMutex),
 	})
 	client.createNewNodeClient = func(conn *grpc.ClientConn) node.NodeClient {
 		return nodeClient

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -48,6 +48,15 @@ type Manager interface {
 	// bundle changes.
 	SubscribeToBundleChanges() *cache.BundleStream
 
+	// GetRotationMtx returns a mutex that locks in SVIDs rotations
+	GetRotationMtx() *sync.RWMutex
+
+	// GetCurrentCredentials returns the current SVID and key
+	GetCurrentCredentials() svid.State
+
+	// SetReleaseConnHook sets a hook that will be called when a rotation finished
+	SetReleaseConnHook(func())
+
 	// MatchingIdentities returns all of the cached identities whose
 	// registration entry selectors are a subset of the passed selectors.
 	MatchingIdentities(selectors []*common.Selector) []cache.Identity
@@ -118,6 +127,18 @@ func (m *manager) SubscribeToSVIDChanges() observer.Stream {
 
 func (m *manager) SubscribeToBundleChanges() *cache.BundleStream {
 	return m.cache.SubscribeToBundleChanges()
+}
+
+func (m *manager) GetRotationMtx() *sync.RWMutex {
+	return m.svid.GetRotationMtx()
+}
+
+func (m *manager) GetCurrentCredentials() svid.State {
+	return m.svid.State()
+}
+
+func (m *manager) SetReleaseConnHook(f func()) {
+	m.svid.SetReleaseConnHook(f)
 }
 
 func (m *manager) MatchingIdentities(selectors []*common.Selector) []cache.Identity {

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -54,8 +54,8 @@ type Manager interface {
 	// GetCurrentCredentials returns the current SVID and key
 	GetCurrentCredentials() svid.State
 
-	// SetReleaseConnHook sets a hook that will be called when a rotation finished
-	SetReleaseConnHook(func())
+	// SetRotationFinishedHook sets a hook that will be called when a rotation finished
+	SetRotationFinishedHook(func())
 
 	// MatchingIdentities returns all of the cached identities whose
 	// registration entry selectors are a subset of the passed selectors.
@@ -137,8 +137,8 @@ func (m *manager) GetCurrentCredentials() svid.State {
 	return m.svid.State()
 }
 
-func (m *manager) SetReleaseConnHook(f func()) {
-	m.svid.SetReleaseConnHook(f)
+func (m *manager) SetRotationFinishedHook(f func()) {
+	m.svid.SetRotationFinishedHook(f)
 }
 
 func (m *manager) MatchingIdentities(selectors []*common.Selector) []cache.Identity {

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -383,8 +383,8 @@ func TestSVIDRotation(t *testing.T) {
 		t.Fatal("PrivateKey is not equals to configured one")
 	}
 
-	releaseConnHookCalled := false
-	m.SetReleaseConnHook(func() { releaseConnHookCalled = true })
+	rotationFinishedHook := false
+	m.SetRotationFinishedHook(func() { rotationFinishedHook = true })
 
 	mockClk.WaitForTickerMulti(time.Second, 2, "svid rotater and syncer didn't create tickers after 1 second")
 
@@ -399,7 +399,7 @@ func TestSVIDRotation(t *testing.T) {
 		s := m.GetCurrentCredentials()
 		svid = s.SVID
 		require.True(t, svidsEqual(svid, baseSVID))
-		require.False(t, releaseConnHookCalled)
+		require.False(t, rotationFinishedHook)
 		time.Sleep(100 * time.Millisecond)
 	}
 
@@ -415,7 +415,7 @@ func TestSVIDRotation(t *testing.T) {
 			svid = s.SVID
 			key = s.Key
 			if !svidsEqual(svid, baseSVID) {
-				require.True(t, releaseConnHookCalled)
+				require.True(t, rotationFinishedHook)
 				break
 			}
 			time.Sleep(100 * time.Millisecond)

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -111,7 +111,7 @@ func (m *manager) fetchUpdates(ctx context.Context, csrs []csrRequest) (_ *cache
 		req.Csrs[csr.EntryID] = csrBytes
 	}
 
-	update, err := m.client.FetchUpdates(ctx, req)
+	update, err := m.client.FetchUpdates(ctx, req, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -23,7 +23,7 @@ type Rotator interface {
 	State() State
 	Subscribe() observer.Stream
 	GetRotationMtx() *sync.RWMutex
-	SetReleaseConnHook(func())
+	SetRotationFinishedHook(func())
 }
 
 type rotator struct {
@@ -39,8 +39,8 @@ type rotator struct {
 	// Mutex used to prevent rotations when a new connection is being created
 	rotMtx *sync.RWMutex
 
-	// Hook to release client resources after an SVID rotation
-	releaseConnHook func()
+	// Hook that will be called when the SVID rotation finishes
+	rotationFinishedHook func()
 }
 
 type State struct {
@@ -86,8 +86,8 @@ func (r *rotator) GetRotationMtx() *sync.RWMutex {
 	return r.rotMtx
 }
 
-func (r *rotator) SetReleaseConnHook(f func()) {
-	r.releaseConnHook = f
+func (r *rotator) SetRotationFinishedHook(f func()) {
+	r.rotationFinishedHook = f
 }
 
 // shouldRotate returns a boolean informing the caller of whether or not the
@@ -160,8 +160,8 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	// the most up-to-date SVID.
 	r.client.Release()
 
-	if r.releaseConnHook != nil {
-		r.releaseConnHook()
+	if r.rotationFinishedHook != nil {
+		r.rotationFinishedHook()
 	}
 
 	return nil

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -22,6 +22,8 @@ type Rotator interface {
 
 	State() State
 	Subscribe() observer.Stream
+	GetRotationMtx() *sync.RWMutex
+	SetReleaseConnHook(func())
 }
 
 type rotator struct {
@@ -33,6 +35,12 @@ type rotator struct {
 
 	// Mutex used to protect access to c.BundleStream.
 	bsm *sync.RWMutex
+
+	// Mutex used to prevent rotations when a new connection is being created
+	rotMtx *sync.RWMutex
+
+	// Hook to release client resources after an SVID rotation
+	releaseConnHook func()
 }
 
 type State struct {
@@ -74,6 +82,14 @@ func (r *rotator) Subscribe() observer.Stream {
 	return r.state.Observe()
 }
 
+func (r *rotator) GetRotationMtx() *sync.RWMutex {
+	return r.rotMtx
+}
+
+func (r *rotator) SetReleaseConnHook(f func()) {
+	r.releaseConnHook = f
+}
+
 // shouldRotate returns a boolean informing the caller of whether or not the
 // SVID should be rotated.
 func (r *rotator) shouldRotate() bool {
@@ -90,7 +106,11 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	counter := telemetry_agent.StartRotateAgentSVIDCall(r.c.Metrics, r.c.SpiffeID)
 	defer counter.Done(&err)
 
-	r.c.Log.Debug("Rotating agent SVID")
+	// Get the mtx before starting the rotation
+	// In this way, the client do not create new connections until the new SVID is received
+	r.rotMtx.Lock()
+	defer r.rotMtx.Unlock()
+	r.c.Log.Debug("Rotating agent SVIDss")
 
 	key, err := r.newKey(ctx)
 	if err != nil {
@@ -110,7 +130,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 			Csrs: map[string][]byte{
 				r.c.SpiffeID: csr,
 			},
-		})
+		}, true)
 	if err != nil {
 		return err
 	}
@@ -128,17 +148,22 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 		return err
 	}
 
-	// We must release the client because its underlaying connection is tied to an
-	// expired SVID, so next time the client is used, it will get a new connection with
-	// the most up-to-date SVID.
-	r.client.Release()
-
 	s := State{
 		SVID: certs,
 		Key:  key,
 	}
 
 	r.state.Update(s)
+
+	// We must release the client because its underlaying connection is tied to an
+	// expired SVID, so next time the client is used, it will get a new connection with
+	// the most up-to-date SVID.
+	r.client.Release()
+
+	if r.releaseConnHook != nil {
+		r.releaseConnHook()
+	}
+
 	return nil
 }
 

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -50,12 +50,14 @@ func NewRotator(c *RotatorConfig) (*rotator, client.Client) {
 		Key:  c.SVIDKey,
 	})
 
+	rotMtx := new(sync.RWMutex)
 	bsm := new(sync.RWMutex)
 
 	cfg := &client.Config{
 		TrustDomain: c.TrustDomain,
 		Log:         c.Log,
 		Addr:        c.ServerAddr,
+		RotMtx:      rotMtx,
 		KeysAndBundle: func() ([]*x509.Certificate, *ecdsa.PrivateKey, []*x509.Certificate) {
 			s := state.Value().(State)
 
@@ -78,5 +80,6 @@ func NewRotator(c *RotatorConfig) (*rotator, client.Client) {
 		state:  state,
 		clk:    c.Clk,
 		bsm:    bsm,
+		rotMtx: rotMtx,
 	}, client
 }

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -198,7 +198,7 @@ func (s *RotatorTestSuite) TestRotateSVID() {
 // the the provided certificate to the client.Client caller.
 func (s *RotatorTestSuite) expectSVIDRotation(cert *x509.Certificate) {
 	s.client.EXPECT().
-		FetchUpdates(gomock.Any(), gomock.Any()).
+		FetchUpdates(gomock.Any(), gomock.Any(), true).
 		Return(&client.Update{
 			SVIDs: map[string]*node.X509SVID{
 				s.r.c.SpiffeID: {

--- a/test/mock/agent/client/client_mock.go
+++ b/test/mock/agent/client/client_mock.go
@@ -51,18 +51,18 @@ func (mr *MockClientMockRecorder) FetchJWTSVID(arg0, arg1 interface{}) *gomock.C
 }
 
 // FetchUpdates mocks base method
-func (m *MockClient) FetchUpdates(arg0 context.Context, arg1 *node.FetchX509SVIDRequest) (*client.Update, error) {
+func (m *MockClient) FetchUpdates(arg0 context.Context, arg1 *node.FetchX509SVIDRequest, arg2 bool) (*client.Update, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchUpdates", arg0, arg1)
+	ret := m.ctrl.Call(m, "FetchUpdates", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*client.Update)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchUpdates indicates an expected call of FetchUpdates
-func (mr *MockClientMockRecorder) FetchUpdates(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) FetchUpdates(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUpdates", reflect.TypeOf((*MockClient)(nil).FetchUpdates), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchUpdates", reflect.TypeOf((*MockClient)(nil).FetchUpdates), arg0, arg1, arg2)
 }
 
 // Release mocks base method

--- a/test/mock/agent/manager/manager_mock.go
+++ b/test/mock/agent/manager/manager_mock.go
@@ -138,16 +138,16 @@ func (mr *MockManagerMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockManager)(nil).Run), arg0)
 }
 
-// SetReleaseConnHook mocks base method
-func (m *MockManager) SetReleaseConnHook(arg0 func()) {
+// SetRotationFinishedHook mocks base method
+func (m *MockManager) SetRotationFinishedHook(arg0 func()) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetReleaseConnHook", arg0)
+	m.ctrl.Call(m, "SetRotationFinishedHook", arg0)
 }
 
-// SetReleaseConnHook indicates an expected call of SetReleaseConnHook
-func (mr *MockManagerMockRecorder) SetReleaseConnHook(arg0 interface{}) *gomock.Call {
+// SetRotationFinishedHook indicates an expected call of SetRotationFinishedHook
+func (mr *MockManagerMockRecorder) SetRotationFinishedHook(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReleaseConnHook", reflect.TypeOf((*MockManager)(nil).SetReleaseConnHook), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRotationFinishedHook", reflect.TypeOf((*MockManager)(nil).SetRotationFinishedHook), arg0)
 }
 
 // SubscribeToBundleChanges mocks base method

--- a/test/mock/agent/manager/manager_mock.go
+++ b/test/mock/agent/manager/manager_mock.go
@@ -10,8 +10,10 @@ import (
 	go_observer "github.com/imkira/go-observer"
 	client "github.com/spiffe/spire/pkg/agent/client"
 	cache "github.com/spiffe/spire/pkg/agent/manager/cache"
+	svid "github.com/spiffe/spire/pkg/agent/svid"
 	common "github.com/spiffe/spire/proto/spire/common"
 	reflect "reflect"
+	sync "sync"
 )
 
 // MockManager is a mock of Manager interface
@@ -66,6 +68,34 @@ func (mr *MockManagerMockRecorder) FetchWorkloadUpdate(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchWorkloadUpdate", reflect.TypeOf((*MockManager)(nil).FetchWorkloadUpdate), arg0)
 }
 
+// GetCurrentCredentials mocks base method
+func (m *MockManager) GetCurrentCredentials() svid.State {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentCredentials")
+	ret0, _ := ret[0].(svid.State)
+	return ret0
+}
+
+// GetCurrentCredentials indicates an expected call of GetCurrentCredentials
+func (mr *MockManagerMockRecorder) GetCurrentCredentials() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentCredentials", reflect.TypeOf((*MockManager)(nil).GetCurrentCredentials))
+}
+
+// GetRotationMtx mocks base method
+func (m *MockManager) GetRotationMtx() *sync.RWMutex {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRotationMtx")
+	ret0, _ := ret[0].(*sync.RWMutex)
+	return ret0
+}
+
+// GetRotationMtx indicates an expected call of GetRotationMtx
+func (mr *MockManagerMockRecorder) GetRotationMtx() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotationMtx", reflect.TypeOf((*MockManager)(nil).GetRotationMtx))
+}
+
 // Initialize mocks base method
 func (m *MockManager) Initialize(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -106,6 +136,18 @@ func (m *MockManager) Run(arg0 context.Context) error {
 func (mr *MockManagerMockRecorder) Run(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockManager)(nil).Run), arg0)
+}
+
+// SetReleaseConnHook mocks base method
+func (m *MockManager) SetReleaseConnHook(arg0 func()) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReleaseConnHook", arg0)
+}
+
+// SetReleaseConnHook indicates an expected call of SetReleaseConnHook
+func (mr *MockManagerMockRecorder) SetReleaseConnHook(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReleaseConnHook", reflect.TypeOf((*MockManager)(nil).SetReleaseConnHook), arg0)
 }
 
 // SubscribeToBundleChanges mocks base method


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
SPIRE agent SVID rotator

**Description of change**
<!-- Please provide a description of the change -->
If an agent request (`fetchX509SVID()`,` fetchJWTSVID()`) is done in the middle of an agent SVID rotation, the validation of the agent SVID may fail on the server-side with the error:

```
SVID does not match expected serial number
```
The problem is that the server may have already updated the datastore with the new SVID, but if the rotation has not finished yet, requests started in this time window will be still using the previous SVID.

This PR, adds a mutex to protect agent SVID rotations. In this way: 
+ Requests will not start during SVIDs rotations
+ Rotations will not start if there is a pending request.

