### PR TITLE
docker: support multiple cgroup patterns

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -6,24 +6,17 @@ import (
 	"strings"
 )
 
-// Token is a character or set of characters that are used during parsing of a cgroup entry.
-type Token string
-
 const (
-	// WildcardToken is used to match a variable number of any character, excluding forward slash (`/`).
-	//
-	// This token MAY be provided any number of times.
-	WildcardToken Token = "*"
+	// A token to match an entire path component in a "/" delimited path
+	wildcardToken = "*"
+	// A regex expression that expresses wildcardToken
+	regexpWildcard = "[^\\/]*"
 
-	// ContainerIDToken is used to match the container id, which MUST not include a forward slash (`/`).
-	//
-	// This token MUST be provided exactly once in a pattern.
-	ContainerIDToken Token = "<id>"
-
-	// used for converting from our tokens to those understood by the regexp package
-	regexpWildcard         = "[^\\/]*"
-	regexpWildcardSubmatch = "([^\\/]*)"
-
+	// A token to match, and extract as a container ID, an entire path component in a
+	// "/" delimited path
+	containerIDToken = "<id>"
+	// A regex expression that expresses containerIDToken
+	regexpContainerID = "([^\\/]*)"
 	// index for slice returned by FindStringSubmatch
 	submatchIndex = 1
 )
@@ -39,17 +32,17 @@ func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
 	elems := strings.Split(pattern, "/")
 	for i, e := range elems {
 		switch e {
-		case string(WildcardToken):
+		case wildcardToken:
 			elems[i] = regexpWildcard
-		case string(ContainerIDToken):
+		case containerIDToken:
 			idTokenCount++
-			elems[i] = regexpWildcardSubmatch
+			elems[i] = regexpContainerID
 		default:
 			elems[i] = regexp.QuoteMeta(e)
 		}
 	}
 	if idTokenCount != 1 {
-		return nil, fmt.Errorf("pattern %q must contain the container id token %q exactly once", pattern, ContainerIDToken)
+		return nil, fmt.Errorf("pattern %q must contain the container id token %q exactly once", pattern, containerIDToken)
 	}
 
 	pattern = "^" + strings.Join(elems, "/") + "$"
@@ -65,7 +58,11 @@ func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
 // NewContainerIDFinder returns a new ContainerIDFinder.
 //
 // The patterns provided should use the Tokens defined in this package in order
-// to describe how a container id should be extracted from a cgroup entry.
+// to describe how a container id should be extracted from a cgroup entry. The
+// given patterns MUST NOT be ambiguous and an error will be returned if multiple
+// patterns can match the same input. An example of invalid input:
+//     "/a/b/<id>"
+//     "/*/b/<id>"
 //
 // Examples:
 //     "/docker/<id>"
