### PR TITLE
Adding read_only database connection string that can be used for read…

### DIFF
--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -19,6 +19,7 @@ plugins {
         plugin_data {
             database_type = "sqlite3"
             connection_string = "./.data/datastore.sqlite3"
+            ro_connection_string = "./.data/datastore.sqlite3"
         }
     }
 

--- a/doc/plugin_server_datastore_sql.md
+++ b/doc/plugin_server_datastore_sql.md
@@ -2,17 +2,18 @@
 
 The `sql` plugin implements a sql based storage option for the SPIRE server using SQLite, PostgreSQL or MySQL databases.
 
-| Configuration     | Description                                                                |
-| ------------------| -------------------------------------------------------------------------- |
-| database_type     | database type                                                              |
-| connection_string | connection string                                                          |
-| root_ca_path      | Path to Root CA bundle (MySQL only)                                        |
-| client_cert_path  | Path to client certificate (MySQL only)                                    |
-| client_key_path   | Path to private key for client certificate (MySQL only)                    |
-| max_open_conns    | The maximum number of open db connections (default: unlimited)             |
-| max_idle_conns    | The maximum number of idle connections in the pool (default: 2)            |
-| conn_max_lifetime | The maximum amount of time a connection may be reused (default: unlimited) |
-| disable_migration | True to disable auto-migration functionality. Use of this flag allows finer control over when datastore migrations occur and coordination of the migration of a datastore shared with a SPIRE Server cluster. Only available for databases from SPIRE Code version 0.9.0 or later. |
+| Configuration        | Description                                                                |
+| ---------------------| -------------------------------------------------------------------------- |
+| database_type        | database type                                                              |
+| connection_string    | connection string                                                          |
+| ro_connection_string | read-only connection string, used for read-only queries if set             |
+| root_ca_path         | Path to Root CA bundle (MySQL only)                                        |
+| client_cert_path     | Path to client certificate (MySQL only)                                    |
+| client_key_path      | Path to private key for client certificate (MySQL only)                    |
+| max_open_conns       | The maximum number of open db connections (default: unlimited)             |
+| max_idle_conns       | The maximum number of idle connections in the pool (default: 2)            |
+| conn_max_lifetime    | The maximum amount of time a connection may be reused (default: unlimited) |
+| disable_migration    | True to disable auto-migration functionality. Use of this flag allows finer control over when datastore migrations occur and coordination of the migration of a datastore shared with a SPIRE Server cluster. Only available for databases from SPIRE Code version 0.9.0 or later. |
 
 The plugin defaults to an in-memory database and any information in the data store is lost on restart.
 
@@ -39,6 +40,7 @@ connection_string=":memory:"
         plugin_data {
             database_type = "sqlite3"
             connection_string = "./.data/datastore.sqlite3"
+            ro_connection_string = "./.data/datastore.sqlite3"
         }
     }
 ```
@@ -100,6 +102,9 @@ username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valu
 #### example
 ```
 connection_string="username:password@tcp(localhost:3306)/dbname?parseTime=true"
