### PR TITLE
Update CODEOWNERS syntax to include comments

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,25 @@
 * @evan2645 @amartinezfayo @azdagron @APTy @marcosy
 
+# Evan Gilman
+# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
+@evan2645	# @evan2645
+
+# Agustin Martínez Fayó
+# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
+@amartinezfayo	# amartinezfayo
+
+# Andrew Harding	# Andrew Harding
+# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
+@azdagron	# azdagron
+
+# Tyler Julian	# Tyler Julian
+# Uber Technologies	# Uber Technologies
+@APTy	# APTy
+
+# Marcos Yedro	# Marcos Yedro
+# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
+@marcosy	# marcosy
+
 # documentation
 /README.md      @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup
 /doc/           @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,24 +1,24 @@
 * @evan2645 @amartinezfayo @azdagron @APTy @marcosy
 
 # Evan Gilman
-# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
-@evan2645	# @evan2645
+# Hewlett-Packard Enterprise
+# @evan2645
 
 # Agustin Martínez Fayó
-# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
-@amartinezfayo	# amartinezfayo
+# Hewlett-Packard Enterprise	
+# amartinezfayo
 
-# Andrew Harding	# Andrew Harding
-# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
-@azdagron	# azdagron
+# Andrew Harding
+# Hewlett-Packard Enterprise
+# azdagron
 
-# Tyler Julian	# Tyler Julian
-# Uber Technologies	# Uber Technologies
-@APTy	# APTy
+# Tyler Julian
+# Uber Technologies
+# APTy
 
-# Marcos Yedro	# Marcos Yedro
-# Hewlett-Packard Enterprise	# Hewlett-Packard Enterprise
-@marcosy	# marcosy
+# Marcos Yedro
+# Hewlett-Packard Enterprise
+# marcosy
 
 # documentation
 /README.md      @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 # azdagron
 
 # Tyler Julian
-# Uber Technologies
+# Uber Technologies, Inc
 # APTy
 
 # Marcos Yedro


### PR DESCRIPTION
Modifying file to use emails instead of user ids. They'll be used to lookup users just like GitHub does for commit author emails. The purpose of this to make affiliations of maintainers explicit.

https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
