### PR TITLE
Use AWS SDK to retrieve ec2 instance identity doc

### DIFF
--- a/pkg/agent/plugin/nodeattestor/aws/iid.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid.go
@@ -3,27 +3,32 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"sync"
 
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/proto/spire/common"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"errors"
-
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
 const (
 	defaultIdentityDocumentURL  = "http://169.254.169.254/latest/dynamic/instance-identity/document"
 	defaultIdentitySignatureURL = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
+
+	docPath = "instance-identity/document"
+	sigPath = "instance-identity/signature"
 )
 
 func BuiltIn() catalog.Plugin {
@@ -36,12 +41,14 @@ func builtin(p *IIDAttestorPlugin) catalog.Plugin {
 
 // IIDAttestorConfig configures a IIDAttestorPlugin.
 type IIDAttestorConfig struct {
-	IdentityDocumentURL  string `hcl:"identity_document_url"`
-	IdentitySignatureURL string `hcl:"identity_signature_url"`
+	EC2MetadataEndpoint            string `hcl:"ec2_metadata_endpoint"`
+	DeprecatedIdentityDocumentURL  string `hcl:"identity_document_url"`
+	DeprecatedIdentitySignatureURL string `hcl:"identity_signature_url"`
 }
 
 // IIDAttestorPlugin implements aws nodeattestation in the agent.
 type IIDAttestorPlugin struct {
+	log    hclog.Logger
 	config *IIDAttestorConfig
 	mtx    sync.RWMutex
 }
@@ -49,6 +56,10 @@ type IIDAttestorPlugin struct {
 // New creates a new IIDAttestorPlugin.
 func New() *IIDAttestorPlugin {
 	return &IIDAttestorPlugin{}
+}
+
+func (p *IIDAttestorPlugin) SetLogger(log hclog.Logger) {
+	p.log = log
 }
 
 // FetchAttestationData fetches attestation data from the aws metadata server and sends an attestation response
@@ -59,19 +70,19 @@ func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttesto
 		return err
 	}
 
-	docBytes, err := httpGetBytes(c.IdentityDocumentURL)
-	if err != nil {
-		return aws.AttestationStepError("retrieving the IID from AWS", err)
-	}
+	var attestationData *aws.IIDAttestationData
 
-	sigBytes, err := httpGetBytes(c.IdentitySignatureURL)
-	if err != nil {
-		return aws.AttestationStepError("retrieving the IID signature from AWS", err)
-	}
-
-	attestationData := aws.IIDAttestationData{
-		Document:  string(docBytes),
-		Signature: string(sigBytes),
+	if c.isLegacyConfig() {
+		// Legacy configuration
+		attestationData, err = legacyFetch(c)
+		if err != nil {
+			return err
+		}
+	} else {
+		attestationData, err = fetchMetadata(c.EC2MetadataEndpoint)
+		if err != nil {
+			return err
+		}
 	}
 
 	respData, err := json.Marshal(attestationData)
@@ -87,6 +98,49 @@ func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttesto
 	})
 }
 
+func fetchMetadata(endpoint string) (*aws.IIDAttestationData, error) {
+	awsCfg := awssdk.NewConfig()
+	if endpoint != "" {
+		awsCfg.WithEndpoint(endpoint)
+	}
+	newSession, err := session.NewSession(awsCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	client := ec2metadata.New(newSession)
+
+	doc, err := client.GetDynamicData(docPath)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := client.GetDynamicData(sigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &aws.IIDAttestationData{
+		Document:  doc,
+		Signature: sig,
+	}, nil
+}
+
+func legacyFetch(c *IIDAttestorConfig) (*aws.IIDAttestationData, error) {
+	docBytes, err := httpGetBytes(c.DeprecatedIdentityDocumentURL)
+	if err != nil {
+		return nil, aws.AttestationStepError("retrieving the IID from AWS", err)
+	}
+	sigBytes, err := httpGetBytes(c.DeprecatedIdentitySignatureURL)
+	if err != nil {
+		return nil, aws.AttestationStepError("retrieving the IID signature from AWS", err)
+	}
+	return &aws.IIDAttestationData{
+		Document:  string(docBytes),
+		Signature: string(sigBytes),
+	}, nil
+}
+
 // Configure configures the IIDAttestorPlugin.
 func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	// Parse HCL config payload into config struct
@@ -95,12 +149,33 @@ func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReq
 		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)
 	}
 
