### PR TITLE
Fix IsAlive() check on linux peertracker

### DIFF
--- a/pkg/common/peertracker/tracker_linux.go
+++ b/pkg/common/peertracker/tracker_linux.go
@@ -30,7 +30,8 @@ type linuxWatcher struct {
 	gid       uint32
 	pid       int32
 	mtx       sync.Mutex
-	procfh    int
+	procPath  string
+	procfd    int
 	starttime string
 	uid       uint32
 }
@@ -41,8 +42,10 @@ func newLinuxWatcher(info CallerInfo) (*linuxWatcher, error) {
 		return nil, errors.New("could not resolve caller information")
 	}
 
+	procPath := fmt.Sprintf("/proc/%v", info.PID)
+
 	// Grab a handle to proc first since that's the fastest thing we can do
-	procfh, err := syscall.Open(fmt.Sprintf("/proc/%v", info.PID), syscall.O_RDONLY, 0)
+	procfd, err := syscall.Open(procPath, syscall.O_RDONLY, 0)
 	if err != nil {
 		return nil, fmt.Errorf("could not open caller's proc directory: %v", err)
 	}
@@ -55,7 +58,8 @@ func newLinuxWatcher(info CallerInfo) (*linuxWatcher, error) {
 	return &linuxWatcher{
 		gid:       info.GID,
 		pid:       info.PID,
-		procfh:    procfh,
+		procPath:  procPath,
+		procfd:    procfd,
 		starttime: starttime,
 		uid:       info.UID,
 	}, nil
@@ -65,19 +69,19 @@ func (l *linuxWatcher) Close() {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	if l.procfh < 0 {
+	if l.procfd < 0 {
 		return
 	}
 
-	syscall.Close(l.procfh)
-	l.procfh = -1
+	syscall.Close(l.procfd)
+	l.procfd = -1
 }
 
 func (l *linuxWatcher) IsAlive() error {
 	l.mtx.Lock()
 	defer l.mtx.Unlock()
 
-	if l.procfh < 0 {
+	if l.procfd < 0 {
 		return errors.New("caller is no longer being watched")
 	}
 
@@ -85,7 +89,7 @@ func (l *linuxWatcher) IsAlive() error {
 	// If the process has exited since we opened it, the read should fail (i.e.
 	// the ReadDirent syscall will return -1)
 	var buf [8196]byte
-	n, err := syscall.ReadDirent(l.procfh, buf[:])
+	n, err := syscall.ReadDirent(l.procfd, buf[:])
 	if err != nil {
 		return fmt.Errorf("caller exit suspected due to failed readdirent: err=%v", err)
 	}
@@ -114,7 +118,7 @@ func (l *linuxWatcher) IsAlive() error {
 	// least get to know that the race winner is running as the same user and group as
 	// the original caller by comparing it to the received CallerInfo.
 	var stat syscall.Stat_t
-	if err := syscall.Fstat(l.procfh, &stat); err != nil {
+	if err := syscall.Stat(l.procPath, &stat); err != nil {
 		return fmt.Errorf("caller exit suspected due to failed proc stat: %v", err)
 	}
 	if stat.Uid != l.uid {


### PR DESCRIPTION
IsAlive() current calls Readdir(1) which causes a false-negative when the directory entries have all been enumerated io.EOF is returned.

The other issue is that the os.File object caches the directory entries, so even if you Seek(0), the call still succeeds.

The solution is to use the syscall package directly to bypass caching. Each call to syscall.ReadDirent will return entries until all have been enumerated. At that point, it will return 0, which we still detect as successful. As soon as the process is closed corresponding to the
/proc/pid directory being tracked, syscall.ReadDirent will return -1, which IsAlive() interprets as failure.