### PR TITLE
Show DNS names in `spire-server entry show` command

### DIFF
--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -77,6 +77,9 @@ func printEntry(e *common.RegistrationEntry) {
 	for _, id := range e.FederatesWith {
 		fmt.Printf("FederatesWith : %s\n", id)
 	}
+	for _, dnsName := range e.DnsNames {
+		fmt.Printf("DNS Name      : %s\n", dnsName)
+	}
 
 	// admin is rare, so only show admin if true to keep
 	// from muddying the output.
@@ -87,7 +90,7 @@ func printEntry(e *common.RegistrationEntry) {
 	fmt.Println()
 }
 
-// Define a custom type for string lists. Doing
+// StringsFlag defines a custom type for string lists. Doing
 // this allows us to support repeatable string flags.
 type StringsFlag []string
 

--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -78,7 +78,7 @@ func printEntry(e *common.RegistrationEntry) {
 		fmt.Printf("FederatesWith : %s\n", id)
 	}
 	for _, dnsName := range e.DnsNames {
-		fmt.Printf("DNS Name      : %s\n", dnsName)
+		fmt.Printf("DNS name      : %s\n", dnsName)
 	}
 
 	// admin is rare, so only show admin if true to keep


### PR DESCRIPTION
- Show DNS names in `spire-server entry show` command
- Fix comment for `StringsFlag` type