### PR TITLE
Add documentation describing SPIRE versioning and upgrade procedures

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ SPIRE provides an implementation of the [Envoy](https://envoyproxy.io)
 (SDS). SDS can be used to transparently install and rotate TLS certificates and
 trust bundles in Envoy. Please see the [SPIRE Agent configuration guide](/doc/spire_agent.md#agent-configuration-file) for more information.
 
+# Upgrading SPIRE
+
+SPIRE server supports zero-downtime upgrades when there's more than one SPIRE server in the cluster. Please seee the [Managing Upgrades/Downgrades](doc/upgrading.md) guide for more information on SPIRE versioning and supported upgrade paths.
+
 # Getting Help
 
 If you have any questions about how SPIRE works, or how to get it up and running, the best place to ask questions is the [SPIFFE Slack Organization](https://slack.spiffe.io/). Most of the maintainers monitor the #spire channel there, and can help direct you to other channels if need be. Please feel free to drop by any time!

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ SPIRE (the [SPIFFE](https://github.com/spiffe/spiffe) Runtime Environment) is a 
 - [Getting started](#getting-started)
 - [Examples](#examples)
 - [Using SPIRE with Envoy](#using-spire-with-envoy)
+- [Upgrading SPIRE](#upgrading-spire)
 - [Getting help](#getting-help)
 - [Community](#community)
 
@@ -45,7 +46,7 @@ trust bundles in Envoy. Please see the [SPIRE Agent configuration guide](/doc/sp
 
 # Upgrading SPIRE
 
-SPIRE server supports zero-downtime upgrades when there's more than one SPIRE server in the cluster. Please seee the [Managing Upgrades/Downgrades](doc/upgrading.md) guide for more information on SPIRE versioning and supported upgrade paths.
+SPIRE Server supports zero-downtime upgrades when there's more than one SPIRE Server in the cluster. Please see the [Managing Upgrades/Downgrades](doc/upgrading.md) guide for more information on SPIRE version compatibility and supported upgrade paths.
 
 # Getting Help
 

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -2,39 +2,41 @@
 This guide describes how to upgrade your SPIRE deployment, as well as the compatibility guarantees that SPIRE users can expect.
 
 ## SPIRE Versioning
-SPIRE versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following Semantic Versioning terminology. The SPIRE project is currently pre-1.0, so minor SPIRE releases act like major releases and patch releases act like minor releases. Despite the fact that the project is pre-1.0, version compatibility guarantees are already in place.
+SPIRE versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following Semantic Versioning terminology. Despite the fact that the project is currently pre-1.0, version compatibility guarantees are already in place. This document will be updated in advance of a 1.0.0 release.
 
 ### SPIRE Server Compatibility
-Version skew within a SPIRE server cluster is supported within +/- 1 minor version. In other words, the newest and oldest SPIRE server instances in any given cluster must be within one minor version of each other.
+Version skew within a SPIRE Server cluster is supported within +/- 1 minor version. In other words, the newest and oldest SPIRE Server instances in any given cluster must be within one minor version of each other.
 
 For example:
-* Newest SPIRE server instance is at 0.9.3
-* Other SPIRE server instances are supported at 0.9.x and 0.8.x
+* Newest SPIRE Server instance is at 0.9.3
+* Other SPIRE Server instances are supported at 0.9.x and 0.8.x
 
 ### SPIRE Agent Compatibility
-SPIRE agents must not be newer than the oldest SPIRE server that they communicate with, and may be up to one minor version older.
+SPIRE Agents must not be newer than the oldest SPIRE Server that they communicate with, and may be up to one minor version older.
 
 For example:
-* SPIRE servers are at both 0.9.3 and 0.9.2
-* SPIRE agents are supported at 0.8.0 through 0.9.2
+* SPIRE Servers are at both 0.9.3 and 0.9.2
+* SPIRE Agents are supported at 0.8.0 through 0.9.2
 
 ## Supported Upgrade Paths
 
-The supported version skew between SPIRE servers and agents has implications on the order in which they must be upgraded. SPIRE servers must be upgraded before SPIRE agents, and is limited to a jump of at most one minor version (regardless of patch version). SPIRE server and agent instances may be upgraded in a rolling fashion.
+The supported version skew between SPIRE Servers and agents has implications on the order in which they must be upgraded. SPIRE Servers must be upgraded before SPIRE Agents, and is limited to a jump of at most one minor version (regardless of patch version). Upgrades that jump two or more minor versions (e.g. 0.8.1 to 0.10.0) are not supported.
+
+SPIRE Server and agent instances may be upgraded in a rolling fashion.
 
 For example, if upgrading from 0.8.1 to 0.9.3:
-* Upgrade SPIRE server instances from 0.8.1 to 0.9.3 one at a time
-* Ensure that the SPIRE server cluster is operating as expected
-* Upgrade SPIRE agent instances from 0.8.1 to 0.9.3 one at a time or in batches
+* Upgrade SPIRE Server instances from 0.8.1 to 0.9.3 one instance at a time
+* Ensure that the SPIRE Server cluster is operating as expected
+* Upgrade SPIRE Agent instances from 0.8.1 to 0.9.3 one instance at a time or in batches
 
-Note that while a rolling upgrade is highly recommended, it is not strictly required. SPIRE server supports zero-downtime upgrades so long as there is more than one SPIRE server in the cluster.
+Note that while a rolling upgrade is highly recommended, it is not strictly required. SPIRE Server supports zero-downtime upgrades so long as there is more than one SPIRE Server in the cluster.
 
 ## Supported Downgrade Paths
 
-SPIRE supports downgrading in the event that a problem is encountered while rolling out an upgrade. Since agents can't be newer than the oldest server they communicate with, it is necessary to first downgrade agents before downgrading servers, assuming that the agents have already been upgraded. For this reason, it is a good idea to ensure that the upgraded SPIRE servers are operating as expected prior to upgrading the agents.
+SPIRE supports downgrading in the event that a problem is encountered while rolling out an upgrade. Since agents can't be newer than the oldest server they communicate with, it is necessary to first downgrade agents before downgrading servers, assuming that the agents have already been upgraded. For this reason, it is a good idea to ensure that the upgraded SPIRE Servers are operating as expected prior to upgrading the agents.
 
 For example, if downgrading from version 0.9.3 to 0.8.1:
-* Downgrade SPIRE agent instances from 0.9.3 to 0.8.1 one at a time or in batches
-* Downgrade SPIRE server instances from 0.9.3 to 0.8.1 one at a time
+* Downgrade SPIRE Agent instances from 0.9.3 to 0.8.1 one at a time or in batches
+* Downgrade SPIRE Server instances from 0.9.3 to 0.8.1 one at a time
 
-Note that while a rolling downgrade is highly recommended, it is not strictly required. SPIRE server supports zero-downtime downgrades so long as there is more than one SPIRE server in the cluster.
+Note that while a rolling downgrade is highly recommended, it is not strictly required. SPIRE Server supports zero-downtime downgrades so long as there is more than one SPIRE Server in the cluster.

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -1,0 +1,40 @@
+# Managing Upgrades/Downgrades
+This guide describes how to upgrade your SPIRE deployment, as well as the compatibility guarantees that SPIRE users can expect.
+
+## SPIRE Versioning
+SPIRE versions are expressed as **x.y.z**, where **x** is the major version, **y** is the minor version, and **z** is the patch version, following Semantic Versioning terminology. The SPIRE project is currently pre-1.0, so minor SPIRE releases act like major releases and patch releases act like minor releases. Despite the fact that the project is pre-1.0, version compatibility guarantees are already in place.
+
+### SPIRE Server Compatibility
+Version skew within a SPIRE server cluster is supported within +/- 1 minor version. In other words, the newest and oldest SPIRE server instances in any given cluster must be within one minor version of each other.
+
+For example:
+* Newest SPIRE server instance is at 0.9.3
+* Other SPIRE server instances are supported at 0.9.x and 0.8.x
+
+### SPIRE Agent Compatibility
+SPIRE agents must not be newer than the oldest SPIRE server that they communicate with, and may be up to one minor version older.
+
+For example:
+* SPIRE servers are at both 0.9.3 and 0.9.2
+* SPIRE agents are supported at 0.8.0 through 0.9.2
+
+## Supported Upgrade Paths
+
+The supported version skew between SPIRE servers and agents has implications on the order in which they must be upgraded. SPIRE servers must be upgraded before SPIRE agents, and is limited to a jump of at most one minor version (regardless of patch version). SPIRE server and agent instances may be upgraded in a rolling fashion.
+
+For example, if upgrading from 0.8.1 to 0.9.3:
+* Upgrade SPIRE server instances from 0.8.1 to 0.9.3 one at a time
+* Ensure that the SPIRE server cluster is operating as expected
+* Upgrade SPIRE agent instances from 0.8.1 to 0.9.3 one at a time or in batches
+
+Note that while a rolling upgrade is highly recommended, it is not strictly required. SPIRE server supports zero-downtime upgrades so long as there is more than one SPIRE server in the cluster.
+
+## Supported Downgrade Paths
+
+SPIRE supports downgrading in the event that a problem is encountered while rolling out an upgrade. Since agents can't be newer than the oldest server they communicate with, it is necessary to first downgrade agents before downgrading servers, assuming that the agents have already been upgraded. For this reason, it is a good idea to ensure that the upgraded SPIRE servers are operating as expected prior to upgrading the agents.
+
+For example, if downgrading from version 0.9.3 to 0.8.1:
+* Downgrade SPIRE agent instances from 0.9.3 to 0.8.1 one at a time or in batches
+* Downgrade SPIRE server instances from 0.9.3 to 0.8.1 one at a time
+
+Note that while a rolling downgrade is highly recommended, it is not strictly required. SPIRE server supports zero-downtime downgrades so long as there is more than one SPIRE server in the cluster.


### PR DESCRIPTION
This PR adds documentation relating to managing SPIRE upgrades/downgrades. Included is information about version compatibility and supported version skew, which is an important detail in this context.

I feel we need to sit down and think through a new structure for all SPIFFE/SPIRE documentation that makes sense given everything we know today... but for now, the easiest thing to do is to check this into our `doc/` directory and link to it from the README.

Fixes #1027

Signed-off-by: Evan Gilman <evan@scytale.io>