### PR TITLE
Ensure there is a CNCF link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ SPIRE (the [SPIFFE](https://github.com/spiffe/spiffe) Runtime Environment) is a 
 - [Getting help](#getting-help)
 - [Community](#community)
 
+SPIRE is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNCF) as a sandbox level project. If you are an organization that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF. For details read the CNCF [announcement](https://www.cncf.io/blog/2018/03/29/cncf-to-host-the-spiffe-project/).
+
 # Get SPIRE
 
 Pre-built releases can be found at [https://github.com/spiffe/spire/releases](https://github.com/spiffe/spire/releases). These releases contain both server and agent binaries plus the officially supported plugins.


### PR DESCRIPTION
It is a CNCF requirement that member projects clearly state that they
are hosted by the CNCF. This commit adds the same language that is
present on other CNCF project READMEs

Signed-off-by: Evan Gilman <evan@scytale.io>
