### PR TITLE
Remove read-only opt since it is not supported in all mysql versions

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -592,7 +592,7 @@ func (ds *SQLPlugin) withWriteTx(ctx context.Context, op func(tx *gorm.DB) error
 }
 
 func (ds *SQLPlugin) withReadTx(ctx context.Context, op func(tx *gorm.DB) error) error {
-	return ds.withTx(ctx, op, true, &sql.TxOptions{ReadOnly: true})
+	return ds.withTx(ctx, op, true, nil)
 }
 
 func (ds *SQLPlugin) withTx(ctx context.Context, op func(tx *gorm.DB) error, readOnly bool, opts *sql.TxOptions) error {


### PR DESCRIPTION
Signed-off-by: Marcos G. Yedro <marcosyedro@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Description of change**
A recent PR has enabled the `ReadOnly` flag in read only transactions. However, this is not supported in all mysql versions. This PR revert that change.


