### PR TITLE
Add database migration dry run feature

### DIFF
--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -12,6 +12,8 @@ The `sql` plugin implements a sql based storage option for the SPIRE server usin
 | max_open_conns    | The maximum number of open db connections (default: unlimited)             |
 | max_idle_conns    | The maximum number of idle connections in the pool (default: 2)            |
 | conn_max_lifetime | The maximum amount of time a connection may be reused (default: unlimited) |
+| migration_dry_run | Dry run printing migration statements (default migration.sql)              |
+| dry_run_file_name | Specify file name where migration output is written.                       |
 
 The plugin defaults to an in-memory database and any information in the data store is lost on restart.
 

--- a/pkg/server/plugin/datastore/sql/migrationlogger.go
+++ b/pkg/server/plugin/datastore/sql/migrationlogger.go
@@ -3,26 +3,24 @@ package sql
 import (
 	"database/sql/driver"
 	"fmt"
-	"os"
+	"io"
 	"reflect"
 	"regexp"
 	"time"
 )
 
-// This will only output upgrade steps for *one* version up
-
 type MigrationLogger struct {
-	outfile *os.File
+	outfile io.Writer
 }
 
 func (logger *MigrationLogger) Print(v ...interface{}) {
 	if v[0] == "sql" && len(v) > 1 {
-		logger.outfile.WriteString(format(v...) + "\n")
+		logger.outfile.Write([]byte(format(v...) + "\n"))
 	}
 }
 
-func (logger *MigrationLogger) SetOutputfile(file *os.File) {
-	logger.outfile = file
+func (logger *MigrationLogger) SetOutput(out io.Writer) {
+	logger.outfile = out
 }
 
 // This is a reduced version of gorm's LogFormatter - https://github.com/jinzhu/gorm/blob/master/logger.go

--- a/pkg/server/plugin/datastore/sql/migrationlogger.go
+++ b/pkg/server/plugin/datastore/sql/migrationlogger.go
@@ -1,0 +1,85 @@
+package sql
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"os"
+	"reflect"
+	"regexp"
+	"time"
+)
+
+// This will only output upgrade steps for *one* version up
+
+type MigrationLogger struct {
+	outfile *os.File
+}
+
+func (logger *MigrationLogger) Print(v ...interface{}) {
+	if v[0] == "sql" && len(v) > 1 {
+		logger.outfile.WriteString(format(v...) + "\n")
+	}
+}
+
+func (logger *MigrationLogger) SetOutputfile(file *os.File) {
+	logger.outfile = file
+}
+
+// This is a reduced version of gorm's LogFormatter - https://github.com/jinzhu/gorm/blob/master/logger.go
+func format(values ...interface{}) string {
+	sqlRegexp := regexp.MustCompile(`\?`)
+	numericPlaceHolderRegexp := regexp.MustCompile(`\$\d+`)
+
+	var (
+		sql             string
+		formattedValues []string
+	)
+
+	for _, value := range values[4].([]interface{}) {
+		indirectValue := reflect.Indirect(reflect.ValueOf(value))
+		if indirectValue.IsValid() {
+			value = indirectValue.Interface()
+			if t, ok := value.(time.Time); ok {
+				formattedValues = append(formattedValues, fmt.Sprintf("'%v'", t.Format("2006-01-02 15:04:05")))
+			} else if b, ok := value.([]byte); ok {
+				formattedValues = append(formattedValues, fmt.Sprintf("'%v'", string(b)))
+			} else if r, ok := value.(driver.Valuer); ok {
+				if value, err := r.Value(); err == nil && value != nil {
+					formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))
+				} else {
+					formattedValues = append(formattedValues, "NULL")
+				}
+			} else {
+				switch value.(type) {
+				case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+					formattedValues = append(formattedValues, fmt.Sprintf("%v", value))
+				default:
+					formattedValues = append(formattedValues, fmt.Sprintf("'%v'", value))
+				}
+			}
+		} else {
+			formattedValues = append(formattedValues, "NULL")
+		}
+	}
+
+	// differentiate between $n placeholders or else treat like ?
+	if numericPlaceHolderRegexp.MatchString(values[3].(string)) {
+		sql = values[3].(string)
+		for index, value := range formattedValues {
+			placeholder := fmt.Sprintf(`\$%d([^\d]|$)`, index+1)
+			sql = regexp.MustCompile(placeholder).ReplaceAllString(sql, value+"$1")
+		}
+	} else {
+		formattedValuesLength := len(formattedValues)
+		for index, value := range sqlRegexp.Split(values[3].(string), -1) {
+			sql += value
+			if index < formattedValuesLength {
+				sql += formattedValues[index]
+			}
+		}
+	}
+	if sql[len(sql)-1] == ';' {
+		return sql
+	}
+	return sql + ";"
+}

