### PR TITLE
Fix agent SVID rotation timer

### DIFF
--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -118,8 +118,6 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 
 	// Get the mtx before starting the rotation
 	// In this way, the client do not create new connections until the new SVID is received
-	r.c.Log.Debug("Acquiring rotation lock")
-	defer r.c.Log.Debug("Releasing rotation lock")
 	r.rotMtx.Lock()
 	defer r.rotMtx.Unlock()
 	r.c.Log.Debug("Rotating agent SVID")

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -106,7 +106,7 @@ func (s *RotatorTestSuite) TestRun() {
 	s.Assert().Equal(key, state.Key)
 
 	cancel()
-	s.Require().NoError(t.Wait())
+	s.Require().Equal(context.Canceled, t.Wait())
 }
 
 func (s *RotatorTestSuite) TestRunWithUpdates() {
@@ -151,7 +151,7 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 	}
 
 	cancel()
-	s.Require().NoError(t.Wait())
+	s.Require().Equal(context.Canceled, t.Wait())
 }
 
 func (s *RotatorTestSuite) TestRotateSVID() {


### PR DESCRIPTION
The agent SVID rotator has a bug whereby the rotation timer is extended when a bundle update happens. This can cause the agent to fail to rotate in time for small TTLs or in the face of frequent bundle updates. It was made worse by a recent change to introduce backoff to the rotation timer.

This change decouples the rotation timer and bundle update handling.