### PR TITLE
Adding @APTy as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
-* @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy
+* @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy
 
 # infrastructure maintenance
-/build.sh        @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy
-/Dockerfile      @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy
-/Makefile        @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy
-/README.md       @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy @ajessup
-/CONTRIBUTING.md @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy
+/build.sh        @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy
+/Dockerfile      @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy
+/Makefile        @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy
+/README.md       @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy @ajessup
+/CONTRIBUTING.md @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy
 
 # documentation
-/doc/           @jennybeth @drrt @evan2645 @amartinezfayo @martincapello @azdagron @marcosdy @marcosy @ajessup
+/doc/           @jennybeth @drrt @evan2645 @amartinezfayo @martincapello @azdagron @APTy @marcosy @ajessup


### PR DESCRIPTION
This commit adds Tyler Julian as a SPIRE maintainer. It also removes
Marcos Yacob, as he has not been active in this project for some time
now.

Welcome @APTy!

Signed-off-by: Evan Gilman <evan@scytale.io>