### PR TITLE
Use namespaced binary when calculating sha

### DIFF
--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"os/user"
+	"path/filepath"
+	"strconv"
 	"sync"
 
 	"github.com/hashicorp/hcl"
@@ -39,6 +41,19 @@ type processInfo interface {
 	Uids() ([]int32, error)
 	Gids() ([]int32, error)
 	Exe() (string, error)
+	NamespacedExe() string
+}
+
+type PSProcessInfo struct {
+	*process.Process
+}
+
+func (ps PSProcessInfo) NamespacedExe() string {
+	procPath := os.Getenv("HOST_PROC")
+	if procPath == "" {
+		procPath = "/proc"
+	}
+	return filepath.Join(procPath, strconv.Itoa(int(ps.Pid)), "exe")
 }
 
 type Configuration struct {
@@ -60,7 +75,7 @@ type Plugin struct {
 
 func New() *Plugin {
 	p := &Plugin{}
-	p.hooks.newProcess = func(pid int32) (processInfo, error) { return process.NewProcess(pid) }
+	p.hooks.newProcess = func(pid int32) (processInfo, error) { p, err := process.NewProcess(pid); return PSProcessInfo{p}, err }
 	p.hooks.lookupUserByID = user.LookupId
 	p.hooks.lookupGroupByID = user.LookupGroupId
 	return p
@@ -110,7 +125,8 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		selectors = append(selectors, makeSelector("path", processPath))
 
 		if config.WorkloadSizeLimit >= 0 {
-			sha256Digest, err := getSHA256Digest(processPath, config.WorkloadSizeLimit)
+			exePath := p.getProcPath(proc)
+			sha256Digest, err := getSHA256Digest(exePath, config.WorkloadSizeLimit)
 			if err != nil {
 				return nil, err
 			}
@@ -208,6 +224,10 @@ func (p *Plugin) getPath(proc processInfo) (string, error) {
 	}
 
 	return path, nil
+}
+
+func (p *Plugin) getProcPath(proc processInfo) string {
+	return proc.NamespacedExe()
 }
 
 func getSHA256Digest(path string, limit int64) (string, error) {

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
@@ -120,7 +121,7 @@ func (s *Suite) TestAttest() {
 			name:   "fail to hash process binary",
 			pid:    10,
 			config: "discover_workload_path = true",
-			err:    fmt.Sprintf("unix: SHA256 digest: open %s: no such file or directory", filepath.Join(s.dir, "unreadable-exe")),
+			err:    "unix: SHA256 digest: open /proc/10/unreadable-exe: no such file or directory",
 		},
 		{
 			name:   "process binary exceeds size limits",
@@ -268,6 +269,15 @@ func (p fakeProcess) Exe() (string, error) {
 		return filepath.Join(p.dir, "exe"), nil
 	default:
 		return "", fmt.Errorf("unhandled exe test case %d", p.pid)
+	}
+}
+
+func (p fakeProcess) NamespacedExe() string {
+	switch p.pid {
+	case 11, 12:
+		return filepath.Join(p.dir, "exe")
+	default:
+		return filepath.Join("/proc", strconv.Itoa(int(p.pid)), "unreadable-exe")
 	}
 }
 


### PR DESCRIPTION
**Affected functionality**
The unix workload attestation plugin

**Description of change**
The unix workload attestor can be configured to resolve the path and sha
as of the workload to selectors. It looks up the path to the running
process by following the `/proc/<pid>/exe` link, then uses that path
when calculating the sha.

When workloads are running in different namespaces (e.g. in docker), the
link resolved through `/proc` is the namespaced path to the workload -
if spire-agent is running in a different namespace to the workload, this
path can resolve to a _different_ file from the agent's perspective,
resulting in the sha of the wrong file being calculated.

Change the sha calculation to use `/proc/<pid>/exe` directly, rather
than the apparent path it links to, which will correctly resolve to the
namespaced workload.

**Which issue this PR fixes**
Resolves spiffe/spire#1403

