### PR TITLE
Use AWS SDK to retrieve ec2 instance identity doc

### DIFF
--- a/pkg/agent/plugin/nodeattestor/aws/iid.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid.go
@@ -3,27 +3,27 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
-	"net/http"
+	"strings"
 	"sync"
 
+	awsSdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/proto/spire/common"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"errors"
-
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
 const (
-	defaultIdentityDocumentURL  = "http://169.254.169.254/latest/dynamic/instance-identity/document"
-	defaultIdentitySignatureURL = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
+	docPath = "instance-identity/document"
+	sigPath = "instance-identity/signature"
 )
 
 func BuiltIn() catalog.Plugin {
@@ -36,15 +36,15 @@ func builtin(p *IIDAttestorPlugin) catalog.Plugin {
 
 // IIDAttestorConfig configures a IIDAttestorPlugin.
 type IIDAttestorConfig struct {
+	EC2MetadataEndpoint  string `hcl:"ec2_metadata_endpoint"`
 	IdentityDocumentURL  string `hcl:"identity_document_url"`
 	IdentitySignatureURL string `hcl:"identity_signature_url"`
-	trustDomain          string
 }
 
 // IIDAttestorPlugin implements aws nodeattestation in the agent.
 type IIDAttestorPlugin struct {
-	config *IIDAttestorConfig
-	mtx    sync.RWMutex
+	session *session.Session
+	mtx     sync.RWMutex
 }
 
 // New creates a new IIDAttestorPlugin.
@@ -55,24 +55,25 @@ func New() *IIDAttestorPlugin {
 // FetchAttestationData fetches attestation data from the aws metadata server and sends an attestation response
 // on given stream.
 func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
-	c, err := p.getConfig()
-	if err != nil {
-		return err
+	if p.session == nil {
+		return errors.New("not configured")
 	}
 
-	docBytes, err := httpGetBytes(c.IdentityDocumentURL)
+	client := ec2metadata.New(p.session)
+
+	doc, err := client.GetDynamicData(docPath)
 	if err != nil {
 		return aws.AttestationStepError("retrieving the IID from AWS", err)
 	}
 
-	sigBytes, err := httpGetBytes(c.IdentitySignatureURL)
+	sig, err := client.GetDynamicData(sigPath)
 	if err != nil {
 		return aws.AttestationStepError("retrieving the IID signature from AWS", err)
 	}
 
 	attestationData := aws.IIDAttestationData{
-		Document:  string(docBytes),
-		Signature: string(sigBytes),
+		Document:  doc,
+		Signature: sig,
 	}
 
 	respData, err := json.Marshal(attestationData)
@@ -96,27 +97,30 @@ func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReq
 		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)
 	}
 
-	if req.GlobalConfig == nil {
-		return nil, status.Error(codes.InvalidArgument, "global configuration is required")
-	}
-	if req.GlobalConfig.TrustDomain == "" {
-		return nil, status.Error(codes.InvalidArgument, "global configuration missing trust domain")
-	}
-	// Set local vars from config struct
-	config.trustDomain = req.GlobalConfig.TrustDomain
-
-	if config.IdentityDocumentURL == "" {
-		config.IdentityDocumentURL = defaultIdentityDocumentURL
+	// If the endpoint isn't explicitly configured but the legacy URLs are, extract the endpoint from it
+	// This code is transitional, here until these deprecated configs are removed
+	if config.EC2MetadataEndpoint == "" && (config.IdentityDocumentURL != "" || config.IdentitySignatureURL != "") {
+		endpoint, err := endpointFromLegacyConfig(config.IdentityDocumentURL, config.IdentitySignatureURL)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		config.EC2MetadataEndpoint = endpoint
 	}
 
-	if config.IdentitySignatureURL == "" {
-		config.IdentitySignatureURL = defaultIdentitySignatureURL
+	awsCfg := awsSdk.NewConfig()
+
+	if config.EC2MetadataEndpoint != "" {
+		awsCfg.WithEndpoint(config.EC2MetadataEndpoint)
+	}
+
+	newSession, err := session.NewSession(awsCfg)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
-
-	p.config = config
+	p.session = newSession
 
 	return &spi.ConfigureResponse{}, nil
 }
@@ -126,30 +130,24 @@ func (*IIDAttestorPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoReque
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func (p *IIDAttestorPlugin) getConfig() (*IIDAttestorConfig, error) {
-	p.mtx.RLock()
-	defer p.mtx.RUnlock()
-
-	if p.config == nil {
-		return nil, errors.New("not configured")
+// endpointFromLegacyConfig extracts the endpoint from legacy configuration values
+// This code is transitional, here until these deprecated configs are removed
+func endpointFromLegacyConfig(docURL, sigURL string) (string, error) {
+	docSuffix := "/dynamic/" + docPath
+	if !strings.HasSuffix(docURL, docSuffix) {
+		return "", fmt.Errorf("IID URL '%s' doesn't end in expected suffix %s", docURL, docSuffix)
 	}
-	return p.config, nil
-}
+	docEndpoint := strings.TrimSuffix(docURL, docSuffix)
 
-func httpGetBytes(url string) ([]byte, error) {
-	resp, err := http.Get(url) //nolint: gosec // URL is provided via explicit configuration
-	if err != nil {
-		return nil, err
+	sigSuffix := "/dynamic/" + sigPath
+	if !strings.HasSuffix(sigURL, sigSuffix) {
+		return "", fmt.Errorf("IID signature URL '%s' doesn't end in expected suffix %s", sigURL, sigSuffix)
 	}
-	defer resp.Body.Close()
+	sigEndpoint := strings.TrimSuffix(sigURL, sigSuffix)
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	if docEndpoint != sigEndpoint {
+		return "", fmt.Errorf("IID URL and Signature URL had different endpoints: %s != %s", docEndpoint, sigEndpoint)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	return bytes, nil
+	return docEndpoint, nil
 }

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -18,12 +18,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/hashicorp/go-hclog"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ not yet ] Documentation updated?

**Affected functionality**
EC2 IID node attestation

**Description of change**
Use AWS SDK to retrieve ec2 instance identity doc

This allows use of the v2 instance identity metadata service, which has improved resilience to SSRF and similar vulnerabilities.

There is some backwards compatibility with the previous configuration that specifies full URLs, however, the SDK wants you to configure a single endpoint.

This change is fully backwards compatible when using AWS IID or a direct proxy for it.  It is theoretically incompatible if you used nonstandard URLs, but that is unlikely given the response must be signed with a fixed Amazon controlled private key.

Still to resolve:
Is this sufficient backwards compatibility?  I think to fully support the old configuration, we'd need two codepaths.  Is that worth the burden of a relatively-unlikely configuration?  I haven't yet added any deprecation warnings; should I simply log a warn-level message?

**Which issue this PR fixes**
fixes #1359 

