### PR TITLE
Add pointer to new SPIRE examples repository

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Examples have been moved
+
+The examples that lived here have moved to a dedicated repository. Please visit https://github.com/spiffe/spire-examples for maintained SPIRE integration and deployment examples.


### PR DESCRIPTION
Consumable examples have been moved to a dedicated repository. This
commit drops a README for folks looking for them in the old location.

Signed-off-by: Evan Gilman <evan@scytale.io>