### PR TITLE
Allow configuring agent sync interval

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/hcl"
 	"github.com/imdario/mergo"
@@ -55,6 +56,7 @@ type agentConfig struct {
 	ServerAddress     string `hcl:"server_address"`
 	ServerPort        int    `hcl:"server_port"`
 	SocketPath        string `hcl:"socket_path"`
+	SyncInterval      string `hcl:"sync_interval"`
 	TrustBundlePath   string `hcl:"trust_bundle_path"`
 	TrustDomain       string `hcl:"trust_domain"`
 
@@ -218,6 +220,14 @@ func newAgentConfig(c *config, logOptions []log.Option) (*agent.Config, error) {
 
 	if err := validateConfig(c); err != nil {
 		return nil, err
+	}
+
+	if c.Agent.SyncInterval != "" {
+		var err error
+		ac.SyncInterval, err = time.ParseDuration(c.Agent.SyncInterval)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse synchronization interval: %v", err)
+		}
 	}
 
 	serverHostPort := net.JoinHostPort(c.Agent.ServerAddress, strconv.Itoa(c.Agent.ServerPort))

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -56,17 +56,23 @@ type agentConfig struct {
 	ServerAddress     string `hcl:"server_address"`
 	ServerPort        int    `hcl:"server_port"`
 	SocketPath        string `hcl:"socket_path"`
-	SyncInterval      string `hcl:"sync_interval"`
 	TrustBundlePath   string `hcl:"trust_bundle_path"`
 	TrustDomain       string `hcl:"trust_domain"`
 
 	ConfigPath string
 
 	// Undocumented configurables
-	ProfilingEnabled bool     `hcl:"profiling_enabled"`
-	ProfilingPort    int      `hcl:"profiling_port"`
-	ProfilingFreq    int      `hcl:"profiling_freq"`
-	ProfilingNames   []string `hcl:"profiling_names"`
+	ProfilingEnabled bool               `hcl:"profiling_enabled"`
+	ProfilingPort    int                `hcl:"profiling_port"`
+	ProfilingFreq    int                `hcl:"profiling_freq"`
+	ProfilingNames   []string           `hcl:"profiling_names"`
+	Experimental     experimentalConfig `hcl:"experimental"`
+
+	UnusedKeys []string `hcl:",unusedKeys"`
+}
+
+type experimentalConfig struct {
+	SyncInterval string `hcl:"sync_interval"`
 
 	UnusedKeys []string `hcl:",unusedKeys"`
 }
@@ -222,9 +228,9 @@ func newAgentConfig(c *config, logOptions []log.Option) (*agent.Config, error) {
 		return nil, err
 	}
 
-	if c.Agent.SyncInterval != "" {
+	if c.Agent.Experimental.SyncInterval != "" {
 		var err error
-		ac.SyncInterval, err = time.ParseDuration(c.Agent.SyncInterval)
+		ac.SyncInterval, err = time.ParseDuration(c.Agent.Experimental.SyncInterval)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse synchronization interval: %v", err)
 		}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -657,7 +657,7 @@ func TestNewAgentConfig(t *testing.T) {
 		{
 			msg: "sync_interval parses a duration",
 			input: func(c *config) {
-				c.Agent.SyncInterval = "2s45ms"
+				c.Agent.Experimental.SyncInterval = "2s45ms"
 			},
 			test: func(t *testing.T, c *agent.Config) {
 				require.EqualValues(t, 2045000000, c.SyncInterval)
@@ -667,7 +667,7 @@ func TestNewAgentConfig(t *testing.T) {
 			msg:         "invalid sync_interval returns an error",
 			expectError: true,
 			input: func(c *config) {
-				c.Agent.SyncInterval = "moo"
+				c.Agent.Experimental.SyncInterval = "moo"
 			},
 			test: func(t *testing.T, c *agent.Config) {
 				require.Nil(t, c)

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -654,6 +654,25 @@ func TestNewAgentConfig(t *testing.T) {
 				require.Nil(t, c)
 			},
 		},
+		{
+			msg: "sync_interval parses a duration",
+			input: func(c *config) {
+				c.Agent.SyncInterval = "2s45ms"
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.EqualValues(t, 2045000000, c.SyncInterval)
+			},
+		},
+		{
+			msg:         "invalid sync_interval returns an error",
+			expectError: true,
+			input: func(c *config) {
+				c.Agent.SyncInterval = "moo"
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.Nil(t, c)
+			},
+		},
 	}
 
 	for _, testCase := range cases {

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -43,7 +43,6 @@ SPIRE configuration files may be represented in either HCL or JSON. Please see t
 | `server_address`     | DNS name or IP address of the SPIRE server                     |                      |
 | `server_port`        | Port number of the SPIRE server                                |                      |
 | `socket_path`        | Location to bind the workload API socket                       | $PWD/spire_api       |
-| `sync_interval`      | Interval that spire agent updates from the server on           | 5s                   |
 | `trust_bundle_path`  | Path to the SPIRE server CA bundle                             |                      |
 | `insecure_bootstrap` | Disables verifying the server's identity when the agent starts for the first time |   |
 | `trust_domain`       | The trust domain that this agent belongs to                    |                      |

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -43,6 +43,7 @@ SPIRE configuration files may be represented in either HCL or JSON. Please see t
 | `server_address`     | DNS name or IP address of the SPIRE server                     |                      |
 | `server_port`        | Port number of the SPIRE server                                |                      |
 | `socket_path`        | Location to bind the workload API socket                       | $PWD/spire_api       |
+| `sync_interval`      | Interval that spire agent updates from the server on           | 5s                   |
 | `trust_bundle_path`  | Path to the SPIRE server CA bundle                             |                      |
 | `insecure_bootstrap` | Disables verifying the server's identity when the agent starts for the first time |   |
 | `trust_domain`       | The trust domain that this agent belongs to                    |                      |

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -190,6 +190,7 @@ func (a *Agent) newManager(ctx context.Context, cat catalog.Catalog, metrics tel
 		Metrics:         metrics,
 		BundleCachePath: a.bundleCachePath(),
 		SVIDCachePath:   a.agentSVIDPath(),
+		SyncInterval:    a.c.SyncInterval,
 	}
 
 	mgr, err := manager.New(config)

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/url"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/catalog"
@@ -34,6 +35,9 @@ type Config struct {
 
 	// Address of SPIRE server
 	ServerAddress string
+
+	// SyncInterval controls how often the agent sync synchronizer waits
+	SyncInterval time.Duration
 
 	// Trust domain and associated CA bundle
 	TrustDomain url.URL


### PR DESCRIPTION
Pull Request check list

 - [x] Commit conforms to CONTRIBUTING.md?
 - [x] Proper tests/regressions included?
 - [x] Documentation updated?

Affected functionality
SPIRE Agent syncing

Description of change
This exposes a new sync_interval configuration option in SPIRE Agent. It is a string parsed as a time.Duration.
