### PR TITLE
Use "address" field as string type exclusively

### DIFF
--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -177,7 +177,7 @@ func (e *endpoints) runTCPServer(ctx context.Context, server *grpc.Server) error
 	}
 
 	// Skip use of tomb here so we don't pollute a clean shutdown with errors
-	e.c.Log.WithField(telemetry.Address, l.Addr()).Info("Starting TCP server")
+	e.c.Log.WithField(telemetry.Address, l.Addr().String()).Info("Starting TCP server")
 	errChan := make(chan error)
 	go func() { errChan <- server.Serve(l) }()
 
@@ -209,7 +209,7 @@ func (e *endpoints) runUDSServer(ctx context.Context, server *grpc.Server) error
 	}
 
 	// Skip use of tomb here so we don't pollute a clean shutdown with errors
-	e.c.Log.WithField(telemetry.Address, l.Addr()).Info("Starting UDS server")
+	e.c.Log.WithField(telemetry.Address, l.Addr().String()).Info("Starting UDS server")
 	errChan := make(chan error)
 	go func() { errChan <- server.Serve(l) }()
 
@@ -230,7 +230,7 @@ func (e *endpoints) getTLSConfig(ctx context.Context) func(*tls.ClientHelloInfo)
 	return func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
 		certs, roots, err := e.getCerts(ctx)
 		if err != nil {
-			e.c.Log.WithError(err).WithField(telemetry.Address, hello.Conn.RemoteAddr()).Error("Could not generate TLS config for gRPC client")
+			e.c.Log.WithError(err).WithField(telemetry.Address, hello.Conn.RemoteAddr().String()).Error("Could not generate TLS config for gRPC client")
 			return nil, err
 		}
 

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -201,7 +201,7 @@ func (h *Handler) Attest(stream node.Node_AttestServer) (err error) {
 
 	p, ok := peer.FromContext(ctx)
 	if ok {
-		log.WithField(telemetry.Address, p.Addr).Info("Node attestation request completed")
+		log.WithField(telemetry.Address, p.Addr.String()).Info("Node attestation request completed")
 	}
 
 	if err := stream.Send(response); err != nil {


### PR DESCRIPTION
Signed-off-by: Ryan Turner <turner@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Log entries in SPIRE Server

**Description of change**
Changing instances where non-String types were being logged in the "address" field to use String representations to be consistent.

**Which issue this PR fixes**
fixes 1185

