### PR TITLE
Support detecting unknown server and agent config options

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -41,6 +41,7 @@ type config struct {
 	Plugins      *catalog.HCLPluginConfigMap `hcl:"plugins"`
 	Telemetry    telemetry.FileConfig        `hcl:"telemetry"`
 	HealthChecks health.Config               `hcl:"health_checks"`
+	UnusedKeys   []string                    `hcl:",unusedKeys"`
 }
 
 type agentConfig struct {
@@ -64,6 +65,8 @@ type agentConfig struct {
 	ProfilingPort    int      `hcl:"profiling_port"`
 	ProfilingFreq    int      `hcl:"profiling_freq"`
 	ProfilingNames   []string `hcl:"profiling_names"`
+
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type RunCLI struct {
@@ -265,6 +268,46 @@ func newAgentConfig(c *config) (*agent.Config, error) {
 }
 
 func validateConfig(c *config) error {
+	// Validations to detect unknown configuration options
+	if len(c.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
+	}
+
+	if a := c.Agent; a != nil && len(a.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in agent block: %v", strings.Join(a.UnusedKeys, ", "))
+	}
+
+	if len(c.Telemetry.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
+	}
+
+	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	for i, v := range c.Telemetry.DogStatsd {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.Statsd {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.M3 {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	if len(c.HealthChecks.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
+	}
+
+	// Validations to detect configuration options that must be configured
 	if c.Agent == nil {
 		return errors.New("agent section must be configured")
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -695,42 +695,42 @@ func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
 		{
 			msg:            "in root block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_root_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in root block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in agent block",
 			testFilePath:   fmt.Sprintf("%v/agent_bad_agent_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in agent block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in agent block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in telemetry block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_telemetry_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in telemetry block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Prometheus block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Prometheus_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested DogStatsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_DogStatsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Statsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Statsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested M3 block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_M3_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested health_checks block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_health_checks_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested health_checks block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
 		},
 	}
 

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -43,6 +43,7 @@ type config struct {
 	Plugins      *catalog.HCLPluginConfigMap `hcl:"plugins"`
 	Telemetry    telemetry.FileConfig        `hcl:"telemetry"`
 	HealthChecks health.Config               `hcl:"health_checks"`
+	UnusedKeys   []string                    `hcl:",unusedKeys"`
 }
 
 type serverConfig struct {
@@ -70,6 +71,8 @@ type serverConfig struct {
 	ProfilingPort    int      `hcl:"profiling_port"`
 	ProfilingFreq    int      `hcl:"profiling_freq"`
 	ProfilingNames   []string `hcl:"profiling_names"`
+
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type experimentalConfig struct {
@@ -80,25 +83,30 @@ type experimentalConfig struct {
 	BundleEndpointPort    int                            `hcl:"bundle_endpoint_port"`
 	BundleEndpointACME    *bundleEndpointACMEConfig      `hcl:"bundle_endpoint_acme"`
 	FederatesWith         map[string]federatesWithConfig `hcl:"federates_with"`
+
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type caSubjectConfig struct {
 	Country      []string `hcl:"country"`
 	Organization []string `hcl:"organization"`
 	CommonName   string   `hcl:"common_name"`
+	UnusedKeys   []string `hcl:",unusedKeys"`
 }
 
 type bundleEndpointACMEConfig struct {
-	DirectoryURL string `hcl:"directory_url"`
-	DomainName   string `hcl:"domain_name"`
-	Email        string `hcl:"email"`
-	ToSAccepted  bool   `hcl:"tos_accepted"`
+	DirectoryURL string   `hcl:"directory_url"`
+	DomainName   string   `hcl:"domain_name"`
+	Email        string   `hcl:"email"`
+	ToSAccepted  bool     `hcl:"tos_accepted"`
+	UnusedKeys   []string `hcl:",unusedKeys"`
 }
 
 type federatesWithConfig struct {
-	BundleEndpointAddress  string `hcl:"bundle_endpoint_address"`
-	BundleEndpointPort     int    `hcl:"bundle_endpoint_port"`
-	BundleEndpointSpiffeID string `hcl:"bundle_endpoint_spiffe_id"`
+	BundleEndpointAddress  string   `hcl:"bundle_endpoint_address"`
+	BundleEndpointPort     int      `hcl:"bundle_endpoint_port"`
+	BundleEndpointSpiffeID string   `hcl:"bundle_endpoint_spiffe_id"`
+	UnusedKeys             []string `hcl:",unusedKeys"`
 }
 
 // Run CLI struct
@@ -379,6 +387,66 @@ func newServerConfig(c *config) (*server.Config, error) {
 }
 
 func validateConfig(c *config) error {
+	// Validations to detect unknown configuration options
+	if len(c.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
+	}
+
+	if c.Server != nil {
+		if len(c.Server.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in server block: %v", strings.Join(c.Server.UnusedKeys, ", "))
+		}
+
+		if cs := c.Server.CASubject; cs != nil && len(cs.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested ca_subject block: %v", strings.Join(cs.UnusedKeys, ", "))
+		}
+
+		if len(c.Server.Experimental.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested experimental block: %v", strings.Join(c.Server.Experimental.UnusedKeys, ", "))
+		}
+
+		if bea := c.Server.Experimental.BundleEndpointACME; bea != nil && len(bea.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested bundle_endpoint_acme block: %v", strings.Join(bea.UnusedKeys, ", "))
+		}
+
+		for k, v := range c.Server.Experimental.FederatesWith {
+			if len(v.UnusedKeys) != 0 {
+				return fmt.Errorf("unknown configuration options in nested federates_with '%v' block: %v", k, strings.Join(v.UnusedKeys, ", "))
+			}
+		}
+	}
+
+	if len(c.Telemetry.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
+	}
+
+	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	for i, v := range c.Telemetry.DogStatsd {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.Statsd {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.M3 {
+		if len(v.UnusedKeys) != 0 {
+			return fmt.Errorf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	if len(c.HealthChecks.UnusedKeys) != 0 {
+		return fmt.Errorf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
+	}
+
+	// Validations to detect configuration options that must be configured
 	if c.Server == nil {
 		return errors.New("server section must be configured")
 	}

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -848,27 +848,27 @@ func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
 		{
 			msg:            "in root block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_root_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in root block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in server block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_server_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in server block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in server block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested ca_subject block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_ca_subject_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested ca_subject block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested ca_subject block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested experimental block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_experimental_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested experimental block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested experimental block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested bundle_endpoint_acme block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_bundle_endpoint_acme_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested bundle_endpoint_acme block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested bundle_endpoint_acme block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested federates_with block",
@@ -878,32 +878,32 @@ func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
 		{
 			msg:            "in telemetry block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_telemetry_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in telemetry block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Prometheus block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Prometheus_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested DogStatsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_DogStatsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Statsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Statsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested M3 block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_M3_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested health_checks block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_health_checks_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested health_checks block: unknwon_option1, unknwon_option2",
+			expectedErrMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
 		},
 	}
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -835,4 +836,85 @@ func defaultValidConfig() *config {
 	c.Plugins = &catalog.HCLPluginConfigMap{}
 
 	return c
+}
+
+func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
+	testFileDir := "../../../../test/fixture/config"
+	cases := []struct {
+		msg            string
+		testFilePath   string
+		expectedErrMsg string
+	}{
+		{
+			msg:            "in root block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_root_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in root block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in server block",
+			testFilePath:   fmt.Sprintf("%v/server_bad_server_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in server block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested ca_subject block",
+			testFilePath:   fmt.Sprintf("%v/server_bad_nested_ca_subject_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested ca_subject block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested experimental block",
+			testFilePath:   fmt.Sprintf("%v/server_bad_nested_experimental_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested experimental block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested bundle_endpoint_acme block",
+			testFilePath:   fmt.Sprintf("%v/server_bad_nested_bundle_endpoint_acme_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested bundle_endpoint_acme block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested federates_with block",
+			testFilePath:   fmt.Sprintf("%v/server_bad_nested_federates_with_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested experimental block: federates_with, test1, test2",
+		},
+		{
+			msg:            "in telemetry block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_telemetry_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in telemetry block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested Prometheus block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Prometheus_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested DogStatsd block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_DogStatsd_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested Statsd block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Statsd_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested M3 block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_M3_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknwon_option1, unknwon_option2",
+		},
+		{
+			msg:            "in nested health_checks block",
+			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_health_checks_block.conf", testFileDir),
+			expectedErrMsg: "unknown configuration options in nested health_checks block: unknwon_option1, unknwon_option2",
+		},
+	}
+
+	for _, testCase := range cases {
+		c, err := parseFile(testCase.testFilePath)
+		require.NoError(t, err)
+
+		t.Run(testCase.msg, func(t *testing.T) {
+			err := validateConfig(c)
+			require.Error(t, err)
+			require.Equal(t, testCase.expectedErrMsg, err.Error())
+		})
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/hashicorp/go-hclog v0.9.2
 	github.com/hashicorp/go-plugin v1.0.1
-	github.com/hashicorp/hcl v1.0.0
+	github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94
 	github.com/imdario/mergo v0.3.7
 	github.com/imkira/go-observer v1.0.3
 	github.com/jinzhu/gorm v1.9.9

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94 h1:LaH4JWe6Q7ICdxL5raxQjSRw7Pj8uTtAENrjejIYZIg=
+github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/pkg/common/health/config.go
+++ b/pkg/common/health/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	// Paths for /ready and /live
 	ReadyPath string `hcl:"ready_path"`
 	LivePath  string `hcl:"live_path"`
+
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 // getReadyPath returns the configured value or a default

--- a/pkg/common/telemetry/config.go
+++ b/pkg/common/telemetry/config.go
@@ -16,22 +16,27 @@ type FileConfig struct {
 	DogStatsd  []DogStatsdConfig `hcl:"DogStatsd"`
 	Statsd     []StatsdConfig    `hcl:"Statsd"`
 	M3         []M3Config        `hcl:"M3"`
+	UnusedKeys []string          `hcl:",unusedKeys"`
 }
 
 type DogStatsdConfig struct {
-	Address string `hcl:"address"`
+	Address    string   `hcl:"address"`
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type PrometheusConfig struct {
-	Host string `hcl:"host"`
-	Port int    `hcl:"port"`
+	Host       string   `hcl:"host"`
+	Port       int      `hcl:"port"`
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type StatsdConfig struct {
-	Address string `hcl:"address"`
+	Address    string   `hcl:"address"`
+	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
 type M3Config struct {
-	Address string `hcl:"address"`
-	Env     string `hcl:"env"`
+	Address    string   `hcl:"address"`
+	Env        string   `hcl:"env"`
+	UnusedKeys []string `hcl:",unusedKeys"`
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"crypto/x509/pkix"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	common "github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/health"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	bundle_client "github.com/spiffe/spire/pkg/server/bundle/client"
+	"github.com/spiffe/spire/pkg/server/endpoints/bundle"
+	"github.com/spiffe/spire/proto/spire/server/keymanager"
+)
+
+type Config struct {
+	// Configurations for server plugins
+	PluginConfigs common.HCLPluginConfigMap
+
+	Log logrus.FieldLogger
+
+	// Address of SPIRE server
+	BindAddress *net.TCPAddr
+
+	// Address of the UDS SPIRE server
+	BindUDSAddress *net.UnixAddr
+
+	// Directory to store runtime data
+	DataDir string
+
+	// Trust domain
+	TrustDomain url.URL
+
+	UpstreamBundle bool
+
+	Experimental ExperimentalConfig
+
+	// If true enables profiling.
+	ProfilingEnabled bool
+
+	// Port used by the pprof web server when ProfilingEnabled == true
+	ProfilingPort int
+
+	// Frequency in seconds by which each profile file will be generated.
+	ProfilingFreq int
+
+	// Array of profiles names that will be generated on each profiling tick.
+	ProfilingNames []string
+
+	// SVIDTTL is default time-to-live for SVIDs
+	SVIDTTL time.Duration
+
+	// CATTL is the time-to-live for the server CA. This only applies to
+	// self-signed CA certificates, otherwise it is up to the upstream CA.
+	CATTL time.Duration
+
+	// JWTIssuer is used as the issuer claim in JWT-SVIDs minted by the server.
+	// If unset, the JWT-SVID will not have an issuer claim.
+	JWTIssuer string
+
+	// CASubject is the subject used in the CA certificate
+	CASubject pkix.Name
+
+	// Telemetry provides the configuration for metrics exporting
+	Telemetry telemetry.FileConfig
+
+	// HealthChecks provides the configuration for health monitoring
+	HealthChecks health.Config
+
+	// CAKeyType is the key type used for the X509 and JWT signing keys
+	CAKeyType keymanager.KeyType
+}
+
+type ExperimentalConfig struct {
+	// Skip agent id validation in node attestation
+	AllowAgentlessNodeAttestors bool
+
+	// BundleEndpointEnabled, if true, enables the federation bundle endpoint
+	BundleEndpointEnabled bool
+
+	// BundleEndpointAddress is the address on which to serve the federation
+	// bundle endpoint.
+	BundleEndpointAddress *net.TCPAddr
+
+	// BundleEndpointACME is the ACME configuration for the bundle endpoint.
+	// If unset, the bundle endpoint will use SPIFFE auth.
+	BundleEndpointACME *bundle.ACMEConfig
+
+	// FederatesWith holds the federation configuration for trust domains this
+	// server federates with.
+	FederatesWith map[string]bundle_client.TrustDomainConfig
+}
+
+func New(config Config) *Server {
+	return &Server{
+		config: config,
+	}
+}

--- a/test/fixture/config/agent_bad_agent_block.conf
+++ b/test/fixture/config/agent_bad_agent_block.conf
@@ -1,4 +1,4 @@
 agent {
-    unknwon_option1 = "unknwon_option1"
-    unknwon_option2 = "unknwon_option2"
+    unknown_option1 = "unknown_option1"
+    unknown_option2 = "unknown_option2"
 }

--- a/test/fixture/config/agent_bad_agent_block.conf
+++ b/test/fixture/config/agent_bad_agent_block.conf
@@ -1,0 +1,4 @@
+agent {
+    unknwon_option1 = "unknwon_option1"
+    unknwon_option2 = "unknwon_option2"
+}

--- a/test/fixture/config/server_and_agent_bad_nested_DogStatsd_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_DogStatsd_block.conf
@@ -1,0 +1,12 @@
+telemetry {
+    DogStatsd = [
+        {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        },
+        {
+            unknwon_option3 = "unknwon_option3"
+            unknwon_option4 = "unknwon_option4"
+        },
+    ]
+}

--- a/test/fixture/config/server_and_agent_bad_nested_DogStatsd_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_DogStatsd_block.conf
@@ -1,12 +1,12 @@
 telemetry {
     DogStatsd = [
         {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         },
         {
-            unknwon_option3 = "unknwon_option3"
-            unknwon_option4 = "unknwon_option4"
+            unknown_option3 = "unknown_option3"
+            unknown_option4 = "unknown_option4"
         },
     ]
 }

--- a/test/fixture/config/server_and_agent_bad_nested_M3_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_M3_block.conf
@@ -1,0 +1,12 @@
+telemetry {
+    M3 = [
+        {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        },
+        {
+            unknwon_option3 = "unknwon_option3"
+            unknwon_option4 = "unknwon_option4"
+        },
+    ]
+}

--- a/test/fixture/config/server_and_agent_bad_nested_M3_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_M3_block.conf
@@ -1,12 +1,12 @@
 telemetry {
     M3 = [
         {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         },
         {
-            unknwon_option3 = "unknwon_option3"
-            unknwon_option4 = "unknwon_option4"
+            unknown_option3 = "unknown_option3"
+            unknown_option4 = "unknown_option4"
         },
     ]
 }

--- a/test/fixture/config/server_and_agent_bad_nested_Prometheus_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_Prometheus_block.conf
@@ -1,6 +1,6 @@
 telemetry {
     Prometheus {
-        unknwon_option1 = "unknwon_option1"
-        unknwon_option2 = "unknwon_option2"
+        unknown_option1 = "unknown_option1"
+        unknown_option2 = "unknown_option2"
     }
 }

--- a/test/fixture/config/server_and_agent_bad_nested_Prometheus_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_Prometheus_block.conf
@@ -1,0 +1,6 @@
+telemetry {
+    Prometheus {
+        unknwon_option1 = "unknwon_option1"
+        unknwon_option2 = "unknwon_option2"
+    }
+}

--- a/test/fixture/config/server_and_agent_bad_nested_Statsd_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_Statsd_block.conf
@@ -1,12 +1,12 @@
 telemetry {
     Statsd = [
         {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         },
         {
-            unknwon_option3 = "unknwon_option3"
-            unknwon_option4 = "unknwon_option4"
+            unknown_option3 = "unknown_option3"
+            unknown_option4 = "unknown_option4"
         },
     ]
 }

--- a/test/fixture/config/server_and_agent_bad_nested_Statsd_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_Statsd_block.conf
@@ -1,0 +1,12 @@
+telemetry {
+    Statsd = [
+        {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        },
+        {
+            unknwon_option3 = "unknwon_option3"
+            unknwon_option4 = "unknwon_option4"
+        },
+    ]
+}

--- a/test/fixture/config/server_and_agent_bad_nested_health_checks_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_health_checks_block.conf
@@ -1,4 +1,4 @@
 health_checks {
-    unknwon_option1 = "unknwon_option1"
-    unknwon_option2 = "unknwon_option2"
+    unknown_option1 = "unknown_option1"
+    unknown_option2 = "unknown_option2"
 }

--- a/test/fixture/config/server_and_agent_bad_nested_health_checks_block.conf
+++ b/test/fixture/config/server_and_agent_bad_nested_health_checks_block.conf
@@ -1,0 +1,4 @@
+health_checks {
+    unknwon_option1 = "unknwon_option1"
+    unknwon_option2 = "unknwon_option2"
+}

--- a/test/fixture/config/server_and_agent_bad_root_block.conf
+++ b/test/fixture/config/server_and_agent_bad_root_block.conf
@@ -1,2 +1,2 @@
-unknwon_option1 = "unknwon_option1"
-unknwon_option2 = "unknwon_option2"
+unknown_option1 = "unknown_option1"
+unknown_option2 = "unknown_option2"

--- a/test/fixture/config/server_and_agent_bad_root_block.conf
+++ b/test/fixture/config/server_and_agent_bad_root_block.conf
@@ -1,0 +1,2 @@
+unknwon_option1 = "unknwon_option1"
+unknwon_option2 = "unknwon_option2"

--- a/test/fixture/config/server_and_agent_bad_telemetry_block.conf
+++ b/test/fixture/config/server_and_agent_bad_telemetry_block.conf
@@ -1,0 +1,4 @@
+telemetry {
+    unknwon_option1 = "unknwon_option1"
+    unknwon_option2 = "unknwon_option2"
+}

--- a/test/fixture/config/server_and_agent_bad_telemetry_block.conf
+++ b/test/fixture/config/server_and_agent_bad_telemetry_block.conf
@@ -1,4 +1,4 @@
 telemetry {
-    unknwon_option1 = "unknwon_option1"
-    unknwon_option2 = "unknwon_option2"
+    unknown_option1 = "unknown_option1"
+    unknown_option2 = "unknown_option2"
 }

--- a/test/fixture/config/server_bad_nested_bundle_endpoint_acme_block.conf
+++ b/test/fixture/config/server_bad_nested_bundle_endpoint_acme_block.conf
@@ -1,8 +1,8 @@
 server {
     experimental {
         bundle_endpoint_acme {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         }
     }
 }

--- a/test/fixture/config/server_bad_nested_bundle_endpoint_acme_block.conf
+++ b/test/fixture/config/server_bad_nested_bundle_endpoint_acme_block.conf
@@ -1,0 +1,8 @@
+server {
+    experimental {
+        bundle_endpoint_acme {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        }
+    }
+}

--- a/test/fixture/config/server_bad_nested_ca_subject_block.conf
+++ b/test/fixture/config/server_bad_nested_ca_subject_block.conf
@@ -1,6 +1,6 @@
 server {
     ca_subject {
-        unknwon_option1 = "unknwon_option1"
-        unknwon_option2 = "unknwon_option2"
+        unknown_option1 = "unknown_option1"
+        unknown_option2 = "unknown_option2"
     }
 }

--- a/test/fixture/config/server_bad_nested_ca_subject_block.conf
+++ b/test/fixture/config/server_bad_nested_ca_subject_block.conf
@@ -1,0 +1,6 @@
+server {
+    ca_subject {
+        unknwon_option1 = "unknwon_option1"
+        unknwon_option2 = "unknwon_option2"
+    }
+}

--- a/test/fixture/config/server_bad_nested_experimental_block.conf
+++ b/test/fixture/config/server_bad_nested_experimental_block.conf
@@ -1,6 +1,6 @@
 server {
     experimental {
-        unknwon_option1 = "unknwon_option1"
-        unknwon_option2 = "unknwon_option2"
+        unknown_option1 = "unknown_option1"
+        unknown_option2 = "unknown_option2"
     }
 }

--- a/test/fixture/config/server_bad_nested_experimental_block.conf
+++ b/test/fixture/config/server_bad_nested_experimental_block.conf
@@ -1,0 +1,6 @@
+server {
+    experimental {
+        unknwon_option1 = "unknwon_option1"
+        unknwon_option2 = "unknwon_option2"
+    }
+}

--- a/test/fixture/config/server_bad_nested_federates_with_block.conf
+++ b/test/fixture/config/server_bad_nested_federates_with_block.conf
@@ -1,0 +1,12 @@
+server {
+    experimental {
+        federates_with "test1" {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        }
+        federates_with "test2" {
+            unknwon_option1 = "unknwon_option1"
+            unknwon_option2 = "unknwon_option2"
+        }
+    }
+}

--- a/test/fixture/config/server_bad_nested_federates_with_block.conf
+++ b/test/fixture/config/server_bad_nested_federates_with_block.conf
@@ -1,12 +1,12 @@
 server {
     experimental {
         federates_with "test1" {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         }
         federates_with "test2" {
-            unknwon_option1 = "unknwon_option1"
-            unknwon_option2 = "unknwon_option2"
+            unknown_option1 = "unknown_option1"
+            unknown_option2 = "unknown_option2"
         }
     }
 }

--- a/test/fixture/config/server_bad_server_block.conf
+++ b/test/fixture/config/server_bad_server_block.conf
@@ -1,4 +1,4 @@
 server {
-    unknwon_option1 = "unknwon_option1"
-    unknwon_option2 = "unknwon_option2"
+    unknown_option1 = "unknown_option1"
+    unknown_option2 = "unknown_option2"
 }

--- a/test/fixture/config/server_bad_server_block.conf
+++ b/test/fixture/config/server_bad_server_block.conf
@@ -1,0 +1,4 @@
+server {
+    unknwon_option1 = "unknwon_option1"
+    unknwon_option2 = "unknwon_option2"
+}


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

This PR affects the functionality of `spire-server run` and `spire-agent run`.

**Description of change**
<!-- Please provide a description of the change -->

The changes are below.

- Separate server-side config struct into another file as well as agent-side
- Upgrade hashicorp/hcl version to merge commit of https://github.com/hashicorp/hcl/pull/275 because there is a bug in the `unusedKeys` feature in current v1.0.0 
- Support detecting unknown server and agent config options

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

This PR fixes ~part of~ https://github.com/spiffe/spire/issues/1101.
~To fix the issue completely, the same changes as this PR are required for agent-side.~
I also added the same changes as server-side to agent-side.

