### PR TITLE
API Refactor: Rate-limiting middleware plus scaffolding

### DIFF
--- a/pkg/server/api/middleware/interceptor.go
+++ b/pkg/server/api/middleware/interceptor.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+func Interceptors(middleware Middleware) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	return UnaryInterceptor(middleware), StreamInterceptor(middleware)
+}
+
+func UnaryInterceptor(middleware Middleware) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx, err := middleware.Preprocess(ctx, info.FullMethod)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := handler(ctx, req)
+		middleware.Postprocess(ctx, info.FullMethod, true, err)
+		return resp, err
+	}
+}
+
+func StreamInterceptor(middleware Middleware) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx, err := middleware.Preprocess(ss.Context(), info.FullMethod)
+		if err != nil {
+			return err
+		}
+		err = handler(srv, serverStream{ServerStream: ss, ctx: ctx})
+		middleware.Postprocess(ctx, info.FullMethod, true, err)
+		return err
+	}
+}

--- a/pkg/server/api/middleware/logger.go
+++ b/pkg/server/api/middleware/logger.go
@@ -1,0 +1,14 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+)
+
+func WithLogger(log logrus.FieldLogger) Middleware {
+	return Preprocess(func(ctx context.Context, methodName string) (context.Context, error) {
+		return rpccontext.WithLogger(ctx, log), nil
+	})
+}

--- a/pkg/server/api/middleware/middleware.go
+++ b/pkg/server/api/middleware/middleware.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type PreprocessFunc = func(ctx context.Context, methodName string) (context.Context, error)
+type PostprocessFunc = func(ctx context.Context, methodName string, handlerInvoked bool, rpcErr error)
+
+type Middleware interface {
+	// Preprocess is invoked before the gRPC handler is called. It returns a
+	// (possibly modified) context that is passed into the handler. The context
+	// should either be the context passed into the function or one derived
+	// from it. If the function returns an error, the gRPC method fails.
+	Preprocess(ctx context.Context, methodName string) (context.Context, error)
+
+	// Postprocess is invoked after the handler is called, or if downstream
+	// middleware returns an error from Preprocess. The function is passed an
+	// error that was returned from the handler or a downstream middleware
+	// during preprocessing. The handlerInvoked boolean, if true, indicates
+	// that the handler was executed. If false, then the call failed during
+	// preprocessing.
+	Postprocess(ctx context.Context, methodName string, handlerInvoked bool, rpcErr error)
+}
+
+func Preprocess(fn PreprocessFunc) Middleware {
+	return funcs{
+		preprocess: fn,
+	}
+}
+
+func Postprocess(fn PostprocessFunc) Middleware {
+	return funcs{
+		postprocess: fn,
+	}
+}
+
+// Funcs constructs a Middleware from a pair of functions, one for preprocessing, one for postprocessing.
+func Funcs(preprocess PreprocessFunc, postprocess PostprocessFunc) Middleware {
+	return funcs{
+		preprocess:  preprocess,
+		postprocess: postprocess,
+	}
+}
+
+func Chain(middleware ...Middleware) Middleware {
+	return middlewares(middleware)
+}
+
+type funcs struct {
+	preprocess  PreprocessFunc
+	postprocess PostprocessFunc
+}
+
+// Preprocess implements the Middleware interface
+func (h funcs) Preprocess(ctx context.Context, methodName string) (context.Context, error) {
+	if h.preprocess != nil {
+		return h.preprocess(ctx, methodName)
+	}
+	return ctx, nil
+}
+
+// Preprocess implements the Middleware interface
+func (h funcs) Postprocess(ctx context.Context, methodName string, handlerInvoked bool, rpcErr error) {
+	if h.postprocess != nil {
+		h.postprocess(ctx, methodName, handlerInvoked, rpcErr)
+	}
+}
+
+type middlewares []Middleware
+
+func (ms middlewares) Preprocess(ctx context.Context, methodName string) (context.Context, error) {
+	if len(ms) == 0 {
+		return ctx, nil
+	}
+
+	m := ms[0]
+	ms = ms[1:]
+
+	ctx, err := m.Preprocess(ctx, methodName)
+	if err != nil {
+		return nil, err
+	}
+
+	downstreamCtx, err := ms.Preprocess(ctx, methodName)
+	if err != nil {
+		// The downstream middleware failed to preprocess. Invoke the
+		// postprocess step of this middleware layer, passing in the context
+		// originally set up by this layer.
+		m.Postprocess(ctx, methodName, false, err)
+		return nil, err
+	}
+
+	return downstreamCtx, nil
+}
+
+func (ms middlewares) Postprocess(ctx context.Context, methodName string, handlerInvoked bool, rpcErr error) {
+	for i := len(ms) - 1; i >= 0; i-- {
+		ms[i].Postprocess(ctx, methodName, handlerInvoked, rpcErr)
+	}
+}
+
+type serverStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (ss serverStream) Context() context.Context {
+	return ss.ctx
+}

