### PR TITLE
pkg/common/x509util: fix dropped test error

### DIFF
--- a/pkg/common/x509util/serialnumber_test.go
+++ b/pkg/common/x509util/serialnumber_test.go
@@ -13,6 +13,7 @@ func TestNewSerialNumber(t *testing.T) {
 	assert.NotEqual(t, big.NewInt(0), number1, "Serial numbers must not be zero")
 
 	number2, err := NewSerialNumber()
+	assert.NoError(t, err)
 	assert.NotEqual(t, number1, number2, "Successive serial numbers must be different")
 	assert.NotEqual(t, number1, number2.Add(number2, big.NewInt(-1)), "Serial numbers must not be sequential")
 }


### PR DESCRIPTION
This picks up a dropped test error in `pkg/common/x509util`.