### PR TITLE
clean up CSR signing entitlement log to use fields

### DIFF
--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -133,6 +133,9 @@ const (
 	// FederatedRemoved labels some count of federated bundles that have been removed from an entity
 	FederatedRemoved = "fed_rem"
 
+	// IDType tags some type of ID (eg. registration ID, SPIFFE ID...)
+	IDType = "id_type"
+
 	// IssuedAt tags an issuance timestamp
 	IssuedAt = "issued_at"
 

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -936,11 +936,16 @@ func (h *Handler) buildSVID(ctx context.Context, id string, csr *CSR, regEntries
 	if !ok {
 		var idType string
 		if strings.HasPrefix(id, "spiffe://") {
-			idType = "SPIFFE ID"
+			idType = telemetry.SPIFFEID
 		} else {
-			idType = "registration entry ID"
+			idType = telemetry.RegistrationID
 		}
-		return nil, fmt.Errorf("not entitled to sign CSR for %s %q", idType, id)
+		msg := "not entitled to sign CSR for given ID type"
+		h.c.Log.WithFields(logrus.Fields{
+			telemetry.IDType: idType,
+			idType:           id,
+		}).Error(msg)
+		return nil, errors.New(msg)
 	}
 
 	svid, err := h.c.ServerCA.SignX509SVID(ctx, ca.X509SVIDParams{

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -648,7 +648,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSR() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		Csrs: s.makeCSRs("an-entry-id", workloadID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for registration entry ID "an-entry-id"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSRLegacy() {
@@ -657,7 +657,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSRLegacy() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		DEPRECATEDCsrs: s.makeCSRsLegacy(workloadID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for SPIFFE ID "spiffe://example.org/workload"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithAgentCSR() {
@@ -717,7 +717,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSR() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		Csrs: s.makeCSRs("an-entry-id", trustDomainID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for registration entry ID "an-entry-id"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSRLegacy() {
@@ -726,7 +726,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSRLegacy() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		DEPRECATEDCsrs: s.makeCSRsLegacy(trustDomainID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for SPIFFE ID "spiffe://example.org"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509CASVIDWithUnauthorizedDownstreamCSR() {


### PR DESCRIPTION
Signed-off-by: Andrew Moore <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Logging in server node API -> CSR signing -> buildSVID.

**Description of change**
Change error logging on ID Type to use fields instead of a high-cardinality message of UUID/SPIFFE ID.
