### PR TITLE
add templating to configuration files

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/configs"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -167,7 +168,12 @@ func parseFile(path string) (*config, error) {
 		return nil, fmt.Errorf("unable to read configuration at %q: %v", path, err)
 	}
 
-	if err := hcl.Decode(&c, string(data)); err != nil {
+	rendered, err := configs.Render(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("unable to render configuration at %q: %v", path, err)
+	}
+
+	if err := hcl.Decode(&c, rendered); err != nil {
 		return nil, fmt.Errorf("unable to decode configuration at %q: %v", path, err)
 	}
 

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/configs"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -200,7 +201,12 @@ func parseFile(path string) (*config, error) {
 		return nil, fmt.Errorf("unable to read configuration at %q: %v", path, err)
 	}
 
-	if err := hcl.Decode(&c, string(data)); err != nil {
+	rendered, err := configs.Render(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("unable to render configuration at %q: %v", path, err)
+	}
+
+	if err := hcl.Decode(&c, rendered); err != nil {
 		return nil, fmt.Errorf("unable to decode configuration %q: %v", path, err)
 	}
 

--- a/pkg/common/configs/configs.go
+++ b/pkg/common/configs/configs.go
@@ -1,0 +1,30 @@
+package configs
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+// Render renders a text template of a configuration file.
+func Render(text string) (string, error) {
+	parsed, err := template.New("").Funcs(map[string]interface{}{"env": getEnv}).Parse(text)
+	if err != nil {
+		return "", fmt.Errorf("error parsing template: [%s]", err.Error())
+	}
+
+	var buffer bytes.Buffer
+
+	err = parsed.Execute(&buffer, nil)
+	if err != nil {
+		return "", fmt.Errorf("error executing template: [%s]", err.Error())
+	}
+
+	return buffer.String(), nil
+}
+
+// getEnv returns the value of an environment variable or an empty string if unset.
+func getEnv(key string) string {
+	return os.Getenv(key)
+}

--- a/pkg/common/configs/configs_test.go
+++ b/pkg/common/configs/configs_test.go
@@ -1,0 +1,53 @@
+package configs
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/spiffe/spire/test/generate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEnv(t *testing.T) {
+	// ensure it returns the environment variable value when set
+	key := generate.MustGenerateHex(t)
+	expected := generate.MustGenerateHex(t)
+	mustSetEnv(key, expected, t)
+	actual := getEnv(key)
+	mustUnsetEnv(key, t)
+	assert.Equal(t, actual, expected)
+
+	// ensure it returns an empty value when unset
+	key = generate.MustGenerateHex(t)
+	expected = ""
+	actual = getEnv(key)
+	assert.Equal(t, actual, expected)
+}
+
+func TestRender(t *testing.T) {
+	key := generate.MustGenerateHex(t)
+	expected := generate.MustGenerateHex(t)
+	text := fmt.Sprintf("{{ env \"%s\" }}", key)
+	mustSetEnv(key, expected, t)
+	actual, err := Render(text)
+	mustUnsetEnv(key, t)
+	assert.Equal(t, expected, actual)
+	assert.Nil(t, err)
+}
+
+// mustSetEnv sets an environment variable or fails the test.
+func mustSetEnv(key string, value string, t *testing.T) {
+	err := os.Setenv(key, value)
+	if err != nil {
+		t.Errorf("unable to set environment variable: [%s=%s]", key, value)
+	}
+}
+
+// mustUnsetEnv unsets an environment variable or fails the test.
+func mustUnsetEnv(key string, t *testing.T) {
+	err := os.Unsetenv(key)
+	if err != nil {
+		t.Errorf("unable to unset environment variable: [%s]", key)
+	}
+}

--- a/test/generate/generate.go
+++ b/test/generate/generate.go
@@ -1,0 +1,35 @@
+package generate
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+)
+
+var (
+	// Random provides a random source for tests.
+	Random = rand.New(rand.NewSource(time.Now().Unix()))
+)
+
+// MustGenerate generates and returns a random value of a type or fails a test.
+func MustGenerate(tipe reflect.Type, test *testing.T) reflect.Value {
+	value, ok := quick.Value(tipe, Random)
+	if !ok {
+		test.Errorf("unable to generate random value of type [%s]", tipe)
+	}
+
+	return value
+}
+
+// MustGenerateBytes generates a random slice of bytes or fails a test.
+func MustGenerateBytes(test *testing.T) []byte {
+	return MustGenerate(reflect.TypeOf([]byte{}), test).Interface().([]byte)
+}
+
+// MustGenerateHex generates a random hexadecimal string or fails a test.
+func MustGenerateHex(test *testing.T) string {
+	return hex.EncodeToString(MustGenerateBytes(test))
+}


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
This is a spike of adding environment variable interpolation within the configuration files.

**Description of change**
Essentially, this change treats the configuration files as Go templates and renders them with a single function exposed (i.e., `env`).  As a result, I can inject secrets via environment variables with syntax like:

```
...
plugins {
  Datastore "sql" {
    plugin_data {
      database_type = "postgres"
      connection_string = "dbname=spire user={{ env "POSTGRES_USERNAME" }} password={{ env "POSTGRES_PASSWORD" }} host={{ env "POSTGRES_HOST" }} port={{ env "POSTGRES_PORT" }}"
    }
  }
}
...
```

**Which issue this PR fixes**
This partially implements the feature for #1364.  I would like some feedback before making more changes as to whether this is desired or if this should be made optional.

