### PR TITLE
Fix build scripts and artifact inconsistencies

### DIFF
--- a/.travis/build-release.sh
+++ b/.travis/build-release.sh
@@ -2,8 +2,8 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-TAG="$(git describe --abbrev=0 2>/dev/null || true)"
-ALWAYS="$(git describe --always || true)"
+TAG="$(git describe --abbrev=0 --match "v[0-9]*" 2>/dev/null || true)"
+ALWAYS="$(git describe --always --match "v[0-9]*" || true)"
 if [ "$TAG" == "$ALWAYS" ]; then
     make -C "${DIR}/.." TAG="${TAG}" OUTDIR=./releases artifact
 fi

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ mockgen_version := $(shell grep github.com/golang/mock go.mod | awk '{print $$2}
 mockgen_dir := $(build_dir)/mockgen/$(mockgen_version)
 mockgen_bin := $(mockgen_dir)/mockgen
 
-git_tag := $(shell git tag --points-at HEAD)
+# There may be more than one tag. Only use one that starts with 'v' followed by
+# a number, e.g., v0.9.3.
+git_tag := $(shell git tag --points-at HEAD | grep '^v[0-9]*')
 git_hash := $(shell git rev-parse --short=7 HEAD)
 git_dirty := $(shell git status -s)
 

--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -8,7 +8,7 @@ BINDIR="${REPODIR}/bin"
 TAG=${TAG:-$(git log -n1 --pretty=%h)}
 OUTDIR=${OUTDIR:-"${REPODIR}/artifacts"}
 
-OS=$(uname -s)
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 # handle the case that we're building for alpine
@@ -24,11 +24,14 @@ fi
 TARBALL="${OUTDIR}/spire-${TAG}-${OS}-${ARCH}${LIBC}.tar.gz"
 CHECKSUM="${OUTDIR}/spire-${TAG}-${OS}-${ARCH}${LIBC}_checksums.txt"
 
-STAGING=$(mktemp -d)
+TMPDIR=$(mktemp -d)
 cleanup() {
-    rm -rf "${STAGING}"
+    rm -rf "${TMPDIR}"
 }
 trap cleanup EXIT
+
+STAGING="${TMPDIR}"/spire-${TAG}
+mkdir ${STAGING}
 
 echo "Creating \"${TARBALL}\""
 
@@ -45,5 +48,5 @@ cp "${BINDIR}"/spire-agent "${STAGING}"/bin
 
 # Create the tarball and checksum
 mkdir -p "${OUTDIR}"
-tar -cvzf "${TARBALL}" --directory "${STAGING}" "${TAROPTS[@]}" .
+tar -cvzf "${TARBALL}" --directory "${TMPDIR}" "${TAROPTS[@]}" .
 echo "$(shasum -a 256 "${TARBALL}" | cut -d' ' -f1) $(basename "${TARBALL}")" > "$CHECKSUM"

--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -31,7 +31,7 @@ cleanup() {
 trap cleanup EXIT
 
 STAGING="${TMPDIR}"/spire-${TAG}
-mkdir ${STAGING}
+mkdir "${STAGING}"
 
 echo "Creating \"${TARBALL}\""
 


### PR DESCRIPTION
The makefile refactor introduced some descrepancies in release asset
creation. This fixes those discrepancies. Namely:

- The top level tarball content is a folder that the rest of the files
reside in, e.g. spire-v0.9.3/
- The name of the asset uses a lowercase OS name, e.g. linux instead of
Linux

The recent change to our tagging methodology to accomodate go module
versioning (i.e. tag with v0.9.2 instead of 0.9.2, also tag
proto/spire/v0.9.2 for multi-module repos) broke build script assumption
that there would be only one tag at a given commit. This change fixes
this by only matching tags beginning with 'v' followed by a number.