### PR TITLE
Implement an Informer strategy for k8s-workload-registrar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,13 @@ artifact: build
 .PHONY: images
 images: spire-server-image spire-agent-image k8s-workload-registrar-image oidc-discovery-provider-image
 
+# go 1.14 introduces asynchronous preemption, which results in
+# https://github.com/golang/go/issues/37436 when building on linux 5.3
+# and later. This requires the flag --ulimit memlock=-1 to be passed
+# to docker build memlock=-1. We're currently using go 1.13 so we
+# leave it out for now, but this is expected to be necessary in the
+# future.
+
 .PHONY: spire-server-image
 spire-server-image: Dockerfile
 	docker build --build-arg goversion=$(go_version_full) --target spire-server -t spire-server .

--- a/go.mod
+++ b/go.mod
@@ -79,4 +79,5 @@ require (
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
+	k8s.io/klog v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -152,6 +152,7 @@ github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903 h1:LbsanbbD6LieFkXbj9YNNBupiGHJgFeLpO0j0Fza1h8=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -181,6 +182,7 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=

--- a/go.sum
+++ b/go.sum
@@ -576,7 +576,6 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
-sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -18,7 +18,6 @@ The registrar has the following command line flags:
 | Flag         | Description                                                      | Default                       |
 | ------------ | -----------------------------------------------------------------| ----------------------------- |
 | `-config`    | Path on disk to the [HCL Configuration](#hcl-configuration) file | `k8s-workload-registrar.conf` |
-| `-kubeconfig` | Path on disk to the kubeconfig file. Only required when using the informer from outside the cluster. | |
 
 
 ### HCL Configuration
@@ -56,6 +55,7 @@ they are ignored.
 | Key                        | Type    | Required? | Description                              | Default |
 | -------------------------- | --------| --------- | ---------------------------------------- | ------- |
 | `informer_resync_interval` | duration| optional  | Every time this interval expires, the informer will resync all registration entries from the API server's config. | `0` (never) |
+| `kubeconfig`               | string  | optional  | Path on disk to the kubeconfig file. Only required when using the informer from outside the cluster. | value of `$KUBECONFIG` |
 
 ### Example
 

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -205,6 +205,19 @@ additional configuration needed is to ensure that the registrar is
 running as a ServiceAccount which has permissions to get, list, and
 watch pods in all namespaces.
 
+An example ClusterRole for this would be:
+
+```
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spire-k8s-registrar-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+```
+
 ## Security Considerations
 
 The registrar authenticates webhook clients by default. This is a very

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -200,6 +200,11 @@ The registrar should be deployed as a container in the SPIRE server pod, since
 it talks to SPIRE server via a Unix domain socket. It will need access to a
 shared volume containing the socket file.
 
+Running multiple replicas of the registrar is encouraged; one per
+replica of the SPIRE server should be reasonable. All replicas will
+attempt to apply all changes, with duplicates resolved in the SPIRE
+server.
+
 Authentication is via the in-cluster Kubernetes API, so the only
 additional configuration needed is to ensure that the registrar is
 running as a ServiceAccount which has permissions to get, list, and

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -18,7 +18,7 @@ The registrar has the following command line flags:
 | Flag         | Description                                                      | Default                       |
 | ------------ | -----------------------------------------------------------------| ----------------------------- |
 | `-config`    | Path on disk to the [HCL Configuration](#hcl-configuration) file | `k8s-workload-registrar.conf` |
-
+| `-mode`      | Selects the operating mode of the registrar, must be admission or informer | `admission`   |
 
 ### HCL Configuration
 
@@ -36,10 +36,9 @@ The following fields are available in any mode:
 | `cluster`                  | string  | required | Logical cluster to register nodes/workloads under. Must match the SPIRE SERVER PSAT node attestor configuration. | |
 | `pod_label`                | string  | optional | The pod label used for [Label Based Workload Registration](#label-based-workload-registration) | |
 | `pod_annotation`           | string  | optional | The pod annotation used for [Annotation Based Workload Registration](#annotation-based-workload-registration) | |
-| `mode`                     | string  | required | "admission" or "informer" | `"admission"` |
 
-The `mode` field selects whether the registrar will use the admission
-controller or informer approach. When `mode = "admission"`, the
+The `-mode` flag selects whether the registrar will use the admission
+controller or informer approach. With `-mode=admission`, the
 following config fields are accepted:
 
 | Key                        | Type    | Required? | Description                              | Default |
@@ -50,7 +49,7 @@ following config fields are accepted:
 | `cacert_path`              | string  | required | Path on disk to the CA certificate used to verify the client (i.e. API server) | `"cacert.pem"` |
 | `insecure_skip_client_verification` | boolean | optional | If true, skips client certificate verification (in which case `cacert_path` is ignored). See [Security Considerations](#security-considerations) for more details. | `false` |
 
-When `mode = "informer"`, the following config fields are accepted:
+With `-mode=informer`, the following config fields are accepted:
 
 | Key                        | Type    | Required? | Description                              | Default |
 | -------------------------- | --------| --------- | ---------------------------------------- | ------- |
@@ -61,7 +60,8 @@ If `informer_resync_interval` is not set, then errors are logged and
 never retried. If it is set, then all registration entries will be
 updated at this interval, which will create some amount of load on the
 spire and kubernetes servers. An appropriate interval depends on the
-size of the cluster.
+size of the cluster. Setting this interval is recommended, but there
+is no safe default.
 
 ### Example
 
@@ -81,7 +81,6 @@ log_level = "debug"
 trust_domain = "domain.test"
 server_socket_path = "/run/spire/sockets/registration.sock"
 cluster = "production"
-mode = "informer"
 informer_resync_interval = "10m"
 ```
 

--- a/support/k8s/k8s-workload-registrar/config.go
+++ b/support/k8s/k8s-workload-registrar/config.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/hashicorp/hcl"
 	"github.com/zeebo/errs"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -32,6 +34,7 @@ type Config struct {
 	PodAnnotation                  string        `hcl:"pod_annotation"`
 	UseInformer                    bool          `hcl:"use_informer"`
 	InformerResyncInterval         time.Duration `hcl:"informer_resync_interval"`
+	KubeConfig                     string        `hcl:"kubeconfig"`
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -62,6 +65,10 @@ func ParseConfig(hclConfig string) (*Config, error) {
 	}
 	if c.KeyPath == "" {
 		c.KeyPath = defaultKeyPath
+	}
+	if c.KubeConfig == "" {
+		// If this environment variable (KUBECONFIG) is set, it is the default
+		c.KubeConfig = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	}
 	if c.ServerSocketPath == "" {
 		return nil, errs.New("server_socket_path must be specified")

--- a/support/k8s/k8s-workload-registrar/config.go
+++ b/support/k8s/k8s-workload-registrar/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"reflect"
 	"time"
 
 	"github.com/hashicorp/hcl"
@@ -19,22 +20,22 @@ const (
 )
 
 type Config struct {
-	LogFormat                      string        `hcl:"log_format"`
-	LogLevel                       string        `hcl:"log_level"`
-	LogPath                        string        `hcl:"log_path"`
-	Addr                           string        `hcl:"addr"`
-	CertPath                       string        `hcl:"cert_path"`
-	KeyPath                        string        `hcl:"key_path"`
-	CaCertPath                     string        `hcl:"cacert_path"`
-	InsecureSkipClientVerification bool          `hcl:"insecure_skip_client_verification"`
-	TrustDomain                    string        `hcl:"trust_domain"`
-	ServerSocketPath               string        `hcl:"server_socket_path"`
-	Cluster                        string        `hcl:"cluster"`
-	PodLabel                       string        `hcl:"pod_label"`
-	PodAnnotation                  string        `hcl:"pod_annotation"`
-	UseInformer                    bool          `hcl:"use_informer"`
-	InformerResyncInterval         time.Duration `hcl:"informer_resync_interval"`
-	KubeConfig                     string        `hcl:"kubeconfig"`
+	LogFormat                      string `hcl:"log_format"`
+	LogLevel                       string `hcl:"log_level"`
+	LogPath                        string `hcl:"log_path"`
+	Addr                           string `hcl:"addr" mode:"admission"`
+	CertPath                       string `hcl:"cert_path" mode:"admission"`
+	KeyPath                        string `hcl:"key_path" mode:"admission"`
+	CaCertPath                     string `hcl:"cacert_path" mode:"admission"`
+	InsecureSkipClientVerification bool   `hcl:"insecure_skip_client_verification" mode:"admission"`
+	TrustDomain                    string `hcl:"trust_domain"`
+	ServerSocketPath               string `hcl:"server_socket_path"`
+	Cluster                        string `hcl:"cluster"`
+	PodLabel                       string `hcl:"pod_label"`
+	PodAnnotation                  string `hcl:"pod_annotation"`
+	Mode                           string `hcl:"mode"`
+	InformerResyncInterval         string `hcl:"informer_resync_interval" mode:"informer"`
+	KubeConfig                     string `hcl:"kubeconfig" mode:"informer"`
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -51,37 +52,101 @@ func ParseConfig(hclConfig string) (*Config, error) {
 		return nil, errs.New("unable to decode configuration: %v", err)
 	}
 
+	if c.Mode == "" {
+		c.Mode = "admission"
+	}
+
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	c.setDefault()
+
+	return c, nil
+}
+
+func (c *Config) validate() error {
+	var errGroup errs.Group
+
+	switch c.Mode {
+	case "admission":
+	case "informer":
+		// Note that time.ParseDuration does not accept "" as zero
+		if c.InformerResyncInterval != "" {
+			if _, err := time.ParseDuration(c.InformerResyncInterval); err != nil {
+				errGroup.Add(errs.New("invalid informer_resync_interval %s: %v", c.InformerResyncInterval, err))
+			}
+		}
+	default:
+		errGroup.Add(errs.New("invalid mode %s", c.Mode))
+	}
+
+	// Validate the 'mode' tag on the struct: can only be set in this mode
+	v := reflect.Indirect(reflect.ValueOf(c))
+	ty := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		fty := ty.Field(i)
+
+		if f.IsZero() {
+			// Unset fields are okay
+			continue
+		}
+
+		name := fty.Name
+		if hclName, ok := fty.Tag.Lookup("hcl"); ok {
+			name = hclName
+		}
+		if mode, ok := fty.Tag.Lookup("mode"); ok {
+			if c.Mode != mode {
+				errGroup.Add(errs.New("%s not valid in %s mode", name, c.Mode))
+			}
+		}
+	}
+
+	if c.ServerSocketPath == "" {
+		errGroup.Add(errs.New("server_socket_path must be specified"))
+	}
+	if c.TrustDomain == "" {
+		errGroup.Add(errs.New("trust_domain must be specified"))
+	}
+	if c.Cluster == "" {
+		errGroup.Add(errs.New("cluster must be specified"))
+	}
+	if c.PodLabel != "" && c.PodAnnotation != "" {
+		errGroup.Add(errs.New("workload registration mode specification is incorrect, can't specify both pod_label and pod_annotation"))
+	}
+
+	return errGroup.Err()
+}
+
+func (c *Config) setDefault() {
 	if c.LogLevel == "" {
 		c.LogLevel = defaultLogLevel
 	}
-	if c.Addr == "" {
-		c.Addr = defaultAddr
-	}
-	if c.CertPath == "" {
-		c.CertPath = defaultCertPath
-	}
-	if c.CaCertPath == "" {
-		c.CaCertPath = defaultCaCertPath
-	}
-	if c.KeyPath == "" {
-		c.KeyPath = defaultKeyPath
-	}
-	if c.KubeConfig == "" {
-		// If this environment variable (KUBECONFIG) is set, it is the default
-		c.KubeConfig = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	}
-	if c.ServerSocketPath == "" {
-		return nil, errs.New("server_socket_path must be specified")
-	}
-	if c.TrustDomain == "" {
-		return nil, errs.New("trust_domain must be specified")
-	}
-	if c.Cluster == "" {
-		return nil, errs.New("cluster must be specified")
-	}
-	if c.PodLabel != "" && c.PodAnnotation != "" {
-		return nil, errs.New("workload registration mode specification is incorrect, can't specify both pod_label and pod_annotation")
-	}
 
-	return c, nil
+	switch c.Mode {
+	case "admission":
+		if c.Addr == "" {
+			c.Addr = defaultAddr
+		}
+		if c.CertPath == "" {
+			c.CertPath = defaultCertPath
+		}
+		if c.CaCertPath == "" {
+			c.CaCertPath = defaultCaCertPath
+		}
+		if c.KeyPath == "" {
+			c.KeyPath = defaultKeyPath
+		}
+	case "informer":
+		if c.KubeConfig == "" {
+			// If this environment variable (KUBECONFIG) is set, it is the default
+			c.KubeConfig = os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+		}
+		if c.InformerResyncInterval == "" {
+			c.InformerResyncInterval = "0"
+		}
+	default:
+	}
 }

--- a/support/k8s/k8s-workload-registrar/config.go
+++ b/support/k8s/k8s-workload-registrar/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"time"
 
 	"github.com/hashicorp/hcl"
 	"github.com/zeebo/errs"
@@ -16,19 +17,21 @@ const (
 )
 
 type Config struct {
-	LogFormat                      string `hcl:"log_format"`
-	LogLevel                       string `hcl:"log_level"`
-	LogPath                        string `hcl:"log_path"`
-	Addr                           string `hcl:"addr"`
-	CertPath                       string `hcl:"cert_path"`
-	KeyPath                        string `hcl:"key_path"`
-	CaCertPath                     string `hcl:"cacert_path"`
-	InsecureSkipClientVerification bool   `hcl:"insecure_skip_client_verification"`
-	TrustDomain                    string `hcl:"trust_domain"`
-	ServerSocketPath               string `hcl:"server_socket_path"`
-	Cluster                        string `hcl:"cluster"`
-	PodLabel                       string `hcl:"pod_label"`
-	PodAnnotation                  string `hcl:"pod_annotation"`
+	LogFormat                      string        `hcl:"log_format"`
+	LogLevel                       string        `hcl:"log_level"`
+	LogPath                        string        `hcl:"log_path"`
+	Addr                           string        `hcl:"addr"`
+	CertPath                       string        `hcl:"cert_path"`
+	KeyPath                        string        `hcl:"key_path"`
+	CaCertPath                     string        `hcl:"cacert_path"`
+	InsecureSkipClientVerification bool          `hcl:"insecure_skip_client_verification"`
+	TrustDomain                    string        `hcl:"trust_domain"`
+	ServerSocketPath               string        `hcl:"server_socket_path"`
+	Cluster                        string        `hcl:"cluster"`
+	PodLabel                       string        `hcl:"pod_label"`
+	PodAnnotation                  string        `hcl:"pod_annotation"`
+	UseInformer                    bool          `hcl:"use_informer"`
+	InformerResyncInterval         time.Duration `hcl:"informer_resync_interval"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/support/k8s/k8s-workload-registrar/controller.go
+++ b/support/k8s/k8s-workload-registrar/controller.go
@@ -105,13 +105,13 @@ func (c *Controller) reviewAdmission(ctx context.Context, req *admv1beta1.Admiss
 }
 
 // Ensure that the entries for this pod in spire are synced with the state of the pod
-func (c *Controller) SyncPod(ctx context.Context, pod *corev1.Pod) {
-	c.syncPodEntry(ctx, pod)
+func (c *Controller) SyncPod(ctx context.Context, pod *corev1.Pod) error {
+	return c.syncPodEntry(ctx, pod)
 }
 
 // Remove all entries for this pod
-func (c *Controller) DeletePod(ctx context.Context, pod *corev1.Pod) {
-	c.deletePodEntry(ctx, pod.Namespace, pod.Name)
+func (c *Controller) DeletePod(ctx context.Context, pod *corev1.Pod) error {
+	return c.deletePodEntry(ctx, pod.Namespace, pod.Name)
 }
 
 // podSpiffeID returns the desired spiffe ID for the pod, or "" if it should be ignored

--- a/support/k8s/k8s-workload-registrar/controller.go
+++ b/support/k8s/k8s-workload-registrar/controller.go
@@ -260,15 +260,15 @@ func (c *Controller) createEntry(ctx context.Context, entry *common.Registration
 		"spiffe_id": entry.SpiffeId,
 		"selectors": selectorsField(entry.Selectors),
 	})
-	_, err := c.c.R.CreateEntry(ctx, entry)
-	switch status.Code(err) {
-	case codes.OK, codes.AlreadyExists:
-		log.Info("Created pod entry")
-		return nil
-	default:
+	res, err := c.c.R.CreateEntryIfNotExists(ctx, entry)
+	if err != nil {
 		log.WithError(err).Error("CreateEntry failed")
 		return errs.Wrap(err)
 	}
+	if !res.Preexisting {
+		log.Info("Created pod entry")
+	}
+	return nil
 }
 
 // Update an existing entry, identified by entry.EntryId

--- a/support/k8s/k8s-workload-registrar/controller.go
+++ b/support/k8s/k8s-workload-registrar/controller.go
@@ -218,6 +218,10 @@ func (c *Controller) syncEntry(ctx context.Context, entry *common.RegistrationEn
 	var errGroup errs.Group
 
 	for _, e := range entries.Entries {
+		if e.ParentId != c.nodeID() {
+			// This is not an entry managed by this registrar
+			continue
+		}
 		if e.SpiffeId != entry.SpiffeId {
 			// This is a stale entry (pod has changed), delete it
 			log := c.c.Log.WithFields(logrus.Fields{

--- a/support/k8s/k8s-workload-registrar/informerhandler.go
+++ b/support/k8s/k8s-workload-registrar/informerhandler.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+)
+
+type InformerHandlerConfig struct {
+	Log        logrus.FieldLogger
+	Controller *Controller
+	Factory    informers.SharedInformerFactory
+}
+
+type InformerHandler struct {
+	c InformerHandlerConfig
+}
+
+func NewInformerHandler(config InformerHandlerConfig) *InformerHandler {
+	return &InformerHandler{
+		c: config,
+	}
+}
+
+func (ih *InformerHandler) Run(ctx context.Context) error {
+	podInformer := ih.c.Factory.Core().V1().Pods().Informer()
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			pod := obj.(*corev1.Pod)
+			ih.c.Controller.SyncPod(ctx, pod)
+		},
+		UpdateFunc: func(old, new interface{}) {
+			oldPod := old.(*corev1.Pod)
+			newPod := new.(*corev1.Pod)
+			if oldPod.ResourceVersion != newPod.ResourceVersion {
+				ih.c.Controller.SyncPod(ctx, newPod)
+			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				// This might be stale, but we're only going to use the name anyway
+				obj = tombstone.Obj
+			}
+			pod := obj.(*corev1.Pod)
+			ih.c.Controller.DeletePod(ctx, pod)
+		},
+	})
+
+	ih.c.Factory.Start(ctx.Done())
+
+	if ok := cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	<-ctx.Done()
+	return nil
+}

--- a/support/k8s/k8s-workload-registrar/informerhandler.go
+++ b/support/k8s/k8s-workload-registrar/informerhandler.go
@@ -77,7 +77,7 @@ func (ih *InformerHandler) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	fmt.Infof("all pods synced")
+	ih.c.Log.Info("all pods synced")
 
 	<-ctx.Done()
 	return nil

--- a/support/k8s/k8s-workload-registrar/informerhandler.go
+++ b/support/k8s/k8s-workload-registrar/informerhandler.go
@@ -89,13 +89,15 @@ func (ih *InformerHandler) Run(ctx context.Context) error {
 		},
 	})
 
+	ih.c.Log.Info("starting initial sync of pods")
+
 	ih.c.Factory.Start(ctx.Done())
 
 	if ok := cache.WaitForCacheSync(ctx.Done(), podInformer.HasSynced); !ok {
 		return fmt.Errorf("failed to wait for caches to sync")
 	}
 
-	ih.c.Log.Info("all pods synced")
+	ih.c.Log.Info("initial sync of pods complete")
 
 	<-ctx.Done()
 	return nil

--- a/support/k8s/k8s-workload-registrar/main.go
+++ b/support/k8s/k8s-workload-registrar/main.go
@@ -66,6 +66,10 @@ func run(ctx context.Context, configPath string, kubeconfig string) error {
 
 	if config.UseInformer {
 		// Route klog output (from client-go) to logrus
+		klogFlags := flag.NewFlagSet("klog", flag.ContinueOnError)
+		klog.InitFlags(klogFlags)
+		// This is the only way to access this setting :(
+		klogFlags.Set("logtostderr", "false")
 		klog.SetOutputBySeverity("INFO", log.WriterLevel(logrus.InfoLevel))
 		klog.SetOutputBySeverity("WARNING", log.WriterLevel(logrus.WarnLevel))
 		klog.SetOutputBySeverity("ERROR", log.WriterLevel(logrus.ErrorLevel))

--- a/support/k8s/k8s-workload-registrar/main.go
+++ b/support/k8s/k8s-workload-registrar/main.go
@@ -6,25 +6,32 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/proto/spire/api/registration"
 	"github.com/zeebo/errs"
 	"google.golang.org/grpc"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
 )
 
 var (
-	configFlag = flag.String("config", "k8s-workload-registrar.conf", "configuration file")
+	configFlag     = flag.String("config", "k8s-workload-registrar.conf", "configuration file")
+	kubeconfigFlag = flag.String("kubeconfig", "", "Path to a kubeconfig file. Only required if using informer, and running out of cluster.")
 )
 
 func main() {
 	flag.Parse()
-	if err := run(context.Background(), *configFlag); err != nil {
+	if err := run(context.Background(), *configFlag, *kubeconfigFlag); err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, configPath string) error {
+func run(ctx context.Context, configPath string, kubeconfig string) error {
 	config, err := LoadConfig(configPath)
 	if err != nil {
 		return err
@@ -57,17 +64,45 @@ func run(ctx context.Context, configPath string) error {
 		return err
 	}
 
-	server, err := NewServer(ServerConfig{
-		Log:                            log,
-		Addr:                           config.Addr,
-		Handler:                        NewWebhookHandler(controller),
-		CertPath:                       config.CertPath,
-		KeyPath:                        config.KeyPath,
-		CaCertPath:                     config.CaCertPath,
-		InsecureSkipClientVerification: config.InsecureSkipClientVerification,
-	})
-	if err != nil {
-		return err
+	if config.UseInformer {
+		// Route klog output (from client-go) to logrus
+		klog.SetOutputBySeverity("INFO", log.WriterLevel(logrus.InfoLevel))
+		klog.SetOutputBySeverity("WARNING", log.WriterLevel(logrus.WarnLevel))
+		klog.SetOutputBySeverity("ERROR", log.WriterLevel(logrus.ErrorLevel))
+		klog.SetOutputBySeverity("FATAL", log.WriterLevel(logrus.FatalLevel))
+
+		cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return err
+		}
+
+		client, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			return err
+		}
+
+		informerFactory := informers.NewSharedInformerFactory(client, config.InformerResyncInterval)
+
+		handler := NewInformerHandler(InformerHandlerConfig{
+			Log:        log,
+			Controller: controller,
+			Factory:    informerFactory,
+		})
+
+		return handler.Run(ctx)
+	} else {
+		server, err := NewServer(ServerConfig{
+			Log:                            log,
+			Addr:                           config.Addr,
+			Handler:                        NewWebhookHandler(controller),
+			CertPath:                       config.CertPath,
+			KeyPath:                        config.KeyPath,
+			CaCertPath:                     config.CaCertPath,
+			InsecureSkipClientVerification: config.InsecureSkipClientVerification,
+		})
+		if err != nil {
+			return err
+		}
+		return server.Run(ctx)
 	}
-	return server.Run(ctx)
 }


### PR DESCRIPTION
The registrar gains an option to use an informer instead of a
webhook. In this mode, it watches the k8s API instead of listening for
updates from a webhook.

The controller code is extended so that when entries are added, 
any outdated entries for the same pod are removed. This means that label
changes are now reflected in the registration entries.

Update client-go version to kubernetes 1.15 to get past API
changes. Regenerate mocks to match.