### PR TITLE
Fix k8s tests in Travis

### DIFF
--- a/examples/k8s/k8s-workload-registrar-secret.yaml
+++ b/examples/k8s/k8s-workload-registrar-secret.yaml
@@ -1,0 +1,9 @@
+# Kubernetes Secret containing the K8S Workload Registrar server key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k8s-workload-registrar-secret
+  namespace: spire
+type: Opaque
+data:
+  server-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ3RqS0h2ckVjVWJDdWtlUG8KaXJSMDRqSnZyWW1ONlF3cHlQSlFFTWtsZ3MraFJBTkNBQVJVdzRwSG1XQ3pyZmprWHNlbjkrbVNQemlmV1Y0MwpzNlNaMUorK3h2RFhNMmpPaE04NlZwL1JkQzBtMkZOajNXWWc2c3VSbEV6dmYvRncyQ3N1WmJtbwotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==

--- a/examples/k8s/spire-agent.yaml
+++ b/examples/k8s/spire-agent.yaml
@@ -90,6 +90,8 @@ spec:
   selector:
     matchLabels:
       app: spire-agent
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       namespace: spire
@@ -111,6 +113,7 @@ spec:
       containers:
         - name: spire-agent
           image: spire-agent:latest-local
+          imagePullPolicy: Never
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/examples/k8s/spire-agent.yaml
+++ b/examples/k8s/spire-agent.yaml
@@ -14,7 +14,7 @@ metadata:
   name: spire-agent-cluster-role
 rules:
 - apiGroups: [""]
-  resources: ["pods","nodes"]
+  resources: ["pods","nodes","nodes/proxy"]
   verbs: ["get"]
 
 ---

--- a/examples/k8s/spire-database.yaml
+++ b/examples/k8s/spire-database.yaml
@@ -26,6 +26,8 @@ spec:
     matchLabels:
       app: spire-database
   serviceName: spire-database
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       namespace: spire

--- a/examples/k8s/spire-server.yaml
+++ b/examples/k8s/spire-server.yaml
@@ -16,6 +16,23 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get"]
+  # allow "get" access to pods (to resolve selectors for PSAT attention)
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+  # allow TokenReview requests (to verify service account tokens for PSAT
+  # attestation)
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["get", "create"]
+  # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
+  # agent bootstrapping, see the spire-bundle ConfigMap below) 
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["spire-bundle"]
+  verbs: ["get", "patch"]
+
+
 
 ---
 
@@ -36,13 +53,6 @@ roleRef:
 
 ---
 
-# Role for the SPIRE server
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  namespace: spire
-  name: spire-server-role
-rules:
   # allow "get" access to pods (to resolve selectors for PSAT attestation)
 - apiGroups: [""]
   resources: ["pods"]
@@ -58,24 +68,6 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["spire-bundle"]
   verbs: ["get", "patch"]
-
----
-
-# RoleBinding granting the spire-server-role to the SPIRE server
-# service account.
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: spire-server-role-binding
-  namespace: spire
-subjects:
-- kind: ServiceAccount
-  name: spire-server
-  namespace: spire
-roleRef:
-  kind: Role
-  name: spire-server-role
-  apiGroup: rbac.authorization.k8s.io
 
 ---
 
@@ -210,6 +202,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: k8s-workload-registrar-secret
+  namespace: spire
 type: Opaque
 data:
   server-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ3RqS0h2ckVjVWJDdWtlUG8KaXJSMDRqSnZyWW1ONlF3cHlQSlFFTWtsZ3MraFJBTkNBQVJVdzRwSG1XQ3pyZmprWHNlbjkrbVNQemlmV1Y0MwpzNlNaMUorK3h2RFhNMmpPaE04NlZwL1JkQzBtMkZOajNXWWc2c3VSbEV6dmYvRncyQ3N1WmJtbwotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==

--- a/examples/k8s/spire-server.yaml
+++ b/examples/k8s/spire-server.yaml
@@ -16,23 +16,11 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get"]
-  # allow "get" access to pods (to resolve selectors for PSAT attention)
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get"]
   # allow TokenReview requests (to verify service account tokens for PSAT
   # attestation)
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
   verbs: ["get", "create"]
-  # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
-  # agent bootstrapping, see the spire-bundle ConfigMap below) 
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["spire-bundle"]
-  verbs: ["get", "patch"]
-
-
 
 ---
 
@@ -53,21 +41,41 @@ roleRef:
 
 ---
 
