### PR TITLE
cmd/spire-server: Add ability to query by multiple selectors

### DIFF
--- a/cmd/spire-server/cli/entry/show.go
+++ b/cmd/spire-server/cli/entry/show.go
@@ -196,19 +196,26 @@ func (s *ShowCLI) fetchBySpiffeID(ctx context.Context) error {
 // fetchBySelectors fetches all registration entries containing the full
 // set of configured selectors, appending them to `entries`
 func (s *ShowCLI) fetchBySelectors(ctx context.Context) error {
-	for _, sel := range s.Config.Selectors {
+	if len(s.Config.Selectors) == 0 {
+		return nil
+	}
+	selectors := make([]*common.Selector, len(s.Config.Selectors))
+	for i, sel := range s.Config.Selectors {
 		selector, err := parseSelector(sel)
 		if err != nil {
 			return err
 		}
-
-		entries, err := s.Client.ListBySelector(ctx, selector)
-		if err != nil {
-			return err
-		}
-
-		s.Entries = append(s.Entries, entries.Entries...)
+		selectors[i] = selector
 	}
+
+	entries, err := s.Client.ListBySelectors(ctx, &common.Selectors{
+		Entries: selectors,
+	})
+	if err != nil {
+		return err
+	}
+
+	s.Entries = append(s.Entries, entries.Entries...)
 
 	return nil
 }

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -95,9 +95,13 @@ func (s *ShowTestSuite) TestRunWithSelector() {
 		"foo:bar",
 	}
 
-	req := &common.Selector{Type: "foo", Value: "bar"}
+	req := &common.Selectors{
+		Entries: []*common.Selector{
+			{Type: "foo", Value: "bar"},
+		},
+	}
 	resp := &common.RegistrationEntries{Entries: entries}
-	s.mockClient.EXPECT().ListBySelector(gomock.Any(), req).Return(resp, nil)
+	s.mockClient.EXPECT().ListBySelectors(gomock.Any(), req).Return(resp, nil)
 
 	s.Require().Equal(0, s.cli.Run(args))
 
@@ -115,13 +119,14 @@ func (s *ShowTestSuite) TestRunWithSelectors() {
 		"bar:baz",
 	}
 
-	req := &common.Selector{Type: "foo", Value: "bar"}
+	req := &common.Selectors{
+		Entries: []*common.Selector{
+			{Type: "foo", Value: "bar"},
+			{Type: "bar", Value: "baz"},
+		},
+	}
 	resp := &common.RegistrationEntries{Entries: entries}
-	s.mockClient.EXPECT().ListBySelector(gomock.Any(), req).Return(resp, nil)
-
-	req = &common.Selector{Type: "bar", Value: "baz"}
-	resp.Entries = entries[1:2]
-	s.mockClient.EXPECT().ListBySelector(gomock.Any(), req).Return(resp, nil)
+	s.mockClient.EXPECT().ListBySelectors(gomock.Any(), req).Return(resp, nil)
 
 	s.Require().Equal(0, s.cli.Run(args))
 	s.Assert().Equal(entries[1:2], s.cli.Entries)
@@ -141,9 +146,13 @@ func (s *ShowTestSuite) TestRunWithParentIDAndSelectors() {
 	resp := &common.RegistrationEntries{Entries: entries}
 	s.mockClient.EXPECT().ListByParentID(gomock.Any(), req1).Return(resp, nil)
 
-	req2 := &common.Selector{Type: "bar", Value: "baz"}
+	req2 := &common.Selectors{
+		Entries: []*common.Selector{
+			{Type: "bar", Value: "baz"},
+		},
+	}
 	resp = &common.RegistrationEntries{Entries: entries[0:1]}
-	s.mockClient.EXPECT().ListBySelector(gomock.Any(), req2).Return(resp, nil)
+	s.mockClient.EXPECT().ListBySelectors(gomock.Any(), req2).Return(resp, nil)
 
 	s.Require().Equal(0, s.cli.Run(args))
 


### PR DESCRIPTION
**Before**
```
$ spire-server entry create -parentID spiffe://example.org/dev -spiffeID spiffe://example.org/tj -selector unix:user:tj -selector unix:group:tj
Entry ID      : e5d34111-b900-4b52-b9cb-0a2ae1f7e06d
SPIFFE ID     : spiffe://example.org/tj
Parent ID     : spiffe://example.org/dev
TTL           : 3600
Selector      : unix:user:tj
Selector      : unix:group:tj

$ spire-server entry show -selector unix:user:tj -selector unix:group:tj
Found 0 entries
```

**After**
```
$ spire-server entry create -parentID spiffe://example.org/dev -spiffeID spiffe://example.org/tj -selector unix:user:tj -selector unix:group:tj
Entry ID      : e5d34111-b900-4b52-b9cb-0a2ae1f7e06d
SPIFFE ID     : spiffe://example.org/tj
Parent ID     : spiffe://example.org/dev
TTL           : 3600
Selector      : unix:user:tj
Selector      : unix:group:tj

$ spire-server entry show -selector unix:user:tj -selector unix:group:tj
Found 1 entry
Entry ID      : e5d34111-b900-4b52-b9cb-0a2ae1f7e06d
SPIFFE ID     : spiffe://example.org/tj
Parent ID     : spiffe://example.org/dev
TTL           : 3600
Selector      : unix:group:tj
Selector      : unix:user:tj
```

Fixes #1398