### PR TITLE
Resolves #1562: Agent broken until restart after SVID expiry

### DIFF
--- a/pkg/common/rotationutil/rotationutil.go
+++ b/pkg/common/rotationutil/rotationutil.go
@@ -13,6 +13,11 @@ func ShouldRotateX509(now time.Time, cert *x509.Certificate) bool {
 	return shouldRotate(now, cert.NotBefore, cert.NotAfter)
 }
 
+// X509Expired returns true if the given X509 cert has expired
+func X509Expired(now time.Time, cert *x509.Certificate) bool {
+	return !now.Before(cert.NotAfter)
+}
+
 // JWTSVIDExpiresSoon determines if the given JWT SVID should be rotated
 // based on presented current time, the JWT's expiration.
 // Also returns true if the JWT is already expired.


### PR DESCRIPTION
**Affected functionality**
Agent SVID rotator.

**Description of change**
If an agent's SVID expires then it is unable to use it to connect to the server, but it will continue to try to do so until restarted. This change makes an error on rotation fatal if the agent's current SVID has expired, forcing an agent restart.

This seems a little brutal, though the case it handles should be rare. Restarting also only helps if the node attestor doesn't have TOFU checks (so it works perfectly for x509pop and k8s, but not for aws iid.) I'm open to suggestions on a better course of action.

**Which issue this PR fixes**
fixes #1562