### PR TITLE
Fix flaky minting tests

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -55,7 +55,7 @@ var (
 )
 
 func TestInitializationFailure(t *testing.T) {
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
 	baseSVID, baseSVIDKey := createSVID(t, clk, ca, cakey, "spiffe://"+trustDomain+"/agent", 1*time.Hour)
 	cat := fakeagentcatalog.New()
@@ -85,7 +85,7 @@ func TestStoreBundleOnStartup(t *testing.T) {
 	dir := createTempDir(t)
 	defer removeTempDir(dir)
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
 	baseSVID, baseSVIDKey := createSVID(t, clk, ca, cakey, "spiffe://"+trustDomain+"/agent", 1*time.Hour)
 	cat := fakeagentcatalog.New()
@@ -137,7 +137,7 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 	dir := createTempDir(t)
 	defer removeTempDir(dir)
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
 	baseSVID, baseSVIDKey := createSVID(t, clk, ca, cakey, "spiffe://"+trustDomain+"/agent", 1*time.Hour)
 	cat := fakeagentcatalog.New()
@@ -185,7 +185,7 @@ func TestStoreKeyOnStartup(t *testing.T) {
 	dir := createTempDir(t)
 	defer removeTempDir(dir)
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
 	baseSVID, baseSVIDKey := createSVID(t, clk, ca, cakey, "spiffe://"+trustDomain+"/agent", 1*time.Hour)
 
@@ -252,7 +252,7 @@ func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
 	}
 	defer l.Close()
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	apiHandler := newMockNodeAPIHandler(&mockNodeAPIHandlerConfig{
 		t:             t,
 		trustDomain:   trustDomain,
@@ -590,7 +590,7 @@ func TestSynchronizationClearsStaleCacheEntries(t *testing.T) {
 	}
 	defer l.Close()
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	apiHandler := newMockNodeAPIHandler(&mockNodeAPIHandlerConfig{
 		t:             t,
 		trustDomain:   trustDomain,
@@ -652,7 +652,7 @@ func TestSynchronizationUpdatesRegistrationEntries(t *testing.T) {
 	}
 	defer l.Close()
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	apiHandler := newMockNodeAPIHandler(&mockNodeAPIHandlerConfig{
 		t:             t,
 		trustDomain:   trustDomain,
@@ -713,7 +713,7 @@ func TestSubscribersGetUpToDateBundle(t *testing.T) {
 	}
 	defer l.Close()
 
-	clk := clock.New()
+	clk := clock.NewMock(t)
 	apiHandler := newMockNodeAPIHandler(&mockNodeAPIHandlerConfig{
 		t:             t,
 		trustDomain:   trustDomain,

--- a/pkg/agent/plugin/workloadattestor/docker/retry.go
+++ b/pkg/agent/plugin/workloadattestor/docker/retry.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	"github.com/spiffe/spire/test/clock"
+	"github.com/andres-erbsen/clock"
 )
 
 const (

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -344,9 +344,9 @@ func (ca *CA) SignJWTSVID(ctx context.Context, params JWTSVIDParams) (string, er
 
 	telemetry_server.IncrServerCASignJWTSVIDCounter(ca.c.Metrics, params.SpiffeID)
 	ca.c.Log.WithFields(logrus.Fields{
-		telemetry.Audience: params.Audience,
+		telemetry.Audience:   params.Audience,
 		telemetry.Expiration: expiresAt.Format(time.RFC3339),
-		telemetry.SPIFFEID: params.SpiffeID,
+		telemetry.SPIFFEID:   params.SpiffeID,
 	}).Debug("Server CA successfully signed JWT SVID")
 
 	return token, nil

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -65,7 +65,7 @@ type PluginSuite struct {
 }
 
 func (s *PluginSuite) SetupSuite() {
-	clk := clock.New()
+	clk := clock.NewMock(s.T())
 
 	expiredNotAfterTime, err := time.Parse(time.RFC3339, _expiredNotAfterString)
 	s.Require().NoError(err)

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -11,11 +11,6 @@ import (
 // Clock is a clock
 type Clock clock.Clock
 
-// New returns a Clock backed by a realtime clock
-func New() Clock {
-	return clock.New()
-}
-
 // Mock is a mock clock that can be precisely controlled
 type Mock struct {
 	*clock.Mock

--- a/test/fakes/fakeserverca/serverca.go
+++ b/test/fakes/fakeserverca/serverca.go
@@ -47,7 +47,7 @@ func New(t *testing.T, trustDomain string, options *Options) *CA {
 		options = new(Options)
 	}
 	if options.Clock == nil {
-		options.Clock = clock.New()
+		options.Clock = clock.NewMock(t)
 	}
 	if options.X509SVIDTTL == 0 {
 		options.X509SVIDTTL = time.Minute


### PR DESCRIPTION
The fake server ca was accidentally initializing itself with a realtime clock when a clock option was not provided. This caused assertion failures verifying TTLs that were off by a second.

Fixed by initializing with a mock test. Removed the New() method from the test clock package and fixed up other misuse to prevent this sort of thing from happening again.

Fixes #1077