### PR TITLE
API Refactor: Downstream and Admin authorizers

### DIFF
--- a/pkg/server/api/middleware/authorize_admin.go
+++ b/pkg/server/api/middleware/authorize_admin.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func AuthorizeAdmin(entryFetcher EntryFetcher) Authorizer {
+	return adminAuthorizer{entryFetcher: entryFetcher}
+}
+
+type adminAuthorizer struct {
+	entryFetcher EntryFetcher
+}
+
+func (a adminAuthorizer) Name() string {
+	return "admin"
+}
+
+func (a adminAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	ctx, entries, err := WithCallerEntries(ctx, a.entryFetcher)
+	if err != nil {
+		return nil, err
+	}
+
+	adminEntries := make([]*types.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Admin {
+			adminEntries = append(adminEntries, entry)
+		}
+	}
+	if len(adminEntries) == 0 {
+		return nil, status.Error(codes.PermissionDenied, "caller is not an admin workload")
+	}
+
+	return rpccontext.WithCallerAdminEntries(ctx, adminEntries), nil
+}

--- a/pkg/server/api/middleware/authorize_admin_test.go
+++ b/pkg/server/api/middleware/authorize_admin_test.go
@@ -1,0 +1,107 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestAdminAuthorizerName(t *testing.T) {
+	assert.Equal(t, "admin", middleware.AuthorizeAdmin(nil).Name())
+}
+
+func TestAdminAuthorizer(t *testing.T) {
+	adminID := spiffeid.Must("example.org", "admin")
+	adminEntries := []*types.Entry{
+		{Id: "1", Admin: true},
+		{Id: "2"},
+	}
+
+	nonAdminID := spiffeid.Must("example.org", "non-admin")
+	nonAdminEntries := []*types.Entry{
+		{Id: "3"},
+	}
+
+	failMeID := spiffeid.Must("example.org", "fail-me")
+
+	authorizer := middleware.AuthorizeAdmin(middleware.EntryFetcherFunc(
+		func(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error) {
+			switch id {
+			case adminID:
+				return adminEntries, nil
+			case nonAdminID:
+				return nonAdminEntries, nil
+			default:
+				return nil, errors.New("ohno")
+			}
+		},
+	))
+
+	for _, tt := range []struct {
+		name          string
+		id            spiffeid.ID
+		expectCode    codes.Code
+		expectMsg     string
+		expectEntries []*types.Entry
+		expectLogs    []spiretest.LogEntry
+	}{
+		{
+			name:       "with admin ID",
+			id:         adminID,
+			expectCode: codes.OK,
+			expectEntries: []*types.Entry{
+				{Id: "1", Admin: true},
+			},
+		},
+		{
+			name:       "with non-admin ID",
+			id:         nonAdminID,
+			expectCode: codes.PermissionDenied,
+			expectMsg:  "caller is not an admin workload",
+		},
+		{
+			name:       "fail to fetch entries",
+			id:         failMeID,
+			expectCode: codes.Internal,
+			expectMsg:  "failed to fetch caller entries: ohno",
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to fetch caller entries",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "ohno",
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			log, hook := test.NewNullLogger()
+			ctx := rpccontext.WithLogger(context.Background(), log)
+			ctx = rpccontext.WithCallerID(ctx, tt.id)
+
+			ctx, err := authorizer.AuthorizeCaller(ctx)
+			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			spiretest.AssertLogs(t, hook.AllEntries(), tt.expectLogs)
+			if tt.expectCode == codes.OK {
+				entries, ok := rpccontext.CallerAdminEntries(ctx)
+				if assert.True(t, ok, "context should have admin entries") {
+					assert.Equal(t, tt.expectEntries, entries, "admin entries don't match")
+				}
+			} else {
+				assert.Nil(t, ctx)
+			}
+		})
+	}
+}

--- a/pkg/server/api/middleware/authorize_downstream.go
+++ b/pkg/server/api/middleware/authorize_downstream.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func AuthorizeDownstream(entryFetcher EntryFetcher) Authorizer {
+	return downstreamAuthorizer{entryFetcher: entryFetcher}
+}
+
+type downstreamAuthorizer struct {
+	entryFetcher EntryFetcher
+}
+
+func (a downstreamAuthorizer) Name() string {
+	return "downstream"
+}
+
+func (a downstreamAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
+	ctx, entries, err := WithCallerEntries(ctx, a.entryFetcher)
+	if err != nil {
+		return nil, err
+	}
+
+	downstreamEntries := make([]*types.Entry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Downstream {
+			downstreamEntries = append(downstreamEntries, entry)
+		}
+	}
+	if len(downstreamEntries) == 0 {
+		return nil, status.Error(codes.PermissionDenied, "caller is not a downstream workload")
+	}
+
+	return rpccontext.WithCallerDownstreamEntries(ctx, downstreamEntries), nil
+}