-	if config.IdentityDocumentURL == "" {
-		config.IdentityDocumentURL = defaultIdentityDocumentURL
+	if config.EC2MetadataEndpoint != "" {
+		if config.DeprecatedIdentityDocumentURL != "" {
+			p.log.Warn("Deprecated configuration identity_document_url ignored because ec2_metadata_endpoint is set")
+		}
+
+		if config.DeprecatedIdentitySignatureURL != "" {
+			p.log.Warn("Deprecated configuration identity_signature_url ignored because ec2_metadata_endpoint is set")
+		}
+	} else {
+		if config.DeprecatedIdentityDocumentURL != "" {
+			p.log.Warn("configuration identity_document_url is deprecated, please use ec2_metadata_endpoint instead")
+		}
+
+		if config.DeprecatedIdentitySignatureURL != "" {
+			p.log.Warn("configuration identity_signature_url is deprecated, please use ec2_metadata_endpoint instead")
+		}
 	}
 
-	if config.IdentitySignatureURL == "" {
-		config.IdentitySignatureURL = defaultIdentitySignatureURL
+	// If we have a legacy config, ensure both have a value
+	if config.isLegacyConfig() {
+		if config.DeprecatedIdentityDocumentURL == "" {
+			config.DeprecatedIdentityDocumentURL = defaultIdentityDocumentURL
+		}
+
+		if config.DeprecatedIdentitySignatureURL == "" {
+			config.DeprecatedIdentitySignatureURL = defaultIdentitySignatureURL
+		}
 	}
 
 	p.mtx.Lock()
@@ -124,6 +199,12 @@ func (p *IIDAttestorPlugin) getConfig() (*IIDAttestorConfig, error) {
 		return nil, errors.New("not configured")
 	}
 	return p.config, nil
+}
+
+// isLegacyConfig returns true if either deprecated configurable is set
+func (c *IIDAttestorConfig) isLegacyConfig() bool {
+	return c.EC2MetadataEndpoint == "" &&
+		(c.DeprecatedIdentitySignatureURL != "" || c.DeprecatedIdentityDocumentURL != "")
 }
 
 func httpGetBytes(url string) ([]byte, error) {

--- a/pkg/agent/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	apiTokenPath                 = "/latest/api/token"   //nolint: gosec // false positive
+	staticToken                  = "It's just some data" //nolint: gosec // false positive
 	defaultIdentityDocumentPath  = "/latest/dynamic/instance-identity/document"
 	defaultIdentitySignaturePath = "/latest/dynamic/instance-identity/signature"
 )
@@ -57,6 +59,10 @@ type Suite struct {
 func (s *Suite) SetupTest() {
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		switch path := req.URL.Path; path {
+		case apiTokenPath:
+			// Token requested by AWS SDK for IMDSv2 authentication
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(staticToken))
 		case defaultIdentityDocumentPath:
 			// write doc resp
 			w.WriteHeader(s.status)
@@ -74,10 +80,7 @@ func (s *Suite) SetupTest() {
 	s.p = s.newPlugin()
 
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
-		Configuration: fmt.Sprintf(`
-identity_document_url = "http://%s%s"
-identity_signature_url = "http://%s%s"
-`, s.server.Listener.Addr().String(), defaultIdentityDocumentPath, s.server.Listener.Addr().String(), defaultIdentitySignaturePath),
+		Configuration: fmt.Sprintf(`ec2_metadata_endpoint = "http://%s/latest"`, s.server.Listener.Addr().String()),
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
 			TrustDomain: "example.org",
 		},
@@ -107,7 +110,7 @@ func (s *Suite) TestUnexpectedStatus() {
 	s.status = http.StatusBadGateway
 	s.docBody = ""
 	_, err := s.fetchAttestationData()
-	s.RequireErrorContains(err, "unexpected status code: 502")
+	s.RequireErrorContains(err, "status code: 502")
 }
 
 func (s *Suite) TestSuccessfulIdentityProcessing() {


### PR DESCRIPTION
This is an alternative design to #1360 
Rather than trying to always use the SDK, the fallback path here uses the old code.
This is thus more compatible, at the expense of being a bit branchier.

Which issue this PR fixes
fixes #1359