### PR TITLE
Remove server only code from common/plugin/aws

### DIFF
--- a/pkg/common/plugin/aws/iid.go
+++ b/pkg/common/plugin/aws/iid.go
@@ -1,16 +1,12 @@
 package aws
 
 import (
-	"bytes"
 	"fmt"
-	"net/url"
-	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
 const (
@@ -21,15 +17,6 @@ const (
 	// SecretAccessKeyVarName env car name for AWS secret access key
 	SecretAccessKeyVarName = "AWS_SECRET_ACCESS_KEY"
 )
-
-// DefaultAgentPathTemplate is the default text/template
-var DefaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"))
-
-type agentPathTemplateData struct {
-	InstanceIdentityDocument
-	PluginName  string
-	TrustDomain string
-}
 
 // SessionConfig is a common config for AWS session config.
 type SessionConfig struct {
@@ -53,19 +40,6 @@ type IIDAttestationData struct {
 // AttestationStepError error with attestation
 func AttestationStepError(step string, cause error) error {
 	return fmt.Errorf("Attempted AWS IID attestation but an error occurred %s: %s", step, cause)
-}
-
-// MakeSpiffeID create spiffe ID from IID data
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc InstanceIdentityDocument) (*url.URL, error) {
-	var agentPath bytes.Buffer
-	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
-		InstanceIdentityDocument: doc,
-		PluginName:               PluginName,
-	}); err != nil {
-		return nil, err
-	}
-
-	return idutil.AgentURI(trustDomain, agentPath.String()), nil
 }
 
 // NewAWSSession create an AWS Session from the config and given region

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -134,7 +134,7 @@ func (p *IIDAttestorPlugin) Attest(stream nodeattestor.NodeAttestor_AttestServer
 		return caws.AttestationStepError("unmarshaling the IID", err)
 	}
 
-	agentID, err := caws.MakeSpiffeID(c.trustDomain, c.pathTemplate, doc)
+	agentID, err := makeSpiffeID(c.trustDomain, c.pathTemplate, doc)
 	if err != nil {
 		return fmt.Errorf("failed to create spiffe ID: %v", err)
 	}
@@ -238,7 +238,7 @@ func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReq
 	}
 	config.trustDomain = req.GlobalConfig.TrustDomain
 
-	config.pathTemplate = caws.DefaultAgentPathTemplate
+	config.pathTemplate = defaultAgentPathTemplate
 	if len(config.AgentPathTemplate) > 0 {
 		tmpl, err := template.New("agent-path").Parse(config.AgentPathTemplate)
 		if err != nil {

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"bytes"
+	"net/url"
+	"text/template"
+
+	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/plugin/aws"
+)
+
+var defaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"))
+
+type agentPathTemplateData struct {
+	aws.InstanceIdentityDocument
+	PluginName  string
+	TrustDomain string
+}
+
+// makeSpiffeID creates a spiffe ID from IID data
+func makeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc aws.InstanceIdentityDocument) (*url.URL, error) {
+	var agentPath bytes.Buffer
+	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
+		InstanceIdentityDocument: doc,
+		PluginName:               aws.PluginName,
+	}); err != nil {
+		return nil, err
+	}
+
+	return idutil.AgentURI(trustDomain, agentPath.String()), nil
+}


### PR DESCRIPTION
The agent path construction helpers are only used by the server
plugin now. This change moves that code to keep the common module
as small as possible.