### PR TITLE
Introduce Matthew McPherrin as a CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @evan2645 @amartinezfayo @azdagron @APTy @marcosy
+* @evan2645 @amartinezfayo @azdagron @APTy @mcpherrinm
 
 # Evan Gilman
 # Hewlett-Packard Enterprise
@@ -16,9 +16,9 @@
 # Uber Technologies, Inc
 # APTy
 
-# Marcos Yedro
-# Hewlett-Packard Enterprise
-# marcosy
+# Matthew McPherrin
+# Square, Inc.
+# mcpherrinm
 
 # documentation
 /README.md      @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup


### PR DESCRIPTION
This PR introduces Matthew McPherrin (@mcpherrinm) as a SPIRE maintainer and CODEOWNER in the project (replacing Marcos Yedro).

Matt has accepted the responsibilities and undergone an onboarding period according to project governance. He has demonstrated competency and willingness to fulfill the obligations required of a maintainer and brings valuable perspective and expertise to the project.