### PR TITLE
API Refactor: Any and Local authorizers

### DIFF
--- a/pkg/server/api/middleware/authorize_any.go
+++ b/pkg/server/api/middleware/authorize_any.go
@@ -1,0 +1,17 @@
+package middleware
+
+import "context"
+
+func AuthorizeAny() Authorizer {
+	return anyAuthorizer{}
+}
+
+type anyAuthorizer struct{}
+
+func (a anyAuthorizer) Name() string {
+	return "any"
+}
+
+func (a anyAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}

--- a/pkg/server/api/middleware/authorize_any_test.go
+++ b/pkg/server/api/middleware/authorize_any_test.go
@@ -1,0 +1,21 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnyAuthorizerName(t *testing.T) {
+	authorizer := middleware.AuthorizeAny()
+	require.Equal(t, "any", authorizer.Name())
+}
+
+func TestAnyAuthorizer(t *testing.T) {
+	authorizer := middleware.AuthorizeAny()
+	ctx, err := authorizer.AuthorizeCaller(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, ctx, context.Background())
+}

--- a/pkg/server/api/middleware/authorize_local.go
+++ b/pkg/server/api/middleware/authorize_local.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func AuthorizeLocal() Authorizer {
+	return localAuthorizer{}
+}
+
+type localAuthorizer struct{}
+
+func (localAuthorizer) Name() string {
+	return "local"
+}
+
+func (localAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	if !rpccontext.CallerIsLocal(ctx) {
+		return nil, status.Error(codes.PermissionDenied, "caller is not local")
+	}
+	return ctx, nil
+}

--- a/pkg/server/api/middleware/authorize_local_test.go
+++ b/pkg/server/api/middleware/authorize_local_test.go
@@ -1,0 +1,36 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestLocalAuthorizerName(t *testing.T) {
+	authorizer := middleware.AuthorizeLocal()
+	require.Equal(t, "local", authorizer.Name())
+}
+
+func TestLocalAuthorizer(t *testing.T) {
+	authorizer := middleware.AuthorizeLocal()
+
+	t.Run("caller is local", func(t *testing.T) {
+		ctxIn := rpccontext.WithLocalCaller(context.Background())
+		ctxOut, err := authorizer.AuthorizeCaller(ctxIn)
+		require.NoError(t, err)
+		require.Equal(t, ctxIn, ctxOut)
+	})
+
+	t.Run("caller is not local", func(t *testing.T) {
+		ctxIn := context.Background()
+		ctxOut, err := authorizer.AuthorizeCaller(ctxIn)
+		spiretest.RequireGRPCStatus(t, err, codes.PermissionDenied, "caller is not local")
+		assert.Nil(t, ctxOut)
+	})
+}


### PR DESCRIPTION
The any authorizer allows any caller. It is used for methods that don't have any authorization 
 requirements since the authorization middleware requires all methods to be registered.

The local authorizer authorizes local clients, i.e., those connecting over the unix domain socket.