### PR TITLE
Determine envoy release for integration test

### DIFF
--- a/test/integration/suites/envoy-sds/00-setup
+++ b/test/integration/suites/envoy-sds/00-setup
@@ -2,4 +2,18 @@
 
 "${ROOTDIR}/setup/x509pop/setup.sh" conf/server conf/upstream-agent conf/downstream-agent
 
+LATEST_ENVOY_RELEASE="$(basename "$(curl -Ls -o /dev/null -w "%{url_effective}" "https://github.com/envoyproxy/envoy/releases/latest")")"
+
+cat > Dockerfile <<EOF
+FROM spire-agent:latest-local as spire-agent
+
+FROM envoyproxy/envoy-alpine:${LATEST_ENVOY_RELEASE} AS envoy-agent-mashup
+COPY --from=spire-agent /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent
+RUN apk --no-cache add dumb-init
+RUN apk --no-cache add supervisor
+COPY conf/supervisord.conf /etc/
+ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration", "/etc/supervisord.conf"]
+CMD []
+EOF
+
 docker build --target envoy-agent-mashup -t envoy-agent-mashup .

--- a/test/integration/suites/envoy-sds/Dockerfile
+++ b/test/integration/suites/envoy-sds/Dockerfile
@@ -1,9 +1,0 @@
-FROM spire-agent:latest-local as spire-agent
-
-FROM envoyproxy/envoy-alpine:latest AS envoy-agent-mashup
-COPY --from=spire-agent /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent
-RUN apk --no-cache add dumb-init
-RUN apk --no-cache add supervisor
-COPY conf/supervisord.conf /etc/
-ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration", "/etc/supervisord.conf"]
-CMD []


### PR DESCRIPTION
The latest tag for envoyproxy/envoy-alpine isn't available. Instead of
relying on the latest tag, use github to determine the latest release
for envoyproxy/envoy.