### PR TITLE
add k8s workload attestor polling configuration option to docs

### DIFF
--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -41,6 +41,8 @@ that can impact permission revocation.
 | `private_key_path` | The path on disk to client key used for kubelet authentication |
 | `node_name_env` | The environment variable used to obtain the node name. Defaults to `MY_NODE_NAME`. |
 | `node_name` | The name of the node. Overrides the value obtained by the environment variable specified by `node_name_env`. |
+| `poll_retry_interval` | The time to wait between retries when attesting a workload. Defaults to `300ms`. |
+| `max_poll_attempts` | The number of attempts to attest a workload before giving up. Defaults to `5`. |
 
 | Selector | Value |
 | -------- | ----- |

--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -41,8 +41,8 @@ that can impact permission revocation.
 | `private_key_path` | The path on disk to client key used for kubelet authentication |
 | `node_name_env` | The environment variable used to obtain the node name. Defaults to `MY_NODE_NAME`. |
 | `node_name` | The name of the node. Overrides the value obtained by the environment variable specified by `node_name_env`. |
-| `poll_retry_interval` | The time to wait between retries when attesting a workload. Defaults to `300ms`. |
-| `max_poll_attempts` | The number of attempts to attest a workload before giving up. Defaults to `5`. |
+| `poll_retry_interval` | The time to wait between retries when attesting a workload. Defaults to `500ms`. |
+| `max_poll_attempts` | The number of attempts to attest a workload before giving up. Defaults to `60`. |
 
 | Selector | Value |
 | -------- | ----- |


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
No functionality changes.

**Description of change**
Adds documentation for `max_poll_attempts` and `poll_retry_interval` options for the `k8s workload attestor`. These are useful for dealing with pod deletion race conditions (see info in issue).

Only reason I can think of for not including this as docs is if it's not planned for these options to be available in the future, but I don't see why that would be the case either :)

**Which issue this PR fixes**
https://github.com/spiffe/spire/issues/1245

