### PR TITLE
Expose logrus options to `package main`

### DIFF
--- a/cmd/spire-agent/cli/cli.go
+++ b/cmd/spire-agent/cli/cli.go
@@ -1,16 +1,21 @@
 package cli
 
 import (
-	"log"
+	stdlog "log"
 
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/api"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/healthcheck"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/run"
+	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/version"
 )
 
-func Run(args []string) int {
+type CLI struct {
+	LogOptions []log.Option
+}
+
+func (cc *CLI) Run(args []string) int {
 	c := cli.NewCLI("spire-agent", version.Version())
 	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
@@ -30,7 +35,7 @@ func Run(args []string) int {
 			return &api.WatchCLI{}, nil
 		},
 		"run": func() (cli.Command, error) {
-			return &run.Command{}, nil
+			return &run.Command{LogOptions: cc.LogOptions}, nil
 		},
 		"healthcheck": func() (cli.Command, error) {
 			return healthcheck.NewHealthCheckCommand(), nil
@@ -39,7 +44,7 @@ func Run(args []string) int {
 
 	exitStatus, err := c.Run()
 	if err != nil {
-		log.Println(err)
+		stdlog.Println(err)
 	}
 	return exitStatus
 }

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -3,6 +3,8 @@ package run
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -662,7 +664,7 @@ func TestNewAgentConfig(t *testing.T) {
 		testCase.input(input)
 
 		t.Run(testCase.msg, func(t *testing.T) {
-			ac, err := newAgentConfig(input)
+			ac, err := newAgentConfig(input, []log.Option{})
 			if testCase.expectError {
 				require.Error(t, err)
 			} else {
@@ -764,4 +766,31 @@ func TestWarnOnUnknownConfig(t *testing.T) {
 			require.Nil(t, hook.LastEntry())
 		})
 	}
+}
+
+// TestLogOptions verifies the log options given to newAgentConfig are applied, and are overridden
+// by values from the config file
+func TestLogOptions(t *testing.T) {
+	fd, err := ioutil.TempFile("", "test")
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+	defer os.Remove(fd.Name())
+
+	logOptions := []log.Option{
+		log.WithLevel("DEBUG"),
+		log.WithFormat(log.JSONFormat),
+		log.WithOutputFile(fd.Name()),
+	}
+
+	agentConfig, err := newAgentConfig(defaultValidConfig(), logOptions)
+	require.NoError(t, err)
+
+	logger := agentConfig.Log.(*log.Logger).Logger
+
+	// defaultConfig() sets level to info,  which should override DEBUG set above
+	require.Equal(t, logrus.InfoLevel, logger.Level)
+
+	// JSON Formatter and output file should be set from above
+	require.IsType(t, &logrus.JSONFormatter{}, logger.Formatter)
+	require.Equal(t, fd.Name(), logger.Out.(*os.File).Name())
 }

--- a/cmd/spire-agent/main.go
+++ b/cmd/spire-agent/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:]))
+	os.Exit(new(cli.CLI).Run(os.Args[1:]))
 }

--- a/cmd/spire-server/cli/cli.go
+++ b/cmd/spire-server/cli/cli.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"log"
+	stdlog "log"
 
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-server/cli/agent"
@@ -12,10 +12,15 @@ import (
 	"github.com/spiffe/spire/cmd/spire-server/cli/run"
 	"github.com/spiffe/spire/cmd/spire-server/cli/token"
 	"github.com/spiffe/spire/cmd/spire-server/cli/x509"
+	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/version"
 )
 
