### PR TITLE
API Refactor: AnyOf Authorizer

### DIFF
--- a/pkg/server/api/middleware/authorization.go
+++ b/pkg/server/api/middleware/authorization.go
@@ -51,8 +51,8 @@ func (m *authorizationMiddleware) Preprocess(ctx context.Context, methodName str
 
 	authorizer, ok := m.authorizers[methodName]
 	if !ok {
-		rpccontext.Logger(ctx).Error("Authorization misconfigured; this is a bug")
-		return nil, status.Errorf(codes.Internal, "authorization misconfigured for %q", methodName)
+		rpccontext.Logger(ctx).Error("Authorization misconfigured (method not registered); this is a bug")
+		return nil, status.Errorf(codes.Internal, "authorization misconfigured for %q (method not registered)", methodName)
 	}
 	return authorizer.AuthorizeCaller(ctx)
 }

--- a/pkg/server/api/middleware/authorization_test.go
+++ b/pkg/server/api/middleware/authorization_test.go
@@ -117,11 +117,11 @@ func TestWithAuthorizationPreprocess(t *testing.T) {
 			fullMethod: "/some.Service/WhatInTheWorld",
 			peer:       unixPeer,
 			expectCode: codes.Internal,
-			expectMsg:  `authorization misconfigured for "/some.Service/WhatInTheWorld"`,
+			expectMsg:  `authorization misconfigured for "/some.Service/WhatInTheWorld" (method not registered)`,
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
-					Message: "Authorization misconfigured; this is a bug",
+					Message: "Authorization misconfigured (method not registered); this is a bug",
 				},
 			},
 		},

--- a/pkg/server/api/middleware/authorize_any_of.go
+++ b/pkg/server/api/middleware/authorize_any_of.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AuthorizeAnyOf combines authorizers where if any authorizer succeeds, then
+// the caller is authorized. Specifically:
+// 1. If any authorizer returns any status code other than OK or
+// PERMISSION_DENIED, the authorization fails.
+// 2. If all authorizers return PERMISSION_DENIED, then authorization
+// fails.
+// 3. Otherwise, if at least one authorizer returns OK, authorization
+// succeeds.
+func AuthorizeAnyOf(authorizers ...Authorizer) Authorizer {
+	names := make([]string, 0, len(authorizers))
+	for _, authorizer := range authorizers {
+		names = append(names, authorizer.Name())
+	}
+
+	return anyOfAuthorizer{
+		names:       names,
+		authorizers: authorizers,
+	}
+}
+
+type anyOfAuthorizer struct {
+	names       []string
+	authorizers []Authorizer
+}
+
+func (a anyOfAuthorizer) Name() string {
+	return fmt.Sprintf("any-of[%s]", strings.Join(a.names, ","))
+}
+
+func (a anyOfAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	if len(a.authorizers) == 0 {
+		rpccontext.Logger(ctx).Error("Authorization misconfigured; this is a bug")
+		return nil, status.Error(codes.Internal, "authorization misconfigured")
+	}
+
+	var authenticated bool
+	for _, authorizer := range a.authorizers {
+		nextCtx, err := authorizer.AuthorizeCaller(ctx)
+		st := status.Convert(err)
+		switch st.Code() {
+		case codes.OK:
+			ctx = nextCtx
+			authenticated = true
+		case codes.PermissionDenied:
+		default:
+			return nil, err
+		}
+	}
+
+	if !authenticated {
+		return nil, status.Errorf(codes.PermissionDenied, "caller must be one of %q", a.names)
+	}
+
+	return ctx, nil
+}