--- a/pkg/server/api/middleware/ratelimit.go
+++ b/pkg/server/api/middleware/ratelimit.go
@@ -1,0 +1,221 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	// NewRateLimiter is used to create a new ratelimiter. It returns a limiter
+	// from the standard rate package by default production.
+	newRawRateLimiter = func(limit rate.Limit, burst int) rawRateLimiter {
+		return rate.NewLimiter(limit, burst)
+	}
+)
+
+// rawRateLimiter represents the raw limiter functionality.
+type rawRateLimiter interface {
+	WaitN(ctx context.Context, count int) error
+	Limit() rate.Limit
+	Burst() int
+}
+
+// NoLimit returns a rate limiter does not rate limit. It is used to configure
+// methods that don't do rate limiting.
+func NoLimit() api.RateLimiter {
+	return noopLimiter{}
+}
+
+// PerCallLimit returns a rate limiter that imposes a server-wide limit for
+// calls to the method. It can be shared across methods to enforce a
+// server-wide limit for a group of methods.
+func PerCallLimit(limit int) api.RateLimiter {
+	return newPerCallLimiter(limit)
+}
+
+// PerIPLimit returns a rate limiter that imposes a per-ip limit on calls
+// to a method. It can be shared across methods to enforce per-ip limits for
+// a group of methods.
+func PerIPLimit(limit int) api.RateLimiter {
+	return newPerIPLimiter(limit)
+}
+
+// WithRateLimits returns a middleware that performs rate limiting for the
+// group of methods descripted by the rateLimits map. It provides the
+// configured rate limiter to the method handlers via the request context. If
+// the middleware is invoked for a method is not described in the map, it will
+// fail the RPC with an INTERNAL error code, describing the RPC that was not
+// configured properly.  The middleware also encourages proper rate limiting by
+// logging errors if a handler fails to invoke the rate limiter provided on the
+// context when a limit has been configured or the handler invokes the rate
+// limiter when a no limit has been configured.
+//
+// The WithRateLimits middleware depends on the Logger and Authorization
+// middlewares.
+func WithRateLimits(rateLimits map[string]api.RateLimiter) Middleware {
+	return rateLimitsMiddleware{
+		limiters: rateLimits,
+	}
+}
+
+type noopLimiter struct{}
+
+func (noopLimiter) RateLimit(ctx context.Context, count int) error {
+	return nil
+}
+
+func (noopLimiter) Noop() bool { return true }
+
+func isNoopLimiter(rateLimiter api.RateLimiter) bool {
+	noop, ok := rateLimiter.(interface{ Noop() bool })
+	return ok && noop.Noop()
+}
+
+type perCallLimiter struct {
+	limiter rawRateLimiter
+}
+
+func newPerCallLimiter(limit int) *perCallLimiter {
+	return &perCallLimiter{limiter: newRawRateLimiter(rate.Limit(limit), limit)}
+}
+
+func (lim *perCallLimiter) RateLimit(ctx context.Context, count int) error {
+	return waitN(ctx, lim.limiter, count)
+}
+
+type perIPLimiter struct {
+	limit int
+
+	mtx      sync.RWMutex
+	limiters map[string]rawRateLimiter
+}
+
+func newPerIPLimiter(limit int) *perIPLimiter {
+	return &perIPLimiter{limit: limit,
+		limiters: make(map[string]rawRateLimiter),
+	}
+}
+
+func (lim *perIPLimiter) RateLimit(ctx context.Context, count int) error {
+	tcpAddr, ok := rpccontext.CallerAddr(ctx).(*net.TCPAddr)
+	if !ok {
+		// Calls not via TCP/IP aren't limited
+		return nil
+	}
+	limiter := lim.getLimiter(tcpAddr.IP.String())
+	return waitN(ctx, limiter, count)
+}
+
+func (lim *perIPLimiter) getLimiter(addr string) rawRateLimiter {
+	lim.mtx.RLock()
+	limiter, ok := lim.limiters[addr]
+	if ok {
+		lim.mtx.RUnlock()
+		return limiter
+	}
+	lim.mtx.RUnlock()
+
+	lim.mtx.Lock()
+	defer lim.mtx.Unlock()
+	limiter, ok = lim.limiters[addr]
+	if !ok {
+		limiter = newRawRateLimiter(rate.Limit(lim.limit), lim.limit)
+		lim.limiters[addr] = limiter
+	}
+
+	return limiter
+}
+
+type rateLimitsMiddleware struct {
+	limiters map[string]api.RateLimiter
+}
+
+func (i rateLimitsMiddleware) Preprocess(ctx context.Context, methodName string) (context.Context, error) {
+	rateLimiter, ok := i.limiters[methodName]
+	if !ok {
+		rpccontext.Logger(ctx).WithField("method", methodName).Error("Rate limiting misconfigured; this is a bug")
+		return nil, status.Errorf(codes.Internal, "rate limiting misconfigured for RPC %q", methodName)
+	}
+	return rpccontext.WithRateLimiter(ctx, &rateLimiterWrapper{rateLimiter: rateLimiter}), nil
+}
+
+func (i rateLimitsMiddleware) Postprocess(ctx context.Context, methodName string, handlerInvoked bool, rpcErr error) {
+	// Handlers are expected to invoke the rate limiter unless they failed to
+	// parse parameters.
+	if handlerInvoked && status.Code(rpcErr) == codes.InvalidArgument {
+		return
+	}
+
+	rateLimiter, ok := rpccontext.RateLimiter(ctx)
+	if !ok {
+		// This shouldn't be the case unless Preprocess is broken and fails to
+		// inject the rate limiter into the context.
+		rpccontext.Logger(ctx).WithField("method", methodName).Error("Rate limiting misconfigured; this is a bug")
+		return
+	}
+
+	wrapper, ok := rateLimiter.(*rateLimiterWrapper)
+	if !ok {
+		// This shouldn't be the case unless Preprocess is broken and fails
+		// to wrap the rate limiter.
+		rpccontext.Logger(ctx).WithField("method", methodName).Error("Rate limiting misconfigured; this is a bug")
+		return
+	}
+
+	noop := isNoopLimiter(wrapper.rateLimiter)
+	used := wrapper.Used()
+
+	switch {
+	case !noop && !used:
+		// The limiter was non-noop and went unused by the handler. This is a bug.
+		rpccontext.Logger(ctx).WithField("method", methodName).Error("Rate limiter went unused; this is a bug")
+	case !noop && used:
+		// The limiter was non-noop and was used. All is well.
+	case noop && !used:
+		// The limiter was noop and was not used. All is well.
+	case noop && used:
+		// The limiter was noop and was used. This is a bug.
+		rpccontext.Logger(ctx).WithField("method", methodName).Error("Rate limiter used unexpectedly; this is a bug")
+	}
+}
+
+type rateLimiterWrapper struct {
+	rateLimiter api.RateLimiter
+	used        bool
+}
+
+func (w *rateLimiterWrapper) RateLimit(ctx context.Context, count int) error {
+	w.used = true
+	return w.rateLimiter.RateLimit(ctx, count)
+}
+
+func (w *rateLimiterWrapper) Used() bool {
+	return w.used
+}
+
+func waitN(ctx context.Context, limiter rawRateLimiter, count int) error {
+	// limiter.WaitN already provides this check but the error returned is not
+	// strongly typed and is a little messy. Lifting this check so we can
+	// provide a clean error message.
+	if count > limiter.Burst() && limiter.Limit() != rate.Inf {
+		return status.Errorf(codes.ResourceExhausted, "rate (%d) exceeds burst size (%d)", count, limiter.Burst())
+	}
+
+	err := limiter.WaitN(ctx, count)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return ctx.Err()
+	default:
+		return status.Error(codes.ResourceExhausted, err.Error())
+	}
+}

