### PR TITLE
Pass Endpoint to AWS Configuration for AWS PCA

### DIFF
--- a/doc/plugin_server_upstreamauthority_aws_pca.md
+++ b/doc/plugin_server_upstreamauthority_aws_pca.md
@@ -12,6 +12,7 @@ The plugin accepts the following configuration options:
 | ca_signing_template_arn   | (Optional) ARN of the signing template to use for the server's CA. Defaults to a signing template for end-entity certificates only. See [Using Templates](https://docs.aws.amazon.com/acm-pca/latest/userguide/UsingTemplates.html) for possible values. |
 | signing_algorithm         | (Optional) Signing algorithm to use for the server's CA. Defaults to the CA's default. See [Issue Certificate](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/issue-certificate.html) for possible values. |
 | assume_role_arn           | (Optional) ARN of an IAM role to assume                           |
+| endpoint                  | (Optional) Endpoint as hostname or fully-qualified URI that overrides the default endpoint.  See [AWS SDK Config docs](https://docs.aws.amazon.com/sdk-for-go/api/aws/#Config) for more information. |
 
 The plugin will attempt to load AWS credentials using the default provider chain. This includes credentials from environment variables, shared credentials files, and EC2 instance roles. See [Specifying Credentials](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials) for the full default credentials chain.
 

--- a/pkg/server/plugin/upstreamauthority/awspca/pca.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca.go
@@ -43,6 +43,7 @@ func builtin(p *PCAPlugin) catalog.Plugin {
 // PCAPluginConfiguration provides configuration context for the plugin
 type PCAPluginConfiguration struct {
 	Region                  string `hcl:"region" json:"region"`
+	Endpoint                string `hcl:"endpoint" json:"endpoint"`
 	CertificateAuthorityARN string `hcl:"certificate_authority_arn" json:"certificate_authority_arn"`
 	SigningAlgorithm        string `hcl:"signing_algorithm" json:"signing_algorithm"`
 	CASigningTemplateARN    string `hcl:"ca_signing_template_arn" json:"ca_signing_template_arn"`

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_client.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_client.go
@@ -23,7 +23,8 @@ type PCAClient interface {
 
 func newPCAClient(config *PCAPluginConfiguration) (PCAClient, error) {
 	awsConfig := &aws.Config{
-		Region: aws.String(config.Region),
+		Region:   aws.String(config.Region),
+		Endpoint: aws.String(config.Endpoint),
 	}
 
 	// Optional: Assuming role


### PR DESCRIPTION
The endpoint variable is a standard AWS configurable.

