### PR TITLE
Make validate and run share the same command flags

### DIFF
--- a/cmd/spire-server/cli/cli.go
+++ b/cmd/spire-server/cli/cli.go
@@ -68,7 +68,7 @@ func (cc *CLI) Run(args []string) int {
 			return &entry.ShowCLI{}, nil
 		},
 		"run": func() (cli.Command, error) {
-			return &run.Command{LogOptions: cc.LogOptions}, nil
+			return run.NewRunCommand(cc.LogOptions), nil
 		},
 		"token generate": func() (cli.Command, error) {
 			return &token.GenerateCLI{}, nil

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -70,12 +70,12 @@ func TestParseConfigGood(t *testing.T) {
 }
 
 func TestParseFlagsGood(t *testing.T) {
-	c, err := parseFlags([]string{
+	c, err := parseFlags("run", []string{
 		"-bindAddress=127.0.0.1",
 		"-registrationUDSPath=/tmp/flag.sock",
 		"-trustDomain=example.org",
 		"-logLevel=INFO",
-	})
+	}, os.Stderr)
 	require.NoError(t, err)
 	assert.Equal(t, c.BindAddress, "127.0.0.1")
 	assert.Equal(t, c.RegistrationUDSPath, "/tmp/flag.sock")

--- a/cmd/spire-server/cli/validate/validate.go
+++ b/cmd/spire-server/cli/validate/validate.go
@@ -1,14 +1,12 @@
 package validate
 
 import (
-	"flag"
-
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-server/cli/run"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 )
 
-const defaultConfigPath = "server.conf"
+const commandName = "validate"
 
 func NewValidateCommand() cli.Command {
 	return newValidateCommand(common_cli.DefaultEnv)
@@ -22,15 +20,11 @@ func newValidateCommand(env *common_cli.Env) *validateCommand {
 
 type validateCommand struct {
 	env *common_cli.Env
-
-	configPath string
-	ExpandEnv  bool
 }
 
+// Help prints the server cmd usage
 func (c *validateCommand) Help() string {
-	// ignoring parsing errors since "-h" is always supported by the flags package
-	_ = c.parseFlags([]string{"-h"})
-	return ""
+	return run.Help(commandName, c.env.Stderr)
 }
 
 func (c *validateCommand) Synopsis() string {
@@ -38,35 +32,11 @@ func (c *validateCommand) Synopsis() string {
 }
 
 func (c *validateCommand) Run(args []string) int {
-	if err := c.parseFlags(args); err != nil {
-		return 1
-	}
-	if err := c.run(); err != nil {
+	if _, err := run.LoadConfig(commandName, args, nil, c.env.Stderr); err != nil {
 		// Ignore error since a failure to write to stderr cannot very well be reported
 		_ = c.env.ErrPrintf("SPIRE server configuration file is invalid: %v\n", err)
 		return 1
 	}
 	_ = c.env.Println("SPIRE server configuration file is valid.")
 	return 0
-}
-
-func (c *validateCommand) parseFlags(args []string) error {
-	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
-	fs.SetOutput(c.env.Stderr)
-	fs.StringVar(&c.configPath, "config", defaultConfigPath, "Path to a SPIRE server configuration file")
-	fs.BoolVar(&c.ExpandEnv, "expandEnv", false, "Expand environment variables in SPIRE config file")
-	return fs.Parse(args)
-}
-
-func (c *validateCommand) run() error {
-	fileInput, err := run.ParseFile(c.configPath, c.ExpandEnv)
-	if err != nil {
-		return err
-	}
-
-	if _, err := run.NewServerConfig(fileInput, nil); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/spire-server/cli/validate/validate_test.go
+++ b/cmd/spire-server/cli/validate/validate_test.go
@@ -43,24 +43,13 @@ func (s *ValidateSuite) TestSynopsis() {
 }
 
 func (s *ValidateSuite) TestHelp() {
-	s.Equal("", s.cmd.Help())
-	s.Equal(`Usage of validate:
-  -config string
-    	Path to a SPIRE server configuration file (default "server.conf")
-  -expandEnv
-    	Expand environment variables in SPIRE config file
-`, s.stderr.String(), "stderr")
+	s.Equal("flag: help requested", s.cmd.Help())
+	s.Contains(s.stderr.String(), "Usage of validate:")
 }
 
 func (s *ValidateSuite) TestBadFlags() {
 	code := s.cmd.Run([]string{"-badflag"})
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
-	s.Equal(`flag provided but not defined: -badflag
-Usage of validate:
-  -config string
-    	Path to a SPIRE server configuration file (default "server.conf")
-  -expandEnv
-    	Expand environment variables in SPIRE config file
-`, s.stderr.String(), "stderr")
+	s.Contains(s.stderr.String(), "flag provided but not defined: -badflag")
 }

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -280,7 +280,8 @@ Checks SPIRE server's health.
 
 ### `spire-server validate`
 
-Validates a SPIRE server configuration file.
+Validates a SPIRE server configuration file.  Arguments are the same as `spire-server run`.
+Typically, you may want at least:
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|


### PR DESCRIPTION
This uses the same default config and merging logic as run.  All flags from run
are now supported by validate.  This should make validate closer to the
real-deal.  Some minor refactoring in run was needed to export an appropriate
configuration-loading function, and a Help function.

While I was at it, `run` was updated to use an `env` instead of printing to
Stderr directly.  This was used by validate tests, but could be used for tests
against the run command in the future.

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
spire-server validate

**Description of change**
The validate command now takes the same flags as `run`

This is solving an issue I ran into indirectly:  The default config values (for example, the UDS registration socket) were not set in `validate` because it was only using the file loading -- not the merging logic for file, cli, and defaults. 
The most straightforward solution was just to use more of the logic from run.

