### PR TITLE
Fix/examples k8s

### DIFF
--- a/examples/k8s/spire-agent.yaml
+++ b/examples/k8s/spire-agent.yaml
@@ -14,7 +14,7 @@ metadata:
   name: spire-agent-cluster-role
 rules:
 - apiGroups: [""]
-  resources: ["pods","nodes"]
+  resources: ["pods","nodes","nodes/proxy"]
   verbs: ["get"]
 
 ---

--- a/examples/k8s/spire-server.yaml
+++ b/examples/k8s/spire-server.yaml
@@ -16,6 +16,23 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get"]
+  # allow "get" access to pods (to resolve selectors for PSAT attention)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+  # allow TokenReview requests (to verify service account tokens for PSAT
+  # attestation)
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["get", "create"]
+  # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
+  # agent bootstrapping, see the spire-bundle ConfigMap below) 
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["spire-bundle"]
+  verbs: ["get", "patch"]
+
+
 
 ---
 
@@ -36,13 +53,6 @@ roleRef:
 
 ---
 
-# Role for the SPIRE server
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: spire
-  name: spire-server-role
-rules:
   # allow "get" access to pods (to resolve selectors for PSAT attestation)
 - apiGroups: [""]
   resources: ["pods"]
@@ -58,24 +68,6 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["spire-bundle"]
   verbs: ["get", "patch"]
-
----
-
-# RoleBinding granting the spire-server-role to the SPIRE server
-# service account.
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: spire-server-role-binding
-  namespace: spire
-subjects:
-- kind: ServiceAccount
-  name: spire-server
-  namespace: spire
-roleRef:
-  kind: Role
-  name: spire-server-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 
@@ -210,6 +202,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: k8s-workload-registrar-secret
+  namespace: spire
 type: Opaque
 data:
   server-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ3RqS0h2ckVjVWJDdWtlUG8KaXJSMDRqSnZyWW1ONlF3cHlQSlFFTWtsZ3MraFJBTkNBQVJVdzRwSG1XQ3pyZmprWHNlbjkrbVNQemlmV1Y0MwpzNlNaMUorK3h2RFhNMmpPaE04NlZwL1JkQzBtMkZOajNXWWc2c3VSbEV6dmYvRncyQ3N1WmJtbwotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -133,6 +133,9 @@ const (
 	// FederatedRemoved labels some count of federated bundles that have been removed from an entity
 	FederatedRemoved = "fed_rem"
 
+	// IDType tags some type of ID (eg. registration ID, SPIFFE ID...)
+	IDType = "id_type"
+
 	// IssuedAt tags an issuance timestamp
 	IssuedAt = "issued_at"
 

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -936,11 +936,16 @@ func (h *Handler) buildSVID(ctx context.Context, id string, csr *CSR, regEntries
 	if !ok {
 		var idType string
 		if strings.HasPrefix(id, "spiffe://") {
-			idType = "SPIFFE ID"
+			idType = telemetry.SPIFFEID
 		} else {
-			idType = "registration entry ID"
+			idType = telemetry.RegistrationID
 		}
-		return nil, fmt.Errorf("not entitled to sign CSR for %s %q", idType, id)
+		msg := "not entitled to sign CSR for given ID type"
+		h.c.Log.WithFields(logrus.Fields{
+			telemetry.IDType: idType,
+			idType:           id,
+		}).Error(msg)
+		return nil, errors.New(msg)
 	}
 
 	svid, err := h.c.ServerCA.SignX509SVID(ctx, ca.X509SVIDParams{

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -648,7 +648,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSR() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		Csrs: s.makeCSRs("an-entry-id", workloadID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for registration entry ID "an-entry-id"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSRLegacy() {
@@ -657,7 +657,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithUnauthorizedCSRLegacy() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		DEPRECATEDCsrs: s.makeCSRsLegacy(workloadID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for SPIFFE ID "spiffe://example.org/workload"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithAgentCSR() {
@@ -717,7 +717,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSR() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		Csrs: s.makeCSRs("an-entry-id", trustDomainID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for registration entry ID "an-entry-id"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSRLegacy() {
@@ -726,7 +726,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithDownstreamCSRLegacy() {
 	s.requireFetchX509SVIDFailure(&node.FetchX509SVIDRequest{
 		DEPRECATEDCsrs: s.makeCSRsLegacy(trustDomainID),
 	}, codes.Internal, "failed to sign CSRs")
-	s.assertLastLogMessageContains(`not entitled to sign CSR for SPIFFE ID "spiffe://example.org"`)
+	s.assertLastLogMessageContains(`not entitled to sign CSR for given ID type`)
 }
 
 func (s *HandlerSuite) TestFetchX509CASVIDWithUnauthorizedDownstreamCSR() {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
1. spire-server can not create resource \"tokenreviews\" in API group \"authentication.k8s.io\" at the cluster scope.
2,spire-agnet agent crashed x509: certificate signed by unknown authority, can not access to https://127.0.0.1:10250
**Description of change**
<!-- Please provide a description of the change -->
1. Change role to clusterrole in the example/k8s/spire-server.yaml and add namepace for  k8s-workload-registrar-secret.
2. Add nodesproxy resource for spire-agent clusterrole in the example/k8s/spire-agent.yaml.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
1. spire-server can not create resouce tokenreviews.
2. spire-agent agent crashed.