+# Role for the SPIRE server
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: spire
+  name: spire-server-role
+rules:
   # allow "get" access to pods (to resolve selectors for PSAT attestation)
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get"]
-  # allow TokenReview requests (to verify service account tokens for PSAT
-  # attestation)
-- apiGroups: ["authentication.k8s.io"]
-  resources: ["tokenreviews"]
-  verbs: ["get", "create"]
   # allow access to "get" and "patch" the spire-bundle ConfigMap (for SPIRE
   # agent bootstrapping, see the spire-bundle ConfigMap below)
 - apiGroups: [""]
   resources: ["configmaps"]
   resourceNames: ["spire-bundle"]
   verbs: ["get", "patch"]
+
+---
+
+# RoleBinding granting the spire-server-role to the SPIRE server
+# service account.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-server-role-binding
+  namespace: spire
+subjects:
+- kind: ServiceAccount
+  name: spire-server
+  namespace: spire
+roleRef:
+  kind: Role
+  name: spire-server-role
+  apiGroup: rbac.authorization.k8s.io
 
 ---
 
@@ -197,18 +205,6 @@ data:
 
 ---
 
-# Kubernetes Secret containing the K8S Workload Registrar server key
-apiVersion: v1
-kind: Secret
-metadata:
-  name: k8s-workload-registrar-secret
-  namespace: spire
-type: Opaque
-data:
-  server-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ3RqS0h2ckVjVWJDdWtlUG8KaXJSMDRqSnZyWW1ONlF3cHlQSlFFTWtsZ3MraFJBTkNBQVJVdzRwSG1XQ3pyZmprWHNlbjkrbVNQemlmV1Y0MwpzNlNaMUorK3h2RFhNMmpPaE04NlZwL1JkQzBtMkZOajNXWWc2c3VSbEV6dmYvRncyQ3N1WmJtbwotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg==
-
----
-
 # This is the Deployment for the SPIRE server. It waits for SPIRE database to
 # initialize and uses the SPIRE healthcheck command for liveness/readiness
 # probes.
@@ -242,6 +238,7 @@ spec:
       containers:
         - name: spire-server
           image: spire-server:latest-local
+          imagePullPolicy: Never
           args: ["-config", "/run/spire/config/server.conf"]
           ports:
             - containerPort: 8081
@@ -264,6 +261,7 @@ spec:
             periodSeconds: 5
         - name: k8s-workload-registrar
           image: k8s-workload-registrar:latest-local
+          imagePullPolicy: Never
           args: ["-config", "/run/spire/k8s-workload-registrar/conf/k8s-workload-registrar.conf"]
           ports:
           - containerPort: 8443

--- a/examples/k8s/test.sh
+++ b/examples/k8s/test.sh
@@ -15,12 +15,12 @@ fail() {
 }
 
 cp-stdin-to-minikube () {
-	ssh \
-		-i $(minikube ssh-key) \
+    ssh \
+        -i $(minikube ssh-key) \
         -oStrictHostKeyChecking=no \
         -oUserKnownHostsFile=/dev/null \
-		docker@$(minikube ip) \
-		-- bash -c "cat - | sudo tee $1 > /dev/null"
+        docker@$(minikube ip) \
+        -- bash -c "cat - | sudo tee $1 > /dev/null"
 }
 
 echo "${bold}Checking for kubectl...${norm}"
@@ -29,23 +29,58 @@ command -v kubectl > /dev/null || fail "kubectl is required."
 echo "${bold}Checking minikube status...${norm}"
 minikube status || fail "minikube isn't running"
 
-echo "${bold}Injecting admission controller credentials...${norm}"
-minikube ssh -- sudo mkdir -p /var/lib/spire
-cat admctrl-admission-control.yaml | cp-stdin-to-minikube /var/lib/spire/admission-control.yaml
-cat admctrl-kubeconfig.yaml | cp-stdin-to-minikube /var/lib/spire/kubeconfig.yaml
-minikube ssh -- sudo cat /etc/kubernetes/manifests/kube-apiserver.yaml | \
-	go run patch-manifest.go | \
-	cp-stdin-to-minikube /etc/kubernetes/manifests/kube-apiserver.yaml
-
 # Build the k8s-test binary and add it to the PATH
 echo "${bold}Installing k8s-test...${norm}"
 ( cd "${DIR}"/../../tools/k8s-test && GO111MODULE=on go install ) || fail "unable to build k8s-test"
+echo "${bold}Installing patch-manifest...${norm}"
+( cd "${DIR}" && GO111MODULE=on go install patch-manifest.go ) || fail "unable to build patch-manifest"
 PATH="$(go env GOPATH)"/bin:$PATH
 export PATH
 
 