--- a/pkg/server/api/middleware/authorize_any_of.go
+++ b/pkg/server/api/middleware/authorize_any_of.go
@@ -41,8 +41,8 @@ func (a anyOfAuthorizer) Name() string {
 
 func (a anyOfAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
 	if len(a.authorizers) == 0 {
-		rpccontext.Logger(ctx).Error("Authorization misconfigured; this is a bug")
-		return nil, status.Error(codes.Internal, "authorization misconfigured")
+		rpccontext.Logger(ctx).Error("Authorization misconfigured (no authorizers); this is a bug")
+		return nil, status.Error(codes.Internal, "authorization misconfigured (no authorizers)")
 	}
 
 	var authenticated bool

--- a/pkg/server/api/middleware/authorize_any_of_test.go
+++ b/pkg/server/api/middleware/authorize_any_of_test.go
@@ -1,0 +1,117 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	authorizerA = makeAuthorizer("A", codes.OK)
+	authorizerB = makeAuthorizer("B", codes.PermissionDenied)
+	authorizerC = makeAuthorizer("C", codes.Internal)
+)
+
+func TestAnyOfAuthorizerName(t *testing.T) {
+	authorizer := middleware.AuthorizeAnyOf(authorizerA, authorizerB)
+	require.Equal(t, "any-of[A,B]", authorizer.Name())
+}
+
+func TestAnyOfAuthorizer(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		authorizers     []middleware.Authorizer
+		expectCode      codes.Code
+		expectMsg       string
+		expectLogs      []spiretest.LogEntry
+		expectWrapCount int
+	}{
+		{
+			name:       "no authorizers",
+			expectCode: codes.Internal,
+			expectMsg:  "authorization misconfigured",
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Authorization misconfigured; this is a bug",
+				},
+			},
+		},
+		{
+			name:            "codes OK and OK",
+			authorizers:     []middleware.Authorizer{authorizerA, authorizerA},
+			expectCode:      codes.OK,
+			expectWrapCount: 3, // 1 initial + two from authorizerA
+		},
+		{
+			name:            "codes OK and PERMISSION_DENIED",
+			authorizers:     []middleware.Authorizer{authorizerA, authorizerB},
+			expectCode:      codes.OK,
+			expectWrapCount: 2, // 1 initial + one from authorizerA
+		},
+		{
+			name:        "codes PERMISSION_DENIED and PERMISSION_DENIED",
+			authorizers: []middleware.Authorizer{authorizerB, authorizerB},
+			expectCode:  codes.PermissionDenied,
+			expectMsg:   `caller must be one of ["B" "B"]`,
+		},
+		{
+			name:        "codes OK and INTERNAL",
+			authorizers: []middleware.Authorizer{authorizerA, authorizerC},
+			expectCode:  codes.Internal,
+			expectMsg:   "Internal",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new context with a logger and a wrap count of one. The
+			// wrap count will help us detect, in a round about way, that the
+			// context was passed through to the authorizers.
+			log, hook := test.NewNullLogger()
+			ctxIn := rpccontext.WithLogger(context.Background(), log)
+			ctxIn = wrapContext(ctxIn)
+
+			authorizer := middleware.AuthorizeAnyOf(tt.authorizers...)
+			ctxOut, err := authorizer.AuthorizeCaller(ctxIn)
+			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			spiretest.AssertLogs(t, hook.AllEntries(), tt.expectLogs)
+			if tt.expectCode == codes.OK {
+				assert.Equal(t, tt.expectWrapCount, wrapCount(ctxOut))
+			} else {
+				assert.Nil(t, ctxOut)
+			}
+		})
+	}
+}
+
+func makeAuthorizer(name string, code codes.Code) middleware.Authorizer {
+	return fakeAuthorizer{
+		name: name,
+		code: code,
+	}
+}
+
+type fakeAuthorizer struct {
+	name string
+	code codes.Code
+}
+
+func (a fakeAuthorizer) Name() string {
+	return a.name
+}
+
+func (a fakeAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	if a.code == codes.OK {
+		return wrapContext(ctx), nil
+	}
+	return nil, status.Error(a.code, a.code.String())
+}

--- a/pkg/server/api/middleware/authorize_any_of_test.go
+++ b/pkg/server/api/middleware/authorize_any_of_test.go
@@ -38,11 +38,11 @@ func TestAnyOfAuthorizer(t *testing.T) {
 		{
 			name:       "no authorizers",
 			expectCode: codes.Internal,
-			expectMsg:  "authorization misconfigured",
+			expectMsg:  "authorization misconfigured (no authorizers)",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
-					Message: "Authorization misconfigured; this is a bug",
+					Message: "Authorization misconfigured (no authorizers); this is a bug",
 				},
 			},
 		},


### PR DESCRIPTION
This authorizer allows one to combine any number of authorizers. The behavior is as follows:

1. If any authorizer returns any status code other than OK or PERMISSION_DENIED, the authorization fails.
2. If all authorizers return PERMISSION_DENIED, then authorization fails.
3. Otherwise, if at least one authorizer returns OK, authorization succeeds.