--- a/pkg/server/api/middleware/ratelimit_test.go
+++ b/pkg/server/api/middleware/ratelimit_test.go
@@ -66,7 +66,7 @@ func TestPerIPLimit(t *testing.T) {
 	// Once within burst size for 1.1.1.1
 	require.NoError(t, m.RateLimit(callerIPCtx("1.1.1.1"), 1))
 
-	// Twice withing burst size for 2.2.2.2
+	// Twice within burst size for 2.2.2.2
 	require.NoError(t, m.RateLimit(callerIPCtx("2.2.2.2"), 2))
 	require.NoError(t, m.RateLimit(callerIPCtx("2.2.2.2"), 3))
 
@@ -80,7 +80,6 @@ func TestPerIPLimit(t *testing.T) {
 		{ID: 2, Count: 2},
 		{ID: 2, Count: 3},
 	}, limiters.WaitNEvents)
-
 }
 
 func TestRateLimits(t *testing.T) {
@@ -217,11 +216,11 @@ type FakeLimiters struct {
 
 func NewFakeLimiters() *FakeLimiters {
 	ls := &FakeLimiters{}
-	newRawRateLimiter = ls.New
+	newRawRateLimiter = ls.newRawRateLimiter
 	return ls
 }
 
-func (ls *FakeLimiters) New(limit rate.Limit, burst int) rawRateLimiter {
+func (ls *FakeLimiters) newRawRateLimiter(limit rate.Limit, burst int) rawRateLimiter {
 	ls.Count++
 	return &fakeLimiter{
 		id:    ls.Count,
@@ -257,8 +256,7 @@ func (l *fakeLimiter) WaitN(ctx context.Context, count int) error {
 		// the rate package.
 		return errors.New("exceeding burst should have already been handled")
 	}
-	l.waitN(ctx, l.id, count)
-	return nil
+	return l.waitN(ctx, l.id, count)
 }
 
 func (l *fakeLimiter) Limit() rate.Limit {

--- a/pkg/server/api/middleware/ratelimit_test.go
+++ b/pkg/server/api/middleware/ratelimit_test.go
@@ -1,0 +1,276 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNoLimit(t *testing.T) {
+	limiters := NewFakeLimiters()
+
+	// NoLimit() does not do rate limiting and should succeed.
+	m := NoLimit()
+	require.NoError(t, m.RateLimit(context.Background(), 99))
+
+	// There should be no rate limiters configured as NoLimit() doesn't use one.
+	assert.Equal(t, 0, limiters.Count)
+}
+
+func TestPerCallLimit(t *testing.T) {
+	limiters := NewFakeLimiters()
+
+	m := PerCallLimit(1)
+
+	// Exceeds burst size.
+	err := m.RateLimit(context.Background(), 2)
+	spiretest.RequireGRPCStatus(t, err, codes.ResourceExhausted, "rate (2) exceeds burst size (1)")
+
+	// Within burst size.
+	require.NoError(t, m.RateLimit(context.Background(), 1))
+
+	// There should be a single rate limiter. WaitN should have only been
+	// called once for the call that didn't exceed the burst size.
+	assert.Equal(t, 1, limiters.Count)
+	assert.Equal(t, []WaitNEvent{
+		{ID: 1, Count: 1},
+	}, limiters.WaitNEvents)
+}
+
+func TestPerIPLimit(t *testing.T) {
+	limiters := NewFakeLimiters()
+
+	m := PerIPLimit(10)
+
+	// Does not rate limit non-TCP/IP callers
+	err := m.RateLimit(context.Background(), 11)
+	require.NoError(t, err)
+
+	// Once exceeding burst size for 1.1.1.1
+	err = m.RateLimit(callerIPCtx("1.1.1.1"), 11)
+	spiretest.RequireGRPCStatus(t, err, codes.ResourceExhausted, "rate (11) exceeds burst size (10)")
+
+	// Once within burst size for 1.1.1.1
+	require.NoError(t, m.RateLimit(callerIPCtx("1.1.1.1"), 1))
+
+	// Twice withing burst size for 2.2.2.2
+	require.NoError(t, m.RateLimit(callerIPCtx("2.2.2.2"), 2))
+	require.NoError(t, m.RateLimit(callerIPCtx("2.2.2.2"), 3))
+
+	// There should be two rate limiters; 1.1.1.1, and 2.2.2.2
+	assert.Equal(t, 2, limiters.Count)
+
+	// WaitN should have only been called once for 1.1.1.1 (burst failure does
+	// not result in a call to WaitN) and twice for 2.2.2.2.
+	assert.Equal(t, []WaitNEvent{
+		{ID: 1, Count: 1},
+		{ID: 2, Count: 2},
+		{ID: 2, Count: 3},
+	}, limiters.WaitNEvents)
+
+}
+
+func TestRateLimits(t *testing.T) {
+	unaryInterceptor := UnaryInterceptor(
+		WithRateLimits(
+			map[string]api.RateLimiter{
+				"/fake.Service/NoLimit":   NoLimit(),
+				"/fake.Service/WithLimit": PerCallLimit(2),
+			},
+		),
+	)
+
+	for _, tt := range []struct {
+		name           string
+		method         string
+		prepareCtx     func(context.Context) context.Context
+		rateLimitCount int
+		returnErr      error
+		expectLogs     []spiretest.LogEntry
+		expectCode     codes.Code
+		expectMsg      string
+	}{
+		{
+			name:       "RPC fails if method not configured for rate limiting",
+			method:     "/fake.Service/Whoopsie",
+			expectCode: codes.Internal,
+			expectMsg:  `rate limiting misconfigured for RPC "/fake.Service/Whoopsie"`,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Rate limiting misconfigured; this is a bug",
+					Data: logrus.Fields{
+						"method": "/fake.Service/Whoopsie",
+					},
+				},
+			},
+		},
+		{
+			name:       "logs when rate limiter not used by handler",
+			method:     "/fake.Service/WithLimit",
+			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Rate limiter went unused; this is a bug",
+					Data: logrus.Fields{
+						"method": "/fake.Service/WithLimit",
+					},
+				},
+			},
+		},
+		{
+			name:       "does not log if handler returns",
+			method:     "/fake.Service/WithLimit",
+			returnErr:  status.Error(codes.InvalidArgument, "ohno!"),
+			expectCode: codes.InvalidArgument,
+			expectMsg:  `ohno!`,
+		},
+		{
+			name:           "logs when handler with no limit tries to rate limit",
+			method:         "/fake.Service/NoLimit",
+			rateLimitCount: 1,
+			expectCode:     codes.OK,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Rate limiter used unexpectedly; this is a bug",
+					Data: logrus.Fields{
+						"method": "/fake.Service/NoLimit",
+					},
+				},
+			},
+		},
+		{
+			name:       "does not when rate limiter not used by unlimited handler",
+			method:     "/fake.Service/NoLimit",
+			expectCode: codes.OK,
+		},
+		{
+			name:           "does not log when rate limiter used by limited handler",
+			method:         "/fake.Service/WithLimit",
+			rateLimitCount: 1,
+		},
+		{
+			name:           "returns resource exhausted when rate limiting fails",
+			method:         "/fake.Service/WithLimit",
+			rateLimitCount: 3,
+			expectCode:     codes.ResourceExhausted,
+			expectMsg:      "rate (3) exceeds burst size (2)",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			log, hook := test.NewNullLogger()
+			ctx := rpccontext.WithLogger(context.Background(), log)
+			if tt.prepareCtx != nil {
+				ctx = tt.prepareCtx(ctx)
+			}
+			serverInfo := &grpc.UnaryServerInfo{FullMethod: tt.method}
+
+			handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+				if tt.rateLimitCount > 0 {
+					if err := rpccontext.RateLimit(ctx, tt.rateLimitCount); err != nil {
+						return nil, err
+					}
+				}
+				if tt.returnErr != nil {
+					return nil, tt.returnErr
+				}
+				return struct{}{}, nil
+			}
+
+			resp, err := unaryInterceptor(ctx, struct{}{}, serverInfo, handler)
+			spiretest.AssertGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			if err == nil {
+				assert.NotNil(t, resp)
+			} else {
+				assert.Nil(t, resp)
+			}
+			spiretest.AssertLogs(t, hook.AllEntries(), tt.expectLogs)
+		})
+	}
+}
+
+type WaitNEvent struct {
+	ID    int
+	Count int
+}
+
+type FakeLimiters struct {
+	Count       int
+	WaitNEvents []WaitNEvent
+}
+
+func NewFakeLimiters() *FakeLimiters {
+	ls := &FakeLimiters{}
+	newRawRateLimiter = ls.New
+	return ls
+}
+
+func (ls *FakeLimiters) New(limit rate.Limit, burst int) rawRateLimiter {
+	ls.Count++
+	return &fakeLimiter{
+		id:    ls.Count,
+		waitN: ls.waitN,
+		limit: limit,
+		burst: burst,
+	}
+}
+
+func (ls *FakeLimiters) waitN(ctx context.Context, id, count int) error {
+	ls.WaitNEvents = append(ls.WaitNEvents, WaitNEvent{
+		ID:    id,
+		Count: count,
+	})
+	return nil
+}
+
+type fakeLimiter struct {
+	id    int
+	waitN func(ctx context.Context, id, count int) error
+	limit rate.Limit
+	burst int
+}
+
+func (l *fakeLimiter) WaitN(ctx context.Context, count int) error {
+	switch {
+	case l.limit == rate.Inf:
+		// Limiters should never be unlimited.
+		return errors.New("unexpected infinite limit on limiter")
+	case count > l.burst:
+		// the waitN() function should have already taken care of this check
+		// in order to provide nicer error messaging than that provided by
+		// the rate package.
+		return errors.New("exceeding burst should have already been handled")
+	}
+	l.waitN(ctx, l.id, count)
+	return nil
+}
+
+func (l *fakeLimiter) Limit() rate.Limit {
+	return l.limit
+}
+
+func (l *fakeLimiter) Burst() int {
+	return l.burst
+}
+
+func callerIPCtx(ip string) context.Context {
+	return rpccontext.WithCallerAddr(context.Background(), &net.TCPAddr{
+		IP: net.ParseIP(ip),
+	})
+}