--- a/pkg/server/api/middleware/authorize_downstream_test.go
+++ b/pkg/server/api/middleware/authorize_downstream_test.go
@@ -1,0 +1,107 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestDownstreamAuthorizerName(t *testing.T) {
+	assert.Equal(t, "downstream", middleware.AuthorizeDownstream(nil).Name())
+}
+
+func TestDownstreamAuthorizer(t *testing.T) {
+	downstreamID := spiffeid.Must("example.org", "downstream")
+	downstreamEntries := []*types.Entry{
+		{Id: "1", Downstream: true},
+		{Id: "2"},
+	}
+
+	nonDownstreamID := spiffeid.Must("example.org", "non-downstream")
+	nonDownstreamEntries := []*types.Entry{
+		{Id: "3"},
+	}
+
+	failMeID := spiffeid.Must("example.org", "fail-me")
+
+	authorizer := middleware.AuthorizeDownstream(middleware.EntryFetcherFunc(
+		func(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error) {
+			switch id {
+			case downstreamID:
+				return downstreamEntries, nil
+			case nonDownstreamID:
+				return nonDownstreamEntries, nil
+			default:
+				return nil, errors.New("ohno")
+			}
+		},
+	))
+
+	for _, tt := range []struct {
+		name          string
+		id            spiffeid.ID
+		expectCode    codes.Code
+		expectMsg     string
+		expectEntries []*types.Entry
+		expectLogs    []spiretest.LogEntry
+	}{
+		{
+			name:       "with downstream ID",
+			id:         downstreamID,
+			expectCode: codes.OK,
+			expectEntries: []*types.Entry{
+				{Id: "1", Downstream: true},
+			},
+		},
+		{
+			name:       "with non-downstream ID",
+			id:         nonDownstreamID,
+			expectCode: codes.PermissionDenied,
+			expectMsg:  "caller is not a downstream workload",
+		},
+		{
+			name:       "fail to fetch entries",
+			id:         failMeID,
+			expectCode: codes.Internal,
+			expectMsg:  "failed to fetch caller entries: ohno",
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to fetch caller entries",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "ohno",
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			log, hook := test.NewNullLogger()
+			ctx := rpccontext.WithLogger(context.Background(), log)
+			ctx = rpccontext.WithCallerID(ctx, tt.id)
+
+			ctx, err := authorizer.AuthorizeCaller(ctx)
+			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			spiretest.AssertLogs(t, hook.AllEntries(), tt.expectLogs)
+			if tt.expectCode == codes.OK {
+				entries, ok := rpccontext.CallerDownstreamEntries(ctx)
+				if assert.True(t, ok, "context should have downstream entries") {
+					assert.Equal(t, tt.expectEntries, entries, "downstream entries don't match")
+				}
+			} else {
+				assert.Nil(t, ctx)
+			}
+		})
+	}
+}

