### PR TITLE
Fix deletion of registration entries

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -2047,6 +2047,11 @@ func deleteRegistrationEntrySupport(tx *gorm.DB, entry RegisteredEntry) error {
 		return sqlError.Wrap(err)
 	}
 
+	// Delete existing selectors
+	if err := tx.Exec("DELETE FROM selectors WHERE registered_entry_id = ?", entry.ID).Error; err != nil {
+		return sqlError.Wrap(err)
+	}
+
 	return nil
 }
 

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -1310,12 +1310,26 @@ func (s *PluginSuite) TestDeleteRegistrationEntry() {
 		Ttl:      2,
 	})
 
+	// We have two registration entries
+	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
+	entriesResp, err := s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
+	expectedCallCounter.Done(nil)
+	s.Require().NoError(err)
+	s.Require().Len(entriesResp.Entries, 2)
+
 	// Make sure we deleted the right one
 	expectedCallCounter = ds_telemetry.StartDeleteRegistrationCall(s.expectedMetrics)
 	delRes, err := s.ds.DeleteRegistrationEntry(ctx, &datastore.DeleteRegistrationEntryRequest{EntryId: entry1.EntryId})
 	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Equal(entry1, delRes.Entry)
+
+	// Make sure we have now only one registration entry
+	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
+	entriesResp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
+	expectedCallCounter.Done(nil)
+	s.Require().NoError(err)
+	s.Require().Len(entriesResp.Entries, 1)
 
 	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -1312,7 +1312,7 @@ func (s *PluginSuite) TestDeleteRegistrationEntry() {
 
 	// We have two registration entries
 	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
-	entriesResp, err := s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
+	entriesResp, err := s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
 	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Len(entriesResp.Entries, 2)
@@ -1326,7 +1326,7 @@ func (s *PluginSuite) TestDeleteRegistrationEntry() {
 
 	// Make sure we have now only one registration entry
 	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
-	entriesResp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
+	entriesResp, err = s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
 	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Len(entriesResp.Entries, 1)


### PR DESCRIPTION
Deletion of registration entries was leaving orphan selectors.
- Fixed to delete the associated selectors.
- Updated the test to catch this.