### PR TITLE
Fix misnamed config options in k8s integration test

### DIFF
--- a/test/integration/suites/k8s/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s/conf/server/spire-server.yaml
@@ -110,9 +110,9 @@ data:
       ca_ttl = "12h"
       upstream_bundle = true
       ca_subject = {
-        Country = ["US"],
-        Organization = ["SPIFFE"],
-        CommonName = "",
+        country = ["US"],
+        organization = ["SPIFFE"],
+        common_name = "",
       }
     }
 


### PR DESCRIPTION
Recent change to fail the server starting if there were unused keys specified in the HCL caught this misconfiguration in the integration tests.
