### PR TITLE
Expose the tolerateStale option for readonly operations as a server configuration.

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -65,6 +65,7 @@ type serverConfig struct {
 	DefaultSVIDTTL      string             `hcl:"default_svid_ttl"`
 	TrustDomain         string             `hcl:"trust_domain"`
 	UpstreamBundle      *bool              `hcl:"upstream_bundle"`
+	TolerateStale       bool               `hcl:"tolerate_stale"`
 
 	ConfigPath string
 
@@ -221,6 +222,7 @@ func parseFlags(args []string) (*serverConfig, error) {
 	flags.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", "", "UDS Path to bind registration API")
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this server belongs to")
 	flags.Var(newMaybeBoolValue(&c.UpstreamBundle), "upstreamBundle", "Include upstream CA certificates in the bundle")
+	flags.BoolVar(&c.TolerateStale, "tolerateStale", false, "Tolerate staleness of read only data allowed")
 
 	err := flags.Parse(args)
 	if err != nil {
@@ -334,6 +336,7 @@ func newServerConfig(c *config, logOptions []log.Option) (*server.Config, error)
 	sc.ProfilingPort = c.Server.ProfilingPort
 	sc.ProfilingFreq = c.Server.ProfilingFreq
 	sc.ProfilingNames = c.Server.ProfilingNames
+	sc.TolerateStale = c.Server.TolerateStale
 
 	if c.Server.DeprecatedSVIDTTL != "" {
 		if c.Server.DefaultSVIDTTL != "" {

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -59,6 +59,7 @@ SPIRE configuration files may be represented in either HCL or JSON. Please see t
 | `default_svid_ttl`          | The default SVID TTL                                                       | 1h                            |
 | `trust_domain`              | The trust domain that this server belongs to                               |                               |
 | `upstream_bundle`           | Include upstream CA certificates in the trust bundle                       | false                         |
+| `tolerate_stale `           | Tolerate staleness of read only data                                       | false                         |
 
 | ca_subject Configuration    | Description                    | Default        |
 |:----------------------------|--------------------------------|----------------|

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -71,6 +71,9 @@ type Config struct {
 
 	// CAKeyType is the key type used for the X509 and JWT signing keys
 	CAKeyType keymanager.KeyType
+
+	// TolerateStale allows some level of staleness by using read replica for few readOnly operations
+	TolerateStale bool
 }
 
 type ExperimentalConfig struct {

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -46,6 +46,9 @@ type Config struct {
 	// Bundle endpoint ACME configuration. If unset, SPIFFE auth will be used.
 	BundleEndpointACME *bundle.ACMEConfig
 
+	// TolerateStale allows some level of staleness by using read replica for few readOnly operations
+	TolerateStale bool
+
 	Log     logrus.FieldLogger
 	Metrics telemetry.Metrics
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -158,11 +158,12 @@ func (e *Endpoints) registerNodeAPI(tcpServer *grpc.Server) {
 // it against the provided gRPC.
 func (e *Endpoints) registerRegistrationAPI(tcpServer, udpServer *grpc.Server) {
 	r := &registration.Handler{
-		Log:         e.c.Log.WithField(telemetry.SubsystemName, telemetry.RegistrationAPI),
-		Metrics:     e.c.Metrics,
-		Catalog:     e.c.Catalog,
-		TrustDomain: e.c.TrustDomain,
-		ServerCA:    e.c.ServerCA,
+		Log:           e.c.Log.WithField(telemetry.SubsystemName, telemetry.RegistrationAPI),
+		Metrics:       e.c.Metrics,
+		Catalog:       e.c.Catalog,
+		TrustDomain:   e.c.TrustDomain,
+		ServerCA:      e.c.ServerCA,
+		TolerateStale: e.c.TolerateStale,
 	}
 
 	registration_pb.RegisterRegistrationServer(tcpServer, r)

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -148,6 +148,7 @@ func (e *Endpoints) registerNodeAPI(tcpServer *grpc.Server) {
 		TrustDomain: e.c.TrustDomain,
 		ServerCA:    e.c.ServerCA,
 
+		TolerateStale:               e.c.TolerateStale,
 		AllowAgentlessNodeAttestors: e.c.AllowAgentlessNodeAttestors,
 	})
 	node_pb.RegisterNodeServer(tcpServer, n)

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -656,7 +656,7 @@ func (h *Handler) GetNodeSelectors(ctx context.Context, req *registration.GetNod
 	log := h.Log.WithField(telemetry.Method, telemetry.GetNodeSelectors)
 	ds := h.Catalog.GetDataStore()
 	r := &datastore.GetNodeSelectorsRequest{
-		SpiffeId: req.SpiffeId,
+		SpiffeId:      req.SpiffeId,
 		TolerateStale: h.TolerateStale,
 	}
 	resp, err := ds.GetNodeSelectors(ctx, r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -330,7 +330,8 @@ func (s *Server) validateTrustDomain(ctx context.Context, ds datastore.DataStore
 		Pagination: &datastore.Pagination{
 			Token:    "",
 			PageSize: pageSize,
-		}})
+		},
+		TolerateStale: s.config.TolerateStale})
 
 	if err != nil {
 		return err

--- a/pkg/server/util/regentryutil/fetch_test.go
+++ b/pkg/server/util/regentryutil/fetch_test.go
@@ -15,6 +15,14 @@ var (
 )
 
 func TestFetchRegistrationEntries(t *testing.T) {
+	registrationEntriesTests(t, false)
+}
+
+func TestFetchRegistrationEntriesWithToleratedStaleness(t *testing.T) {
+	registrationEntriesTests(t, true)
+}
+
+func registrationEntriesTests(t *testing.T, tolerateStale bool) {
 	assert := assert.New(t)
 	dataStore := fakedatastore.New()
 
@@ -82,7 +90,7 @@ func TestFetchRegistrationEntries(t *testing.T) {
 
 	setNodeSelectors(twoID, a1, b2)
 
-	actual, err := FetchRegistrationEntries(ctx, dataStore, rootID)
+	actual, err := FetchRegistrationEntries(ctx, dataStore, rootID, tolerateStale)
 	assert.NoError(err)
 
 	expected := []*common.RegistrationEntry{


### PR DESCRIPTION
Expose the tolerateStale option for readonly operations as a server configuration.

Signed-off-by :Kirutthika Raja <kirutthika.raja@uber.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Expose the tolerateStale option for readonly operations as a server configuration. tolerateStale flag is already a request param for ListRegistrationEntries and GetNodeSelectors operations. Exposing the flag as a server option for consumers to use it.

**Description of change**
Expose the tolerateStale option for readonly operations as a server configuration.

**Which issue this PR fixes**
#1239 

