### PR TITLE
Remove volume claim for database in k8s test

### DIFF
--- a/test/integration/suites/k8s/conf/spire-database.yaml
+++ b/test/integration/suites/k8s/conf/spire-database.yaml
@@ -56,20 +56,6 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 3
-          volumeMounts:
-            - name: postgres-data
-              mountPath: /var/lib/postgresql/data
-              readOnly: false
-  volumeClaimTemplates:
-    - metadata:
-        name: postgres-data
-        namespace: spire
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 64Mi
 
 ---
 


### PR DESCRIPTION
The k8s integration test currently uses a volume claim to create a volume to store the database data. This was a carryover from the spire-tutorials example where you want the database data persisted across stateful set failover.

The volume claim is overkill and is (we think) contributing to some sporadic failures deploying the stateful set when running in Travis.

Since it isn't needed for the integration test, this PR removes the volume claim.