### PR TITLE
Update AWS SDK and use SDK-defined InstanceIdentityDocument struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129
 	github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878
-	github.com/aws/aws-sdk-go v1.21.7
+	github.com/aws/aws-sdk-go v1.28.9
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/containerd/containerd v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878 h1:EFSB7Zo9Eg91v7
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.21.7 h1:ml+k7szyVaq4YD+3LhqOGl9tgMTqgMbpnuUSkB6UJvQ=
-github.com/aws/aws-sdk-go v1.21.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.28.9 h1:grIuBQc+p3dTRXerh5+2OxSuWFi0iXuxbFdTSg0jaW0=
+github.com/aws/aws-sdk-go v1.28.9/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/agent/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid_test.go
@@ -12,12 +12,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/common/pemutil"
-	"github.com/spiffe/spire/test/spiretest"
-
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/spiretest"
 )
 
 const (
@@ -183,7 +183,7 @@ func (s *Suite) fetchAttestationData() (*nodeattestor.FetchAttestationDataRespon
 
 func (s *Suite) buildDefaultIIDDocAndSig() (docBytes []byte, sigBytes []byte) {
 	// doc body
-	doc := aws.InstanceIdentityDocument{
+	doc := ec2metadata.EC2InstanceIdentityDocument{
 		AccountID:  "test-account",
 		InstanceID: "test-instance",
 		Region:     "test-region",

--- a/pkg/common/plugin/aws/iid.go
+++ b/pkg/common/plugin/aws/iid.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const (
@@ -22,13 +21,6 @@ const (
 type SessionConfig struct {
 	AccessKeyID     string `hcl:"access_key_id"`
 	SecretAccessKey string `hcl:"secret_access_key"`
-}
-
-// InstanceIdentityDocument AWS IID struct
-type InstanceIdentityDocument struct {
-	InstanceID string `json:"instanceId" `
-	AccountID  string `json:"accountId"`
-	Region     string `json:"region"`
 }
 
 // IIDAttestationData AWS IID attestation data

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/hcl"
-	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
-
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
@@ -316,7 +316,7 @@ func (p *IIDAttestorPlugin) getConfig() (*IIDAttestorConfig, error) {
 	return p.config, nil
 }
 
-func (p *IIDAttestorPlugin) getEC2Instance(ctx context.Context, c *IIDAttestorConfig, doc caws.InstanceIdentityDocument) (*ec2.Instance, error) {
+func (p *IIDAttestorPlugin) getEC2Instance(ctx context.Context, c *IIDAttestorConfig, doc ec2metadata.EC2InstanceIdentityDocument) (*ec2.Instance, error) {
 	awsSession, err := caws.NewAWSSession(c.AccessKeyID, c.SecretAccessKey, doc.Region)
 	if err != nil {
 		return nil, caws.AttestationStepError("creating AWS session", err)
@@ -361,26 +361,26 @@ func tagsFromInstance(instance *ec2.Instance) instanceTags {
 	return tags
 }
 
-func unmarshalAndValidateIdentityDocument(data []byte, pubKey *rsa.PublicKey) (caws.InstanceIdentityDocument, error) {
+func unmarshalAndValidateIdentityDocument(data []byte, pubKey *rsa.PublicKey) (ec2metadata.EC2InstanceIdentityDocument, error) {
 	var attestationData caws.IIDAttestationData
 	if err := json.Unmarshal(data, &attestationData); err != nil {
-		return caws.InstanceIdentityDocument{}, caws.AttestationStepError("unmarshaling the attestation data", err)
+		return ec2metadata.EC2InstanceIdentityDocument{}, caws.AttestationStepError("unmarshaling the attestation data", err)
 	}
 
-	var doc caws.InstanceIdentityDocument
+	var doc ec2metadata.EC2InstanceIdentityDocument
 	if err := json.Unmarshal([]byte(attestationData.Document), &doc); err != nil {
-		return caws.InstanceIdentityDocument{}, caws.AttestationStepError("unmarshaling the IID", err)
+		return ec2metadata.EC2InstanceIdentityDocument{}, caws.AttestationStepError("unmarshaling the IID", err)
 	}
 
 	docHash := sha256.Sum256([]byte(attestationData.Document))
 
 	sigBytes, err := base64.StdEncoding.DecodeString(attestationData.Signature)
 	if err != nil {
-		return caws.InstanceIdentityDocument{}, caws.AttestationStepError("base64 decoding the IID signature", err)
+		return ec2metadata.EC2InstanceIdentityDocument{}, caws.AttestationStepError("base64 decoding the IID signature", err)
 	}
 
 	if err := rsa.VerifyPKCS1v15(pubKey, crypto.SHA256, docHash[:], sigBytes); err != nil {
-		return caws.InstanceIdentityDocument{}, caws.AttestationStepError("verifying the cryptographic signature", err)
+		return ec2metadata.EC2InstanceIdentityDocument{}, caws.AttestationStepError("verifying the cryptographic signature", err)
 	}
 
 	return doc, nil

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -13,23 +13,22 @@ import (
 	"io"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/common/pemutil"
-	"google.golang.org/grpc/codes"
-
-	"github.com/spiffe/spire/pkg/common/plugin/aws"
-	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
-	"github.com/spiffe/spire/test/fakes/fakeagentstore"
-	mock_aws "github.com/spiffe/spire/test/mock/server/aws"
-	"github.com/spiffe/spire/test/spiretest"
-
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
+	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/pkg/common/plugin/aws"
+	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/fakes/fakeagentstore"
+	mock_aws "github.com/spiffe/spire/test/mock/server/aws"
+	"github.com/spiffe/spire/test/spiretest"
+	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -546,7 +545,7 @@ func (s *IIDAttestorSuite) attest(req *nodeattestor.AttestRequest) (*nodeattesto
 
 func (s *IIDAttestorSuite) buildIIDAttestationData(instanceID, accountID, region string) *aws.IIDAttestationData {
 	// doc body
-	doc := aws.InstanceIdentityDocument{
+	doc := ec2metadata.EC2InstanceIdentityDocument{
 		AccountID:  accountID,
 		InstanceID: instanceID,
 		Region:     region,

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid.go
@@ -13,7 +13,9 @@ import (
 var defaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"))
 
 type agentPathTemplateData struct {
-	ec2metadata.EC2InstanceIdentityDocument
+	InstanceID  string
+	AccountID   string
+	Region      string
 	PluginName  string
 	TrustDomain string
 	Tags        instanceTags
@@ -25,9 +27,11 @@ type instanceTags map[string]string
 func makeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc ec2metadata.EC2InstanceIdentityDocument, tags instanceTags) (*url.URL, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
-		EC2InstanceIdentityDocument: doc,
-		PluginName:                  aws.PluginName,
-		Tags:                        tags,
+		InstanceID: doc.InstanceID,
+		AccountID:  doc.AccountID,
+		Region:     doc.Region,
+		PluginName: aws.PluginName,
+		Tags:       tags,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"text/template"
 
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
 )
@@ -12,7 +13,7 @@ import (
 var defaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"))
 
 type agentPathTemplateData struct {
-	aws.InstanceIdentityDocument
+	ec2metadata.EC2InstanceIdentityDocument
 	PluginName  string
 	TrustDomain string
 	Tags        instanceTags
@@ -21,12 +22,12 @@ type agentPathTemplateData struct {
 type instanceTags map[string]string
 
 // makeSpiffeID creates a spiffe ID from IID data
-func makeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc aws.InstanceIdentityDocument, tags instanceTags) (*url.URL, error) {
+func makeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc ec2metadata.EC2InstanceIdentityDocument, tags instanceTags) (*url.URL, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
-		InstanceIdentityDocument: doc,
-		PluginName:               aws.PluginName,
-		Tags:                     tags,
+		EC2InstanceIdentityDocument: doc,
+		PluginName:                  aws.PluginName,
+		Tags:                        tags,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
@@ -1,0 +1,52 @@
+package aws
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/stretchr/testify/require"
+)
+
+var templateWithTags = template.Must(template.New("agent-svid").Parse("{{ .Tags.a }}/{{ .Tags.b }}"))
+
+func TestMakeSpiffeID(t *testing.T) {
+	tests := []struct {
+		name              string
+		trustDomain       string
+		agentPathTemplate *template.Template
+		doc               ec2metadata.EC2InstanceIdentityDocument
+		tags              instanceTags
+		want              string
+	}{
+		{
+			name:              "default",
+			trustDomain:       "example.org",
+			agentPathTemplate: defaultAgentPathTemplate,
+			doc: ec2metadata.EC2InstanceIdentityDocument{
+				Region:     "region",
+				InstanceID: "instanceID",
+				AccountID:  "accountID",
+			},
+			want: "spiffe://example.org/spire/agent/aws_iid/accountID/region/instanceID",
+		},
+		{
+			name:              "instance tags",
+			trustDomain:       "example.org",
+			agentPathTemplate: templateWithTags,
+			tags: instanceTags{
+				"a": "c",
+				"b": "d",
+			},
+			want: "spiffe://example.org/spire/agent/c/d",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeSpiffeID(tt.trustDomain, tt.agentPathTemplate, tt.doc, tt.tags)
+			require.NoError(t, err)
+			require.Equal(t, got.String(), tt.want)
+		})
+	}
+}


### PR DESCRIPTION
This is pulled out of pull #1360 to separate cleanup tasks from feature changes.

Using SDK-provided types is less error-prone and less chance of incompatibilities with AWS

