### PR TITLE
Add registration entries cache for FetchX509SVID API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/hashicorp/go-hclog v0.9.2
 	github.com/hashicorp/go-plugin v1.0.1
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94
 	github.com/imdario/mergo v0.3.7
 	github.com/imkira/go-observer v1.0.3

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -86,7 +86,7 @@ func (s *EndpointsTestSuite) TestCreateUDSServer() {
 }
 
 func (s *EndpointsTestSuite) TestRegisterNodeAPI() {
-	s.Assert().NotPanics(func() { s.e.registerNodeAPI(s.e.createTCPServer(ctx)) })
+	s.Require().NoError(s.e.registerNodeAPI(s.e.createTCPServer(ctx)))
 }
 
 func (s *EndpointsTestSuite) TestRegisterRegistrationAPI() {

--- a/pkg/server/util/regentryutil/cache.go
+++ b/pkg/server/util/regentryutil/cache.go
@@ -1,0 +1,85 @@
+package regentryutil
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/spiffe/spire/proto/spire/common"
+)
+
+type RegistrationEntriesCache interface {
+	Get(key string) ([]*common.RegistrationEntry, bool)
+	AddWithExpire(key string, value []*common.RegistrationEntry, expire time.Duration)
+}
+
+// FetchRegistrationEntriesCache is a wrapper around LRU cache with expiry, used for caching registration entries of a agent
+type FetchRegistrationEntriesCache struct {
+	Cache   *lru.Cache
+	TimeNow func() time.Time
+
+	mu sync.RWMutex
+}
+
+type cacheValue struct {
+	entries   []*common.RegistrationEntry
+	expiresAt time.Time
+}
+
+func NewFetchX509SVIDCache(cacheSize int) (*FetchRegistrationEntriesCache, error) {
+	cache, err := lru.New(cacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create lru cache: %v", err)
+	}
+	return &FetchRegistrationEntriesCache{
+		Cache:   cache,
+		TimeNow: time.Now,
+	}, nil
+}
+
+func (c *FetchRegistrationEntriesCache) Get(key string) ([]*common.RegistrationEntry, bool) {
+	c.mu.RLock()
+	ifc, ok := c.Cache.Get(key)
+	if !ok {
+		c.mu.RUnlock()
+		return nil, false
+	}
+	value, ok := ifc.(*cacheValue)
+	if !ok {
+		c.mu.RUnlock()
+		return nil, false
+	}
+	if c.TimeNow().After(value.expiresAt) {
+		c.mu.RUnlock()
+		c.processExpiredEntry(key)
+		return nil, false
+	}
+	c.mu.RUnlock()
+	return value.entries, true
+}
+
+func (c *FetchRegistrationEntriesCache) processExpiredEntry(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ifc, ok := c.Cache.Get(key)
+	if !ok {
+		return
+	}
+	value, ok := ifc.(*cacheValue)
+	if !ok {
+		return
+	}
+	if c.TimeNow().After(value.expiresAt) {
+		c.Cache.Remove(key)
+	}
+}
+
+func (c *FetchRegistrationEntriesCache) AddWithExpire(key string, value []*common.RegistrationEntry, expire time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.Cache.Add(key, &cacheValue{
+		entries:   value,
+		expiresAt: c.TimeNow().Add(expire),
+	})
+}

--- a/pkg/server/util/regentryutil/cache_test.go
+++ b/pkg/server/util/regentryutil/cache_test.go
@@ -1,0 +1,59 @@
+package regentryutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/clock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchSVIDCache(t *testing.T) {
+	clk := clock.NewMock(t)
+	ttl := time.Minute
+	cache, err := NewFetchX509SVIDCache(10)
+	require.NoError(t, err)
+	cache.TimeNow = clk.Now
+
+	key := "spiffe://example.org/root"
+	oneID := "spiffe://example.org/1"
+
+	entries := []*common.RegistrationEntry{
+		&common.RegistrationEntry{
+			ParentId: key,
+			SpiffeId: oneID,
+		},
+	}
+
+	// cache is empty
+	val, ok := cache.Get(key)
+	require.Empty(t, val)
+	require.False(t, ok)
+
+	cache.AddWithExpire(key, entries, ttl)
+
+	// cached value exists
+	val, ok = cache.Get(key)
+	require.Equal(t, entries, val)
+	require.True(t, ok)
+
+	clk.Add(ttl - time.Millisecond)
+
+	// cached value still exists after some time
+	val, ok = cache.Get(key)
+	require.Equal(t, entries, val)
+	require.True(t, ok)
+
+	clk.Add(2 * time.Millisecond)
+
+	// cached value disappears after TTL
+	val, ok = cache.Get(key)
+	require.Empty(t, val)
+	require.False(t, ok)
+
+	// verify its actually removed from internal cache
+	ifc, ok := cache.Cache.Get(key)
+	require.Nil(t, ifc)
+	require.False(t, ok)
+}

--- a/pkg/server/util/regentryutil/fetch_test.go
+++ b/pkg/server/util/regentryutil/fetch_test.go
@@ -18,6 +18,9 @@ func TestFetchRegistrationEntries(t *testing.T) {
 	assert := assert.New(t)
 	dataStore := fakedatastore.New()
 
+	cache, err := NewFetchX509SVIDCache(10)
+	assert.NoError(err)
+
 	createRegistrationEntry := func(entry *common.RegistrationEntry) *common.RegistrationEntry {
 		resp, err := dataStore.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{
 			Entry: entry,
@@ -82,9 +85,6 @@ func TestFetchRegistrationEntries(t *testing.T) {
 
 	setNodeSelectors(twoID, a1, b2)
 
-	actual, err := FetchRegistrationEntries(ctx, dataStore, rootID)
-	assert.NoError(err)
-
 	expected := []*common.RegistrationEntry{
 		oneEntry,
 		twoEntry,
@@ -92,5 +92,9 @@ func TestFetchRegistrationEntries(t *testing.T) {
 		fourEntry,
 		fiveEntry,
 	}
+
+	actual, err := FetchRegistrationEntriesWithCache(ctx, dataStore, cache, rootID)
+	assert.NoError(err)
+
 	assert.Equal(expected, actual)
 }


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?


**Description of change**
<!-- Please provide a description of the change -->
In current implementation of `FetchX509SVID`, multiple calls for list registrations are made. It causes increased read load to db and high `FetchX509SVID` latency.

With this change we are caching `agentId -> list of registrations` in memory. So the repeated lookups of agents and registration entries in its tree are saved.

Config: cache size = 100k and cache TTL = 1 sec.

1. During tests we noticed that with the change, db read load is reduced by around **4 to 5 times**.
2. The memory usage will be proportional to number of `FetchX509SVID` calls per cache TTL and total number of registrations. So it's hard to predict but we expect it to be around lower digit of GB with above cfg.
