### PR TITLE
Added 2 fuzzers

### DIFF
--- a/cmd/spire-agent/cli/run/fuzz.go
+++ b/cmd/spire-agent/cli/run/fuzz.go
@@ -1,0 +1,23 @@
+package run
+
+import (
+	"os"
+)
+
+func FuzzArgs(data []byte) int {
+	f, err := os.Create("data.conf")
+	if err != nil {
+		return -1
+	}
+	defer f.Close()
+	defer os.Remove("data.conf")
+	_, err = f.Write(data)
+	if err != nil {
+		return -1
+	}
+	_, err = ParseFile("data.conf", false)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/common/pemutil/fuzz.go
+++ b/pkg/common/pemutil/fuzz.go
@@ -1,0 +1,9 @@
+package pemutil
+
+func FuzzBlocks(data []byte) int {
+	_, err := ParseBlocks(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
**Description of change**
This PR introduces fuzzing by adding 2 fuzzers.
The fuzzers can run locally, and I have managed to run them on oss-fuzz's infrastructure as well. I will be glad to integrate Spire into oss-fuzz so that they can run continuously. This helps by adding more fuzzing time and not requiring developers to run locally.
oss-fuzz is free with an implied expectation that bugs are fixed, so that the resources spent on fuzzing Spire are put to good use.
All I need to integrate the fuzzers into oss-fuzz are the email addresses to which potential bug reports should be sent.

**Affected functionality**
This PR does not affect the core functionality of Spire.

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

Signed-off-by: AdamKorcz <adam@adalogics.com>