### PR TITLE
Update release date for 0.9.3 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.9.3] - 2020-02-28
+## [0.9.3] - 2020-03-05
 - Significantly reduced the server's database load (#1350, #1355, #1397)
 - Improved consistency in SVID propagation time for some cases (#1352)
 - AWS IID node attestor now supports the v2 metadata service (#1369)


### PR DESCRIPTION
    Update release date for 0.9.3 in the changelog
    The 0.9.3 release was postponed last week due to some problems we
    encountered during the release process. Those issues were fixed in pull
    request #1429 and we're ready to give it another shot.

    This commit updates the release date for SPIRE 0.9.3 to today's date.

    Signed-off-by: Evan Gilman <evan@scytale.io>