--- a/pkg/server/api/ratelimit.go
+++ b/pkg/server/api/ratelimit.go
@@ -1,0 +1,13 @@
+package api
+
+import "context"
+
+type RateLimiter interface {
+	RateLimit(ctx context.Context, count int) error
+}
+
+type RateLimiterFunc func(ctx context.Context, count int) error
+
+func (fn RateLimiterFunc) RateLimit(ctx context.Context, count int) error {
+	return fn(ctx, count)
+}

--- a/test/spiretest/logs.go
+++ b/test/spiretest/logs.go
@@ -1,0 +1,29 @@
+package spiretest
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type LogEntry struct {
+	Level   logrus.Level
+	Message string
+	Data    logrus.Fields
+}
+
+func AssertLogs(t *testing.T, entries []*logrus.Entry, expected []LogEntry) {
+	assert.Equal(t, expected, convertLogEntries(entries), "unexpected logs")
+}
+
+func convertLogEntries(entries []*logrus.Entry) (out []LogEntry) {
+	for _, entry := range entries {
+		out = append(out, LogEntry{
+			Level:   entry.Level,
+			Message: entry.Message,
+			Data:    entry.Data,
+		})
+	}
+	return out
+}


### PR DESCRIPTION
- Middleware interface provides pre and post processing steps
- Provides interceptor implemementations for gRPC
- Implements logger middleware
- Implements per-rpc and per-caller rate limiting

** Update ** This PR does not handle periodic pruning of the per-ip limiter map. It also doesn't have direct unit-tests for the middleware chaining, etc. These will come in follow up PRs.