### PR TITLE
Remove minikube-based k8s tests from v0.8 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,26 +91,11 @@ jobs:
       before_script:
         # Decrypt credentials needed to log into gcr registry
         - openssl aes-256-cbc -K $encrypted_b48f9e852489_key -iv $encrypted_b48f9e852489_iv -in .travis/spire-travis-ci.json.enc -out .travis/spire-travis-ci.json -d
-        # Download stable kubectl
-        - curl -s -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-        # Download latest minikube
-        - curl -s -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-        # Start up minikube
-        - sudo minikube start --vm-driver=none --extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key --extra-config=apiserver.service-account-key-file=/var/lib/minikube/certs/sa.pub --extra-config=apiserver.service-account-issuer=api --extra-config=apiserver.service-account-api-audiences=api,spire-server --extra-config=apiserver.authorization-mode=RBAC
-
-        # Make sure kubectl configuration is up to date
-        - sudo chown -R $USER.$USER ~/.kube
-        - sudo chown -R $USER.$USER ~/.minikube
-        - minikube update-context
-        # Wait for stuff to become ready
-        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
       script:
         # Build spire images
-        - eval $(minikube docker-env) && make spire-images
-        # Run systems tests
-        - examples/k8s/test-all.sh
+        - make spire-images
         # Publish images
-        - eval $(minikube docker-env) && .travis/publish-images.sh
+        - .travis/publish-images.sh
 
 notifications:
     slack:


### PR DESCRIPTION
Somewhere along the way, the travis environment was updated in such a
way that our minikube tests all broke. This breakage was observed by
@azdagron to not be related to any changes on our side. A copy of the
error is pasted below.

We knew that we wanted to move away from minikube for these tests in
favor of kind, so rather than shave the minikube yak, we rolled
forward. The result is that any commit prior to that change will no
longer pass the minikube-related tests in travis.

Unfortunately, the 0.8.2 release does not include kind support (which,
of course, the new test suite relies on). Rather than pull a new feature
into 0.8.2, this commit removes the minikube-related tests from
travis.yml in the v0.8 branch. This is justified because 1) we know the
tests to be passing, and 2) we expect this to be the last meaningful 0.8
release.

```
$ minikube update-context
*
X update config: Kubeconfig does not have a record of the machine cluster
*
* Sorry that minikube crashed. If this was unexpected, we would love to hear from you:
  - https://github.com/kubernetes/minikube/issues/new/choose
The command "minikube update-context" failed and exited with 70 during .
Your build has been stopped.
```

Signed-off-by: Evan Gilman <evan@scytale.io>