### PR TITLE
Add compatibility layer to SPIRE Server catalog for UpstreamAuthority

### DIFF
--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -3,41 +3,43 @@ package catalog
 import (
 	"context"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
-	"time"
 
-	"github.com/hashicorp/hcl"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/server/plugin/upstreamauthority"
 	"github.com/spiffe/spire/pkg/server/plugin/upstreamca"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
+	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/fakes/fakeidentityprovider"
 	"github.com/spiffe/spire/test/fakes/fakemetrics"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoad(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
-	tempDir, err := ioutil.TempDir("", "database")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	// Create a custom list of BuiltIn plugins, it contains the minimal necessary plugins, and UpstreamCA with UpstreamAuthority
+	builtIns = []catalog.Plugin{
+		// Fake Datastore
+		catalog.MakePlugin("fake_ds",
+			datastore.PluginServer(fakedatastore.New())),
+		// Fake key manager
+		catalog.MakePlugin("fake_km",
+			keymanager.PluginServer(&fakeKeyManager{})),
+		// Fake UpstreamCA
+		catalog.MakePlugin("fake_up",
+			upstreamca.PluginServer(&fakeUpstreamCAPlugin{})),
+		// Fake UpstreamAuthority
+		catalog.MakePlugin("fake_up",
+			upstreamauthority.PluginServer(&fakeUpstreamAuthorityPlugin{})),
+	}
 
-	hclConfig := createDefaultConfig(t, tempDir)
-
-	builtIn = append(builtIn, catalog.MakePlugin("testUpstream",
-		upstreamca.PluginServer(fakeUpstreamCAPlugin{}),
-	), catalog.MakePlugin("testUpstream",
-		upstreamauthority.PluginServer(fakeUpstreamAuthorityPlugin{}),
-	))
-
+	// Create all fakes needed on Load method
 	identityProvider := fakeidentityprovider.New()
 	agentStore := fakeagentstore.New()
 
@@ -47,91 +49,79 @@ func TestLoad(t *testing.T) {
 	log, _ := test.NewNullLogger()
 
 	testCases := []struct {
-		name            string
+		// Test case name
+		name string
+		// Function to create plugin configurations
 		createHclConfig func() HCLPluginConfigMap
-		ported          map[string]bool
-		err             string
-		verifyRepo      func(*testing.T, *Repository)
+		// Ported UpstreamCAs
+		ported map[string]bool
+		// Expected error
+		err string
+		// Expect an upstream
+		expectUpstream bool
 	}{
 		{
-			name: "default config",
-			createHclConfig: func() HCLPluginConfigMap {
-				return hclConfig
-			},
-			verifyRepo: func(t *testing.T, repository *Repository) {
-				upstream, ok := repository.Catalog.GetUpstreamAuthority()
-				require.False(t, ok)
-				require.Nil(t, upstream)
-			},
+			name:            "no UpstreamCA or UpstreamAuthority config",
+			createHclConfig: createDefaultConfig,
+			expectUpstream:  false,
 		},
 		{
-			name: "contains unported UpstreamCA",
+			name: "unported UpstreamCA",
 			createHclConfig: func() HCLPluginConfigMap {
-				c := hclConfig
-				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				c := createDefaultConfig()
+				// Add fakeUpstreamCA to configuration
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"fake_up": {}}
 				return c
 			},
-			verifyRepo: func(t *testing.T, repository *Repository) {
-				upstream, ok := repository.Catalog.GetUpstreamAuthority()
-				require.True(t, ok)
-				require.NotNil(t, upstream)
-
-				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
-				require.Error(t, err, "fakeUpstreamCA")
-			},
+			expectUpstream: true,
 		},
 		{
-			name: "contains ported UpstreamCA",
+			name: "ported UpstreamCA",
 			createHclConfig: func() HCLPluginConfigMap {
-				c := hclConfig
-				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				c := createDefaultConfig()
+				// Add fakeUpstreamCA to configuration
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"fake_up": {}}
 				return c
 			},
+			// Mark fake_up as ported plugin
 			ported: map[string]bool{
-				"testUpstream": true,
+				"fake_up": true,
 			},
-			verifyRepo: func(t *testing.T, repository *Repository) {
-				upstream, ok := repository.Catalog.GetUpstreamAuthority()
-				require.True(t, ok)
-				require.NotNil(t, upstream)
-
-				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
-				require.Error(t, err, "fakeUpstreamAuthority")
-			},
+			expectUpstream: true,
 		},
 		{
 			name: "contains UpstreamAuthority",
 			createHclConfig: func() HCLPluginConfigMap {
-				c := hclConfig
-				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				c := createDefaultConfig()
+				// Add fakeUpstreamAuthority to configuration
+				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"fake_up": {}}
 				return c
 			},
-			verifyRepo: func(t *testing.T, repository *Repository) {
-				upstream, ok := repository.Catalog.GetUpstreamAuthority()
-				require.True(t, ok)
-				require.NotNil(t, upstream)
-
-				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
-				require.Error(t, err, "fakeUpstreamAuthority")
-			},
+			expectUpstream: true,
 		},
 		{
 			name: "contains UpstreamAuthority and UpstreamCA",
 			createHclConfig: func() HCLPluginConfigMap {
-				c := hclConfig
-				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
-				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				c := createDefaultConfig()
+				// Add UpstreamCA and UpstreamAuthority
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"fake_up": {}}
+				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"fake_up": {}}
 				return c
 			},