--- a/pkg/server/api/middleware/entries.go
+++ b/pkg/server/api/middleware/entries.go
@@ -25,7 +25,7 @@ func (fn EntryFetcherFunc) FetchEntries(ctx context.Context, id spiffeid.ID) ([]
 
 type callerEntriesKey struct{}
 
-// WithCallerEntries returns a the caller entries retrieved using the given
+// WithCallerEntries returns the caller entries retrieved using the given
 // fetcher. If the context already has the caller entries, they are returned
 // without re-fetching. This reduces entry fetching in the face of multiple
 // authorizers.

--- a/pkg/server/api/middleware/entries.go
+++ b/pkg/server/api/middleware/entries.go
@@ -1,0 +1,49 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type EntryFetcher interface {
+	// FetchEntries fetches the downstream entries matching the given SPIFFE ID.
+	FetchEntries(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error)
+}
+
+// EntryFetcherFunc implements EntryFetcher with a function
+type EntryFetcherFunc func(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error)
+
+// FetchEntries fetches the downstream entries matching the given SPIFFE ID.
+func (fn EntryFetcherFunc) FetchEntries(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error) {
+	return fn(ctx, id)
+}
+
+type callerEntriesKey struct{}
+
+// WithCallerEntries returns a the caller entries retrieved using the given
+// fetcher. If the context already has the caller entries, they are returned
+// without re-fetching. This reduces entry fetching in the face of multiple
+// authorizers.
+func WithCallerEntries(ctx context.Context, entryFetcher EntryFetcher) (context.Context, []*types.Entry, error) {
+	if entries, ok := ctx.Value(callerEntriesKey{}).([]*types.Entry); ok {
+		return ctx, entries, nil
+	}
+
+	var entries []*types.Entry
+	id, ok := rpccontext.CallerID(ctx)
+	if !ok {
+		return ctx, nil, nil
+	}
+
+	entries, err := entryFetcher.FetchEntries(ctx, id)
+	if err != nil {
+		rpccontext.Logger(ctx).WithError(err).Error("Failed to fetch caller entries")
+		return nil, nil, status.Errorf(codes.Internal, "failed to fetch caller entries: %v", err)
+	}
+	return context.WithValue(ctx, callerEntriesKey{}, entries), entries, nil
+}

--- a/pkg/server/api/middleware/entries_test.go
+++ b/pkg/server/api/middleware/entries_test.go
@@ -1,0 +1,84 @@
+package middleware_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/server/api/middleware"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/proto/spire-next/types"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+)
+
+func TestWithCallerEntries(t *testing.T) {
+	adminID := spiffeid.Must("example.org", "admin")
+	adminEntries := []*types.Entry{{Id: "A"}}
+
+	failMeID := spiffeid.Must("example.org", "fail-me")
+
+	entryFetcher := middleware.EntryFetcherFunc(
+		func(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error) {
+			if id == adminID {
+				return adminEntries, nil
+			}
+			return nil, errors.New("ohno")
+		},
+	)
+
+	failingFetcher := middleware.EntryFetcherFunc(
+		func(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error) {
+			return nil, errors.New("should not have been called")
+		},
+	)
+
+	t.Run("success", func(t *testing.T) {
+		ctxIn := rpccontext.WithCallerID(context.Background(), adminID)
+		ctxOut1, entries, err := middleware.WithCallerEntries(ctxIn, entryFetcher)
+		// Assert that the call succeeds and returns a new context and the entries.
+		assert.NotEqual(t, ctxIn, ctxOut1)
+		assert.Equal(t, adminEntries, entries)
+		assert.NoError(t, err)
+
+		// Now call again and make sure it returns the same context. The failing
+		// fetcher is used to ensure it is not called because the context
+		// already has the entries.
+		ctxOut2, entries, err := middleware.WithCallerEntries(ctxOut1, failingFetcher)
+		assert.Equal(t, ctxOut1, ctxOut2)
+		assert.Equal(t, adminEntries, entries)
+		assert.NoError(t, err)
+	})
+
+	t.Run("no caller ID", func(t *testing.T) {
+		ctxIn := context.Background()
+		ctxOut, entries, err := middleware.WithCallerEntries(ctxIn, entryFetcher)
+		// Assert that the call succeeds and returns an unchanged context and no entries.
+		assert.Equal(t, ctxIn, ctxOut)
+		assert.Nil(t, entries)
+		assert.NoError(t, err)
+	})
+
+	t.Run("fetch fails", func(t *testing.T) {
+		log, hook := test.NewNullLogger()
+		ctxIn := rpccontext.WithCallerID(rpccontext.WithLogger(context.Background(), log), failMeID)
+		ctxOut, entries, err := middleware.WithCallerEntries(ctxIn, entryFetcher)
+		// Assert that the call fails and returns a nil context and no entries.
+		assert.Nil(t, ctxOut)
+		assert.Nil(t, entries)
+		spiretest.AssertGRPCStatus(t, err, codes.Internal, "failed to fetch caller entries: ohno")
+		spiretest.AssertLogs(t, hook.AllEntries(), []spiretest.LogEntry{
+			{
+				Level:   logrus.ErrorLevel,
+				Message: "Failed to fetch caller entries",
+				Data: logrus.Fields{
+					logrus.ErrorKey: "ohno",
+				},
+			},
+		})
+	})
+}


### PR DESCRIPTION
These authorizers authorize the caller as a downstream or admin workload by looking up the registration entries matching the caller ID.

They attach the respective downstream or admin entries to the context.

These authorizers use a helper to obtain the entries for the caller that uses the context to cache retrieved entries. This prevents the entry lookup from happening more than once if these authorizers are used for the same RPC (e.g., via AuthorizeAnyOf).