### PR TITLE
server/handler: Log agent spiffe id on attestation failure

### DIFF
--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -495,8 +495,8 @@ func (h *Handler) AuthorizeCall(ctx context.Context, fullMethod string) (context
 
 		if err := h.validateAgentSVID(ctx, peerCert); err != nil {
 			h.c.Log.WithError(err).WithFields(logrus.Fields{
-				telemetry.Method: fullMethod,
-				"id":             getSpiffeIDFromCertUnsafe(peerCert),
+				telemetry.Method:  fullMethod,
+				telemetry.AgentID: tryGetSpiffeIDFromCert(peerCert),
 			}).Error("Agent is not attested or no longer valid")
 			return nil, status.Error(codes.PermissionDenied, "agent is not attested or no longer valid")
 		}
@@ -1134,7 +1134,7 @@ func createAttestationEntry(ctx context.Context, ds datastore.DataStore, cert *x
 }
 
 // Gets the SPIFFE ID from a cert or returns an empty string if there is an error.
-func getSpiffeIDFromCertUnsafe(cert *x509.Certificate) string {
+func tryGetSpiffeIDFromCert(cert *x509.Certificate) string {
 	spiffeid, _ := getSpiffeIDFromCert(cert)
 	return spiffeid
 }

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -494,10 +494,10 @@ func (h *Handler) AuthorizeCall(ctx context.Context, fullMethod string) (context
 		}
 
 		if err := h.validateAgentSVID(ctx, peerCert); err != nil {
-			h.c.Log.WithError(err).WithField(
-				telemetry.Method, fullMethod,
-				"id", getSpiffeIDFromCertUnsafe(peerCert),
-			).Error("Agent is not attested or no longer valid")
+			h.c.Log.WithError(err).WithFields(logrus.Fields{
+				telemetry.Method: fullMethod,
+				"id":             getSpiffeIDFromCertUnsafe(peerCert),
+			}).Error("Agent is not attested or no longer valid")
 			return nil, status.Error(codes.PermissionDenied, "agent is not attested or no longer valid")
 		}
 

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -494,7 +494,10 @@ func (h *Handler) AuthorizeCall(ctx context.Context, fullMethod string) (context
 		}
 
 		if err := h.validateAgentSVID(ctx, peerCert); err != nil {
-			h.c.Log.WithError(err).WithField(telemetry.Method, fullMethod).Error("Agent is not attested or no longer valid")
+			h.c.Log.WithError(err).WithField(
+				telemetry.Method, fullMethod,
+				"id", getSpiffeIDFromCertUnsafe(peerCert),
+			).Error("Agent is not attested or no longer valid")
 			return nil, status.Error(codes.PermissionDenied, "agent is not attested or no longer valid")
 		}
 
@@ -1128,6 +1131,12 @@ func createAttestationEntry(ctx context.Context, ds datastore.DataStore, cert *x
 	}
 
 	return nil
+}
+
+// Gets the SPIFFE ID from a cert or returns an empty string if there is an error.
+func getSpiffeIDFromCertUnsafe(cert *x509.Certificate) string {
+	spiffeid, _ := getSpiffeIDFromCert(cert)
+	return spiffeid
 }
 
 func getSpiffeIDFromCert(cert *x509.Certificate) (string, error) {


### PR DESCRIPTION
When looking at server logs, encountering the `Agent is not attested or no longer valid` error is not sufficient to debug a faulty agent without looking at other data sources (metrics, agent logs). By adding the agent's SPIFFE ID on a best-effort basis, it becomes easier to look at server logs and understand the issue.
