### PR TITLE
Fix up version tag usage

### DIFF
--- a/.travis/build-release.sh
+++ b/.travis/build-release.sh
@@ -5,5 +5,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TAG="$(git describe --abbrev=0 --match "v[0-9]*" 2>/dev/null || true)"
 ALWAYS="$(git describe --always --match "v[0-9]*" || true)"
 if [ "$TAG" == "$ALWAYS" ]; then
+    # Strip off the leading "v" from the release tag. Release artifacts are
+    # named just with the version number (e.g. v0.9.3 tag produces
+    # spire-0.9.3-linux-x64.tar.gz).`
+    TAG=${TAG##v}
     make -C "${DIR}/.." TAG="${TAG}" OUTDIR=./releases artifact
 fi

--- a/.travis/publish-images.sh
+++ b/.travis/publish-images.sh
@@ -9,6 +9,12 @@ echo "Travis Branch : ${TRAVIS_BRANCH}"
 echo "Travis Tag    : ${TRAVIS_TAG}"
 echo "Travis Commit : ${TRAVIS_COMMIT}"
 
+# Strip the leading "v" off of the tag name if this is a version tag (e.g.
+# v0.9.3). SPIRE images are tagged with just the version number.
+if [[ "${TRAVIS_TAG}" =~ v[0-9.]+ ]]; then
+    TRAVIS_TAG=${TRAVIS_TAG##v}
+fi
+
 # Log in to gcr.io using a key file for the Travis CI service account. The key
 # file is NOT stored plaintext and is decrypted by Travis CI before this script
 # is run.

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,10 @@ endif
 go_ldflags := -s -w
 ifeq ($(git_dirty),)
   ifneq ($(git_tag),)
-    go_ldflags += -X github.com/spiffe/spire/pkg/common/version.gittag=$(git_tag)
+	# Remove the "v" prefix from the git_tag for use as the version number.
+	# e.g. 0.9.3 instead of v0.9.3
+	git_version_tag := $(git_tag:v%=%)
+    go_ldflags += -X github.com/spiffe/spire/pkg/common/version.gittag=$(git_version_tag)
   endif
   ifneq ($(git_hash),)
     go_ldflags += -X github.com/spiffe/spire/pkg/common/version.githash=$(git_hash)

--- a/Makefile
+++ b/Makefile
@@ -256,15 +256,15 @@ endif
 # provided to the linker unless the git status is dirty.
 go_ldflags := -s -w
 ifeq ($(git_dirty),)
-  ifneq ($(git_tag),)
-	# Remove the "v" prefix from the git_tag for use as the version number.
-	# e.g. 0.9.3 instead of v0.9.3
-	git_version_tag := $(git_tag:v%=%)
-    go_ldflags += -X github.com/spiffe/spire/pkg/common/version.gittag=$(git_version_tag)
-  endif
-  ifneq ($(git_hash),)
-    go_ldflags += -X github.com/spiffe/spire/pkg/common/version.githash=$(git_hash)
-  endif
+	ifneq ($(git_tag),)
+		# Remove the "v" prefix from the git_tag for use as the version number.
+		# e.g. 0.9.3 instead of v0.9.3
+		git_version_tag := $(git_tag:v%=%)
+		go_ldflags += -X github.com/spiffe/spire/pkg/common/version.gittag=$(git_version_tag)
+	endif
+	ifneq ($(git_hash),)
+		go_ldflags += -X github.com/spiffe/spire/pkg/common/version.githash=$(git_hash)
+	endif
 endif
 go_ldflags := '${go_ldflags}'
 


### PR DESCRIPTION
This change fixes up scripts in relation to our recent change to semver compatible version tags (e.g. v0.9.3). It keeps things consistent in terms of docker image naming, artifact names, etc by removing the "v" prefix.