+```
+```
+ro_connection_string="ro_username:password@tcp(localhost:3308)/dbname?parseTime=true"
 ```
 
 Read MySQL driver for more `connection_string` options [here](https://github.com/go-sql-driver/mysql#usage).

--- a/pkg/server/plugin/datastore/sql/postgres.go
+++ b/pkg/server/plugin/datastore/sql/postgres.go
@@ -8,8 +8,8 @@ import (
 
 type postgres struct{}
 
-func (p postgres) connect(cfg *configuration) (*gorm.DB, error) {
-	db, err := gorm.Open("postgres", cfg.ConnectionString)
+func (p postgres) connect(cfg *configuration, connectionString string) (*gorm.DB, error) {
+	db, err := gorm.Open("postgres", connectionString)
 	if err != nil {
 		return nil, sqlError.Wrap(err)
 	}

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -7,6 +7,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/spiffe/spire/pkg/common/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -18,7 +21,6 @@ import (
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
 	ds_telemetry "github.com/spiffe/spire/pkg/common/telemetry/server/datastore"
-	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/spire/common"
 	proto_services "github.com/spiffe/spire/proto/spire/common/hostservices"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
@@ -30,8 +32,6 @@ import (
 	testutil "github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -137,7 +137,8 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 				database_type = "sqlite3"
 				log_sql = true
 				connection_string = "%s"
-				`, dbPath),
+				ro_connection_string = "%s"
+				`, dbPath, dbPath),
 		})
 		s.Require().NoError(err)
 
@@ -147,12 +148,16 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 		}{}
 		p.db.Raw("PRAGMA journal_mode").Scan(&jm)
 		s.Require().Equal(jm.JournalMode, "wal")
+		p.roDb.Raw("PRAGMA journal_mode").Scan(&jm)
+		s.Require().Equal(jm.JournalMode, "wal")
 
 		// assert that foreign_key support is enabled
 		fk := struct {
 			ForeignKeys string
 		}{}
 		p.db.Raw("PRAGMA foreign_keys").Scan(&fk)
+		s.Require().Equal(fk.ForeignKeys, "1")
+		p.roDb.Raw("PRAGMA foreign_keys").Scan(&fk)
 		s.Require().Equal(fk.ForeignKeys, "1")
 	case "mysql":
 		s.T().Logf("CONN STRING: %q", TestConnString)
@@ -163,7 +168,8 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 				database_type = "mysql"
 				log_sql = true
 				connection_string = "%s"
-				`, TestConnString),
+				ro_connection_string = "%s"
+				`, TestConnString, TestConnString),
 		})
 		s.Require().NoError(err)
 	case "postgres":
@@ -175,7 +181,8 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 				database_type = "postgres"
 				log_sql = true
 				connection_string = "%s"
-				`, TestConnString),
+				ro_connection_string = "%s"
+				`, TestConnString, TestConnString),
 		})
 		s.Require().NoError(err)
 	default:
@@ -203,6 +210,21 @@ func (s *PluginSuite) TestInvalidMySQLConfiguration() {
 		`,
 	})
 	s.RequireErrorContains(err, "datastore-sql: invalid mysql config: missing parseTime=true param in connection_string")
