### PR TITLE
Update golangci-lint to v1.23.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ go_bin_dir := $(go_dir)/bin
 go_url = https://storage.googleapis.com/golang/go$(go_version).$(os1)-$(arch2).tar.gz
 go := PATH="$(go_bin_dir):$(PATH)" go
 
-golangci_lint_version = v1.21.0
+golangci_lint_version = v1.23.2
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 


### PR DESCRIPTION
Includes a fix for sporadic linting failures due to "failed prerequisites".

Fixed #1349
