### PR TITLE
patch alt cgroups regex

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -12,7 +12,7 @@ const (
 	wildcardToken = "*"
 	// A regex expression that expresses wildcardToken
 	regexpWildcard = "[^\\/]*"
-	// A refex expression that matches non standard containerIDToken
+	// A regex expression that matches non standard containerIDToken
 	altContainerIDToken = "docker-<id>.scope"
 
 	// A token to match, and extract as a container ID, an entire path component in a

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder.go
@@ -12,12 +12,16 @@ const (
 	wildcardToken = "*"
 	// A regex expression that expresses wildcardToken
 	regexpWildcard = "[^\\/]*"
+	// A refex expression that matches non standard containerIDToken
+	altContainerIDToken = "docker-<id>.scope"
 
 	// A token to match, and extract as a container ID, an entire path component in a
 	// "/" delimited path
 	containerIDToken = "<id>"
 	// A regex expression that expresses containerIDToken
 	regexpContainerID = "([^\\/]*)"
+	// A regex expression that expresses non-standard containerIDToken
+	regexpAltContainerID = "docker-([0-9a-f]+).scope"
 	// index for slice returned by FindStringSubmatch
 	submatchIndex = 1
 )
@@ -38,6 +42,9 @@ func newContainerIDFinder(pattern string) (ContainerIDFinder, error) {
 		case containerIDToken:
 			idTokenCount++
 			elems[i] = regexpContainerID
+		case altContainerIDToken:
+			idTokenCount++
+			elems[i] = regexpAltContainerID
 		default:
 			elems[i] = regexp.QuoteMeta(e)
 		}
@@ -101,7 +108,7 @@ func (f *containerIDFinder) FindContainerID(cgroup string) (string, bool) {
 	if len(matches) == 0 {
 		return "", false
 	}
-	return matches[submatchIndex], true
+	return string(matches[submatchIndex]), true
 }
 
 type containerIDFinders struct {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [x ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
spire-agent worload attestor docker plugin does not match id from cgroups matching pattern `docker-<id>.scope`

**Description of change**
added two new constants: `altContainerIDToken` and `regexpAltContainerID` plus a new case statement:
```go
		case altContainerIDToken:
			idTokenCount++
			elems[i] = regexpAltContainerID
```
This will work on matching patterns of type `/system.slice/docker-<id>.scope`.

As sugested in the issue comment - it will need the following configuration in spire-agent:

```yaml
WorkloadAttestor "docker" {
    plugin_data = {
        container_id_cgroup_matchers = ["/system.slice/docker-<id>.scope"]
    }
}
```

**Which issue this PR fixes**
Issue #1518 

Tested on RHEL 7.7
```bash
uname -a 
3.10.0-1062.12.1.el7.x86_64
```