### PR TITLE
Fix log message using %v in non-formatted call

### DIFF
--- a/support/oidc-discovery-provider/registration_api.go
+++ b/support/oidc-discovery-provider/registration_api.go
@@ -90,7 +90,7 @@ func (s *RegistrationAPISource) pollEvery(ctx context.Context, conn *grpc.Client
 		s.pollOnce(ctx, client)
 		select {
 		case <-ctx.Done():
-			s.log.Debug("Polling done: %v", ctx.Err())
+			s.log.WithError(ctx.Err()).Debug("Polling done")
 			return
 		case <-s.clock.After(interval):
 		}

--- a/support/oidc-discovery-provider/workload_api.go
+++ b/support/oidc-discovery-provider/workload_api.go
@@ -102,7 +102,7 @@ func (s *WorkloadAPISource) pollEvery(ctx context.Context, conn *grpc.ClientConn
 		s.pollOnce(ctx, client)
 		select {
 		case <-ctx.Done():
-			s.log.Debug("Polling done: %v", ctx.Err())
+			s.log.WithError(ctx.Err()).Debug("Polling done")
 			return
 		case <-s.clock.After(interval):
 		}


### PR DESCRIPTION
This used Debug, not Debugf.
I switch to use WithError instead of a format string instead.


