### PR TITLE
Increase resilience to very low/high TTLs

### DIFF
--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -48,7 +48,7 @@ func New(c *Config) (*manager, error) {
 	}
 
 	if c.RotationInterval == 0 {
-		c.RotationInterval = 60 * time.Second
+		c.RotationInterval = 5 * time.Second
 	}
 
 	if c.Clk == nil {

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -81,7 +81,6 @@ func (r *rotator) shouldRotate() bool {
 
 	ttl := s.SVID[0].NotAfter.Sub(r.clk.Now())
 	watermark := s.SVID[0].NotAfter.Sub(s.SVID[0].NotBefore) / 2
-
 	return ttl <= watermark
 }
 

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const defaultInterval = 60 * time.Second
+const defaultInterval = 5 * time.Second
 
 type RotatorConfig struct {
 	Catalog     catalog.Catalog

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -506,6 +506,26 @@ func (s *ManagerSuite) TestRunFailsIfNotifierFails() {
 	s.Equal("Notifier failed to handle event", entry.Message)
 }
 
+func (s *ManagerSuite) TestPreparationThresholdCap() {
+	issuedAt := time.Now()
+	notAfter := issuedAt.Add(365 * 24 * time.Hour)
+
+	// Expect the preparation threshold to get capped since 1/2 of the lifetime
+	// exceeds the thirty day cap.
+	threshold := preparationThreshold(issuedAt, notAfter)
+	s.Require().Equal(thirtyDays, notAfter.Sub(threshold))
+}
+
+func (s *ManagerSuite) TestActivationThreshholdCap() {
+	issuedAt := time.Now()
+	notAfter := issuedAt.Add(365 * 24 * time.Hour)
+
+	// Expect the activation threshold to get capped since 1/6 of the lifetime
+	// exceeds the seven day cap.
+	threshold := activationThreshold(issuedAt, notAfter)
+	s.Require().Equal(sevenDays, notAfter.Sub(threshold))
+}
+
 func (s *ManagerSuite) initSelfSignedManager() {
 	s.cat.SetUpstreamCA(nil)
 	s.m = NewManager(s.selfSignedConfig())

--- a/pkg/server/svid/rotator_config.go
+++ b/pkg/server/svid/rotator_config.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	DefaultRotatorInterval = 30 * time.Second
+	DefaultRotatorInterval = 5 * time.Second
 )
 
 type RotatorConfig struct {


### PR DESCRIPTION
When TTLs are very low (i.e. lower than ~2x the internal timers that check for expiration) then the agent or server can miss its chance for renewal. The current timers are set to 30 seconds, which makes it hard to use low TTLs for testing/demo purposes. This PR drops the timers down to 5 seconds.

When CA TTLs are very high, SPIRE server prepares and activates **much** to early. For example, if the CA TTL is one year, a new one will be prepared at six months and activated with two months remaining. This change caps the preparation/activation time to 30 and 7 days from expiration, respectively.