### PR TITLE
Automatically install the included Google .proto files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ tools/spire-plugingen/spire-plugingen
 # Editor specific configuration
 .idea
 .vscode
+
+# Ignore the vendored Google protobuf definitions
+proto/google

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ goversion-required := $(shell cat .go-version)
 gittag := $(shell git tag --points-at HEAD)
 githash := $(shell git rev-parse --short=7 HEAD)
 gitdirty := $(shell git status -s)
+google_proto_version := 3.10.1
 
 # Determine the ldflags passed to the go linker. The git tag and hash will be
 # provided to the linker unless the git status is dirty.
@@ -43,7 +44,8 @@ external_utils = github.com/golang/protobuf/protoc-gen-go \
 		github.com/jteeuwen/go-bindata/go-bindata \
 		github.com/golang/mock/mockgen \
 		github.com/AlekSi/gocoverutil \
-		github.com/mattn/goveralls
+		github.com/mattn/goveralls \
+		github.com/alrs/protogetter
 
 # Help message settings
 cyan := $(shell which tput > /dev/null && tput setaf 6 || echo "")
@@ -103,6 +105,9 @@ distclean: clean ## Remove object files, vendor and .cache folders
 	rm -rf .cache
 	rm -rf vendor
 
+.PHONY: protoclean
+protoclean:
+	rm -rf proto/google
 
 ##@ Container
 container: Dockerfile ## Build Docker container for compilation
@@ -171,6 +176,9 @@ protobuf: utils ## Regenerate the gRPC pb.go and README_pb.md files
 
 protobuf_verify: utils ## Check that the checked-in generated code is up-to-date
 	$(docker) ./build.sh protobuf_verify
+
+proto/google:
+	protogetter -version $(google_proto_version) -destination proto
 
 noop:
 

--- a/build.sh
+++ b/build.sh
@@ -85,13 +85,15 @@ build_utils() {
 
 ## Rebuild all .proto files and associated README's
 build_protobuf() {
+	# only download the Google proto files if they aren't available
+	make proto/google
 	local _proto_file _all_proto_files _proto_dir _proto_dirs _outdir _srcdir _out="$1"
 	eval "$(build_env)"
 
-	# Generate protobufs in the proto/ and pkg/ subdirectories. README markdown
+	# Generate protobufs in the proto/spire and pkg/ subdirectories. README markdown
 	# will also be generated for protobufs in proto/. Unless an "_out" argument
 	# has been set the output will sit alongside the proto files.
-	_all_proto_files="$(find proto pkg -name '*.proto' 2>/dev/null)"
+	_all_proto_files="$(find proto/spire pkg -name '*.proto' 2>/dev/null)"
 	for _proto_file in ${_all_proto_files}; do
 		_srcdir="$(dirname "${_proto_file}")"
 		_outdir="${_srcdir}"
@@ -105,7 +107,7 @@ build_protobuf() {
 			--go_out=paths=source_relative,plugins=grpc:"${_outdir}" "${_proto_file}"
 	done
 
-	_proto_dirs="$(find proto -type d 2>/dev/null)"
+	_proto_dirs="$(find proto/spire -type d 2>/dev/null)"
 	for _proto_dir in ${_proto_dirs}; do
 		_outdir="${_proto_dir}"
 		if [[ -n ${_out} ]]; then

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20190618163018-fdf1049a943a
 	google.golang.org/api v0.6.0
+	google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873
 	google.golang.org/grpc v1.23.1
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1

--- a/tools/external/go.mod
+++ b/tools/external/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/Masterminds/goutils v1.1.0 // indirect
 	github.com/Masterminds/semver v1.4.2 // indirect
 	github.com/Masterminds/sprig v2.18.0+incompatible // indirect
+	github.com/alrs/protogetter v0.0.0-20191122225617-e84febc27577 // indirect
 	github.com/golang/mock v1.2.0 // indirect
 	github.com/golang/protobuf v1.3.0
 	github.com/huandu/xstrings v1.2.0 // indirect

--- a/tools/external/go.sum
+++ b/tools/external/go.sum
@@ -6,6 +6,8 @@ github.com/Masterminds/semver v1.4.2 h1:WBLTQ37jOCzSLtXNdoo8bNM8876KhNqOKvrlGITg
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.18.0+incompatible h1:QoGhlbC6pter1jxKnjMFxT8EqsLuDE6FEcNbWEpw+lI=
 github.com/Masterminds/sprig v2.18.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
+github.com/alrs/protogetter v0.0.0-20191122225617-e84febc27577 h1:5f9M9cOObFGm6mFbFrl93bZDXea335A0UPqbn+RwnmA=
+github.com/alrs/protogetter v0.0.0-20191122225617-e84febc27577/go.mod h1:ev6j9yXXkEZsE3H10Uj2/ru40V8eEjCbx05ZKVc9ofI=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.3.0 h1:kbxbvI4Un1LUWKxufD+BiE6AEExYYgkQLQmLFqA1LFk=


### PR DESCRIPTION
This changes build.sh and the Makefile to automatically
download the github.com/protocolbuffers/protobuf .proto
files so that generating protobuf does not error on a
failed include.

Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>