@@ -74,6 +71,9 @@ func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
 // Note: The pattern provided is *not* a regular expression. It is a simplified matching
 // language that enforces a forward slash-delimited schema.
 func NewContainerIDFinder(patterns []string) (ContainerIDFinder, error) {
+	if ambiguousPatterns := findAmbiguousPatterns(patterns); len(ambiguousPatterns) != 0 {
+		return nil, fmt.Errorf("dockerfinder: patterns must not be ambiguous: %q", ambiguousPatterns)
+	}
 	var finders []ContainerIDFinder
 	for _, pattern := range patterns {
 		finder, err := newContainerIDFinder(pattern)
@@ -111,4 +111,71 @@ func (f *containerIDFinders) FindContainerID(cgroup string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// There must be exactly 0 or 1 pattern that matches a given input. Enforcing
+// this at startup, instead of at runtime (e.g. in `FindContainerID`) ensures that
+// a bad configuration is found immediately during rollout, rather than once a
+// specific cgroup input is encountered.
+//
+// Given the restricted grammar of wildcardToken and containerIDToken and
+// the goal of protecting a user from invalid configuration, detecting ambiguous patterns
+// is done as follows:
+//
+// 1. If the number of path components in two patterns differ, they cannot match identical inputs.
+// This assertions follows from the path focused grammar and the fact that the regex
+// wildcards (regexpWildcard and regexpContainerID) cannot match "/".
+// 2. If the number of path components in two patterns are the same, we test "component
+// equivalence". wildcardToken and containerIDToken are equivalent to anything other
+// string, else string equivalence is required.
+// From this and the fact the regex wildcards cannot match "/" follows that a single
+// non-equivalent path component means the two patterns cannot match the same inputs.
+func findAmbiguousPatterns(patterns []string) []string {
+	p := patterns[0]
+	rest := patterns[1:]
+	foundPatterns := make(map[string]struct{})
+
+	// generate all combinations except for equivalent
+	// index combinations which will always match.
+	for len(rest) > 0 {
+		for _, p2 := range rest {
+			if equivalentPatterns(p, p2) {
+				foundPatterns[p] = struct{}{}
+				foundPatterns[p2] = struct{}{}
+			}
+		}
+
+		p = rest[0]
+		rest = rest[1:]
+	}
+
+	out := make([]string, 0, len(foundPatterns))
+	for foundPattern := range foundPatterns {
+		out = append(out, foundPattern)
+	}
+
+	return out
+}
+
+func equivalentPatterns(a, b string) bool {
+	if a == b {
+		return true
+	}
+
+	aComponents := strings.Split(a, "/")
+	bComponents := strings.Split(b, "/")
+	if len(aComponents) != len(bComponents) {
+		return false
+	}
+
+	for i, comp := range aComponents {
+		switch {
+		case comp == bComponents[i]:
+		case comp == wildcardToken || bComponents[i] == wildcardToken:
+		case comp == containerIDToken || bComponents[i] == containerIDToken:
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -1,0 +1,103 @@
+package cgroup
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Token is a character or set of characters that are used during parsing of a cgroup entry.
+type Token string
+
+const (
+	// WildcardToken is used to match a variable number of any character, excluding forward slash (`/`).
+	//
+	// This token MAY be provided any number of times.
+	WildcardToken Token = "*"
+
+	// ContainerIDToken is used to match the container id, which MUST not include a forward slash (`/`).
+	//
+	// This token MUST be provided exactly once in a pattern.
+	ContainerIDToken Token = "<id>"
+
+	// used for converting from our tokens to those understood by the regexp package
+	regexpWildcard         = "[^\\/]*"
+	regexpWildcardSubmatch = "([^\\/]*)"
+
+	// index for slice returned by FindSubmatch
+	// fullmatchIndex = 0
+	submatchIndex = 1
+)
+
+// ContainerIDFinder finds a container id from a cgroup entry.
+type ContainerIDFinder interface {
+	// FindContainerID returns a container id and true if the known pattern is matched, false otherwise.
+	FindContainerID(cgroup string) (containerID string, found bool)
+}
+
+func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
+	if strings.Count(pattern, string(ContainerIDToken)) != 1 {
+		return nil, fmt.Errorf("pattern %q must contain the container id token %q exactly once", pattern, ContainerIDToken)
+	}
+	pattern = strings.ReplaceAll(pattern, string(WildcardToken), regexpWildcard)
+	pattern = strings.Replace(pattern, string(ContainerIDToken), regexpWildcardSubmatch, 1)
+	pattern = "^" + pattern + "$"
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create container id fetcher: %v", err)
+	}
+	return &containerIDFinder{
+		re: re,
+	}, nil
+}
+
+// NewContainerIDFinder returns a new ContainerIDFinder.
+//
+// The patterns provided should use the Tokens defined in this package in order
+// to describe how a container id should be extracted from a cgroup entry.
+//
+// Examples:
+//     "/docker/<id>"
+//     "/my.slice/*/<id>/*"
+//
+// Note: The pattern provided is *not* a regular expression. It is a simplified matching
+// language that enforces a forward slash-delimited schema.
+func NewContainerIDFinder(patterns []string) (ContainerIDFinder, error) {
+	var finders []ContainerIDFinder
+	for _, pattern := range patterns {
+		finder, err := newContainerIDFinder(pattern)
+		if err != nil {
+			return nil, err
+		}
+		finders = append(finders, finder)
+	}
+	return &containerIDFinders{
+		finders: finders,
+	}, nil
+}
+
+type containerIDFinder struct {
+	re *regexp.Regexp
+}
+
+func (f *containerIDFinder) FindContainerID(cgroup string) (string, bool) {
+	matches := f.re.FindSubmatch([]byte(cgroup))
+	if len(matches) == 0 {
+		return "", false
+	}
+	return string(matches[submatchIndex]), true
+}
+
+type containerIDFinders struct {
+	finders []ContainerIDFinder
+}
+
+func (f *containerIDFinders) FindContainerID(cgroup string) (string, bool) {
+	for _, finder := range f.finders {
+		id, ok := finder.FindContainerID(cgroup)
+		if ok {
+			return id, ok
+		}
+	}
+	return "", false
+}

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -24,8 +24,7 @@ const (
 	regexpWildcard         = "[^\\/]*"
 	regexpWildcardSubmatch = "([^\\/]*)"
 
-	// index for slice returned by FindSubmatch
-	// fullmatchIndex = 0
+	// index for slice returned by FindStringSubmatch
 	submatchIndex = 1
 )
 
@@ -81,7 +80,7 @@ type containerIDFinder struct {
 }
 
 func (f *containerIDFinder) FindContainerID(cgroup string) (string, bool) {
-	matches := f.re.FindSubmatch([]byte(cgroup))
+	matches := f.re.FindStringSubmatch(cgroup)
 	if len(matches) == 0 {
 		return "", false
 	}

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -1,6 +1,7 @@
 package cgroup
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -71,6 +72,10 @@ func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
 // Note: The pattern provided is *not* a regular expression. It is a simplified matching
 // language that enforces a forward slash-delimited schema.
 func NewContainerIDFinder(patterns []string) (ContainerIDFinder, error) {
+	if len(patterns) < 1 {
+		return nil, errors.New("dockerfinder: at least 1 pattern must be supplied")
+	}
+
 	if ambiguousPatterns := findAmbiguousPatterns(patterns); len(ambiguousPatterns) != 0 {
 		return nil, fmt.Errorf("dockerfinder: patterns must not be ambiguous: %q", ambiguousPatterns)
 	}

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -131,8 +131,8 @@ func (f *containerIDFinders) FindContainerID(cgroup string) (string, bool) {
 // This assertions follows from the path focused grammar and the fact that the regex
 // wildcards (regexpWildcard and regexpContainerID) cannot match "/".
 // 2. If the number of path components in two patterns are the same, we test "component
-// equivalence". wildcardToken and containerIDToken are equivalent to anything other
-// string, else string equivalence is required.
+// equivalence" at each index. wildcardToken and containerIDToken are equivalent to
+// any other, otherwise, the two components at an index are directly compared.
 // From this and the fact the regex wildcards cannot match "/" follows that a single
 // non-equivalent path component means the two patterns cannot match the same inputs.
 func findAmbiguousPatterns(patterns []string) []string {

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
@@ -1,0 +1,124 @@
+package cgroup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerIDFinders(t *testing.T) {
+	type match struct {
+		cgroup string
+		id     string
+	}
+	tests := []struct {
+		msg           string
+		matchers      []string
+		expectErr     string
+		expectNoMatch []string
+		expectMatches []match
+	}{
+		{
+			msg: "single matcher",
+			matchers: []string{
+				"/docker/<id>",
+			},
+			expectMatches: []match{
+				{
+					cgroup: "/docker/",
+					id:     "",
+				},
+				{
+					cgroup: "/docker/foo",
+					id:     "foo",
+				},
+			},
+			expectNoMatch: []string{
+				"",
+				"/",
+				"/docker",
+				"/dockerfoo",
+				"/docker/foo/",
+				"/docker/foo/bar",
+				"/docker/foo/docker/foo",
+			},
+		},
+		{
+			msg: "multiple wildcards",
+			matchers: []string{
+				"/long.slice/*/*/<id>/*",
+			},
+			expectMatches: []match{
+				{
+					cgroup: "/long.slice/foo/bar//qux",
+					id:     "",
+				},
+				{
+					cgroup: "/long.slice/foo/bar/baz/",
+					id:     "baz",
+				},
+				{
+					cgroup: "/long.slice/foo/bar/baz/qux",
+					id:     "baz",
+				},
+			},
+			expectNoMatch: []string{
+				"",
+				"/",
+				"/long.slice",
+				"/long.slicefoo",
+				"/long.slice/foo",
+				"/long.slice/foo/",
+				"/long.slice/foo/bar",
+				"/long.slice/foo/long.slice/foo",
+				"/long.slice/foo/bar/baz",
+				"/long.slice/foo/bar/baz/qux/qax",
+			},
+		},
+		{
+			msg: "no id token",
+			matchers: []string{
+				"/noid",
+			},
+			expectErr: `pattern "/noid" must contain the container id token "<id>" exactly once`,
+		},
+		{
+			msg: "extra id token",
+			matchers: []string{
+				"/<id>/<id>",
+			},
+			expectErr: `pattern "/<id>/<id>" must contain the container id token "<id>" exactly once`,
+		},
+		{
+			msg: "bad regex characters",
+			matchers: []string{
+				"\\<id>",
+			},
+			expectErr: "error parsing regexp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			cf, err := NewContainerIDFinder(tt.matchers)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			for _, noMatch := range tt.expectNoMatch {
+				id, ok := cf.FindContainerID(noMatch)
+				assert.False(t, ok, "expected to not find %q but did", noMatch)
+				assert.Equal(t, "", id)
+			}
+
+			for _, m := range tt.expectMatches {
+				id, ok := cf.FindContainerID(m.cgroup)
+				assert.True(t, ok, "expected to find %q but did not", m.cgroup)
+				assert.Equal(t, m.id, id)
+			}
+		})
+	}
+}

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
@@ -90,13 +90,6 @@ func TestContainerIDFinders(t *testing.T) {
 			},
 			expectErr: `pattern "/<id>/<id>" must contain the container id token "<id>" exactly once`,
 		},
-		{
-			msg: "bad regex characters",
-			matchers: []string{
-				"\\<id>",
-			},
-			expectErr: "error parsing regexp",
-		},
 	}
 
 	for _, tt := range tests {
@@ -108,6 +101,8 @@ func TestContainerIDFinders(t *testing.T) {
 				return
 			}
 
+			require.NoError(t, err)
+			require.NotNil(t, cf)
 			for _, noMatch := range tt.expectNoMatch {
 				id, ok := cf.FindContainerID(noMatch)
 				assert.False(t, ok, "expected to not find %q but did", noMatch)

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
@@ -116,6 +116,10 @@ func TestContainerIDFinders(t *testing.T) {
 			},
 			expectErr: "dockerfinder: patterns must not be ambiguous:",
 		},
+		{
+			msg:       "no patterns",
+			expectErr: "dockerfinder: at least 1 pattern must be supplied",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
@@ -90,6 +90,32 @@ func TestContainerIDFinders(t *testing.T) {
 			},
 			expectErr: `pattern "/<id>/<id>" must contain the container id token "<id>" exactly once`,
 		},
+		{
+			msg: "ambiguous patterns",
+			matchers: []string{
+				"/docker/<id>",
+				"/*/<id>",
+			},
+			expectErr: "dockerfinder: patterns must not be ambiguous:",
+		},
+		{
+			msg: "identical patterns",
+			matchers: []string{
+				"/docker/<id>",
+				"/docker/<id>",
+			},
+			expectErr: "dockerfinder: patterns must not be ambiguous:",
+		},
+		{
+			msg: "many ambiguous patterns",
+			matchers: []string{
+				"/docker/<id>",
+				"/*/<id>",
+				"/a/b/*/d/<id>",
+				"/<id>/*/*/*/*",
+			},
+			expectErr: "dockerfinder: patterns must not be ambiguous:",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -2,7 +2,9 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/docker/docker/api/types"
@@ -13,6 +15,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/common/cgroups"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/cgroup"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/proto/spire/agent/workloadattestor"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
@@ -50,6 +53,11 @@ type DockerPlugin struct {
 	mtx               *sync.RWMutex
 	retryer           *retryer
 	containerIDFinder cgroup.ContainerIDFinder
+	findContainerID   func(string) (string, bool)
+
+	// legacy ID extraction
+	cgroupPrefix         string
+	cgroupContainerIndex int
 }
 
 func New() *DockerPlugin {
@@ -65,6 +73,11 @@ type dockerPluginConfig struct {
 	DockerSocketPath string `hcl:"docker_socket_path"`
 	// DockerVersion is the API version of the docker daemon (default: "1.40").
 	DockerVersion string `hcl:"docker_version"`
+	// CgroupPrefix (DEPRECATED) is the cgroup prefix to look for in the cgroup entries (default: "/docker").
+	CgroupPrefix string `hcl:"cgroup_prefix"`
+	// CgroupContainerIndex (DEPRECATED) is the index within the cgroup path where the container ID should be found (default: 1).
+	// This is a *int to allow differentiation between the default int value (0) and the absence of the field.
+	CgroupContainerIndex *int `hcl:"cgroup_container_index"`
 	// ContainerIDCGroupMatchers
 	ContainerIDCGroupMatchers []string `hcl:"container_id_cgroup_matchers"`
 }
@@ -87,13 +100,14 @@ func (p *DockerPlugin) Attest(ctx context.Context, req *workloadattestor.AttestR
 	for _, cgroup := range cgroupList {
 		// We are only interested in cgroup entries that match our desired pattern. Example entry:
 		// "10:perf_event:/docker/2235ebefd9babe0dde4df4e7c49708e24fb31fb851edea55c0ee29a18273cdf4"
-		id, ok := p.containerIDFinder.FindContainerID(cgroup.GroupPath)
+		id, ok := p.findContainerID(cgroup.GroupPath)
 		if !ok {
 			continue
 		}
 		hasDockerEntries = true
 		containerID = id
 		break
+
 	}
 
 	// Not a docker workload. Since it is expected that non-docker workloads will call the
@@ -167,6 +181,21 @@ func (p *DockerPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest)
 		return nil, err
 	}
 
+	if config.CgroupPrefix != "" || config.CgroupContainerIndex != nil {
+		if config.CgroupPrefix == "" || config.CgroupContainerIndex == nil {
+			return nil, errors.New("cgroup_prefix and cgroup_container_index must be specified together")
+		}
+
+		p.cgroupPrefix = config.CgroupPrefix
+		// index 0 will always be "" as the prefix must start with /.
+		// We add 1 to the requested index to hide this from the user.
+		p.cgroupContainerIndex = *config.CgroupContainerIndex + 1
+
+		p.findContainerID = p.legacyExtractID
+
+		return &spi.ConfigureResponse{}, nil
+	}
+
 	matchers := config.ContainerIDCGroupMatchers
 	if len(matchers) == 0 {
 		matchers = defaultContainerIDMatchers
@@ -177,9 +206,26 @@ func (p *DockerPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest)
 		return nil, err
 	}
 
+	p.findContainerID = p.containerIDFinder.FindContainerID
+
 	return &spi.ConfigureResponse{}, nil
 }
 
 func (*DockerPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p *DockerPlugin) legacyExtractID(cgroupPath string) (string, bool) {
+	if !strings.HasPrefix(cgroupPath, p.cgroupPrefix) {
+		return "", false
+	}
+
+	parts := strings.Split(cgroupPath, "/")
+
+	if len(parts) <= p.cgroupContainerIndex {
+		p.log.Warn("Docker entry found, but is missing the container id", telemetry.CGroupPath, cgroupPath)
+		return "", false
+	}
+
+	return parts[p.cgroupContainerIndex], true
 }

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -185,6 +185,7 @@ func (p *DockerPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest)
 		if config.CgroupPrefix == "" || config.CgroupContainerIndex == nil {
 			return nil, errors.New("cgroup_prefix and cgroup_container_index must be specified together")
 		}
+		p.log.Warn("cgroup_prefix and cgroup_container_index are deprecated and will be removed in a future release")
 
 		p.cgroupPrefix = config.CgroupPrefix
 		// index 0 will always be "" as the prefix must start with /.


### PR DESCRIPTION
Support extracting docker container IDs from multiple
different cgroup patterns. This is useful in an environment
that has multiple ways of scheduling a docker container
on the same OS instance that don't use the same cgroup
naming scheme. For example, you may use the docker
cgroup-parent option [1] to group many containers under
a single cgroup/systemd slice.

This replaces earlier undocumented configurables which
could control the cgroup prefix to match against and
the index from which to extract the container ID. Since
these were unexported (and were added on my deployments behalf)
there has been no effort put forth to ensure compatibility.

[1]: https://docs.docker.com/engine/reference/commandline/dockerd/#miscellaneous-options

Fixes #1137

Signed-off-by: Tyler Dixon <tylerd@uber.com>