### PR TITLE
Improve a script to create entries in envoy sds example

### DIFF
--- a/examples/envoy/3-create-registration-entries.sh
+++ b/examples/envoy/3-create-registration-entries.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-set -e
+set -eo pipefail
 
 bb=$(tput bold)
 nn=$(tput sgr0)


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Nothing.

**Description of change**
<!-- Please provide a description of the change -->
Thank you for providing great Envoy SDS Example!
It was very helpful for me to understand SPIRE's Envoy SDS Support.

I was doing the Envoy SDS Example on **macOS** and an error occurred in `openssh sha1 -r` in`. / 3-create-registration-entries.sh` (as described in the comments in the script). However, because the subsequent processing has been executed, an unintended entry (SPIFFE ID that doesn't contain fingerprint is set in Parent ID) has been created as bellow:

```bash
$ docker-compose exec spire-server /opt/spire/bin/spire-server entry show
Found 2 entries
Entry ID      : 6a51a768-8c74-4238-9e9d-cca741401697
SPIFFE ID     : spiffe://domain.test/echo-server
Parent ID     : spiffe://domain.test/spire/agent/x509pop/
TTL           : 3600
Selector      : unix:user:root

Entry ID      : 111d9c3e-7db1-4d8a-bcae-9f8a0491fcce
SPIFFE ID     : spiffe://domain.test/web-server
Parent ID     : spiffe://domain.test/spire/agent/x509pop/
TTL           : 3600
Selector      : unix:user:root
```

So I added the `pipefail` option to the script to avoid unintended entries being registered before fixing the error.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

Nothing.
