### PR TITLE
Don't pollute repo with .tmp file

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -55,6 +55,9 @@ var (
 )
 
 func TestInitializationFailure(t *testing.T) {
+	dir := createTempDir(t)
+	defer removeTempDir(dir)
+
 	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
 	baseSVID, baseSVIDKey := createSVID(t, clk, ca, cakey, "spiffe://"+trustDomain+"/agent", 1*time.Hour)
@@ -62,13 +65,15 @@ func TestInitializationFailure(t *testing.T) {
 	cat.SetKeyManager(fakeagentcatalog.KeyManager(memory.New()))
 
 	c := &Config{
-		SVID:        baseSVID,
-		SVIDKey:     baseSVIDKey,
-		Log:         testLogger,
-		Metrics:     &telemetry.Blackhole{},
-		TrustDomain: trustDomainID,
-		Clk:         clk,
-		Catalog:     cat,
+		SVID:            baseSVID,
+		SVIDKey:         baseSVIDKey,
+		Log:             testLogger,
+		Metrics:         &telemetry.Blackhole{},
+		TrustDomain:     trustDomainID,
+		SVIDCachePath:   path.Join(dir, "svid.der"),
+		BundleCachePath: path.Join(dir, "bundle.der"),
+		Clk:             clk,
+		Catalog:         cat,
 	}
 	m, err := New(c)
 	if err != nil {


### PR DESCRIPTION
The agent manager initialization test does not provide an SVID or bundle storage path.  This results in the test writing temporary files into the working directory during test execution.

This change fixes the test to use a temp directory so the repo is not polluted on a test run.

