### PR TITLE
Remove 'go-check' from the dependency of 'dev-shell' in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ mockgen: $(foreach x,$(mockgen_mocks),$(call mockgen-out,$x))
 dev-image:
 	$(E)docker build -t spire-dev -f Dockerfile.dev .
 
-dev-shell: | go-check
+dev-shell:
 	$(E)docker run --rm -v "$(call goenv,GOCACHE)":/root/.cache/go-build -v "$(DIR):/spire" -v "$(call goenv,GOPATH)/pkg/mod":/root/go/pkg/mod -it -h spire-dev spire-dev
 
 #############################################################################


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Nothing. I updated only target for development in Makefile.

**Description of change**
<!-- Please provide a description of the change -->

I removed `go-check` target from the dependency of `dev-shell` in Makefile. Because only go-binary which depends on the developer's OS/Arch is installed, it does not necessarily match to the container that is started by `dev-shell`.

e.g. Unnecessary 'go-check' is executed before launching container for development

- the developer's OS/Arch: Darwin/x86_64 (macOS)
- the container's OS/Arch: Linux/x86_64

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

Nothing.