+echo "${bold}Injecting admission controller credentials...${norm}"
+if [ -n "${TRAVIS}" ]; then
+    # travis runs minikube via driver=none, so commands should be
+    # executed directly on the host...
+    sudo mkdir -p /var/lib/spire
+    sudo cp "${DIR}/admctrl-admission-control.yaml" /var/lib/spire/admission-control.yaml
+    sudo cp "${DIR}/admctrl-kubeconfig.yaml" /var/lib/spire/kubeconfig.yaml
+    sudo cat /etc/kubernetes/manifests/kube-apiserver.yaml | patch-manifest | sudo tee /etc/kubernetes/manifests/kube-apiserver.yaml.tmp > /dev/null
+    sudo mv /etc/kubernetes/manifests/kube-apiserver.yaml.tmp /etc/kubernetes/manifests/kube-apiserver.yaml
+else
+    minikube ssh -- sudo mkdir -p /var/lib/spire
+    cat "${DIR}/admctrl-admission-control.yaml" | cp-stdin-to-minikube /var/lib/spire/admission-control.yaml
+    cat "${DIR}/admctrl-kubeconfig.yaml" | cp-stdin-to-minikube /var/lib/spire/kubeconfig.yaml
+    minikube ssh -- sudo cat /etc/kubernetes/manifests/kube-apiserver.yaml | \
+        patch-manifest | \
+        cp-stdin-to-minikube /etc/kubernetes/manifests/kube-apiserver.yaml
+fi
+
+echo "${bold}Waiting for API server to restart...${norm}"
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
+
+
 cleanup() {
+    if [ -z $DONE ]; then
+       kubectl -nspire logs deployment/spire-server --all-containers || true
+       kubectl -nspire logs daemonset/spire-agent --all-containers || true
+       kubectl -nspire logs deployment/example-workload --all-containers || true
+    fi
 	k8s-test clean
+}
+
+wait-for-rollout() {
+    ns=$1
+    obj=$2
+    for ((i=0; i<12; i++)); do
+        if kubectl -n${ns} rollout status $obj --timeout=15s; then
+            return
+        fi
+        kubectl -n${ns} describe pods
+        kubectl -n${ns} logs --all-containers $obj || true
+    done
+    echo "${red}Failed waiting for ${obj} to roll out.${norm}" 1>&2
+    exit 1
 }
 
 trap cleanup EXIT
@@ -53,11 +88,22 @@ trap cleanup EXIT
 echo "${bold}Running test...${norm}"
 
 k8s-test init
-k8s-test apply "${DIR}"/spire-database.yaml
-k8s-test apply "${DIR}"/spire-server.yaml
-k8s-test apply "${DIR}"/spire-agent.yaml
-k8s-test apply "${DIR}"/workload.yaml
+
+kubectl create -f "${DIR}/k8s-workload-registrar-secret.yaml"
+
+k8s-test apply --no-wait "${DIR}"/spire-database.yaml
+wait-for-rollout spire statefulset/spire-database
+
+k8s-test apply --no-wait "${DIR}"/spire-server.yaml
+wait-for-rollout spire deployment/spire-server
+
+k8s-test apply --no-wait "${DIR}"/spire-agent.yaml
+wait-for-rollout spire daemonset/spire-agent
+
+k8s-test apply --no-wait "${DIR}"/workload.yaml
+wait-for-rollout spire deployment/example-workload
 
 k8s-test wait workload-creds example-workload- spiffe://example.org/ns/spire/sa/default
 
+DONE=1
 echo "${bold}Done.${norm}"

--- a/examples/k8s/workload.yaml
+++ b/examples/k8s/workload.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: example-workload
+  namespace: spire
   labels:
     app: example-workload
 spec:
@@ -10,6 +11,7 @@ spec:
       app: example-workload
   template:
     metadata:
+      namespace: spire
       labels:
         app: example-workload
         spire-workload: example-workload

--- a/tools/k8s-test/go.mod
+++ b/tools/k8s-test/go.mod
@@ -17,3 +17,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190216013122-f05b8decd79c
 	k8s.io/klog v0.2.0 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
Fixes the k8s example test in Travis.

- Fixes up cluster role permissions, missing namespaces, etc (thanks @zanghau2 for the contribution!)
- Installs the webhook properly in the none driver environment 
- Uses `kubectl rollout` to monitor status instead of the k8s-test driver
- Other small fixes and debuggability improvements