-func Run(args []string) int {
+type CLI struct {
+	LogOptions []log.Option
+}
+
+func (cc *CLI) Run(args []string) int {
 	c := cli.NewCLI("spire-server", version.Version())
 	c.Args = args
 	c.Commands = map[string]cli.CommandFactory{
@@ -62,7 +67,7 @@ func Run(args []string) int {
 			return &entry.ShowCLI{}, nil
 		},
 		"run": func() (cli.Command, error) {
-			return &run.Command{}, nil
+			return &run.Command{LogOptions: cc.LogOptions}, nil
 		},
 		"token generate": func() (cli.Command, error) {
 			return &token.GenerateCLI{}, nil
@@ -80,7 +85,7 @@ func Run(args []string) int {
 
 	exitStatus, err := c.Run()
 	if err != nil {
-		log.Println(err)
+		stdlog.Println(err)
 	}
 	return exitStatus
 }

--- a/cmd/spire-server/main.go
+++ b/cmd/spire-server/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	os.Exit(cli.Run(os.Args[1:]))
+	os.Exit(new(cli.CLI).Run(os.Args[1:]))
 }

--- a/pkg/common/log/log.go
+++ b/pkg/common/log/log.go
@@ -1,17 +1,10 @@
 package log
 
 import (
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
-)
-
-const (
-	DefaultFormat = ""
-	JSONFormat    = "JSON"
-	TextFormat    = "TEXT"
 )
 
 type Logger struct {
@@ -19,42 +12,20 @@ type Logger struct {
 	io.Closer
 }
 
-func NewLogger(logLevel, format, outputFile string) (*Logger, error) {
-	level, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		return nil, err
+func NewLogger(options ...Option) (*Logger, error) {
+	logger := &Logger{
+		Logger: logrus.New(),
+		Closer: nopCloser{},
 	}
+	logger.SetOutput(os.Stdout)
 
-	var out io.Writer = os.Stdout
-	var closer io.Closer = nopCloser{}
-	if outputFile != "" {
-		fd, err := os.OpenFile(outputFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
-		if err != nil {
+	for _, option := range options {
+		if err := option(logger); err != nil {
 			return nil, err
 		}
-		out = fd
-		closer = fd
 	}
 
-	logger := logrus.New()
-	logger.SetOutput(out)
-	logger.SetLevel(level)
-
-	switch format {
-	case DefaultFormat:
-		// Logrus has a default formatter set up in logrus.New(), so we don't change it
-	case JSONFormat:
-		logger.Formatter = &logrus.JSONFormatter{}
-	case TextFormat:
-		logger.Formatter = &logrus.TextFormatter{}
-	default:
-		return nil, fmt.Errorf("unknown logger format: %q", format)
-	}
-
-	return &Logger{
-		Logger: logger,
-		Closer: closer,
-	}, nil
+	return logger, nil
 }
 
 type nopCloser struct{}

--- a/pkg/common/log/log_test.go
+++ b/pkg/common/log/log_test.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Basic smoketest: set up a logger, make sure options work
+func TestLogger(t *testing.T) {
+	testHook := test.Hook{}
+
+	// Set up a logger with a test hook
+	logger, err := NewLogger(WithLevel("warning"),
+		func(logger *Logger) error {
+			logger.AddHook(&testHook)
+			return nil
+		})
+	require.NoError(t, err)
+
+	logger.Info("info should be discarded, as it's below warn")
+
+	require.Empty(t, testHook.Entries)
+
+	msg := "Expected warning"
+	logger.Warning(msg)
+
+	require.Equal(t, msg, testHook.LastEntry().Message)
+}
+
+// Make sure writing to an output file works with various formats
+func TestOutputFile(t *testing.T) {
+	msg := "This should get written"
+
+	for _, format := range []string{DefaultFormat, TextFormat, JSONFormat} {
+		f, err := ioutil.TempFile("", "testoutputfile")
+		require.NoError(t, err)
+		tmpfile := f.Name()
+		defer os.Remove(tmpfile)
+
+		logger, err := NewLogger(WithOutputFile(tmpfile), WithFormat(format))
+		require.NoError(t, err)
+
+		logger.Warning(msg)
+
+		require.NoError(t, logger.Close())
+
+		log, err := ioutil.ReadAll(f)
+		require.NoError(t, err)
+
+		if format == JSONFormat {
+			var data map[string]string
+			require.NoError(t, json.Unmarshal(log, &data))
+			assert.Equal(t, data["level"], "warning")
+			assert.Equal(t, data["msg"], msg)
+			assert.Contains(t, data, "time")
+			assert.EqualValues(t, len(data), 3, "%q", data)
+		} else {
+			expected := fmt.Sprintf("level=warning msg=\"%s\"", msg)
+			require.Contains(t, string(log), expected)
+		}
+	}
+}

--- a/pkg/common/log/options.go
+++ b/pkg/common/log/options.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultFormat = ""
+	JSONFormat    = "JSON"
+	TextFormat    = "TEXT"
+)
+
+// An Option can change the Logger to apply desired configuration in NewLogger
+type Option func(*Logger) error
+
+func WithOutputFile(file string) Option {
+	return func(logger *Logger) error {
+		if file == "" {
+			return nil
+		}
+		fd, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+		if err != nil {
+			return err
+		}
+
+		logger.SetOutput(fd)
+
+		// If, for some reason, there's another closer set, close it first.
+		if logger.Closer != nil {
+			if err := logger.Closer.Close(); err != nil {
+				return err
+			}
+		}
+
+		logger.Closer = fd
+		return nil
+	}
+}
+
+func WithFormat(format string) Option {
+	return func(logger *Logger) error {
+		switch strings.ToUpper(format) {
+		case DefaultFormat:
+			// Logrus has a default formatter set up in logrus.New(), so we don't change it
+		case JSONFormat:
+			logger.Formatter = &logrus.JSONFormatter{}
+		case TextFormat:
+			logger.Formatter = &logrus.TextFormatter{}
+		default:
+			return fmt.Errorf("unknown logger format: %q", format)
+		}
+		return nil
+	}
+}
+
+func WithLevel(logLevel string) Option {
+	return func(logger *Logger) error {
+		level, err := logrus.ParseLevel(logLevel)
+		if err != nil {
+			return err
+		}
+		logger.SetLevel(level)
+		return nil
+	}
+}

--- a/support/k8s/k8s-workload-registrar/main.go
+++ b/support/k8s/k8s-workload-registrar/main.go
@@ -30,7 +30,7 @@ func run(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	log, err := log.NewLogger(config.LogLevel, config.LogFormat, config.LogPath)
+	log, err := log.NewLogger(log.WithLevel(config.LogLevel), log.WithFormat(config.LogFormat), log.WithOutputFile(config.LogPath))
 	if err != nil {
 		return err
 	}

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -31,7 +31,7 @@ func run(configPath string) error {
 		return err
 	}
 
-	log, err := log.NewLogger(config.LogLevel, config.LogFormat, config.LogPath)
+	log, err := log.NewLogger(log.WithLevel(config.LogLevel), log.WithFormat(config.LogFormat), log.WithOutputFile(config.LogPath))
 	if err != nil {
 		return errs.Wrap(err)
 	}


### PR DESCRIPTION
Switch log package to "Functional options" style
The functional options style of arguments is flexible as adding new options is
a non-breaking change to the NewLogger, and defaults are easier to use as those
options can be omitted.  Additionally they are less error-prone than a series
of positional string arguments which could easily be mixed up.

The options are plumbed up to cli.Run (in both server and agent).
Logrus has a number of options not exposed by SPIRE, and this allows those to
be configured in a custom `package main`.

I plan to use this for a custom Logrus formatter and hook to align with our
existing monitoring infrastructure.

Signed-off-by: Matthew McPherrin <mmc@squareup.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [n/a] Documentation updated?