### PR TITLE
Update docker version to 1.38 on nested rotation integration test

### DIFF
--- a/test/integration/suites/nested-rotation/intermediateA/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/agent/agent.conf
@@ -27,7 +27,7 @@ plugins {
     WorkloadAttestor "docker" {
         plugin_data {
             # Error when using default (1.41)
-            docker_version = "1.40"
+            docker_version = "1.38"
         }
     }
 }

--- a/test/integration/suites/nested-rotation/intermediateB/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/agent/agent.conf
@@ -27,7 +27,7 @@ plugins {
     WorkloadAttestor "docker" {
         plugin_data {
             # Error when using default (1.41)
-            docker_version = "1.40"
+            docker_version = "1.38"
         }
     }
 }

--- a/test/integration/suites/nested-rotation/root/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/root/agent/agent.conf
@@ -23,7 +23,7 @@ plugins {
     WorkloadAttestor "docker" {
         plugin_data {
             # Error when using default (1.41)
-            docker_version = "1.40"
+            docker_version = "1.38"
         }
     }
 }


### PR DESCRIPTION
Solve build error because docker version is too new:
```
root-agent_1_929f9eeac315 | time="2020-04-15T01:11:29Z" level=error msg="Failed to collect all selectors for PID" error="workload attestor \"docker\" failed: rpc error: code = Unknown desc = Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.38" pid=23 subsystem_name=workload_api ```