### PR TITLE
Docker Workload Attestor should negotiate docker version

### DIFF
--- a/doc/plugin_agent_workloadattestor_docker.md
+++ b/doc/plugin_agent_workloadattestor_docker.md
@@ -7,7 +7,7 @@ the docker daemon for the container's labels.
 | Configuration | Description |
 | ------------- | ----------- |
 | docker_socket_path | The location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix). |
-| docker_version | The API version of the docker daemon (default: "1.25").
+| docker_version | The API version of the docker daemon. If not specified, is negotiated by the client.           |
 
 Since selectors are created dynamically based on the container's docker labels, there isn't a list of known selectors.
 Instead, each of the container's labels are used in creating the list of selectors.

--- a/doc/plugin_agent_workloadattestor_docker.md
+++ b/doc/plugin_agent_workloadattestor_docker.md
@@ -7,7 +7,7 @@ the docker daemon for the container's labels.
 | Configuration | Description |
 | ------------- | ----------- |
 | docker_socket_path | The location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix). |
-| docker_version | The API version of the docker daemon. If not specified, is negotiated by the client.           |
+| docker_version | The API version of the docker daemon. If not specified, the version is negotiated by the client.           |
 
 Since selectors are created dynamically based on the container's docker labels, there isn't a list of known selectors.
 Instead, each of the container's labels are used in creating the list of selectors.

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -70,7 +70,7 @@ func New() *Plugin {
 type dockerPluginConfig struct {
 	// DockerSocketPath is the location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix).
 	DockerSocketPath string `hcl:"docker_socket_path"`
-	// DockerVersion is the API version of the docker daemon (default: "1.40").
+	// DockerVersion is the API version of the docker daemon. If not specified, is negotiated by the client.
 	DockerVersion string `hcl:"docker_version"`
 	// CgroupPrefix (DEPRECATED) is the cgroup prefix to look for in the cgroup entries (default: "/docker").
 	CgroupPrefix string `hcl:"cgroup_prefix"`
@@ -171,8 +171,11 @@ func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi
 	if config.DockerSocketPath != "" {
 		opts = append(opts, dockerclient.WithHost(config.DockerSocketPath))
 	}
-	if config.DockerVersion != "" {
+	switch {
+	case config.DockerVersion != "":
 		opts = append(opts, dockerclient.WithVersion(config.DockerVersion))
+	default:
+		opts = append(opts, dockerclient.WithAPIVersionNegotiation())
 	}
 	p.docker, err = dockerclient.NewClientWithOpts(opts...)
 	if err != nil {

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -70,7 +70,7 @@ func New() *Plugin {
 type dockerPluginConfig struct {
 	// DockerSocketPath is the location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix).
 	DockerSocketPath string `hcl:"docker_socket_path"`
-	// DockerVersion is the API version of the docker daemon. If not specified, is negotiated by the client.
+	// DockerVersion is the API version of the docker daemon. If not specified, the version is negotiated by the client.
 	DockerVersion string `hcl:"docker_version"`
 	// CgroupPrefix (DEPRECATED) is the cgroup prefix to look for in the cgroup entries (default: "/docker").
 	CgroupPrefix string `hcl:"cgroup_prefix"`

--- a/test/integration/suites/nested-rotation/intermediateA/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/agent/agent.conf
@@ -26,8 +26,6 @@ plugins {
     }
     WorkloadAttestor "docker" {
         plugin_data {
-            # Error when using default (1.41)
-            docker_version = "1.38"
         }
     }
 }

--- a/test/integration/suites/nested-rotation/intermediateB/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/agent/agent.conf
@@ -26,8 +26,6 @@ plugins {
     }
     WorkloadAttestor "docker" {
         plugin_data {
-            # Error when using default (1.41)
-            docker_version = "1.38"
         }
     }
 }

--- a/test/integration/suites/nested-rotation/root/agent/agent.conf
+++ b/test/integration/suites/nested-rotation/root/agent/agent.conf
@@ -22,8 +22,6 @@ plugins {
     }
     WorkloadAttestor "docker" {
         plugin_data {
-            # Error when using default (1.41)
-            docker_version = "1.38"
         }
     }
 }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Negotiate docker api version when it is not present on docker workload attestor plugin configuration

**Which issue this PR fixes**
fixes #1503

