### PR TITLE
Refactor entry creation in k8s-workload-registrar

### DIFF
--- a/support/k8s/k8s-workload-registrar/config_test.go
+++ b/support/k8s/k8s-workload-registrar/config_test.go
@@ -30,7 +30,7 @@ func TestLoadConfig(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 
-	err = ioutil.WriteFile(confPath, []byte(testMinimalConfig), 0644)
+	err = ioutil.WriteFile(confPath, []byte(testMinimalConfig), 0600)
 	require.NoError(err)
 
 	config, err := LoadConfig(confPath)

--- a/support/k8s/k8s-workload-registrar/controller_test.go
+++ b/support/k8s/k8s-workload-registrar/controller_test.go
@@ -285,8 +285,7 @@ func TestControllerLabelBasedRegistrationIgnoresPodsWithoutLabel(t *testing.T) {
 func TestPodSpiffeId(t *testing.T) {
 	for _, test := range []struct {
 		expectIgnorePod   bool
-		expectedSpiffeId  string
-		expectError       bool
+		expectedSpiffeID  string
 		configLabel       string
 		podLabel          string
 		configAnnotation  string
@@ -295,22 +294,22 @@ func TestPodSpiffeId(t *testing.T) {
 		podServiceAccount string
 	}{
 		{
-			expectedSpiffeId:  "spiffe://domain.test/ns/NS/sa/SA",
+			expectedSpiffeID:  "spiffe://domain.test/ns/NS/sa/SA",
 			podNamespace:      "NS",
 			podServiceAccount: "SA",
 		},
 		{
-			expectedSpiffeId: "spiffe://domain.test/LABEL",
+			expectedSpiffeID: "spiffe://domain.test/LABEL",
 			configLabel:      "spiffe.io/label",
 			podLabel:         "LABEL",
 		},
 		{
-			expectedSpiffeId: "spiffe://domain.test/ANNOTATION",
+			expectedSpiffeID: "spiffe://domain.test/ANNOTATION",
 			configAnnotation: "spiffe.io/annotation",
 			podAnnotation:    "ANNOTATION",
 		},
 		{
-			expectedSpiffeId: "spiffe://domain.test/LABEL",
+			expectedSpiffeID: "spiffe://domain.test/LABEL",
 			configLabel:      "spiffe.io/label",
 			podLabel:         "LABEL",
 		},
@@ -344,18 +343,14 @@ func TestPodSpiffeId(t *testing.T) {
 		}
 
 		// Test:
-		spiffeId, err := c.podSpiffeId(pod)
+		spiffeID := c.podSpiffeID(pod)
 
 		// Verify result:
-		if test.expectError {
-			require.Error(t, err)
-		} else if test.expectIgnorePod {
-			require.NoError(t, err)
-			require.Nil(t, spiffeId)
+		if test.expectIgnorePod {
+			require.Nil(t, spiffeID)
 		} else {
-			require.NoError(t, err)
-			require.NotNil(t, spiffeId)
-			require.Equal(t, test.expectedSpiffeId, *spiffeId)
+			require.NotNil(t, spiffeID)
+			require.Equal(t, test.expectedSpiffeID, *spiffeID)
 		}
 	}
 }

--- a/support/k8s/k8s-workload-registrar/controller_test.go
+++ b/support/k8s/k8s-workload-registrar/controller_test.go
@@ -284,7 +284,6 @@ func TestControllerLabelBasedRegistrationIgnoresPodsWithoutLabel(t *testing.T) {
 
 func TestPodSpiffeId(t *testing.T) {
 	for _, test := range []struct {
-		expectIgnorePod   bool
 		expectedSpiffeID  string
 		configLabel       string
 		podLabel          string
@@ -315,11 +314,11 @@ func TestPodSpiffeId(t *testing.T) {
 		},
 		{
 			configAnnotation: "someannotation",
-			expectIgnorePod:  true,
+			expectedSpiffeID: "",
 		},
 		{
-			configLabel:     "somelabel",
-			expectIgnorePod: true,
+			configLabel:      "somelabel",
+			expectedSpiffeID: "",
 		},
 	} {
 		c, _ := newTestController(test.configLabel, test.configAnnotation)
@@ -346,12 +345,7 @@ func TestPodSpiffeId(t *testing.T) {
 		spiffeID := c.podSpiffeID(pod)
 
 		// Verify result:
-		if test.expectIgnorePod {
-			require.Nil(t, spiffeID)
-		} else {
-			require.NotNil(t, spiffeID)
-			require.Equal(t, test.expectedSpiffeID, *spiffeID)
-		}
+		require.Equal(t, test.expectedSpiffeID, spiffeID)
 	}
 }
 


### PR DESCRIPTION
This reduces the amount of duplication of code for creating registration
entries, and improves testability by extracting the branchy bit of the
code into a stateless method.

This makes it easier to ensure registration entries are consistent when
using different methods of extracting the SPIFFE ID from the pod.

It should have no externally visible impact, and be purely a refactor.