### PR TITLE
If a bundle doesn't exist yet when creating a federation reg. entry, create it

### DIFF
--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -17,8 +17,9 @@ server {
 plugins {
     DataStore "sql" {
         plugin_data {
-            database_type = "sqlite3"
-            connection_string = "./.data/datastore.sqlite3"
+            database_type = "postgres"
+#            connection_string = "./.data/datastore.sqlite3"
+            connection_string = "user=spire password=spire dbname=spire sslmode=disable"
         }
     }
 

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -1616,7 +1616,7 @@ func (s *PluginSuite) TestRegistrationEntriesFederatesWithAgainstMissingBundle()
 	_, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{
 		Entry: makeFederatedRegistrationEntry(),
 	})
-	s.RequireErrorContains(err, `unable to find federated bundle "spiffe://otherdomain.org"`)
+	s.Require().NoError(err)
 }
 
 func (s *PluginSuite) TestRegistrationEntriesFederatesWithSuccess() {


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Creation of federation bundle entries 

**Description of change**
Currently when creating a new federation registration entry, if no bundle is present for the federated SPIFFE ID, the operation fails. This is actually the normal case because typically you don't have the bundle bootstrapped. With this change we will auto-create a bundle. 

Note: These empty bundles will show up in bundle list operations, and won't auto-delete when the federation relationship is deleted. One could argue these should happen. I'm not sure. 

**Which issue this PR fixes**
#1256 
