### PR TITLE
Add upstreamca wrapper

### DIFF
--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -102,12 +102,14 @@ type Notifier struct {
 }
 
 type Plugins struct {
-	DataStore         datastore.DataStore
-	NodeAttestors     map[string]nodeattestor.NodeAttestor
-	NodeResolvers     map[string]noderesolver.NodeResolver
-	UpstreamCA        *upstreamca.UpstreamCA
-	KeyManager        keymanager.KeyManager
-	Notifiers         []Notifier
+	DataStore     datastore.DataStore
+	NodeAttestors map[string]nodeattestor.NodeAttestor
+	NodeResolvers map[string]noderesolver.NodeResolver
+	UpstreamCA    *upstreamca.UpstreamCA
+	KeyManager    keymanager.KeyManager
+	Notifiers     []Notifier
+
+	// It is unexported to prevent to be processed by Fill, it is handled by ourselves
 	upstreamAuthority upstreamauthority.UpstreamAuthority
 }
 
@@ -143,11 +145,7 @@ func (p *Plugins) GetNotifiers() []Notifier {
 }
 
 func (p *Plugins) GetUpstreamAuthority() (upstreamauthority.UpstreamAuthority, bool) {
-	if p.upstreamAuthority != nil {
-		return p.upstreamAuthority, true
-	}
-
-	return nil, false
+	return p.upstreamAuthority, p.upstreamAuthority != nil
 }
 
 type Config struct {

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -18,7 +18,7 @@ func Wrap(upstreamCA upstreamca.UpstreamCA) UpstreamAuthority {
 	return &wrapper{upstreamCA: upstreamCA}
 }
 
-// MintX509CA pass request to UpstreamCA SubmitCSR RPC, parse SubmitCSRResponse into MintX509CAResponse
+// MintX509CA mints an X509CA by forwarding the request to the wrapped UpstreamCA's SubmitCSR method
 func (w *wrapper) MintX509CA(ctx context.Context, request *MintX509CARequest) (*MintX509CAResponse, error) {
 	// Create a SubmitCSRRequest from MintX509CARequest
 	req := &upstreamca.SubmitCSRRequest{

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -18,7 +18,7 @@ func Wrap(upstreamCA upstreamca.UpstreamCA) UpstreamAuthority {
 	return &wrapper{upstreamCA: upstreamCA}
 }
 
-// MintX509CA pass MinMintX509CA request to UpstreamCA SubmitCSR RPC, parse SubmitCSRResponse into MintX509CAResponse
+// MintX509CA pass request to UpstreamCA SubmitCSR RPC, parse SubmitCSRResponse into MintX509CAResponse
 func (w *wrapper) MintX509CA(ctx context.Context, request *MintX509CARequest) (*MintX509CAResponse, error) {
 	// Create a SubmitCSRRequest from MintX509CARequest
 	req := &upstreamca.SubmitCSRRequest{
@@ -50,16 +50,6 @@ func (w *wrapper) MintX509CA(ctx context.Context, request *MintX509CARequest) (*
 	}, nil
 }
 
-// PublishJWTKey it is not implemented for wrapper
-func (w *wrapper) PublishJWTKey(ctx context.Context, request *PublishJWTKeyRequest) (*PublishJWTKeyResponse, error) {
-	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
-}
-
-// PublishX509CA it is not implemented for wrapper
-func (w *wrapper) PublishX509CA(ctx context.Context, request *PublishX509CARequest) (*PublishX509CAResponse, error) {
-	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
-}
-
 // parseCertificates parse certificates and return an array with each certificate raw
 func parseCertificates(rawCerts []byte) ([][]byte, error) {
 	var certificates [][]byte
@@ -73,6 +63,16 @@ func parseCertificates(rawCerts []byte) ([][]byte, error) {
 	}
 
 	return certificates, nil
+}
+
+// PublishJWTKey it is not implemented for wrapper
+func (w *wrapper) PublishJWTKey(ctx context.Context, request *PublishJWTKeyRequest) (*PublishJWTKeyResponse, error) {
+	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
+}
+
+// PublishX509CA it is not implemented for wrapper
+func (w *wrapper) PublishX509CA(ctx context.Context, request *PublishX509CARequest) (*PublishX509CAResponse, error) {
+	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
 func makeError(code codes.Code, format string, args ...interface{}) error {

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -1,0 +1,81 @@
+package upstreamauthority
+
+import (
+	"context"
+	"crypto/x509"
+
+	"github.com/spiffe/spire/pkg/server/plugin/upstreamca"
+	"github.com/zeebo/errs"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	wrapperErr = errs.Class("upstreamauthority-wrapper")
+)
+
+type wrapper struct {
+	upstreamCA upstreamca.UpstreamCA
+}
+
+// Wrap creates a wrapper for UpstreamCA interface that satisfies the UpstreamAuthority interface
+func Wrap(upstreamCA upstreamca.UpstreamCA) UpstreamAuthority {
+	return &wrapper{upstreamCA: upstreamCA}
+}
+
+// MintX509CA pass MinMintX509CA request to UpstreamCA SubmitCSR RPC, parse SubmitCSRResponse into MintX509CAResponse
+func (w *wrapper) MintX509CA(ctx context.Context, request *MintX509CARequest) (*MintX509CAResponse, error) {
+	// Create a SubmitCSRRequest from MintX509CARequest
+	req := &upstreamca.SubmitCSRRequest{
+		Csr:          request.Csr,
+		PreferredTtl: request.PreferredTtl,
+	}
+
+	// Call upstreamCA SubmitCSR
+	resp, err := w.upstreamCA.SubmitCSR(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Creates an array of []byte from response CertChain
+	caChain, err := parseCertificates(resp.SignedCertificate.CertChain)
+	if err != nil {
+		return nil, wrapperErr.New("unable to parse cert chain: %v", err)
+	}
+
+	// Creates an array of []byte from response Bundle
+	roots, err := parseCertificates(resp.SignedCertificate.Bundle)
+	if err != nil {
+		return nil, wrapperErr.New("unable to parse bundle: %v", err)
+	}
+
+	return &MintX509CAResponse{
+		X509CaChain:       caChain,
+		UpstreamX509Roots: roots,
+	}, nil
+}
+
+// PublishJWTKey it is not implemented for wrapper
+func (w *wrapper) PublishJWTKey(ctx context.Context, request *PublishJWTKeyRequest) (*PublishJWTKeyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "publishing upstream is unsupported")
+}
+
+// PublishX509CA it is not implemented for wrapper
+func (w *wrapper) PublishX509CA(ctx context.Context, request *PublishX509CARequest) (*PublishX509CAResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "publishing upstream is unsupported")
+}
+
+// parseCertificates parse certificates and return an array with each certificate raw
+func parseCertificates(rawCerts []byte) ([][]byte, error) {
+	var certificates [][]byte
+	certChain, err := x509.ParseCertificates(rawCerts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cert := range certChain {
+		certificates = append(certificates, cert.Raw)
+	}
+
+	return certificates, nil
+}

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -70,7 +70,7 @@ func (w *wrapper) PublishJWTKey(ctx context.Context, request *PublishJWTKeyReque
 	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
-// PublishX509CA it is not implemented for wrapper
+// PublishX509CA is not implemented by the wrapper and returns a codes.Unimplemented status
 func (w *wrapper) PublishX509CA(ctx context.Context, request *PublishX509CARequest) (*PublishX509CAResponse, error) {
 	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
 }

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -13,7 +13,7 @@ type wrapper struct {
 	upstreamCA upstreamca.UpstreamCA
 }
 
-// Wrap creates a wrapper for UpstreamCA interface that satisfies the UpstreamAuthority interface
+// Wrap produces a conforming UpstreamAuthority by wrapping an UpstreamCA. The PublishX509CA and PublishJWTKey methods are not implemented and return a codes.Unimplemented status.
 func Wrap(upstreamCA upstreamca.UpstreamCA) UpstreamAuthority {
 	return &wrapper{upstreamCA: upstreamCA}
 }

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -65,7 +65,7 @@ func parseCertificates(rawCerts []byte) ([][]byte, error) {
 	return certificates, nil
 }
 
-// PublishJWTKey it is not implemented for wrapper
+// PublishJWTKey is not implemented by the wrapper and returns a codes.Unimplemented status
 func (w *wrapper) PublishJWTKey(ctx context.Context, request *PublishJWTKeyRequest) (*PublishJWTKeyResponse, error) {
 	return nil, makeError(codes.Unimplemented, "publishing upstream is unsupported")
 }

--- a/pkg/server/plugin/upstreamauthority/wrapper.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper.go
@@ -34,7 +34,7 @@ func (w *wrapper) MintX509CA(ctx context.Context, request *MintX509CARequest) (*
 	// Call upstreamCA SubmitCSR
 	resp, err := w.upstreamCA.SubmitCSR(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, wrapperErr.Wrap(err)
 	}
 
 	// Creates an array of []byte from response CertChain

--- a/pkg/server/plugin/upstreamauthority/wrapper_test.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper_test.go
@@ -55,7 +55,7 @@ func TestMintX509CA(t *testing.T) {
 			req: &MintX509CARequest{
 				Csr: csrAnotherTD,
 			},
-			err: "\"spiffe://another-td\" does not belong to trust domain \"domain.test\"",
+			err: "upstreamauthority-wrapper: unable to submit csr: \"spiffe://another-td\" does not belong to trust domain \"domain.test\"",
 			config: fakeupstreamca.Config{
 				TrustDomain: "domain.test",
 			},
@@ -70,7 +70,7 @@ func TestMintX509CA(t *testing.T) {
 
 			resp, err := wrapper.MintX509CA(ctx, testCase.req)
 			if testCase.err != "" {
-				spiretest.AssertErrorContains(t, err, testCase.err)
+				spiretest.RequireGRPCStatus(t, err, codes.Internal, testCase.err)
 				return
 			}
 
@@ -97,7 +97,7 @@ func TestPublishX509CA(t *testing.T) {
 	resp, err := wrapper.PublishX509CA(ctx, &PublishX509CARequest{})
 	require.Nil(t, resp, "no response expected")
 
-	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "publishing upstream is unsupported")
+	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "upstreamauthority-wrapper: publishing upstream is unsupported")
 }
 
 func TestPublishJWTKey(t *testing.T) {
@@ -110,7 +110,7 @@ func TestPublishJWTKey(t *testing.T) {
 	resp, err := wrapper.PublishJWTKey(ctx, &PublishJWTKeyRequest{})
 	require.Nil(t, resp, "no response expected")
 
-	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "publishing upstream is unsupported")
+	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "upstreamauthority-wrapper: publishing upstream is unsupported")
 }
 
 func validateX509CaChain(t *testing.T, caChain [][]byte, pubKey crypto.PublicKey, useIntermediate bool, upstreamCA *fakeupstreamca.UpstreamCA) {

--- a/pkg/server/plugin/upstreamauthority/wrapper_test.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper_test.go
@@ -6,10 +6,10 @@ import (
 	"crypto/x509"
 	"testing"
 
-	"github.com/spiffe/spire/.cache/cache/src/https-github.com-stretchr-testify/require"
 	"github.com/spiffe/spire/test/fakes/fakeupstreamca"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/util"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 )
 

--- a/pkg/server/plugin/upstreamauthority/wrapper_test.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper_test.go
@@ -1,0 +1,133 @@
+package upstreamauthority
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"testing"
+
+	"github.com/spiffe/spire/.cache/cache/src/https-github.com-stretchr-testify/require"
+	"github.com/spiffe/spire/test/fakes/fakeupstreamca"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/spiffe/spire/test/util"
+	"google.golang.org/grpc/codes"
+)
+
+var ctx = context.Background()
+
+func TestMintX509CA(t *testing.T) {
+	csr, pubKey, err := util.NewCSRTemplate("spiffe://domain.test")
+	require.NoError(t, err)
+
+	csrAnotherTD, _, err := util.NewCSRTemplate("spiffe://another-td")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name   string
+		req    *MintX509CARequest
+		config fakeupstreamca.Config
+		pubKey crypto.PublicKey
+		err    string
+	}{
+		{
+			name: "upstream without intermediate",
+			req: &MintX509CARequest{
+				Csr: csr,
+			},
+			pubKey: pubKey,
+			config: fakeupstreamca.Config{
+				TrustDomain: "domain.test",
+			},
+		},
+		{
+			name: "upstream with intermediate",
+			req: &MintX509CARequest{
+				Csr: csr,
+			},
+			pubKey: pubKey,
+			config: fakeupstreamca.Config{
+				TrustDomain:     "domain.test",
+				UseIntermediate: true,
+			},
+		},
+		{
+			name: "another trust domain",
+			req: &MintX509CARequest{
+				Csr: csrAnotherTD,
+			},
+			err: "\"spiffe://another-td\" does not belong to trust domain \"domain.test\"",
+			config: fakeupstreamca.Config{
+				TrustDomain: "domain.test",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			upstreamCA := fakeupstreamca.New(t, testCase.config)
+			wrapper := Wrap(upstreamCA)
+
+			resp, err := wrapper.MintX509CA(ctx, testCase.req)
+			if testCase.err != "" {
+				spiretest.AssertErrorContains(t, err, testCase.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			validateX509CaChain(t, resp.X509CaChain, testCase.pubKey, testCase.config.UseIntermediate, upstreamCA)
+
+			require.Len(t, resp.UpstreamX509Roots, 1)
+			bundle, err := x509.ParseCertificate(resp.UpstreamX509Roots[0])
+			require.NoError(t, err)
+			require.Equal(t, upstreamCA.Root(), bundle)
+		})
+	}
+}
+
+func TestPublishX509CA(t *testing.T) {
+	upstreamCA := fakeupstreamca.New(t, fakeupstreamca.Config{
+		TrustDomain:     "domain.test",
+		UseIntermediate: true,
+	})
+	wrapper := Wrap(upstreamCA)
+
+	resp, err := wrapper.PublishX509CA(ctx, &PublishX509CARequest{})
+	require.Nil(t, resp, "no response expected")
+
+	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "publishing upstream is unsupported")
+}
+
+func TestPublishJWTKey(t *testing.T) {
+	upstreamCA := fakeupstreamca.New(t, fakeupstreamca.Config{
+		TrustDomain:     "domain.test",
+		UseIntermediate: true,
+	})
+	wrapper := Wrap(upstreamCA)
+
+	resp, err := wrapper.PublishJWTKey(ctx, &PublishJWTKeyRequest{})
+	require.Nil(t, resp, "no response expected")
+
+	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "publishing upstream is unsupported")
+}
+
+func validateX509CaChain(t *testing.T, caChain [][]byte, pubKey crypto.PublicKey, useIntermediate bool, upstreamCA *fakeupstreamca.UpstreamCA) {
+	chain, err := x509.ParseCertificate(caChain[0])
+	require.NoError(t, err)
+	require.Equal(t, pubKey, chain.PublicKey)
+
+	if useIntermediate {
+		require.Len(t, caChain, 2)
+		require.Equal(t, upstreamCA.Intermediate().Subject, chain.Issuer)
+
+		intermediate, err := x509.ParseCertificate(caChain[1])
+		require.NoError(t, err)
+		require.Equal(t, upstreamCA.Intermediate(), intermediate)
+		return
+	}
+
+	require.Len(t, caChain, 1)
+	require.Equal(t, upstreamCA.Root().Subject, chain.Issuer)
+}

--- a/pkg/server/plugin/upstreamauthority/wrapper_test.go
+++ b/pkg/server/plugin/upstreamauthority/wrapper_test.go
@@ -2,87 +2,126 @@ package upstreamauthority
 
 import (
 	"context"
-	"crypto"
-	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"testing"
 
+	"github.com/spiffe/spire/pkg/server/plugin/upstreamca"
 	"github.com/spiffe/spire/test/fakes/fakeupstreamca"
 	"github.com/spiffe/spire/test/spiretest"
-	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 )
 
-var ctx = context.Background()
+var (
+	ctx = context.Background()
+	ca1 = pemBytes([]byte(`-----BEGIN CERTIFICATE-----
+MIIBVzCB4gIJAJur7ujAmyDhMA0GCSqGSIb3DQEBCwUAMBMxETAPBgNVBAMMCFRF
+U1RST09UMB4XDTE4MTAxNTE4NDQxMVoXDTE5MTAxNTE4NDQxMVowEzERMA8GA1UE
+AwwIVEVTVFJPT1QwfDANBgkqhkiG9w0BAQEFAANrADBoAmEAoYPq4DlrjDhanDM4
+gDbEefDYi4IOmwUkQPAiJgQ2+CRm/pb/qc2zuj5FQZps1jxt3VtoDJnwfJuX6B4M
+Zq0dHJF0ykfVonfxJbQsynge7yYA1avCLjlOv72Sk9/U8UQhAgMBAAEwDQYJKoZI
+hvcNAQELBQADYQAXWlJO3EoYW3Uss0QjlqJJCC2M21HkF1AkWP6mUDgQ0PtbH2Vu
+P58nzUo3Kzc3mfg3hocdt7vCDm75zdhjoDTLrT9IgU2XbDcbZF+yg51HZstonDiM
+3JzUe9WQUljuQlM=
+-----END CERTIFICATE-----
+`))
+	ca2 = pemBytes([]byte(`-----BEGIN CERTIFICATE-----
+MIIBWTCB5AIJAOIaaEWcPCB2MA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNVBAMMCVRF
+U1RST09UMjAeFw0xODEwMTUxODQ0MjdaFw0xOTEwMTUxODQ0MjdaMBQxEjAQBgNV
+BAMMCVRFU1RST09UMjB8MA0GCSqGSIb3DQEBAQUAA2sAMGgCYQCmsAlaUc8YCFs5
+hl44gZ3CJvpR0Yc4DAQkgSfed06iN0rmBuQzeCl3hiJ9ogqw4va2ciVQ8hTPeMw6
+047YCMKOkmhDa4dFgGzk9GlvUQF5qft1MTWYlCI6/jEfx4Zsd4ECAwEAATANBgkq
+hkiG9w0BAQsFAANhADQochC62F37uubcBDR70qhJlC7Bsz/KgxtduQR4pSOj4uZh
+zFHHu+k8dS32+KooMqtUp71bhMgtlvYIRay4OMD6VurfP70caOHkCVFPxibAW9o9
+NbyKVndd7aGvTed1PQ==
+-----END CERTIFICATE-----
+`))
+)
 
 func TestMintX509CA(t *testing.T) {
-	csr, pubKey, err := util.NewCSRTemplate("spiffe://domain.test")
-	require.NoError(t, err)
-
-	csrAnotherTD, _, err := util.NewCSRTemplate("spiffe://another-td")
-	require.NoError(t, err)
-
 	testCases := []struct {
-		name   string
-		req    *MintX509CARequest
-		config fakeupstreamca.Config
-		pubKey crypto.PublicKey
-		err    string
+		// Test case name
+		name string
+		// Expected error
+		err string
+		// Certificate signing request presented to upstreamCA
+		csr []byte
+		// Preferred TTL  presented to upstreamCA
+		preferredTTL int32
+		// Error returned from upstreamCA
+		upstreamErr error
+		// Cert chain returned by upstreamCA
+		certChain [][]byte
+		// Bundle returned by upstreamCA
+		bundle [][]byte
 	}{
 		{
-			name: "upstream without intermediate",
-			req: &MintX509CARequest{
-				Csr: csr,
-			},
-			pubKey: pubKey,
-			config: fakeupstreamca.Config{
-				TrustDomain: "domain.test",
-			},
+			name:         "upstream success",
+			csr:          []byte("some csr"),
+			preferredTTL: 1,
+			certChain:    [][]byte{ca1, ca2},
+			bundle:       [][]byte{ca1, ca2},
 		},
 		{
-			name: "upstream with intermediate",
-			req: &MintX509CARequest{
-				Csr: csr,
-			},
-			pubKey: pubKey,
-			config: fakeupstreamca.Config{
-				TrustDomain:     "domain.test",
-				UseIntermediate: true,
-			},
+			name: "upstreamca returns error",
+			csr:  []byte("some csr"),
+			err:  "upstreamauthority-wrapper: unable to submit csr: some error",
+
+			upstreamErr: errors.New("some error"),
 		},
 		{
-			name: "another trust domain",
-			req: &MintX509CARequest{
-				Csr: csrAnotherTD,
-			},
-			err: "upstreamauthority-wrapper: unable to submit csr: \"spiffe://another-td\" does not belong to trust domain \"domain.test\"",
-			config: fakeupstreamca.Config{
-				TrustDomain: "domain.test",
-			},
+			name: "upstreamca invalid cert chain",
+			csr:  []byte("some csr"),
+			err:  "upstreamauthority-wrapper: unable to parse cert chain",
+
+			certChain: [][]byte{[]byte("some invalid certchain")},
+			bundle:    [][]byte{ca1},
+		},
+		{
+			name: "upstreamca invalid bundle",
+			csr:  []byte("some csr"),
+			err:  "upstreamauthority-wrapper: unable to parse bundle",
+
+			certChain: [][]byte{ca2},
+			bundle:    [][]byte{[]byte("some invalid certchain")},
 		},
 	}
 
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			upstreamCA := fakeupstreamca.New(t, testCase.config)
+			// Create a fake upstream, it will return error or CAs depending expected result
+			upstreamCA := &fakeUpstreamCA{
+				t:            t,
+				csr:          testCase.csr,
+				preferredTTL: testCase.preferredTTL,
+				err:          testCase.upstreamErr,
+				certChain:    testCase.certChain,
+				bundle:       testCase.bundle,
+			}
+			// Create wrapper using fake UpstreamCA
 			wrapper := Wrap(upstreamCA)
 
-			resp, err := wrapper.MintX509CA(ctx, testCase.req)
+			// Request Mint to wrapper
+			resp, err := wrapper.MintX509CA(ctx, &MintX509CARequest{
+				Csr:          testCase.csr,
+				PreferredTtl: testCase.preferredTTL,
+			})
+
+			// if test case expect an error validates it has expected code and message
 			if testCase.err != "" {
-				spiretest.RequireGRPCStatus(t, err, codes.Internal, testCase.err)
+				spiretest.RequireGRPCStatusContains(t, err, codes.Internal, testCase.err)
 				return
 			}
 
+			// No error expected and response must not be nil
 			require.NoError(t, err)
 			require.NotNil(t, resp)
 
-			validateX509CaChain(t, resp.X509CaChain, testCase.pubKey, testCase.config.UseIntermediate, upstreamCA)
-
-			require.Len(t, resp.UpstreamX509Roots, 1)
-			bundle, err := x509.ParseCertificate(resp.UpstreamX509Roots[0])
-			require.NoError(t, err)
-			require.Equal(t, upstreamCA.Root(), bundle)
+			// Mint must return an array of []byte, instead of a single []byte
+			require.Equal(t, testCase.certChain, resp.X509CaChain)
+			require.Equal(t, testCase.bundle, resp.UpstreamX509Roots)
 		})
 	}
 }
@@ -113,21 +152,56 @@ func TestPublishJWTKey(t *testing.T) {
 	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "upstreamauthority-wrapper: publishing upstream is unsupported")
 }
 
-func validateX509CaChain(t *testing.T, caChain [][]byte, pubKey crypto.PublicKey, useIntermediate bool, upstreamCA *fakeupstreamca.UpstreamCA) {
-	chain, err := x509.ParseCertificate(caChain[0])
-	require.NoError(t, err)
-	require.Equal(t, pubKey, chain.PublicKey)
+// fakeUpstreamCA is a custom UpstreamCA that returns error or response depending on its configurations
+type fakeUpstreamCA struct {
+	t *testing.T
 
-	if useIntermediate {
-		require.Len(t, caChain, 2)
-		require.Equal(t, upstreamCA.Intermediate().Subject, chain.Issuer)
+	// request parameters
+	csr          []byte
+	preferredTTL int32
 
-		intermediate, err := x509.ParseCertificate(caChain[1])
-		require.NoError(t, err)
-		require.Equal(t, upstreamCA.Intermediate(), intermediate)
-		return
+	// fake will return error as response of SubmitCSR in case it is defined
+	err       error
+	certChain [][]byte
+	bundle    [][]byte
+}
+
+// SubmitCSR process fake configurations in order to return an error or certChain and bundle in a single []byte
+// it validates if request provided expected values
+func (f *fakeUpstreamCA) SubmitCSR(ctx context.Context, req *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
+	// Returns error if it is expected
+	if f.err != nil {
+		return nil, f.err
 	}
 
-	require.Len(t, caChain, 1)
-	require.Equal(t, upstreamCA.Root().Subject, chain.Issuer)
+	// Validates request
+	require.Equal(f.t, f.csr, req.Csr)
+	require.Equal(f.t, f.preferredTTL, req.PreferredTtl)
+
+	// Concatenate certChain into a single []byte
+	var certChain []byte
+	for _, b := range f.certChain {
+		certChain = append(certChain, b...)
+	}
+
+	// Concatenate certChain into a single []byte
+	var bundle []byte
+	for _, b := range f.bundle {
+		bundle = append(bundle, b...)
+	}
+
+	return &upstreamca.SubmitCSRResponse{
+		SignedCertificate: &upstreamca.SignedCertificate{
+			CertChain: certChain,
+			Bundle:    bundle,
+		},
+	}, nil
+}
+
+func pemBytes(p []byte) []byte {
+	b, _ := pem.Decode(p)
+	if b != nil {
+		return b.Bytes
+	}
+	return nil
 }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Create a wrapper to use UpstreamCA as UpstreamAuthority, It is calling SubmitCSR from UpstreamCA when MintX509CA is called

**Description of change**

* Create a wrapper for UpstreamCA plugin interface that satisfies the UpstreamAuthority interface
* Pass wrapper requests for new X.509 CAs to SubmitCSR RPC on the wrapped UpstreamCA plugin
* Return gRPC code NotImplemented when the wrapper is called to publish a new JWK and X509
* Expose a GetUpstreamAuthority() method on the SPIRE Server catalog that returns the wrapped 

**Which issue this PR fixes**
fixes #1371  

