### PR TITLE
Only build from master and version branches/tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ cache:
     # so this is hitting the default go env of $HOME/go
     - $HOME/go/bin
 
+# Only build for master and branches that look like versions. This also covers
+# tags, which keeps us from building (and deploying) from the extra tags we set
+# during a release for go multi-module repo support (i.e. proto/spire/v1.2.3).
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?$/
+
 stages:
   - lint and test
   - build release


### PR DESCRIPTION
Due to our multi-module repo, we need two tags when pushing a release
(e.g. v1.2.3 and proto/spire/v1.2.3). We only want to build (and deploy)
from the version tag (e.g. v1.2.3) and not the one for the inner module.


