### PR TITLE
Only emit CSR update telemetry when actually updating

### DIFF
--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -65,10 +65,10 @@ func (m *manager) synchronize(ctx context.Context) (err error) {
 			})
 		}
 	})
-	telemetry_agent.AddCacheManagerExpiredSVIDsSample(m.c.Metrics, float32(expiring))
-	m.c.Log.WithField(telemetry.ExpiringSVIDs, expiring).Debug("Updated SVIDs in cache")
-
 	if len(csrs) > 0 {
+		telemetry_agent.AddCacheManagerExpiredSVIDsSample(m.c.Metrics, float32(expiring))
+		m.c.Log.WithField(telemetry.ExpiringSVIDs, expiring).Debug("Updating SVIDs in cache")
+
 		update, err := m.fetchUpdates(ctx, csrs)
 		if err != nil {
 			return err


### PR DESCRIPTION
Prevents the following over and over in logs:

```
DEBU[0005] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0010] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0015] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0020] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0025] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0030] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0035] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0040] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
DEBU[0045] Updated SVIDs in cache                        expiring_svids=0 subsystem_name=manager
```