### PR TITLE
Robust cgroup path parsing of docker container ID

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -28,10 +29,6 @@ const (
 	subselectorEnv     = "env"
 )
 
-var defaultContainerIDMatchers = []string{
-	"/docker/<id>",
-}
-
 func BuiltIn() catalog.Plugin {
 	return builtin(New())
 }
@@ -52,11 +49,6 @@ type Plugin struct {
 	mtx               *sync.RWMutex
 	retryer           *retryer
 	containerIDFinder cgroup.ContainerIDFinder
-	findContainerID   func(string) (string, bool)
-
-	// legacy ID extraction
-	cgroupPrefix         string
-	cgroupContainerIndex int
 }
 
 func New() *Plugin {
@@ -94,27 +86,13 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		return nil, err
 	}
 
-	var containerID string
-	var hasDockerEntries bool
-	for _, cgroup := range cgroupList {
-		// We are only interested in cgroup entries that match our desired pattern. Example entry:
-		// "10:perf_event:/docker/2235ebefd9babe0dde4df4e7c49708e24fb31fb851edea55c0ee29a18273cdf4"
-		id, ok := p.findContainerID(cgroup.GroupPath)
-		if !ok {
-			continue
-		}
-		hasDockerEntries = true
-		containerID = id
-		break
-	}
-
-	// Not a docker workload. Since it is expected that non-docker workloads will call the
-	// workload API, it is fine to return a response without any selectors.
-	if !hasDockerEntries {
+	containerID, err := getContainerIDFromCGroups(p.containerIDFinder, cgroupList)
+	switch {
+	case err != nil:
+		return nil, err
+	case containerID == "":
+		// Not a docker workload. Nothing more to do.
 		return &workloadattestor.AttestResponse{}, nil
-	}
-	if containerID == "" {
-		return nil, fmt.Errorf("workloadattestor/docker: a pattern matched, but no container id was found")
 	}
 
 	var container types.ContainerJSON
@@ -182,33 +160,28 @@ func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi
 		return nil, err
 	}
 
-	if config.CgroupPrefix != "" || config.CgroupContainerIndex != nil {
+	switch {
+	case config.CgroupPrefix != "" || config.CgroupContainerIndex != nil:
 		if config.CgroupPrefix == "" || config.CgroupContainerIndex == nil {
 			return nil, errors.New("cgroup_prefix and cgroup_container_index must be specified together")
 		}
 		p.log.Warn("cgroup_prefix and cgroup_container_index are deprecated and will be removed in a future release")
 
-		p.cgroupPrefix = config.CgroupPrefix
-		// index 0 will always be "" as the prefix must start with /.
-		// We add 1 to the requested index to hide this from the user.
-		p.cgroupContainerIndex = *config.CgroupContainerIndex + 1
-
-		p.findContainerID = p.legacyExtractID
-
-		return &spi.ConfigureResponse{}, nil
+		p.containerIDFinder = &legacyContainerIDFinder{
+			log:          p.log,
+			cgroupPrefix: config.CgroupPrefix,
+			// index 0 will always be "" as the prefix must start with /.
+			// We add 1 to the requested index to hide this from the user.
+			cgroupContainerIndex: *config.CgroupContainerIndex + 1,
+		}
+	case len(config.ContainerIDCGroupMatchers) > 0:
+		p.containerIDFinder, err = cgroup.NewContainerIDFinder(config.ContainerIDCGroupMatchers)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		p.containerIDFinder = &defaultContainerIDFinder{}
 	}
-
-	matchers := config.ContainerIDCGroupMatchers
-	if len(matchers) == 0 {
-		matchers = defaultContainerIDMatchers
-	}
-
-	p.containerIDFinder, err = cgroup.NewContainerIDFinder(matchers)
-	if err != nil {
-		return nil, err
-	}
-
-	p.findContainerID = p.containerIDFinder.FindContainerID
 
 	return &spi.ConfigureResponse{}, nil
 }