--- a/pkg/server/plugin/datastore/sql/migrationlogger_test.go
+++ b/pkg/server/plugin/datastore/sql/migrationlogger_test.go
@@ -1,0 +1,71 @@
+package sql
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+)
+
+// Creates a database at a specified migration level
+func createTestDB(targetlevel int, s *PluginSuite) string {
+	dbName := fmt.Sprintf("v%d.sqlite3", targetlevel)
+	dbPath := filepath.Join(s.dir, "migrationtest-"+dbName)
+
+	database, _ := sql.Open("sqlite3", dbPath)
+	dump := migrationDump(5)
+
+	_, err := database.Exec(dump)
+	s.Require().NoError(err)
+
+	database.Close()
+
+	return dbPath
+}
+
+func (s *PluginSuite) TestDryRunOutput() {
+	dbPath := createTestDB(5, s)
+
+	db, err := sqlite{}.connect(&configuration{
+		DatabaseType:     "sqlite3",
+		ConnectionString: fmt.Sprintf("file://%s", dbPath),
+		MigrationDryRun:  true,
+	})
+
+	s.Require().NoError(err)
+
+	db.LogMode(true)
+	migratelogger := MigrationLogger{}
+
+	testlogger := bytes.NewBufferString("")
+	migratelogger.SetOutput(testlogger)
+	db.SetLogger(&migratelogger)
+
+	err = migrateToV6(db)
+	s.Require().NoError(err)
+	s.Require().Equal(testlogger.String(), "ALTER TABLE \"registered_entries\" ADD \"downstream\" bool;\n")
+
+	testlogger = bytes.NewBufferString("")
+	migratelogger.SetOutput(testlogger)
+	err = migrateToV7(db)
+	s.Require().NoError(err)
+	s.Require().Equal(testlogger.String(), "ALTER TABLE \"registered_entries\" ADD \"expiry\" bigint;\n")
+
+	testlogger = bytes.NewBufferString("")
+	migratelogger.SetOutput(testlogger)
+	err = migrateToV8(db)
+	s.Require().NoError(err)
+	s.Require().Equal(testlogger.String(), "CREATE TABLE \"dns_names\" (\"id\" integer primary key autoincrement,\"created_at\" datetime,\"updated_at\" datetime,\"registered_entry_id\" integer,\"value\" varchar(255) );\nCREATE UNIQUE INDEX idx_dns_entry ON \"dns_names\"(registered_entry_id, \"value\") ;\n")
+
+	testlogger = bytes.NewBufferString("")
+	migratelogger.SetOutput(testlogger)
+	err = migrateToV9(db)
+	s.Require().NoError(err)
+	s.Require().Equal(testlogger.String(), "CREATE INDEX idx_registered_entries_spiffe_id ON \"registered_entries\"(spiffe_id) ;\nCREATE INDEX idx_registered_entries_parent_id ON \"registered_entries\"(parent_id) ;\nCREATE INDEX idx_selectors_type_value ON \"selectors\"(\"type\", \"value\") ;\n")
+
+	testlogger = bytes.NewBufferString("")
+	migratelogger.SetOutput(testlogger)
+	err = migrateToV10(db)
+	s.Require().NoError(err)
+	s.Require().Equal(testlogger.String(), "CREATE INDEX idx_registered_entries_expiry ON \"registered_entries\"(\"expiry\") ;\n")
+}


### PR DESCRIPTION
**Affected functionality**
This PR adds a dry run feature for migrations. It will write the migration procedure per migration level to a file and exit. The migrations are performed against the database - transactions are opened and rolled back.


**Description of change**
Two new configuration options: `migration_dry_run` and `dry_run_file_name`.

When starting a migration dry run with the database at level 6 where the code is at level 10, this is the output of spire server:

```
...
INFO[0000] Done printing migration to 7. Rolling back.   subsystem_name=built-in_plugin.sql
INFO[0000] Done printing migration to 8. Rolling back.   subsystem_name=built-in_plugin.sql
INFO[0000] Done printing migration to 9. Rolling back.   subsystem_name=built-in_plugin.sql
INFO[0000] Done printing migration to 10. Rolling back.  subsystem_name=built-in_plugin.sql
INFO[0000] Migrations written to file migration.sql      subsystem_name=built-in_plugin.sql

Process finished with exit code 0
```

The output file looks as follows for sqlite:

```
-- Migration from v6 to v7
ALTER TABLE "registered_entries" ADD "expiry" bigint;
UPDATE "migrations" SET "updated_at" = '2019-09-09 11:17:04', "version" = 7  ;
-- Migration from v7 to v8
ALTER TABLE "registered_entries" ADD "expiry" bigint;
CREATE TABLE "dns_names" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"registered_entry_id" integer,"value" varchar(255) );
CREATE UNIQUE INDEX idx_dns_entry ON "dns_names"(registered_entry_id, "value") ;
UPDATE "migrations" SET "updated_at" = '2019-09-09 11:17:04', "version" = 8  ;
-- Migration from v8 to v9
ALTER TABLE "registered_entries" ADD "expiry" bigint;
CREATE INDEX idx_registered_entries_spiffe_id ON "registered_entries"(spiffe_id) ;
CREATE INDEX idx_registered_entries_parent_id ON "registered_entries"(parent_id) ;
CREATE INDEX idx_selectors_type_value ON "selectors"("type", "value") ;
UPDATE "migrations" SET "updated_at" = '2019-09-09 11:17:04', "version" = 9  ;
-- Migration from v9 to v10
ALTER TABLE "registered_entries" ADD "expiry" bigint;
CREATE INDEX idx_registered_entries_spiffe_id ON "registered_entries"(spiffe_id) ;
CREATE INDEX idx_registered_entries_parent_id ON "registered_entries"(parent_id) ;
CREATE INDEX idx_registered_entries_expiry ON "registered_entries"("expiry") ;
UPDATE "migrations" SET "updated_at" = '2019-09-09 11:17:04', "version" = 10  ;
```


