### PR TITLE
Warn when unknown config options are encountered

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cli"
@@ -264,54 +265,17 @@ func newAgentConfig(c *config) (*agent.Config, error) {
 	ac.Telemetry = c.Telemetry
 	ac.HealthChecks = c.HealthChecks
 
+	// Warn if we detect unknown config options. We need a logger to do this. In
+	// the future, we can move from warning to bailing out (once folks have had
+	// ample time to detect any pre-existing errors)
+	//
+	// TODO: Move this check into validateConfig for 0.11.0
+	warnOnUnknownConfig(c, ac.Log)
+
 	return ac, nil
 }
 
 func validateConfig(c *config) error {
-	// Validations to detect unknown configuration options
-	if len(c.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
-	}
-
-	if a := c.Agent; a != nil && len(a.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in agent block: %v", strings.Join(a.UnusedKeys, ", "))
-	}
-
-	if len(c.Telemetry.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
-	}
-
-	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
-	}
-
-	for i, v := range c.Telemetry.DogStatsd {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	for i, v := range c.Telemetry.Statsd {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	for i, v := range c.Telemetry.M3 {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	if p := c.Telemetry.InMem; p != nil && len(p.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested InMem block: %v", strings.Join(p.UnusedKeys, ", "))
-	}
-
-	if len(c.HealthChecks.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
-	}
-
-	// Validations to detect configuration options that must be configured
 	if c.Agent == nil {
 		return errors.New("agent section must be configured")
 	}
@@ -337,6 +301,50 @@ func validateConfig(c *config) error {
 	}
 
 	return nil
+}
+
+func warnOnUnknownConfig(c *config, l logrus.FieldLogger) {
+	if len(c.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
+	}
+
+	if a := c.Agent; a != nil && len(a.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in agent block: %v", strings.Join(a.UnusedKeys, ", "))
+	}
+
+	if len(c.Telemetry.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
+	}
+
+	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	for i, v := range c.Telemetry.DogStatsd {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.Statsd {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.M3 {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	if p := c.Telemetry.InMem; p != nil && len(p.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested InMem block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	if len(c.HealthChecks.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
+	}
 }
 
 func defaultConfig() *config {

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -685,57 +686,57 @@ func defaultValidConfig() *config {
 	return c
 }
 
-func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
+func TestWarnOnUnknownConfig(t *testing.T) {
 	testFileDir := "../../../../test/fixture/config"
 	cases := []struct {
 		msg            string
 		testFilePath   string
-		expectedErrMsg string
+		expectedLogMsg string
 	}{
 		{
 			msg:            "in root block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_root_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in agent block",
 			testFilePath:   fmt.Sprintf("%v/agent_bad_agent_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in agent block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in agent block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in telemetry block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_telemetry_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Prometheus block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Prometheus_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested DogStatsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_DogStatsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Statsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Statsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested M3 block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_M3_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested InMem block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_InMem_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested InMem block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested InMem block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested health_checks block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_health_checks_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
 		},
 	}
 
@@ -743,10 +744,15 @@ func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
 		c, err := parseFile(testCase.testFilePath)
 		require.NoError(t, err)
 
+		log, hook := test.NewNullLogger()
+
 		t.Run(testCase.msg, func(t *testing.T) {
-			err := validateConfig(c)
-			require.Error(t, err)
-			require.Equal(t, testCase.expectedErrMsg, err.Error())
+			warnOnUnknownConfig(c, log)
+			require.NotNil(t, hook.LastEntry())
+			require.Equal(t, testCase.expectedLogMsg, hook.AllEntries()[0].Message)
+
+			hook.Reset()
+			require.Nil(t, hook.LastEntry())
 		})
 	}
 }

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/health"
@@ -383,74 +384,17 @@ func newServerConfig(c *config) (*server.Config, error) {
 		sc.Log.Warn("The `upstream_bundle` configurable is not set, and you are using an UpstreamCA. The default value will be changed from `false` to `true` in a future release.  Please see issue #1095 and the configuration documentation for more information.")
 	}
 
+	// Warn if we detect unknown config options. We need a logger to do this. In
+	// the future, we can move from warning to bailing out (once folks have had
+	// ample time to detect any pre-existing errors)
+	//
+	// TODO: Move this check into validateConfig for 0.11.0
+	warnOnUnknownConfig(c, sc.Log)
+
 	return sc, nil
 }
 
 func validateConfig(c *config) error {
-	// Validations to detect unknown configuration options
-	if len(c.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
-	}
-
-	if c.Server != nil {
-		if len(c.Server.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in server block: %v", strings.Join(c.Server.UnusedKeys, ", "))
-		}
-
-		if cs := c.Server.CASubject; cs != nil && len(cs.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested ca_subject block: %v", strings.Join(cs.UnusedKeys, ", "))
-		}
-
-		if len(c.Server.Experimental.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested experimental block: %v", strings.Join(c.Server.Experimental.UnusedKeys, ", "))
-		}
-
-		if bea := c.Server.Experimental.BundleEndpointACME; bea != nil && len(bea.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested bundle_endpoint_acme block: %v", strings.Join(bea.UnusedKeys, ", "))
-		}
-
-		for k, v := range c.Server.Experimental.FederatesWith {
-			if len(v.UnusedKeys) != 0 {
-				return fmt.Errorf("unknown configuration options in nested federates_with '%v' block: %v", k, strings.Join(v.UnusedKeys, ", "))
-			}
-		}
-	}
-
-	if len(c.Telemetry.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
-	}
-
-	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
-	}
-
-	for i, v := range c.Telemetry.DogStatsd {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	for i, v := range c.Telemetry.Statsd {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	for i, v := range c.Telemetry.M3 {
-		if len(v.UnusedKeys) != 0 {
-			return fmt.Errorf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
-		}
-	}
-
-	if p := c.Telemetry.InMem; p != nil && len(p.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested InMem block: %v", strings.Join(p.UnusedKeys, ", "))
-	}
-
-	if len(c.HealthChecks.UnusedKeys) != 0 {
-		return fmt.Errorf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
-	}
-
-	// Validations to detect configuration options that must be configured
 	if c.Server == nil {
 		return errors.New("server section must be configured")
 	}
@@ -492,6 +436,70 @@ func validateConfig(c *config) error {
 	}
 
 	return nil
+}
+
+func warnOnUnknownConfig(c *config, l logrus.FieldLogger) {
+	if len(c.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in root block: %v", strings.Join(c.UnusedKeys, ", "))
+	}
+
+	if c.Server != nil {
+		if len(c.Server.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in server block: %v", strings.Join(c.Server.UnusedKeys, ", "))
+		}
+
+		if cs := c.Server.CASubject; cs != nil && len(cs.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested ca_subject block: %v", strings.Join(cs.UnusedKeys, ", "))
+		}
+
+		if len(c.Server.Experimental.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested experimental block: %v", strings.Join(c.Server.Experimental.UnusedKeys, ", "))
+		}
+
+		if bea := c.Server.Experimental.BundleEndpointACME; bea != nil && len(bea.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested bundle_endpoint_acme block: %v", strings.Join(bea.UnusedKeys, ", "))
+		}
+
+		for k, v := range c.Server.Experimental.FederatesWith {
+			if len(v.UnusedKeys) != 0 {
+				l.Warnf("unknown configuration options in nested federates_with '%v' block: %v", k, strings.Join(v.UnusedKeys, ", "))
+			}
+		}
+	}
+
+	if len(c.Telemetry.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in telemetry block: %v", strings.Join(c.Telemetry.UnusedKeys, ", "))
+	}
+
+	if p := c.Telemetry.Prometheus; p != nil && len(p.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested Prometheus block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	for i, v := range c.Telemetry.DogStatsd {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested DogStatsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.Statsd {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested Statsd %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	for i, v := range c.Telemetry.M3 {
+		if len(v.UnusedKeys) != 0 {
+			l.Warnf("unknown configuration options in nested M3 %v block: %v", i, strings.Join(v.UnusedKeys, ", "))
+		}
+	}
+
+	if p := c.Telemetry.InMem; p != nil && len(p.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested InMem block: %v", strings.Join(p.UnusedKeys, ", "))
+	}
+
+	if len(c.HealthChecks.UnusedKeys) != 0 {
+		l.Warnf("unknown configuration options in nested health_checks block: %v", strings.Join(c.HealthChecks.UnusedKeys, ", "))
+	}
 }
 
 func defaultConfig() *config {

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/server"
@@ -838,77 +839,77 @@ func defaultValidConfig() *config {
 	return c
 }
 
-func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
+func TestWarnOnUnknownConfig(t *testing.T) {
 	testFileDir := "../../../../test/fixture/config"
 	cases := []struct {
 		msg            string
 		testFilePath   string
-		expectedErrMsg string
+		expectedLogMsg string
 	}{
 		{
 			msg:            "in root block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_root_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in root block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in server block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_server_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in server block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in server block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested ca_subject block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_ca_subject_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested ca_subject block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested ca_subject block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested experimental block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_experimental_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested experimental block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested experimental block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested bundle_endpoint_acme block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_bundle_endpoint_acme_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested bundle_endpoint_acme block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested bundle_endpoint_acme block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested federates_with block",
 			testFilePath:   fmt.Sprintf("%v/server_bad_nested_federates_with_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested experimental block: federates_with, test1, test2",
+			expectedLogMsg: "unknown configuration options in nested experimental block: federates_with, test1, test2",
 		},
 		{
 			msg:            "in telemetry block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_telemetry_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in telemetry block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Prometheus block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Prometheus_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested Prometheus block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested DogStatsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_DogStatsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested DogStatsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested Statsd block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_Statsd_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested Statsd 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested M3 block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_M3_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested M3 0 block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested InMem block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_InMem_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested InMem block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested InMem block: unknown_option1, unknown_option2",
 		},
 		{
 			msg:            "in nested health_checks block",
 			testFilePath:   fmt.Sprintf("%v/server_and_agent_bad_nested_health_checks_block.conf", testFileDir),
-			expectedErrMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
+			expectedLogMsg: "unknown configuration options in nested health_checks block: unknown_option1, unknown_option2",
 		},
 	}
 
@@ -916,10 +917,15 @@ func TestValidateConfigDetectUnknownConfigOpts(t *testing.T) {
 		c, err := parseFile(testCase.testFilePath)
 		require.NoError(t, err)
 
+		log, hook := test.NewNullLogger()
+
 		t.Run(testCase.msg, func(t *testing.T) {
-			err := validateConfig(c)
-			require.Error(t, err)
-			require.Equal(t, testCase.expectedErrMsg, err.Error())
+			warnOnUnknownConfig(c, log)
+			require.NotNil(t, hook.LastEntry())
+			require.Equal(t, testCase.expectedLogMsg, hook.AllEntries()[0].Message)
+
+			hook.Reset()
+			require.Nil(t, hook.LastEntry())
 		})
 	}
 }


### PR DESCRIPTION
SPIRE recently gained a feature in which it can detect when unknown
config options are present in its configuration file. When this
condition is detected, an error message is returned and SPIRE exits.
While this is probably the behavior that we want to have in the long
run, it could be unexpected for a config that worked with 0.9.0 to stop
working with 0.9.1.

To address this, it feels appropriate for us to first log a warning that
unknown config options have been detected. In a future ".0" release, we
can flip that behavior back to the current logic. Since 0.9.0 -> 0.10.0
is a supported upgrade path, and users of 0.9.0 don't receive this
warning, we should probably wait until 0.11.0 to do this.

Since the (current) plan is to eventually move this from a warning back
to bailing out, the warning message should probably state something to
that effect (e.g. "this will be a fatal error in a future release").
Once this PR is merged, I will send another with changes to the actual
logged messages.

Signed-off-by: Evan Gilman <evan@scytale.io>