@@ -217,17 +190,95 @@ func (*Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.G
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func (p *Plugin) legacyExtractID(cgroupPath string) (string, bool) {
-	if !strings.HasPrefix(cgroupPath, p.cgroupPrefix) {
+// getContainerIDFromCGroups returns the container ID from a set of cgroups
+// using the given finder. The container ID found on each cgroup path (if any)
+// must be consistent. If no container ID is found among the cgroups, i.e.,
+// this isn't a docker workload, the function returns an empty string. If more
+// than one container ID is found, or the "found" container ID is blank, the
+// function will fail.
+func getContainerIDFromCGroups(finder cgroup.ContainerIDFinder, cgroups []cgroups.Cgroup) (string, error) {
+	var hasDockerEntries bool
+	var containerID string
+	for _, cgroup := range cgroups {
+		candidate, ok := finder.FindContainerID(cgroup.GroupPath)
+		if !ok {
+			continue
+		}
+
+		hasDockerEntries = true
+
+		switch {
+		case containerID == "":
+			// This is the first container ID found so far.
+			containerID = candidate
+		case containerID != candidate:
+			// More than one container ID found in the cgroups.
+			return "", fmt.Errorf("workloadattestor/docker: multiple container IDs found in cgroups (%s, %s)",
+				containerID, candidate)
+		}
+	}
+
+	switch {
+	case !hasDockerEntries:
+		// Not a docker workload. Since it is expected that non-docker workloads will call the
+		// workload API, it is fine to return a response without any selectors.
+		return "", nil
+	case containerID == "":
+		// The "finder" found a container ID, but it was blank. This is a
+		// defensive measure against bad matcher patterns and shouldn't
+		// be possible with the default finder.
+		return "", errors.New("workloadattestor/docker: a pattern matched, but no container id was found")
+	default:
+		return containerID, nil
+	}
+}
+
+type legacyContainerIDFinder struct {
+	log                  hclog.Logger
+	cgroupPrefix         string
+	cgroupContainerIndex int
+}
+
+// FindContainerID returns the container ID from the given cgroup path. It only
+// considers cgroup paths matching the configured prefix. The path is split
+// into a number of slash separated segments. The container ID is assumed to
+// occupy the segment at the configured index. If the cgroup path does not
+// match the prefix or does not have enough segments to accommodate the index,
+// the method returns false.
+func (f *legacyContainerIDFinder) FindContainerID(cgroupPath string) (string, bool) {
+	if !strings.HasPrefix(cgroupPath, f.cgroupPrefix) {
 		return "", false
 	}
 
 	parts := strings.Split(cgroupPath, "/")
 
-	if len(parts) <= p.cgroupContainerIndex {
-		p.log.Warn("Docker entry found, but is missing the container id", telemetry.CGroupPath, cgroupPath)
+	if len(parts) <= f.cgroupContainerIndex {
+		f.log.Warn("Docker entry found, but is missing the container id", telemetry.CGroupPath, cgroupPath)
 		return "", false
 	}
 
-	return parts[p.cgroupContainerIndex], true
+	return parts[f.cgroupContainerIndex], true
+}
+
+// dockerCGroupRE matches cgroup paths that have the following properties.
+// 1) `\bdocker\b` the whole word docker
+// 2) `.+` followed by one or more characters (which will start on a word boundary due to #1)
+// 3) `\b([[:xdigit:]][64])\b` followed by a 64 hex-character container id on word boundary
+//
+// The "docker" prefix and 64-hex character container id can be anywhere in the path. The only
+// requirement is that the docker prefix comes before the id.
+var dockerCGroupRE = regexp.MustCompile(`\bdocker\b.+\b([[:xdigit:]]{64})\b`)
+
+type defaultContainerIDFinder struct{}
+
+// FindContainerID returns the container ID in the given cgroup path. The cgroup
+// path must have the whole word "docker" at some point in the path followed
+// at some point by a 64 hex-character container ID. If the cgroup path does
+// not match the above description, the method returns false.
+func (f *defaultContainerIDFinder) FindContainerID(cgroupPath string) (string, bool) {
+	m := dockerCGroupRE.FindStringSubmatch(cgroupPath)
+	if m != nil {
+		return m[1], true
+	}
+	return "", false
 }


### PR DESCRIPTION
 **Affected functionality** 

Changes the default docker container ID parsing behavior. Current default behavior parses cgroup paths that look like `/docker/<containerid>`. This however does not work in general and the existing (undocumented) options are inflexible enough to handle cgroup paths like those generated by RHEL.

@vbotez prepared a targeted fix with #1522 (thank you!!). It opened up a discussion of the desired semantics, which ended up being quite the departure for the direction the PR started with. This PR 
summarizes the functionality we landed with during that discussion.

**Description of change**

- Uses a simple regex to extract the 64 hex character container ID from any cgroup path with a "docker" whole word prefix somewhere before the ID.
- Replaces the default finder with the above regex
- Still supports the legacy and pattern-based finders
- Does a light refactoring to clean up the mixture of the legacy and pattern based mechanisms and to present one unified "finder" pattern.

**Which issue this PR fixes**
Fixes #1518