### PR TITLE
Make test pass on Golang 1.14

### DIFF
--- a/pkg/common/idutil/spiffeid_test.go
+++ b/pkg/common/idutil/spiffeid_test.go
@@ -24,7 +24,7 @@ func TestValidateSpiffeID(t *testing.T) {
 			name:          "test_validate_spiffe_id_invalid_uri",
 			spiffeID:      "192.168.2.2:6688",
 			mode:          AllowAny(),
-			expectedError: "could not parse SPIFFE ID: parse 192.168.2.2:6688: first path segment in URL cannot contain colon",
+			expectedError: "could not parse SPIFFE ID:",
 		},
 		{
 			name:          "test_validate_spiffe_id_invalid_scheme",
@@ -255,7 +255,8 @@ func TestValidateSpiffeID(t *testing.T) {
 			if test.expectedError == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.EqualError(t, err, test.expectedError)
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), test.expectedError)
 			}
 		})
 	}


### PR DESCRIPTION
This removes the portion of the error message returned from the
standard library, as it has changed.
The test now only asserts the error contains the expected string.

**Which issue this PR fixes**
Fixes #1560

