### PR TITLE
Use correct go binary for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -504,6 +504,9 @@ ifneq (go$(go_version), $(shell $(go) version 2>/dev/null | cut -f3 -d' '))
 	$(E)curl -sSfL $(go_url) | tar xz -C $(go_dir) --strip-components=1
 endif
 
+go-bin-path: go-check
+	@echo "$(go_bin_dir):${PATH}"
+
 install-toolchain: install-protoc install-golangci-lint install-protoc-gen-go install-protoc-gen-doc install-mockgen | go-check
 
 install-protoc: $(protoc_bin)

--- a/test/integration/setup/x509pop/setup.sh
+++ b/test/integration/setup/x509pop/setup.sh
@@ -4,6 +4,4 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
-
-PATH="${GOBINPATH}" go run "${DIR}/gencerts.go" "$@"
+go run "${DIR}/gencerts.go" "$@"

--- a/test/integration/setup/x509pop/setup.sh
+++ b/test/integration/setup/x509pop/setup.sh
@@ -4,4 +4,6 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-go run "${DIR}/gencerts.go" "$@"
+GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
+
+PATH="${GOBINPATH}" go run "${DIR}/gencerts.go" "$@"

--- a/test/integration/suites/datastore-mysql/00-setup
+++ b/test/integration/suites/datastore-mysql/00-setup
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PKGDIR="${REPODIR}/pkg/server/plugin/datastore/sql"
 
+GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
+
 log-debug "building mysql test harness..."
-(cd ${PKGDIR}; go test -c -o "${DIR}"/mysql.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=mysql -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true")
+(cd "${PKGDIR}"; PATH="${GOBINPATH}" go test -c -o "${DIR}"/mysql.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=mysql -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true")
 
 log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .

--- a/test/integration/suites/datastore-mysql/00-setup
+++ b/test/integration/suites/datastore-mysql/00-setup
@@ -6,10 +6,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PKGDIR="${REPODIR}/pkg/server/plugin/datastore/sql"
 
-GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
-
 log-debug "building mysql test harness..."
-(cd "${PKGDIR}"; PATH="${GOBINPATH}" go test -c -o "${DIR}"/mysql.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=mysql -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true")
+(cd "${PKGDIR}"; go test -c -o "${DIR}"/mysql.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=mysql -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=spire:test@tcp(localhost:9999)/spire?parseTime=true")
 
 log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .

--- a/test/integration/suites/datastore-postgres/00-setup
+++ b/test/integration/suites/datastore-postgres/00-setup
@@ -6,10 +6,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PKGDIR="${REPODIR}/pkg/server/plugin/datastore/sql"
 
-GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
-
 log-debug "building postgres test harness..."
-(cd "${PKGDIR}"; PATH="${GOBINPATH}" go test -c -o "${DIR}"/postgres.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=postgres -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable")
+(cd "${PKGDIR}"; go test -c -o "${DIR}"/postgres.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=postgres -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable")
 
 log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .

--- a/test/integration/suites/datastore-postgres/00-setup
+++ b/test/integration/suites/datastore-postgres/00-setup
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+set -e
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PKGDIR="${REPODIR}/pkg/server/plugin/datastore/sql"
 
+GOBINPATH=$(cd "${REPODIR}"; make go-bin-path)
+
 log-debug "building postgres test harness..."
-(cd ${PKGDIR}; go test -c -o "${DIR}"/postgres.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=postgres -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable")
+(cd "${PKGDIR}"; PATH="${GOBINPATH}" go test -c -o "${DIR}"/postgres.test -ldflags "-X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestDialect=postgres -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable -X github.com/spiffe/spire/pkg/server/plugin/datastore/sql.TestROConnString=postgres://postgres:password@localhost:9999/postgres?sslmode=disable")
 
 log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .

--- a/test/integration/test-one.sh
+++ b/test/integration/test-one.sh
@@ -15,6 +15,11 @@ TESTNAME="$(basename "${TESTDIR}")"
 # Capture the top level directory of the repository
 REPODIR=$(git rev-parse --show-toplevel)
 
+# Set and export the PATH to one that includes a go binary installed by the
+# Makefile, if necessary.
+PATH=$(cd "${REPODIR}"; make go-bin-path)
+export PATH
+
 log-info "running \"${TESTNAME}\" test suite..."
 
 [ -x "${TESTDIR}"/teardown ] || fail-now "missing required teardown script or it is not executable"


### PR DESCRIPTION
Go binaries built for the purposes of integration tests were expecting, and using, the `go` binary available in the path. SPIRE builds don't require `go` to be installed in the path, and don't use it unless it matches the right version.

This PR changes the integration tests scripts to set a path before invoking the `go` command that will include the go toolchain installed by the `Makefile`, if necessary.