### PR TITLE
Ensure go modules are tidy as part of CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ jobs:
       name: lint
       script:
         - make lint
+        - make tidy-check
         - make generate-check
         - shellcheck script/*.sh
         - shellcheck .travis/*.sh

--- a/Makefile
+++ b/Makefile
@@ -350,9 +350,20 @@ oidc-discovery-provider-image: Dockerfile
 # Code cleanliness
 #############################################################################
 
-.PHONY: tidy lint lint-code
+.PHONY: tidy tidy-check lint lint-code
 tidy: | go-check
 	$(E)$(go) mod tidy
+	$(E)cd proto/spire; $(go) mod tidy
+	$(E)cd tools/external; $(go) mod tidy
+
+tidy-check:
+ifneq ($(git_dirty),)
+	$(error tidy-check must be invoked on a clean repository)
+endif
+	@echo "Running go tidy..."
+	$(E)$(MAKE) tidy
+	@echo "Ensuring git repository is clean..."
+	$(E)$(MAKE) git-clean-check
 
 lint: lint-code
 
@@ -381,9 +392,9 @@ ifneq ($(git_dirty),)
 	$(error protogen-check must be invoked on a clean repository)
 endif
 	$(E)find . -type f -name "*.proto" -exec touch {} \;
-	@echo "Compiling protocol buffers..." 
+	@echo "Compiling protocol buffers..."
 	$(E)$(MAKE) protogen
-	@echo "Ensuring git repository is clean..." 
+	@echo "Ensuring git repository is clean..."
 	$(E)$(MAKE) git-clean-check
 
 define protodoc-rule
@@ -431,9 +442,9 @@ ifneq ($(git_dirty),)
 	$(error plugingen-check must be invoked on a clean repository)
 endif
 	$(E)find . -type f -name "*.pb.go" -exec touch {} \;
-	@echo "Generating plugin interface code..." 
+	@echo "Generating plugin interface code..."
 	$(E)$(MAKE) plugingen
-	@echo "Ensuring git repository is clean..." 
+	@echo "Ensuring git repository is clean..."
 	$(E)$(MAKE) git-clean-check
 
 mockgen-pkg = $(word 1,$(subst $(comma),$(space),$1))


### PR DESCRIPTION
- Changes `make tidy` to also tidy up the proto/spire and tools/external modules modules
- Adds `make tidy-check` to ensure the repo is tidy
- Adds a CI step to invoke `make tidy-check` as part of the "lint" step.

Fixes #1159