-			err: "only one UpstreamCA or UpstreamAuthority is allowed. Please remove one of them",
-			verifyRepo: func(t *testing.T, repository *Repository) {
-				upstream, ok := repository.Catalog.GetUpstreamAuthority()
-				require.True(t, ok)
-				require.NotNil(t, upstream)
-
-				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
-				require.Error(t, err, "fakeUpstreamAuthority")
+			err: "plugins UpstreamCA and UpstreamAuthority are mutually exclusive",
+		},
+		{
+			name: "contains ported UpstreamCA and UpstreamAuthority",
+			createHclConfig: func() HCLPluginConfigMap {
+				c := createDefaultConfig()
+				// Add UpstreamCA and UpstreamAuthority
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"fake_up": {}}
+				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"fake_up": {}}
+				return c
 			},
+			// Add fake_up to ported plugins list
+			ported: map[string]bool{"fake_up": true},
+			err:    "\"fake_up\" cannot be configured as both an UpstreamCA and UpstreamAuthority",
 		},
 	}
 
@@ -153,79 +143,62 @@ func TestLoad(t *testing.T) {
 			})
 
 			if testCase.err != "" {
-				require.Error(t, err, testCase.err)
+				require.EqualError(t, err, testCase.err)
 				return
 			}
 
 			require.NoError(t, err)
-			testCase.verifyRepo(t, repo)
+
+			// Get upstream authority from catalog
+			upstreamAuthority, ok := repo.Catalog.GetUpstreamAuthority()
+
+			// Verify upstream is expected
+			switch {
+			case testCase.expectUpstream:
+				require.True(t, ok)
+				require.NotNil(t, upstreamAuthority)
+			default:
+				require.False(t, ok)
+				require.Nil(t, upstreamAuthority)
+			}
 		})
 	}
 }
 