+
+	_, roErr := s.ds.Configure(context.Background(), &spi.ConfigureRequest{
+		Configuration: `
+		database_type = "mysql"
+		ro_connection_string = "username:@tcp(127.0.0.1)/spire_test"
+		`,
+	})
+	s.RequireErrorContains(roErr, "rpc error: code = Unknown desc = connection_string must be set")
+
+	_, error := s.ds.Configure(context.Background(), &spi.ConfigureRequest{
+		Configuration: `
+		database_type = "mysql"
+		`,
+	})
+	s.RequireErrorContains(error, "rpc error: code = Unknown desc = connection_string must be set")
 }
 
 func (s *PluginSuite) TestBundleCRUD() {
@@ -1860,7 +1882,8 @@ func (s *PluginSuite) TestMigration() {
 			Configuration: fmt.Sprintf(`
 				database_type = "sqlite3"
 				connection_string = "file://%s"
-			`, dbPath),
+				ro_connection_string = "file://%s"
+			`, dbPath, dbPath),
 		})
 		s.Require().NoError(err)
 
@@ -1997,7 +2020,8 @@ func (s *PluginSuite) TestMigration() {
 			db, err := sqlite{}.connect(&configuration{
 				DatabaseType:     "sqlite3",
 				ConnectionString: fmt.Sprintf("file://%s", dbPath),
-			})
+				RoConnectionString: fmt.Sprintf("file://%s", dbPath),
+			}, fmt.Sprintf("file://%s", dbPath))
 			s.Require().NoError(err)
 			s.Require().True(db.Dialect().HasIndex("registered_entries", "idx_registered_entries_parent_id"))
 			s.Require().True(db.Dialect().HasIndex("registered_entries", "idx_registered_entries_spiffe_id"))
@@ -2006,21 +2030,24 @@ func (s *PluginSuite) TestMigration() {
 			db, err := sqlite{}.connect(&configuration{
 				DatabaseType:     "sqlite3",
 				ConnectionString: fmt.Sprintf("file://%s", dbPath),
-			})
+				RoConnectionString: fmt.Sprintf("file://%s", dbPath),
+			}, fmt.Sprintf("file://%s", dbPath))
 			s.Require().NoError(err)
 			s.Require().True(db.Dialect().HasIndex("registered_entries", "idx_registered_entries_expiry"))
 		case 10:
 			db, err := sqlite{}.connect(&configuration{
 				DatabaseType:     "sqlite3",
 				ConnectionString: fmt.Sprintf("file://%s", dbPath),
-			})
+				RoConnectionString: fmt.Sprintf("file://%s", dbPath),
+			}, fmt.Sprintf("file://%s", dbPath))
 			s.Require().NoError(err)
 			s.Require().True(db.Dialect().HasIndex("federated_registration_entries", "idx_federated_registration_entries_registered_entry_id"))
 		case 11:
 			db, err := sqlite{}.connect(&configuration{
 				DatabaseType:     "sqlite3",
 				ConnectionString: fmt.Sprintf("file://%s", dbPath),
-			})
+				RoConnectionString: fmt.Sprintf("file://%s", dbPath),
+			}, fmt.Sprintf("file://%s", dbPath))
 			s.Require().NoError(err)
 			s.Require().True(db.Dialect().HasColumn("migrations", "code_version"))
 		case 12:
@@ -2028,7 +2055,8 @@ func (s *PluginSuite) TestMigration() {
 			db, err := sqlite{}.connect(&configuration{
 				DatabaseType:     "sqlite3",
 				ConnectionString: fmt.Sprintf("file://%s", dbPath),
-			})
+				RoConnectionString: fmt.Sprintf("file://%s", dbPath),
+			}, fmt.Sprintf("file://%s", dbPath))
 			s.Require().NoError(err)
 			// Assert migration version is now 13
 			migration := Migration{}
@@ -2224,22 +2252,30 @@ func (s *PluginSuite) TestConfigure() {
 				database_type = "sqlite3"
 				log_sql = true
 				connection_string = "%s"
+                ro_connection_string = "%s"
 				%s
-		`, dbPath, tt.giveDBConfig),
+		`, dbPath, dbPath, tt.giveDBConfig),
 			})
 			require.NoError(t, err)
 
 			db := p.db.DB.DB()
+			roDb := p.roDb.DB.DB()
 
 			require.Equal(t, tt.expectMaxOpenConns, db.Stats().MaxOpenConnections)
+			require.Equal(t, tt.expectMaxOpenConns, roDb.Stats().MaxOpenConnections)
 
 			// begin many queries simultaneously
 			numQueries := 100
 			var rowsList []*sql.Rows
+			var roRowsList []*sql.Rows
 			for i := 0; i < numQueries; i++ {
 				rows, err := db.Query("SELECT * FROM bundles")
 				require.NoError(t, err)
 				rowsList = append(rowsList, rows)
+
+				roRows, roErr := roDb.Query("SELECT * FROM bundles")
+				require.NoError(t, roErr)
+				roRowsList = append(roRowsList, roRows)
 			}
 
 			// close all open queries, which results in idle connections
@@ -2247,6 +2283,10 @@ func (s *PluginSuite) TestConfigure() {
 				require.NoError(t, rows.Close())
 			}
 			require.Equal(t, tt.expectIdle, db.Stats().Idle)
+			for _, rows := range roRowsList {
+				require.NoError(t, rows.Close())
+			}
+			require.Equal(t, tt.expectIdle, roDb.Stats().Idle)
 		})
 	}
 }

--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -10,8 +10,8 @@ import (
 
 type sqlite struct{}
 
-func (s sqlite) connect(cfg *configuration) (*gorm.DB, error) {
-	embellished, err := embellishSQLite3ConnString(cfg.ConnectionString)
+func (s sqlite) connect(cfg *configuration, connectionString string) (*gorm.DB, error) {
+	embellished, err := embellishSQLite3ConnString(connectionString)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding read_only database connection string that can be used for read-only replicas.

Signed-off-by: Kirutthika Raja <kirutthika.raja@uber.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Adding read_only database connection string that can be used for read only replicas

**Description of change**
To take advantage of read replicas, enabling MySQL plugin to allow configuration of a read-only connection string.
Write connection string is mandatory, and if no Read-only is set then the Write string is used for Read as well. If Read is set, then the read connection string is use for Read operations.

**Which issue this PR fixes**
https://github.com/spiffe/spire/issues/1239

