### PR TITLE
Make sure to set the value of directory parameter

### DIFF
--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -125,6 +125,10 @@ func (d *DiskPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
+	if config.Directory == "" {
+		return nil, errors.New("directory is required")
+	}
+
 	// Create directory in which to store the private key if not exists
 	if err := os.MkdirAll(config.Directory, 0755); err != nil {
 		return nil, err

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -3,6 +3,7 @@ package disk
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -76,6 +77,18 @@ func TestDisk_Configure(t *testing.T) {
 	assert.NoError(t, e)
 	assert.Equal(t, keysDir, plugin.dir)
 	assert.DirExists(t, keysDir)
+}
+
+func TestDisk_Configure_DirectoryIsRequired(t *testing.T) {
+	expectedErr := errors.New("directory is required")
+
+	plugin := New()
+	cReq := &spi.ConfigureRequest{
+		Configuration: fmt.Sprintf("directory = \"%s\"", ""),
+	}
+	_, e := plugin.Configure(ctx, cReq)
+	assert.NotNil(t, e)
+	assert.Equal(t, expectedErr, e)
 }
 
 func TestDisk_GetPluginInfo(t *testing.T) {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

This commits validates the value of `directory` parameter.
This means if empty value is set to `directory` parameter, the plugin returns error.

**Description of change**
<!-- Please provide a description of the change -->

Agent Disk KeyManager plugin deal with `directory` as mandatory

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

fixes #1312 
