### PR TITLE
Remove peertracker from server UDS

### DIFF
--- a/pkg/common/auth/untracked_uds.go
+++ b/pkg/common/auth/untracked_uds.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+)
+
+// UntrackedUDSCredentials returns credentials for UDS servers that rely solely
+// on file permissions for access control. If the caller information (e.g. PID,
+// UID, GID) is in any way used for further access control or authorization
+// decisions, these credentials SHOULD NOT be used. The peertracker package
+// should instead be used, which provides mitigation against PID reuse and
+// related attacks.
+func UntrackedUDSCredentials() credentials.TransportCredentials {
+	return untrackedUDSCredentials{}
+}
+
+func IsUntrackedUDSAuth(authInfo credentials.AuthInfo) bool {
+	_, ok := authInfo.(UntrackedUDSAuthInfo)
+	return ok
+}
+
+type UntrackedUDSAuthInfo struct{}
+
+func (UntrackedUDSAuthInfo) AuthType() string { return "untracked-uds" }
+
+type untrackedUDSCredentials struct{}
+
+func (c untrackedUDSCredentials) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn.Close()
+	return conn, nil, errors.New("untracked UDS credentials do not implement the client handshake")
+}
+
+func (c untrackedUDSCredentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, UntrackedUDSAuthInfo{}, nil
+}
+
+func (c untrackedUDSCredentials) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{}
+}
+
+func (c untrackedUDSCredentials) Clone() credentials.TransportCredentials {
+	return untrackedUDSCredentials{}
+}
+
+func (c untrackedUDSCredentials) OverrideServerName(_ string) error {
+	return nil
+}

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -3,10 +3,8 @@ package endpoints
 import (
 	"net"
 	"net/url"
-	"sync"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/catalog"
@@ -56,10 +54,6 @@ type Config struct {
 // New creates new endpoints struct
 func New(c *Config) *Endpoints {
 	return &Endpoints{
-		c:   c,
-		mtx: new(sync.RWMutex),
-		unixListener: &peertracker.ListenerFactory{
-			Log: c.Log,
-		},
+		c: c,
 	}
 }

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -13,8 +13,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/common/auth"
 	"github.com/spiffe/spire/pkg/common/idutil"
-	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_common "github.com/spiffe/spire/pkg/common/telemetry/common"
 	telemetry_registrationapi "github.com/spiffe/spire/pkg/common/telemetry/server/registrationapi"
@@ -907,7 +907,7 @@ func authorizeCaller(ctx context.Context, ds datastore.DataStore) (spiffeID stri
 		if err != nil {
 			return "", status.Error(codes.PermissionDenied, err.Error())
 		}
-	case peertracker.AuthInfo:
+	case auth.UntrackedUDSAuthInfo:
 		// The caller came over UDS and is therefore authorized but does not
 		// provide a spiffeID. The file permissions on the UDS are restricted to
 		// processes belonging to the same user or group as the server.

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/pkg/common/auth"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
-	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
@@ -1361,7 +1361,7 @@ func (s *HandlerSuite) TestAuthorizeCall() {
 		},
 		{
 			Peer: &peer.Peer{
-				AuthInfo: peertracker.AuthInfo{},
+				AuthInfo: auth.UntrackedUDSAuthInfo{},
 			},
 		},
 		{


### PR DESCRIPTION
This change removes peertracker use on the server.

The server historically inspected the UID and GID of clients connecting over UDS to determine if they belonged to the same user or group of the server in order to grant access. At some point the server switched to relying on the process-wide umask (`0027`) and a specific `chmod(0770)`
to restrict access to those running as as the same UID/GID of the server.

The server now wholly relies on file permissions for access control to the administrative UDS.

The peertracker code prevents tracks caller PIDs to mitigate PID re-use. However, since the server is not relying on PID information for access control, the peertracker provides no benefit. Furthermore, the peertracker requires SPIRE server and UDS clients to share a process
namespace, which requires special (and often discourages) configuration in containerized environments (e.g. `shareProcessNamespace` in K8s).