-func createDefaultConfig(t *testing.T, sqlPath string) HCLPluginConfigMap {
-	config := fmt.Sprintf(`
- 	DataStore "sql" {
-        plugin_data {
-            database_type = "sqlite3"
-            connection_string = "%s/testit"
-
-        }
-    }
-    NodeAttestor "join_token" {
-        plugin_data {
-        }
-    }
-
-    NodeResolver "noop" {
-        plugin_data {}
-    }
-
-    KeyManager "memory" {
-        plugin_data = {}
-    }
-`, sqlPath)
-	var hclConfig HCLPluginConfigMap
-	err := hcl.Decode(&hclConfig, config)
-	require.NoError(t, err)
-
-	return hclConfig
+// createDefaultConfig create a HclPluginConfigMap with the minimal necessary plugins configuration
+func createDefaultConfig() HCLPluginConfigMap {
+	return HCLPluginConfigMap{
+		datastore.Type:  map[string]HCLPluginConfig{"fake_ds": {}},
+		keymanager.Type: map[string]HCLPluginConfig{"fake_km": {}},
+	}
 }
 
 type fakeUpstreamAuthorityPlugin struct {
+	upstreamauthority.UpstreamAuthorityServer
 }
 
-func (p fakeUpstreamAuthorityPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *fakeUpstreamAuthorityPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	return &spi.ConfigureResponse{}, nil
-}
-
-func (p fakeUpstreamAuthorityPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
 }
 
 func (p fakeUpstreamAuthorityPlugin) MintX509CA(context.Context, *upstreamauthority.MintX509CARequest) (*upstreamauthority.MintX509CAResponse, error) {
+	// Returning error with upstream name, it is done this way because wrapper is not exported, we are not able to get type from there
 	return nil, errors.New("fakeUpstreamAuthority")
 }
 
-func (p fakeUpstreamAuthorityPlugin) PublishJWTKey(context.Context, *upstreamauthority.PublishJWTKeyRequest) (*upstreamauthority.PublishJWTKeyResponse, error) {
-	return &upstreamauthority.PublishJWTKeyResponse{}, nil
-}
+type fakeUpstreamCAPlugin struct{ upstreamca.UpstreamCAServer }
 
-func (p fakeUpstreamAuthorityPlugin) PublishX509CA(context.Context, *upstreamauthority.PublishX509CARequest) (*upstreamauthority.PublishX509CAResponse, error) {
-	return &upstreamauthority.PublishX509CAResponse{}, nil
-}
-
-type fakeUpstreamCAPlugin struct {
-}
-
-func (p fakeUpstreamCAPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *fakeUpstreamCAPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	return &spi.ConfigureResponse{}, nil
 }
 
-func (p fakeUpstreamCAPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
+func (p fakeUpstreamCAPlugin) SubmitCSR(context.Context, *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
+	// Returning error with upstream name, it is done this way because wrapper is not exported, we are not able to get type from there
+	return &upstreamca.SubmitCSRResponse{}, errors.New("fakeUpstreamCA")
 }
 
-func (p fakeUpstreamCAPlugin) SubmitCSR(context.Context, *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
-	return &upstreamca.SubmitCSRResponse{}, errors.New("fakeUpstreamCA")
+type fakeKeyManager struct{ keymanager.KeyManagerServer }
+
+func (p *fakeKeyManager) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return &spi.ConfigureResponse{}, nil
 }

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -1,0 +1,231 @@
+package catalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/hcl"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
+	"github.com/spiffe/spire/pkg/server/plugin/upstreamauthority"
+	"github.com/spiffe/spire/pkg/server/plugin/upstreamca"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/fakes/fakeagentstore"
+	"github.com/spiffe/spire/test/fakes/fakeidentityprovider"
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	tempDir, err := ioutil.TempDir("", "database")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	hclConfig := createDefaultConfig(t, tempDir)
+
+	builtIn = append(builtIn, catalog.MakePlugin("testUpstream",
+		upstreamca.PluginServer(fakeUpstreamCAPlugin{}),
+	), catalog.MakePlugin("testUpstream",
+		upstreamauthority.PluginServer(fakeUpstreamAuthorityPlugin{}),
+	))
+
+	identityProvider := fakeidentityprovider.New()
+	agentStore := fakeagentstore.New()
+
+	metricsService := metricsservice.New(metricsservice.Config{
+		Metrics: fakemetrics.New(),
+	})
+	log, _ := test.NewNullLogger()
+
+	testCases := []struct {
+		name            string
+		createHclConfig func() HCLPluginConfigMap
+		ported          map[string]bool
+		err             string
+		verifyRepo      func(*testing.T, *Repository)
+	}{
+		{
+			name: "default config",
+			createHclConfig: func() HCLPluginConfigMap {
+				return hclConfig
+			},
+			verifyRepo: func(t *testing.T, repository *Repository) {
+				upstream, ok := repository.Catalog.GetUpstreamAuthority()
+				require.False(t, ok)
+				require.Nil(t, upstream)
+			},
+		},
+		{
+			name: "contains unported UpstreamCA",
+			createHclConfig: func() HCLPluginConfigMap {
+				c := hclConfig
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				return c
+			},
+			verifyRepo: func(t *testing.T, repository *Repository) {
+				upstream, ok := repository.Catalog.GetUpstreamAuthority()
+				require.True(t, ok)
+				require.NotNil(t, upstream)
+
+				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
+				require.Error(t, err, "fakeUpstreamCA")
+			},
+		},
+		{
+			name: "contains ported UpstreamCA",
+			createHclConfig: func() HCLPluginConfigMap {
+				c := hclConfig
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				return c
+			},
+			ported: map[string]bool{
+				"testUpstream": true,
+			},
+			verifyRepo: func(t *testing.T, repository *Repository) {
+				upstream, ok := repository.Catalog.GetUpstreamAuthority()
+				require.True(t, ok)
+				require.NotNil(t, upstream)
+
+				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
+				require.Error(t, err, "fakeUpstreamAuthority")
+			},
+		},
+		{
+			name: "contains UpstreamAuthority",
+			createHclConfig: func() HCLPluginConfigMap {
+				c := hclConfig
+				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				return c
+			},
+			verifyRepo: func(t *testing.T, repository *Repository) {
+				upstream, ok := repository.Catalog.GetUpstreamAuthority()
+				require.True(t, ok)
+				require.NotNil(t, upstream)
+
+				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
+				require.Error(t, err, "fakeUpstreamAuthority")
+			},
+		},
+		{
+			name: "contains UpstreamAuthority and UpstreamCA",
+			createHclConfig: func() HCLPluginConfigMap {
+				c := hclConfig
+				c[upstreamca.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				c[upstreamauthority.Type] = map[string]HCLPluginConfig{"testUpstream": {}}
+				return c
+			},
+			err: "only one UpstreamCA or UpstreamAuthority is allowed. Please remove one of them",
+			verifyRepo: func(t *testing.T, repository *Repository) {
+				upstream, ok := repository.Catalog.GetUpstreamAuthority()
+				require.True(t, ok)
+				require.NotNil(t, upstream)
+
+				_, err := upstream.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{})
+				require.Error(t, err, "fakeUpstreamAuthority")
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			portedUpstreamCA = testCase.ported
+			hclConfig := testCase.createHclConfig()
+
+			repo, err := Load(ctx, Config{
+				Log: log,
+				GlobalConfig: catalog.GlobalConfig{
+					TrustDomain: "domain.test",
+				},
+				PluginConfig:     hclConfig,
+				IdentityProvider: identityProvider,
+				AgentStore:       agentStore,
+				MetricsService:   metricsService,
+			})
+
+			if testCase.err != "" {
+				require.Error(t, err, testCase.err)
+				return
+			}
+
+			require.NoError(t, err)
+			testCase.verifyRepo(t, repo)
+		})
+	}
+}
+
+func createDefaultConfig(t *testing.T, sqlPath string) HCLPluginConfigMap {
+	config := fmt.Sprintf(`
+ 	DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "%s/testit"
+
+        }
+    }
+    NodeAttestor "join_token" {
+        plugin_data {
+        }
+    }
+
+    NodeResolver "noop" {
+        plugin_data {}
+    }
+
+    KeyManager "memory" {
+        plugin_data = {}
+    }
+`, sqlPath)
+	var hclConfig HCLPluginConfigMap
+	err := hcl.Decode(&hclConfig, config)
+	require.NoError(t, err)
+
+	return hclConfig
+}
+
+type fakeUpstreamAuthorityPlugin struct {
+}
+
+func (p fakeUpstreamAuthorityPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (p fakeUpstreamAuthorityPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p fakeUpstreamAuthorityPlugin) MintX509CA(context.Context, *upstreamauthority.MintX509CARequest) (*upstreamauthority.MintX509CAResponse, error) {
+	return nil, errors.New("fakeUpstreamAuthority")
+}
+
+func (p fakeUpstreamAuthorityPlugin) PublishJWTKey(context.Context, *upstreamauthority.PublishJWTKeyRequest) (*upstreamauthority.PublishJWTKeyResponse, error) {
+	return &upstreamauthority.PublishJWTKeyResponse{}, nil
+}
+
+func (p fakeUpstreamAuthorityPlugin) PublishX509CA(context.Context, *upstreamauthority.PublishX509CARequest) (*upstreamauthority.PublishX509CAResponse, error) {
+	return &upstreamauthority.PublishX509CAResponse{}, nil
+}
+
+type fakeUpstreamCAPlugin struct {
+}
+
+func (p fakeUpstreamCAPlugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (p fakeUpstreamCAPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+func (p fakeUpstreamCAPlugin) SubmitCSR(context.Context, *upstreamca.SubmitCSRRequest) (*upstreamca.SubmitCSRResponse, error) {
+	return &upstreamca.SubmitCSRResponse{}, errors.New("fakeUpstreamCA")
+}

--- a/test/fakes/fakeservercatalog/catalog.go
+++ b/test/fakes/fakeservercatalog/catalog.go
@@ -13,8 +13,6 @@ import (
 
 type Catalog struct {
 	catalog.Plugins
-
-	upstreamAuthority upstreamauthority.UpstreamAuthority
 }
 
 func New() *Catalog {
@@ -39,13 +37,11 @@ func (c *Catalog) AddNodeResolverNamed(name string, nodeResolver noderesolver.No
 }
 
 func (c *Catalog) SetUpstreamAuthority(upstreamAuthority upstreamauthority.UpstreamAuthority) {
-	c.upstreamAuthority = upstreamAuthority
-}
-
-// GetUpstreamAuthority obtains upstream authority from fake instead original catalog,
-// it can be removed once upstream authority is properly loaded on catalog. Please see issue #1374.
-func (c *Catalog) GetUpstreamAuthority() (upstreamauthority.UpstreamAuthority, bool) {
-	return c.upstreamAuthority, c.upstreamAuthority != nil
+	if upstreamAuthority == nil {
+		c.UpstreamAuthority = nil
+	} else {
+		c.UpstreamAuthority = &upstreamAuthority
+	}
 }
 
 func (c *Catalog) SetKeyManager(keyManager keymanager.KeyManager) {


### PR DESCRIPTION
**Description of change**

Add PortedUpstreamCA list to keep ported UpstreamCAs list
Munge HCL configuration, to allow ported UpstreamCA keep load as UpstreamCA, but it is really an UpstreamAuthority.
catelog sever Load method now, support UpstreamAuthority.
In case UpstreamAuthority and UpstreamCA are configured at same time, Load() returns an error


**Which issue this PR fixes**
fixes #1374 

