### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile.images
+++ b/Dockerfile.images
@@ -6,15 +6,15 @@ ADD go.mod /spire/go.mod
 ADD proto/spire/go.mod /spire/proto/spire/go.mod
 RUN cd /spire && go mod download
 ADD . /spire
-RUN cd /spire && make test
-RUN cd /spire && make cmd/spire-server
-RUN cd /spire && make cmd/spire-agent
-RUN cd /spire/support/k8s/k8s-workload-registrar && go build
+WORKDIR /spire
+RUN make cmd/spire-server
+RUN make cmd/spire-agent
+RUN make support/k8s/k8s-workload-registrar
 
 # Common base
 FROM alpine AS spire-base
-RUN apk add dumb-init 
-RUN apk add ca-certificates
+RUN apk --no-cache add dumb-init
+RUN apk --no-cache add ca-certificates
 RUN mkdir -p /opt/spire/bin
 
 # SPIRE Server

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ gitdirty := $(shell git status -s)
 ifneq ($(gitdirty),)
 	gittag :=
 endif
-ldflags := '-X github.com/spiffe/spire/pkg/common/version.gittag=$(gittag)'
+ldflags := '-s -w -X github.com/spiffe/spire/pkg/common/version.gittag=$(gittag)'
 
 utils = github.com/spiffe/spire/tools/spire-plugingen
 


### PR DESCRIPTION
- build go binaries with "-w -s" ldflags to strip DWARF info.
- used `--no-cache` with apk on the base image to prevent apk cruft.
- spire-server image went from 80.8MB to 61MB
- spire-agent image went from 45.4MB to 35.2MB
- k8s-workload-registrar image went from 27.5MB to 22MB

