### PR TITLE
Require >= TLS 1.2 in the endpoint API server

### DIFF
--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -258,6 +258,8 @@ func (e *Endpoints) getTLSConfig(ctx context.Context) func(*tls.ClientHelloInfo)
 
 			Certificates: certs,
 			ClientCAs:    roots,
+
+			MinVersion: tls.VersionTLS12,
 		}
 		return c, nil
 	}


### PR DESCRIPTION
There's no good reason to have older protocols enabled, especially in
SPIRE APIs where we control the clients.

The risk mitigated here is small, as clients will generally support 1.2 and not
be vulnerable to downgrade attacks.

This will avoid us requiring an exception to security policy though, as we
scan continuously to detect servers accepting TLS 1.0 connections as part of
our PCI-DSS compliance regimen.

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [  ] Documentation updated?

**Which issue this PR fixes**
fixes #1524 

