### PR TITLE
Refactor agent to share run/validate logic

### DIFF
--- a/cmd/spire-agent/cli/cli.go
+++ b/cmd/spire-agent/cli/cli.go
@@ -36,7 +36,7 @@ func (cc *CLI) Run(args []string) int {
 			return &api.WatchCLI{}, nil
 		},
 		"run": func() (cli.Command, error) {
-			return &run.Command{LogOptions: cc.LogOptions}, nil
+			return run.NewRunCommand(cc.LogOptions), nil
 		},
 		"healthcheck": func() (cli.Command, error) {
 			return healthcheck.NewHealthCheckCommand(), nil

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -15,10 +16,11 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/imdario/mergo"
+	"github.com/mitchellh/cli"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/pkg/common/cli"
+	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -28,6 +30,8 @@ import (
 )
 
 const (
+	commandName = "run"
+
 	defaultConfigPath = "conf/agent/agent.conf"
 	defaultSocketPath = "./spire_api"
 
@@ -88,35 +92,60 @@ type experimentalConfig struct {
 
 type Command struct {
 	LogOptions []log.Option
+	env        *common_cli.Env
 }
 
-func (*Command) Help() string {
-	_, err := parseFlags([]string{"-h"})
+func NewRunCommand(logOptions []log.Option) cli.Command {
+	return newRunCommand(common_cli.DefaultEnv, logOptions)
+}
+
+func newRunCommand(env *common_cli.Env, logOptions []log.Option) *Command {
+	return &Command{
+		env:        env,
+		LogOptions: logOptions,
+	}
+}
+
+// Help prints the agent cmd usage
+func (cmd *Command) Help() string {
+	return Help(commandName, cmd.env.Stderr)
+}
+
+// Help is a standalone function that prints a help message to writer.
+// It is used by both the run and validate commands, so they can share flag usage messages.
+func Help(name string, writer io.Writer) string {
+	_, err := parseFlags(name, []string{"-h"}, writer)
+	// Error is always present because -h is passed
 	return err.Error()
 }
 
-func (cmd *Command) Run(args []string) int {
-	cliInput, err := parseFlags(args)
+func LoadConfig(name string, args []string, logOptions []log.Option, output io.Writer) (*agent.Config, error) {
+	// First parse the CLI flags so we can get the config
+	// file path, if set
+	cliInput, err := parseFlags(name, args, output)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return nil, err
 	}
 
+	// Load and parse the config file using either the default
+	// path or CLI-specified value
 	fileInput, err := ParseFile(cliInput.ConfigPath, cliInput.ExpandEnv)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return nil, err
 	}
 
 	input, err := mergeInput(fileInput, cliInput)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return 1
+		return nil, err
 	}
 
-	c, err := NewAgentConfig(input, cmd.LogOptions)
+	return NewAgentConfig(input, logOptions)
+}
+
+func (cmd *Command) Run(args []string) int {
+	c, err := LoadConfig(commandName, args, cmd.LogOptions, cmd.env.Stderr)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(cmd.env.Stderr, err)
 		return 1
 	}
 
@@ -125,13 +154,13 @@ func (cmd *Command) Run(args []string) int {
 	if _, statErr := os.Stat(dir); os.IsNotExist(statErr) {
 		c.Log.WithField("dir", dir).Infof("Creating spire agent UDS directory")
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(cmd.env.Stderr, err)
 			return 1
 		}
 	}
 
 	// Set umask before starting up the agent
-	cli.SetUmask(c.Log)
+	common_cli.SetUmask(c.Log)
 
 	a := agent.New(c)
 
@@ -189,8 +218,9 @@ func ParseFile(path string, expandEnv bool) (*Config, error) {
 	return c, nil
 }
 
-func parseFlags(args []string) (*agentConfig, error) {
-	flags := flag.NewFlagSet("run", flag.ContinueOnError)
+func parseFlags(name string, args []string, output io.Writer) (*agentConfig, error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(output)
 	c := &agentConfig{}
 
 	flags.StringVar(&c.ConfigPath, "config", defaultConfigPath, "Path to a SPIRE config file")

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -65,7 +65,7 @@ func TestParseConfigGood(t *testing.T) {
 }
 
 func TestParseFlagsGood(t *testing.T) {
-	c, err := parseFlags([]string{
+	c, err := parseFlags("run", []string{
 		"-dataDir=.",
 		"-logLevel=INFO",
 		"-serverAddress=127.0.0.1",
@@ -73,7 +73,7 @@ func TestParseFlagsGood(t *testing.T) {
 		"-socketPath=/tmp/agent.sock",
 		"-trustBundle=conf/agent/dummy_root_ca.crt",
 		"-trustDomain=example.org",
-	})
+	}, os.Stderr)
 	require.NoError(t, err)
 	assert.Equal(t, c.DataDir, ".")
 	assert.Equal(t, c.LogLevel, "INFO")

--- a/cmd/spire-agent/cli/validate/validate.go
+++ b/cmd/spire-agent/cli/validate/validate.go
@@ -1,14 +1,12 @@
 package validate
 
 import (
-	"flag"
-
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/run"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 )
 
-const defaultConfigPath = "agent.conf"
+const commandName = "validate"
 
 func NewValidateCommand() cli.Command {
 	return newValidateCommand(common_cli.DefaultEnv)
@@ -22,15 +20,11 @@ func newValidateCommand(env *common_cli.Env) *validateCommand {
 
 type validateCommand struct {
 	env *common_cli.Env
-
-	configPath string
-	ExpandEnv  bool
 }
 
+// Help prints the agent cmd usage
 func (c *validateCommand) Help() string {
-	// ignoring parsing errors since "-h" is always supported by the flags package
-	_ = c.parseFlags([]string{"-h"})
-	return ""
+	return run.Help(commandName, c.env.Stderr)
 }
 
 func (c *validateCommand) Synopsis() string {
@@ -38,35 +32,11 @@ func (c *validateCommand) Synopsis() string {
 }
 
 func (c *validateCommand) Run(args []string) int {
-	if err := c.parseFlags(args); err != nil {
-		return 1
-	}
-	if err := c.run(); err != nil {
+	if _, err := run.LoadConfig(commandName, args, nil, c.env.Stderr); err != nil {
 		// Ignore error since a failure to write to stderr cannot very well be reported
 		_ = c.env.ErrPrintf("SPIRE agent configuration file is invalid: %v\n", err)
 		return 1
 	}
 	_ = c.env.Println("SPIRE agent configuration file is valid.")
 	return 0
-}
-
-func (c *validateCommand) parseFlags(args []string) error {
-	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
-	fs.SetOutput(c.env.Stderr)
-	fs.StringVar(&c.configPath, "config", defaultConfigPath, "Path to a SPIRE agent configuration file")
-	fs.BoolVar(&c.ExpandEnv, "expandEnv", false, "Expand environment variables in SPIRE config file")
-	return fs.Parse(args)
-}
-
-func (c *validateCommand) run() error {
-	fileInput, err := run.ParseFile(c.configPath, c.ExpandEnv)
-	if err != nil {
-		return err
-	}
-
-	if _, err := run.NewAgentConfig(fileInput, nil); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cmd/spire-agent/cli/validate/validate_test.go
+++ b/cmd/spire-agent/cli/validate/validate_test.go
@@ -43,24 +43,13 @@ func (s *ValidateSuite) TestSynopsis() {
 }
 
 func (s *ValidateSuite) TestHelp() {
-	s.Equal("", s.cmd.Help())
-	s.Equal(`Usage of validate:
-  -config string
-    	Path to a SPIRE agent configuration file (default "agent.conf")
-  -expandEnv
-    	Expand environment variables in SPIRE config file
-`, s.stderr.String(), "stderr")
+	s.Equal("flag: help requested", s.cmd.Help())
+	s.Contains(s.stderr.String(), "Usage of validate:", "stderr")
 }
 
 func (s *ValidateSuite) TestBadFlags() {
 	code := s.cmd.Run([]string{"-badflag"})
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
-	s.Equal(`flag provided but not defined: -badflag
-Usage of validate:
-  -config string
-    	Path to a SPIRE agent configuration file (default "agent.conf")
-  -expandEnv
-    	Expand environment variables in SPIRE config file
-`, s.stderr.String(), "stderr")
+	s.Contains(s.stderr.String(), "flag provided but not defined: -badflag", "stderr")
 }

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -151,6 +151,7 @@ func (cmd *Command) Help() string {
 // It is used by both the run and validate commands, so they can share flag usage messages.
 func Help(name string, writer io.Writer) string {
 	_, err := parseFlags(name, []string{"-h"}, writer)
+	// Error is always present because -h is passed
 	return err.Error()
 }
 


### PR DESCRIPTION
This makes it match the server much more closely, and reduces the amount of
code needed to support validate.  It now supports all flags that the run
command does, and performs the same config merging.

This means default config values are also applied

fixes #1557 because the default configuration means the field won't be nil

