### PR TITLE
Fix syntax error in fallback

### DIFF
--- a/pkg/common/peertracker/tracker_fallback.go
+++ b/pkg/common/peertracker/tracker_fallback.go
@@ -6,6 +6,6 @@
 
 package peertracker
 
-func newTracker(PeerTracker, error) {
+func newTracker() (PeerTracker, error) {
 	return nil, ErrUnsupportedPlatform
 }


### PR DESCRIPTION
tracker_fallback.go did not compile.
