### PR TITLE
Fix agent SVID rotation backoff

### DIFF
--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -75,6 +75,7 @@ func (r *rotator) runRotation(ctx context.Context) error {
 					// Since our X509 cert has expired, and we weren't able to carry out a rotation request, we're probably unrecoverable without re-attesting.
 					return fmt.Errorf("current SVID has already expired and rotation failed: %v", err)
 				}
+			} else {
 				r.backoff.Reset()
 			}
 		}


### PR DESCRIPTION
Recent change broke the agent SVID rotation backoff mechanism so that the backoff was only being reset by failure (instead of the opposite).