### PR TITLE
Update upgrade test suite for 0.10.0

### DIFF
--- a/test/integration/suites/upgrade/00-setup
+++ b/test/integration/suites/upgrade/00-setup
@@ -15,6 +15,7 @@ cat <<EOF >> docker-compose.yaml
   spire-server-${_version}:
     image: ${_registry}spire-server:${_version}
     hostname: spire-server
+    user: "${UID}"
     networks:
       our-network:
         aliases:
@@ -26,12 +27,7 @@ cat <<EOF >> docker-compose.yaml
   spire-agent-${_version}:
     image: ${_registry}spire-agent:${_version}
     hostname: spire-agent
-    # The 0.8.x SPIRE server does not have the tuned up rotation check intervals
-    # and can therefore not rotate the server SVID when the interval is small,
-    # causing the agent to fail the TLS handshake during bootstrapping and
-    # needs to be allowed to restart on failure. After 0.10.0 is released and
-    # the "old" version is 0.9.x+ we can remove this restart policy.
-    restart: on-failure
+    user: "${UID}"
     networks:
       - our-network
     volumes:
@@ -57,5 +53,3 @@ make-service "" latest-local
 while read -r version; do
   make-service gcr.io/spiffe-io/ "${version}"
 done < versions.txt
-
-cat docker-compose.yaml

--- a/test/integration/suites/upgrade/01-run-upgrade-tests
+++ b/test/integration/suites/upgrade/01-run-upgrade-tests
@@ -22,7 +22,7 @@ create-registration-entry() {
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/workload" \
-        -selector "unix:uid:0" \
+        -selector "unix:uid:${UID}" \
         -ttl 0
 
     # Check at most 30 times (with one second in between) that the agent has

--- a/test/integration/suites/upgrade/conf/server/server.conf
+++ b/test/integration/suites/upgrade/conf/server/server.conf
@@ -6,7 +6,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
     ca_ttl = "1m"
-	svid_ttl = "10s"
+	default_svid_ttl = "10s"
 }
 
 plugins {


### PR DESCRIPTION
- updated server config to stop using svid_ttl configurable that is
fully deprecated (and a server error) in 0.10.0
- removed 0.8.x cruft
- removed some verbose output
- changed the test to run the containers as the user. Otherwise there are files in the bind mounts that the test cannot remove (since they are owned as root).