### PR TITLE
Move DataStore metrics out of SQL plugin

### DIFF
--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -1,0 +1,167 @@
+package datastore
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+)
+
+func WithMetrics(ds datastore.DataStore, metrics telemetry.Metrics) datastore.DataStore {
+	return metricsWrapper{ds: ds, m: metrics}
+}
+
+type metricsWrapper struct {
+	ds datastore.DataStore
+	m  telemetry.Metrics
+}
+
+func (w metricsWrapper) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (_ *datastore.AppendBundleResponse, err error) {
+	callCounter := StartAppendBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.AppendBundle(ctx, req)
+}
+
+func (w metricsWrapper) CreateAttestedNode(ctx context.Context, req *datastore.CreateAttestedNodeRequest) (_ *datastore.CreateAttestedNodeResponse, err error) {
+	callCounter := StartCreateNodeCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.CreateAttestedNode(ctx, req)
+}
+
+func (w metricsWrapper) CreateBundle(ctx context.Context, req *datastore.CreateBundleRequest) (_ *datastore.CreateBundleResponse, err error) {
+	callCounter := StartCreateBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.CreateBundle(ctx, req)
+}
+
+func (w metricsWrapper) CreateJoinToken(ctx context.Context, req *datastore.CreateJoinTokenRequest) (_ *datastore.CreateJoinTokenResponse, err error) {
+	callCounter := StartCreateJoinTokenCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.CreateJoinToken(ctx, req)
+}
+
+func (w metricsWrapper) CreateRegistrationEntry(ctx context.Context, req *datastore.CreateRegistrationEntryRequest) (_ *datastore.CreateRegistrationEntryResponse, err error) {
+	callCounter := StartCreateRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.CreateRegistrationEntry(ctx, req)
+}
+
+func (w metricsWrapper) DeleteAttestedNode(ctx context.Context, req *datastore.DeleteAttestedNodeRequest) (_ *datastore.DeleteAttestedNodeResponse, err error) {
+	callCounter := StartDeleteNodeCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.DeleteAttestedNode(ctx, req)
+}
+
+func (w metricsWrapper) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleRequest) (_ *datastore.DeleteBundleResponse, err error) {
+	callCounter := StartDeleteBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.DeleteBundle(ctx, req)
+}
+
+func (w metricsWrapper) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (_ *datastore.DeleteJoinTokenResponse, err error) {
+	callCounter := StartDeleteJoinTokenCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.DeleteJoinToken(ctx, req)
+}
+
+func (w metricsWrapper) DeleteRegistrationEntry(ctx context.Context, req *datastore.DeleteRegistrationEntryRequest) (_ *datastore.DeleteRegistrationEntryResponse, err error) {
+	callCounter := StartDeleteRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.DeleteRegistrationEntry(ctx, req)
+}
+
+func (w metricsWrapper) FetchAttestedNode(ctx context.Context, req *datastore.FetchAttestedNodeRequest) (_ *datastore.FetchAttestedNodeResponse, err error) {
+	callCounter := StartFetchNodeCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.FetchAttestedNode(ctx, req)
+}
+
+func (w metricsWrapper) FetchBundle(ctx context.Context, req *datastore.FetchBundleRequest) (_ *datastore.FetchBundleResponse, err error) {
+	callCounter := StartFetchBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.FetchBundle(ctx, req)
+}
+
+func (w metricsWrapper) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTokenRequest) (_ *datastore.FetchJoinTokenResponse, err error) {
+	callCounter := StartFetchJoinTokenCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.FetchJoinToken(ctx, req)
+}
+
+func (w metricsWrapper) FetchRegistrationEntry(ctx context.Context, req *datastore.FetchRegistrationEntryRequest) (_ *datastore.FetchRegistrationEntryResponse, err error) {
+	callCounter := StartFetchRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.FetchRegistrationEntry(ctx, req)
+}
+
+func (w metricsWrapper) GetNodeSelectors(ctx context.Context, req *datastore.GetNodeSelectorsRequest) (_ *datastore.GetNodeSelectorsResponse, err error) {
+	callCounter := StartGetNodeSelectorsCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.GetNodeSelectors(ctx, req)
+}
+
+func (w metricsWrapper) ListAttestedNodes(ctx context.Context, req *datastore.ListAttestedNodesRequest) (_ *datastore.ListAttestedNodesResponse, err error) {
+	callCounter := StartListNodeCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.ListAttestedNodes(ctx, req)
+}
+
+func (w metricsWrapper) ListBundles(ctx context.Context, req *datastore.ListBundlesRequest) (_ *datastore.ListBundlesResponse, err error) {
+	callCounter := StartListBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.ListBundles(ctx, req)
+}
+
+func (w metricsWrapper) ListRegistrationEntries(ctx context.Context, req *datastore.ListRegistrationEntriesRequest) (_ *datastore.ListRegistrationEntriesResponse, err error) {
+	callCounter := StartListRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.ListRegistrationEntries(ctx, req)
+}
+
+func (w metricsWrapper) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (_ *datastore.PruneBundleResponse, err error) {
+	callCounter := StartPruneBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.PruneBundle(ctx, req)
+}
+
+func (w metricsWrapper) PruneJoinTokens(ctx context.Context, req *datastore.PruneJoinTokensRequest) (_ *datastore.PruneJoinTokensResponse, err error) {
+	callCounter := StartPruneJoinTokenCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.PruneJoinTokens(ctx, req)
+}
+
+func (w metricsWrapper) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (_ *datastore.PruneRegistrationEntriesResponse, err error) {
+	callCounter := StartPruneRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.PruneRegistrationEntries(ctx, req)
+}
+
+func (w metricsWrapper) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (_ *datastore.SetBundleResponse, err error) {
+	callCounter := StartSetBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.SetBundle(ctx, req)
+}
+
+func (w metricsWrapper) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (_ *datastore.SetNodeSelectorsResponse, err error) {
+	callCounter := StartSetNodeSelectorsCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.SetNodeSelectors(ctx, req)
+}
+
+func (w metricsWrapper) UpdateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest) (_ *datastore.UpdateAttestedNodeResponse, err error) {
+	callCounter := StartUpdateNodeCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.UpdateAttestedNode(ctx, req)
+}
+
+func (w metricsWrapper) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (_ *datastore.UpdateBundleResponse, err error) {
+	callCounter := StartUpdateBundleCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.UpdateBundle(ctx, req)
+}
+
+func (w metricsWrapper) UpdateRegistrationEntry(ctx context.Context, req *datastore.UpdateRegistrationEntryRequest) (_ *datastore.UpdateRegistrationEntryResponse, err error) {
+	callCounter := StartUpdateRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.UpdateRegistrationEntry(ctx, req)
+}

--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -7,6 +7,9 @@ import (
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 )
 
+// WithMetrics wraps a datastore interface and provides per-call metrics. The
+// metrics produced include a call counter and elapsed time measurement with
+// labels for the status code.
 func WithMetrics(ds datastore.DataStore, metrics telemetry.Metrics) datastore.DataStore {
 	return metricsWrapper{ds: ds, m: metrics}
 }

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -1,0 +1,285 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestWithMetrics(t *testing.T) {
+	m := fakemetrics.New()
+	ds := &fakeDataStore{}
+	w := WithMetrics(ds, m)
+
+	for _, tt := range []struct {
+		key    string
+		method interface{}
+	}{
+		{
+			key:    "datastore.bundle.append",
+			method: w.AppendBundle,
+		},
+		{
+			key:    "datastore.node.create",
+			method: w.CreateAttestedNode,
+		},
+		{
+			key:    "datastore.bundle.create",
+			method: w.CreateBundle,
+		},
+		{
+			key:    "datastore.join_token.create",
+			method: w.CreateJoinToken,
+		},
+		{
+			key:    "datastore.registration_entry.create",
+			method: w.CreateRegistrationEntry,
+		},
+		{
+			key:    "datastore.node.delete",
+			method: w.DeleteAttestedNode,
+		},
+		{
+			key:    "datastore.bundle.delete",
+			method: w.DeleteBundle,
+		},
+		{
+			key:    "datastore.join_token.delete",
+			method: w.DeleteJoinToken,
+		},
+		{
+			key:    "datastore.registration_entry.delete",
+			method: w.DeleteRegistrationEntry,
+		},
+		{
+			key:    "datastore.node.fetch",
+			method: w.FetchAttestedNode,
+		},
+		{
+			key:    "datastore.bundle.fetch",
+			method: w.FetchBundle,
+		},
+		{
+			key:    "datastore.join_token.fetch",
+			method: w.FetchJoinToken,
+		},
+		{
+			key:    "datastore.registration_entry.fetch",
+			method: w.FetchRegistrationEntry,
+		},
+		{
+			key:    "datastore.node.selectors.fetch",
+			method: w.GetNodeSelectors,
+		},
+		{
+			key:    "datastore.node.list",
+			method: w.ListAttestedNodes,
+		},
+		{
+			key:    "datastore.bundle.list",
+			method: w.ListBundles,
+		},
+		{
+			key:    "datastore.registration_entry.list",
+			method: w.ListRegistrationEntries,
+		},
+		{
+			key:    "datastore.bundle.prune",
+			method: w.PruneBundle,
+		},
+		{
+			key:    "datastore.join_token.prune",
+			method: w.PruneJoinTokens,
+		},
+		{
+			key:    "datastore.registration_entry.prune",
+			method: w.PruneRegistrationEntries,
+		},
+		{
+			key:    "datastore.bundle.set",
+			method: w.SetBundle,
+		},
+		{
+			key:    "datastore.node.selectors.set",
+			method: w.SetNodeSelectors,
+		},
+		{
+			key:    "datastore.node.update",
+			method: w.UpdateAttestedNode,
+		},
+		{
+			key:    "datastore.bundle.update",
+			method: w.UpdateBundle,
+		},
+		{
+			key:    "datastore.registration_entry.update",
+			method: w.UpdateRegistrationEntry,
+		},
+	} {
+		tt := tt
+		doCall := func(err error) interface{} {
+			m.Reset()
+			ds.SetError(err)
+			method := reflect.ValueOf(tt.method)
+			out := method.Call([]reflect.Value{
+				reflect.ValueOf(context.Background()),
+				reflect.New(method.Type().In(1)).Elem(),
+			})
+			require.Len(t, out, 2)
+			// Our fake always returns a response even on failure, which
+			// our metrics shim should not be concerned about.
+			require.NotNil(t, out[0].Interface(), "response should not be nil")
+			return out[1].Interface()
+		}
+
+		expectedMetrics := func(code codes.Code) []fakemetrics.MetricItem {
+			key := strings.Split(tt.key, ".")
+			return []fakemetrics.MetricItem{
+				{
+					Type: fakemetrics.IncrCounterWithLabelsType,
+					Key:  key,
+					Labels: []telemetry.Label{
+						{Name: "status", Value: code.String()},
+					},
+					Val: 1,
+				},
+				{
+					Type: fakemetrics.MeasureSinceWithLabelsType,
+					Key:  append(key, "elapsed_time"),
+					Labels: []telemetry.Label{
+						{Name: "status", Value: code.String()},
+					},
+				},
+			}
+		}
+
+		t.Run(tt.key+"(success)", func(t *testing.T) {
+			err := doCall(nil)
+			assert.Nil(t, err, "error should be nil")
+			assert.Equal(t, expectedMetrics(codes.OK), m.AllMetrics())
+		})
+
+		t.Run(tt.key+"(failure)", func(t *testing.T) {
+			err := doCall(errors.New("ohno"))
+			assert.NotNil(t, err, "error should be not nil")
+			assert.Equal(t, expectedMetrics(codes.Unknown), m.AllMetrics())
+		})
+	}
+}
+
+type fakeDataStore struct {
+	err error
+}
+
+func (ds *fakeDataStore) SetError(err error) {
+	ds.err = err
+}
+
+func (ds *fakeDataStore) AppendBundle(context.Context, *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
+	return &datastore.AppendBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) CreateAttestedNode(context.Context, *datastore.CreateAttestedNodeRequest) (*datastore.CreateAttestedNodeResponse, error) {
+	return &datastore.CreateAttestedNodeResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) CreateBundle(context.Context, *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {
+	return &datastore.CreateBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) CreateJoinToken(context.Context, *datastore.CreateJoinTokenRequest) (*datastore.CreateJoinTokenResponse, error) {
+	return &datastore.CreateJoinTokenResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) CreateRegistrationEntry(context.Context, *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
+	return &datastore.CreateRegistrationEntryResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) DeleteAttestedNode(context.Context, *datastore.DeleteAttestedNodeRequest) (*datastore.DeleteAttestedNodeResponse, error) {
+	return &datastore.DeleteAttestedNodeResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) DeleteBundle(context.Context, *datastore.DeleteBundleRequest) (*datastore.DeleteBundleResponse, error) {
+	return &datastore.DeleteBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) DeleteJoinToken(context.Context, *datastore.DeleteJoinTokenRequest) (*datastore.DeleteJoinTokenResponse, error) {
+	return &datastore.DeleteJoinTokenResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) DeleteRegistrationEntry(context.Context, *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
+	return &datastore.DeleteRegistrationEntryResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) FetchAttestedNode(context.Context, *datastore.FetchAttestedNodeRequest) (*datastore.FetchAttestedNodeResponse, error) {
+	return &datastore.FetchAttestedNodeResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) FetchBundle(context.Context, *datastore.FetchBundleRequest) (*datastore.FetchBundleResponse, error) {
+	return &datastore.FetchBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) FetchJoinToken(context.Context, *datastore.FetchJoinTokenRequest) (*datastore.FetchJoinTokenResponse, error) {
+	return &datastore.FetchJoinTokenResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) FetchRegistrationEntry(context.Context, *datastore.FetchRegistrationEntryRequest) (*datastore.FetchRegistrationEntryResponse, error) {
+	return &datastore.FetchRegistrationEntryResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) GetNodeSelectors(context.Context, *datastore.GetNodeSelectorsRequest) (*datastore.GetNodeSelectorsResponse, error) {
+	return &datastore.GetNodeSelectorsResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) ListAttestedNodes(context.Context, *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
+	return &datastore.ListAttestedNodesResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) ListBundles(context.Context, *datastore.ListBundlesRequest) (*datastore.ListBundlesResponse, error) {
+	return &datastore.ListBundlesResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) ListRegistrationEntries(context.Context, *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {
+	return &datastore.ListRegistrationEntriesResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) PruneBundle(context.Context, *datastore.PruneBundleRequest) (*datastore.PruneBundleResponse, error) {
+	return &datastore.PruneBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) PruneJoinTokens(context.Context, *datastore.PruneJoinTokensRequest) (*datastore.PruneJoinTokensResponse, error) {
+	return &datastore.PruneJoinTokensResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) PruneRegistrationEntries(context.Context, *datastore.PruneRegistrationEntriesRequest) (*datastore.PruneRegistrationEntriesResponse, error) {
+	return &datastore.PruneRegistrationEntriesResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) SetBundle(context.Context, *datastore.SetBundleRequest) (*datastore.SetBundleResponse, error) {
+	return &datastore.SetBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) SetNodeSelectors(context.Context, *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
+	return &datastore.SetNodeSelectorsResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) UpdateAttestedNode(context.Context, *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+	return &datastore.UpdateAttestedNodeResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) UpdateBundle(context.Context, *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
+	return &datastore.UpdateBundleResponse{}, ds.err
+}
+
+func (ds *fakeDataStore) UpdateRegistrationEntry(context.Context, *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
+	return &datastore.UpdateRegistrationEntryResponse{}, ds.err
+}

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	common_services "github.com/spiffe/spire/pkg/common/plugin/hostservices"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	datastore_telemetry "github.com/spiffe/spire/pkg/common/telemetry/server/datastore"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 	ds_sql "github.com/spiffe/spire/pkg/server/plugin/datastore/sql"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
@@ -171,6 +173,7 @@ type Config struct {
 	GlobalConfig GlobalConfig
 	PluginConfig HCLPluginConfigMap
 
+	Metrics          telemetry.Metrics
 	IdentityProvider hostservices.IdentityProvider
 	AgentStore       hostservices.AgentStore
 	MetricsService   common_services.MetricsService
@@ -232,6 +235,8 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	p.DataStore = datastore_telemetry.WithMetrics(p.DataStore, config.Metrics)
 
 	switch {
 	case p.UpstreamCA == nil:

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -21,11 +21,8 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
 	"github.com/spiffe/spire/pkg/common/idutil"
-	"github.com/spiffe/spire/pkg/common/plugin/hostservices"
 	"github.com/spiffe/spire/pkg/common/telemetry"
-	ds_telemetry "github.com/spiffe/spire/pkg/common/telemetry/server/datastore"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
@@ -107,11 +104,10 @@ func (db *sqlDB) QueryContext(ctx context.Context, query string, args ...interfa
 
 // Plugin is a DataStore plugin implemented via a SQL database
 type Plugin struct {
-	mu             sync.Mutex
-	db             *sqlDB
-	roDb           *sqlDB
-	log            hclog.Logger
-	metricsService hostservices.MetricsService
+	mu   sync.Mutex
+	db   *sqlDB
+	roDb *sqlDB
+	log  hclog.Logger
 }
 
 // New creates a new sql plugin struct. Configure must be called
@@ -124,22 +120,8 @@ func (ds *Plugin) SetLogger(logger hclog.Logger) {
 	ds.log = logger
 }
 
-func (ds *Plugin) BrokerHostServices(broker catalog.HostServiceBroker) error {
-	has, err := broker.GetHostService(hostservices.MetricsServiceHostServiceClient(&ds.metricsService))
-	if err != nil {
-		return err
-	}
-	if !has {
-		return errors.New("required Metrics host service is not available")
-	}
-	return nil
-}
-
 // CreateBundle stores the given bundle
 func (ds *Plugin) CreateBundle(ctx context.Context, req *datastore.CreateBundleRequest) (resp *datastore.CreateBundleResponse, err error) {
-	callCounter := ds_telemetry.StartCreateBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = createBundle(tx, req)
 		return err
@@ -152,9 +134,6 @@ func (ds *Plugin) CreateBundle(ctx context.Context, req *datastore.CreateBundleR
 // UpdateBundle updates an existing bundle with the given CAs. Overwrites any
 // existing certificates.
 func (ds *Plugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (resp *datastore.UpdateBundleResponse, err error) {
-	callCounter := ds_telemetry.StartUpdateBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteRepeatableReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = updateBundle(tx, req)
 		return err
@@ -166,9 +145,6 @@ func (ds *Plugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleR
 
 // SetBundle sets bundle contents. If no bundle exists for the trust domain, it is created.
 func (ds *Plugin) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (resp *datastore.SetBundleResponse, err error) {
-	callCounter := ds_telemetry.StartSetBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = setBundle(tx, req)
 		return err
@@ -180,9 +156,6 @@ func (ds *Plugin) SetBundle(ctx context.Context, req *datastore.SetBundleRequest
 
 // AppendBundle append bundle contents to the existing bundle (by trust domain). If no existing one is present, create it.
 func (ds *Plugin) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (resp *datastore.AppendBundleResponse, err error) {
-	callCounter := ds_telemetry.StartAppendBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteRepeatableReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = appendBundle(tx, req)
 		return err
@@ -194,9 +167,6 @@ func (ds *Plugin) AppendBundle(ctx context.Context, req *datastore.AppendBundleR
 
 // DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
 func (ds *Plugin) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleRequest) (resp *datastore.DeleteBundleResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = deleteBundle(tx, req)
 		return err
@@ -208,9 +178,6 @@ func (ds *Plugin) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleR
 
 // FetchBundle returns the bundle matching the specified Trust Domain.
 func (ds *Plugin) FetchBundle(ctx context.Context, req *datastore.FetchBundleRequest) (resp *datastore.FetchBundleResponse, err error) {
-	callCounter := ds_telemetry.StartFetchBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = fetchBundle(tx, req)
 		return err
@@ -222,9 +189,6 @@ func (ds *Plugin) FetchBundle(ctx context.Context, req *datastore.FetchBundleReq
 
 // ListBundles can be used to fetch all existing bundles.
 func (ds *Plugin) ListBundles(ctx context.Context, req *datastore.ListBundlesRequest) (resp *datastore.ListBundlesResponse, err error) {
-	callCounter := ds_telemetry.StartListBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listBundles(tx, req)
 		return err
@@ -236,9 +200,6 @@ func (ds *Plugin) ListBundles(ctx context.Context, req *datastore.ListBundlesReq
 
 // PruneBundle removes expired certs and keys from a bundle
 func (ds *Plugin) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (resp *datastore.PruneBundleResponse, err error) {
-	callCounter := ds_telemetry.StartPruneBundleCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteRepeatableReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = pruneBundle(tx, req, ds.log)
 		return err
@@ -252,9 +213,6 @@ func (ds *Plugin) PruneBundle(ctx context.Context, req *datastore.PruneBundleReq
 // CreateAttestedNode stores the given attested node
 func (ds *Plugin) CreateAttestedNode(ctx context.Context,
 	req *datastore.CreateAttestedNodeRequest) (resp *datastore.CreateAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartCreateNodeCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if req.Node == nil {
 		return nil, sqlError.New("invalid request: missing attested node")
 	}
@@ -271,9 +229,6 @@ func (ds *Plugin) CreateAttestedNode(ctx context.Context,
 // FetchAttestedNode fetches an existing attested node by SPIFFE ID
 func (ds *Plugin) FetchAttestedNode(ctx context.Context,
 	req *datastore.FetchAttestedNodeRequest) (resp *datastore.FetchAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartFetchNodeCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = fetchAttestedNode(tx, req)
 		return err
@@ -286,9 +241,6 @@ func (ds *Plugin) FetchAttestedNode(ctx context.Context,
 // ListAttestedNodes lists all attested nodes (pagination available)
 func (ds *Plugin) ListAttestedNodes(ctx context.Context,
 	req *datastore.ListAttestedNodesRequest) (resp *datastore.ListAttestedNodesResponse, err error) {
-	callCounter := ds_telemetry.StartListNodeCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listAttestedNodes(tx, req)
 		return err
@@ -301,9 +253,6 @@ func (ds *Plugin) ListAttestedNodes(ctx context.Context,
 // UpdateAttestedNode updates the given node's cert serial and expiration.
 func (ds *Plugin) UpdateAttestedNode(ctx context.Context,
 	req *datastore.UpdateAttestedNodeRequest) (resp *datastore.UpdateAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartUpdateNodeCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = updateAttestedNode(tx, req)
 		return err
@@ -316,9 +265,6 @@ func (ds *Plugin) UpdateAttestedNode(ctx context.Context,
 // DeleteAttestedNode deletes the given attested node
 func (ds *Plugin) DeleteAttestedNode(ctx context.Context,
 	req *datastore.DeleteAttestedNodeRequest) (resp *datastore.DeleteAttestedNodeResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteNodeCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = deleteAttestedNode(tx, req)
 		return err
@@ -330,9 +276,6 @@ func (ds *Plugin) DeleteAttestedNode(ctx context.Context,
 
 // SetNodeSelectors sets node (agent) selectors by SPIFFE ID, deleting old selectors first
 func (ds *Plugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (resp *datastore.SetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartSetNodeSelectorsCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if req.Selectors == nil {
 		return nil, errors.New("invalid request: missing selectors")
 	}
@@ -349,9 +292,6 @@ func (ds *Plugin) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSe
 // GetNodeSelectors gets node (agent) selectors by SPIFFE ID
 func (ds *Plugin) GetNodeSelectors(ctx context.Context,
 	req *datastore.GetNodeSelectorsRequest) (resp *datastore.GetNodeSelectorsResponse, err error) {
-	callCounter := ds_telemetry.StartGetNodeSelectorsCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if req.TolerateStale && ds.roDb != nil {
 		return getNodeSelectors(ctx, ds.roDb, req)
 	}
@@ -361,9 +301,6 @@ func (ds *Plugin) GetNodeSelectors(ctx context.Context,
 // CreateRegistrationEntry stores the given registration entry
 func (ds *Plugin) CreateRegistrationEntry(ctx context.Context,
 	req *datastore.CreateRegistrationEntryRequest) (resp *datastore.CreateRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartCreateRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	// TODO: Validations should be done in the ProtoBuf level [https://github.com/spiffe/spire/issues/44]
 	if err = validateRegistrationEntry(req.Entry); err != nil {
 		return nil, err
@@ -381,18 +318,12 @@ func (ds *Plugin) CreateRegistrationEntry(ctx context.Context,
 // FetchRegistrationEntry fetches an existing registration by entry ID
 func (ds *Plugin) FetchRegistrationEntry(ctx context.Context,
 	req *datastore.FetchRegistrationEntryRequest) (resp *datastore.FetchRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartFetchRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	return fetchRegistrationEntry(ctx, ds.db, req)
 }
 
 // ListRegistrationEntries lists all registrations (pagination available)
 func (ds *Plugin) ListRegistrationEntries(ctx context.Context,
 	req *datastore.ListRegistrationEntriesRequest) (resp *datastore.ListRegistrationEntriesResponse, err error) {
-	callCounter := ds_telemetry.StartListRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if req.TolerateStale && ds.roDb != nil {
 		return listRegistrationEntries(ctx, ds.roDb, req)
 	}
@@ -402,9 +333,6 @@ func (ds *Plugin) ListRegistrationEntries(ctx context.Context,
 // UpdateRegistrationEntry updates an existing registration entry
 func (ds *Plugin) UpdateRegistrationEntry(ctx context.Context,
 	req *datastore.UpdateRegistrationEntryRequest) (resp *datastore.UpdateRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartUpdateRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = validateRegistrationEntry(req.Entry); err != nil {
 		return nil, err
 	}
@@ -421,9 +349,6 @@ func (ds *Plugin) UpdateRegistrationEntry(ctx context.Context,
 // DeleteRegistrationEntry deletes the given registration
 func (ds *Plugin) DeleteRegistrationEntry(ctx context.Context,
 	req *datastore.DeleteRegistrationEntryRequest) (resp *datastore.DeleteRegistrationEntryResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = deleteRegistrationEntry(tx, req)
 		return err
@@ -436,9 +361,6 @@ func (ds *Plugin) DeleteRegistrationEntry(ctx context.Context,
 // PruneRegistrationEntries takes a registration entry message, and deletes all entries which have expired
 // before the date in the message
 func (ds *Plugin) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (resp *datastore.PruneRegistrationEntriesResponse, err error) {
-	callCounter := ds_telemetry.StartPruneRegistrationCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = pruneRegistrationEntries(tx, req)
 		return err
@@ -450,9 +372,6 @@ func (ds *Plugin) PruneRegistrationEntries(ctx context.Context, req *datastore.P
 
 // CreateJoinToken takes a Token message and stores it
 func (ds *Plugin) CreateJoinToken(ctx context.Context, req *datastore.CreateJoinTokenRequest) (resp *datastore.CreateJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartCreateJoinTokenCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if req.JoinToken == nil || req.JoinToken.Token == "" || req.JoinToken.Expiry == 0 {
 		return nil, errors.New("token and expiry are required")
 	}
@@ -469,9 +388,6 @@ func (ds *Plugin) CreateJoinToken(ctx context.Context, req *datastore.CreateJoin
 // FetchJoinToken takes a Token message and returns one, populating the fields
 // we have knowledge of
 func (ds *Plugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTokenRequest) (resp *datastore.FetchJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartFetchJoinTokenCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = fetchJoinToken(tx, req)
 		return err
@@ -484,9 +400,6 @@ func (ds *Plugin) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTo
 
 // DeleteJoinToken deletes the given join token
 func (ds *Plugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (resp *datastore.DeleteJoinTokenResponse, err error) {
-	callCounter := ds_telemetry.StartDeleteJoinTokenCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = deleteJoinToken(tx, req)
 		return err
@@ -499,9 +412,6 @@ func (ds *Plugin) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoin
 // PruneJoinTokens takes a Token message, and deletes all tokens which have expired
 // before the date in the message
 func (ds *Plugin) PruneJoinTokens(ctx context.Context, req *datastore.PruneJoinTokensRequest) (resp *datastore.PruneJoinTokensResponse, err error) {
-	callCounter := ds_telemetry.StartPruneJoinTokenCall(ds.prepareMetricsForCall())
-	defer callCounter.Done(&err)
-
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = pruneJoinTokens(tx, req)
 		return err
@@ -696,10 +606,6 @@ func (ds *Plugin) openDB(cfg *configuration, isReadOnly bool) (*gorm.DB, string,
 	}
 
 	return db, version, supportsCTE, nil
-}
-
-func (ds *Plugin) prepareMetricsForCall() telemetry.Metrics {
-	return metricsservice.WrapPluginMetrics(ds.metricsService, ds.log)
 }
 
 func createBundle(tx *gorm.DB, req *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -16,22 +15,16 @@ import (
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
-	"github.com/spiffe/spire/pkg/common/hostservices/metricsservice"
-	proto_services "github.com/spiffe/spire/pkg/common/plugin/hostservices"
-	ds_telemetry "github.com/spiffe/spire/pkg/common/telemetry/server/datastore"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/clock"
-	"github.com/spiffe/spire/test/fakes/fakemetrics"
-	"github.com/spiffe/spire/test/fakes/fakepluginmetrics"
 	"github.com/spiffe/spire/test/spiretest"
 	testutil "github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -66,9 +59,6 @@ type PluginSuite struct {
 	nextID    int
 	ds        datastore.Plugin
 	sqlPlugin *Plugin
-
-	m               *fakemetrics.FakeMetrics
-	expectedMetrics *fakepluginmetrics.FakePluginMetrics
 }
 
 type ListRegistrationReq struct {
@@ -124,16 +114,7 @@ func (s *PluginSuite) newPlugin() datastore.Plugin {
 	s.sqlPlugin = p
 
 	var ds datastore.Plugin
-
-	s.expectedMetrics = fakepluginmetrics.New()
-
-	s.m = fakemetrics.New()
-	metricsService := metricsservice.New(metricsservice.Config{
-		Metrics: s.m,
-	})
-
-	s.LoadPlugin(builtin(p), &ds,
-		spiretest.HostService(proto_services.MetricsServiceHostServiceServer(metricsService)))
+	s.LoadPlugin(builtin(p), &ds)
 
 	// When the test suite is executed normally, we test against sqlite3 since
 	// it requires no external dependencies. The integration test framework
@@ -236,53 +217,37 @@ func (s *PluginSuite) TestBundleCRUD() {
 	bundle := bundleutil.BundleProtoFromRootCA("spiffe://foo", s.cert)
 
 	// fetch non-existent
-	expectedCallCounter := ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{TrustDomainId: "spiffe://foo"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(fresp)
 	s.Require().Nil(fresp.Bundle)
 
 	// update non-existent
-	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	_, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{Bundle: bundle})
-	expectedErr := status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedErr)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
 	// delete non-existent
-	expectedCallCounter = ds_telemetry.StartDeleteBundleCall(s.expectedMetrics)
 	_, err = s.ds.DeleteBundle(ctx, &datastore.DeleteBundleRequest{TrustDomainId: "spiffe://foo"})
-	expectedErr = status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedErr)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
 	// create
-	expectedCallCounter = ds_telemetry.StartCreateBundleCall(s.expectedMetrics)
 	_, err = s.ds.CreateBundle(ctx, &datastore.CreateBundleRequest{
 		Bundle: bundle,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	// fetch
-	expectedCallCounter = ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	fresp, err = s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{TrustDomainId: "spiffe://foo"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle, fresp.Bundle)
 
 	// fetch (with denormalized id)
-	expectedCallCounter = ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	fresp, err = s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{TrustDomainId: "spiffe://fOO"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle, fresp.Bundle)
 
 	// list
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err := s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Equal(1, len(lresp.Bundles))
 	s.AssertProtoEqual(bundle, lresp.Bundles[0])
@@ -292,138 +257,106 @@ func (s *PluginSuite) TestBundleCRUD() {
 		[]*x509.Certificate{s.cert, s.cacert})
 
 	// append
-	expectedCallCounter = ds_telemetry.StartAppendBundleCall(s.expectedMetrics)
 	aresp, err := s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
 		Bundle: bundle2,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(aresp.Bundle)
 	s.AssertProtoEqual(appendedBundle, aresp.Bundle)
 
 	// append identical
-	expectedCallCounter = ds_telemetry.StartAppendBundleCall(s.expectedMetrics)
 	aresp, err = s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
 		Bundle: bundle2,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(aresp.Bundle)
 	s.AssertProtoEqual(appendedBundle, aresp.Bundle)
 
 	// append on a new bundle
 	bundle3 := bundleutil.BundleProtoFromRootCA("spiffe://bar", s.cacert)
-	expectedCallCounter = ds_telemetry.StartAppendBundleCall(s.expectedMetrics)
 	anresp, err := s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
 		Bundle: bundle3,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle3, anresp.Bundle)
 
 	// update with mask: RootCas
-	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	uresp, err := s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
 		Bundle: bundle,
 		InputMask: &common.BundleMask{
 			RootCas: true,
 		},
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle, uresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	assertBundlesEqual(s.T(), []*common.Bundle{bundle, bundle3}, lresp.Bundles)
 
 	// update with mask: RefreshHint
 	bundle.RefreshHint = 60
-	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
 		Bundle: bundle,
 		InputMask: &common.BundleMask{
 			RefreshHint: true,
 		},
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle, uresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	assertBundlesEqual(s.T(), []*common.Bundle{bundle, bundle3}, lresp.Bundles)
 
 	// update with mask: JwtSingingKeys
 	bundle.JwtSigningKeys = []*common.PublicKey{{Kid: "jwt-key-1"}}
-	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
 		Bundle: bundle,
 		InputMask: &common.BundleMask{
 			JwtSigningKeys: true,
 		},
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle, uresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	assertBundlesEqual(s.T(), []*common.Bundle{bundle, bundle3}, lresp.Bundles)
 
 	// update without mask
-	expectedCallCounter = ds_telemetry.StartUpdateBundleCall(s.expectedMetrics)
 	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
 		Bundle: bundle2,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle2, uresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	assertBundlesEqual(s.T(), []*common.Bundle{bundle2, bundle3}, lresp.Bundles)
 
 	// delete
-	expectedCallCounter = ds_telemetry.StartDeleteBundleCall(s.expectedMetrics)
 	dresp, err := s.ds.DeleteBundle(ctx, &datastore.DeleteBundleRequest{
 		TrustDomainId: bundle.TrustDomainId,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle2, dresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Equal(1, len(lresp.Bundles))
 	s.AssertProtoEqual(bundle3, lresp.Bundles[0])
 
 	// delete (with denormalized id)
-	expectedCallCounter = ds_telemetry.StartDeleteBundleCall(s.expectedMetrics)
 	dresp, err = s.ds.DeleteBundle(ctx, &datastore.DeleteBundleRequest{
 		TrustDomainId: "spiffe://bAR",
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(bundle3, dresp.Bundle)
 
-	expectedCallCounter = ds_telemetry.StartListBundleCall(s.expectedMetrics)
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Empty(lresp.Bundles)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestListBundlesWithPagination() {
@@ -561,24 +494,18 @@ func (s *PluginSuite) TestSetBundle() {
 	s.Require().Nil(s.fetchBundle("spiffe://foo"))
 
 	// set the bundle and make sure it is created
-	expectedCallCounter := ds_telemetry.StartSetBundleCall(s.expectedMetrics)
 	_, err := s.ds.SetBundle(ctx, &datastore.SetBundleRequest{
 		Bundle: bundle,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(bundle, s.fetchBundle("spiffe://foo"))
 
 	// set the bundle and make sure it is updated
-	expectedCallCounter = ds_telemetry.StartSetBundleCall(s.expectedMetrics)
 	_, err = s.ds.SetBundle(ctx, &datastore.SetBundleRequest{
 		Bundle: bundle2,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(bundle2, s.fetchBundle("spiffe://foo"))
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestBundlePrune() {
@@ -603,42 +530,33 @@ func (s *PluginSuite) TestBundlePrune() {
 	}
 
 	// Store bundle in datastore
-	expectedCallCounter := ds_telemetry.StartCreateBundleCall(s.expectedMetrics)
 	_, err = s.ds.CreateBundle(ctx, &datastore.CreateBundleRequest{Bundle: bundle})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	// Prune
 	// prune non existent bundle should not return error, no bundle to prune
 	expiration := time.Now().Unix()
-	expectedCallCounter = ds_telemetry.StartPruneBundleCall(s.expectedMetrics)
 	presp, err := s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
 		TrustDomainId: "spiffe://notexistent",
 		ExpiresBefore: expiration,
 	})
-	expectedCallCounter.Done(nil)
 	s.NoError(err)
 	s.AssertProtoEqual(presp, &datastore.PruneBundleResponse{})
 
 	// prune fails if internal prune bundle fails. For instance, if all certs are expired
 	expiration = time.Now().Unix()
-	expectedCallCounter = ds_telemetry.StartPruneBundleCall(s.expectedMetrics)
 	presp, err = s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
 		TrustDomainId: bundle.TrustDomainId,
 		ExpiresBefore: expiration,
 	})
-	expectedError := errors.New("prune failed: would prune all certificates")
-	expectedCallCounter.Done(&expectedError)
-	s.Error(err, expectedError.Error())
+	s.AssertGRPCStatus(err, codes.Unknown, "prune failed: would prune all certificates")
 	s.Nil(presp)
 
 	// prune should remove expired certs
-	expectedCallCounter = ds_telemetry.StartPruneBundleCall(s.expectedMetrics)
 	presp, err = s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
 		TrustDomainId: bundle.TrustDomainId,
 		ExpiresBefore: middleTime.Unix(),
 	})
-	expectedCallCounter.Done(nil)
 	s.NoError(err)
 	s.NotNil(presp)
 	s.True(presp.BundleChanged)
@@ -646,13 +564,9 @@ func (s *PluginSuite) TestBundlePrune() {
 	// Fetch and verify pruned bundle is the expected
 	expectedPrunedBundle := bundleutil.BundleProtoFromRootCAs("spiffe://foo", []*x509.Certificate{s.cert})
 	expectedPrunedBundle.JwtSigningKeys = []*common.PublicKey{{NotAfter: nonExpiredKeyTime.Unix()}}
-	expectedCallCounter = ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{TrustDomainId: "spiffe://foo"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(expectedPrunedBundle, fresp.Bundle)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestCreateAttestedNode() {
@@ -663,40 +577,28 @@ func (s *PluginSuite) TestCreateAttestedNode() {
 		CertNotAfter:        time.Now().Add(time.Hour).Unix(),
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateNodeCall(s.expectedMetrics)
 	cresp, err := s.ds.CreateAttestedNode(ctx, &datastore.CreateAttestedNodeRequest{Node: node})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(node, cresp.Node)
 
-	expectedCallCounter = ds_telemetry.StartFetchNodeCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{SpiffeId: node.SpiffeId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(node, fresp.Node)
 
 	expiration := time.Now().Unix()
-	expectedCallCounter = ds_telemetry.StartListNodeCall(s.expectedMetrics)
 	sresp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{
 		ByExpiresBefore: &wrappers.Int64Value{
 			Value: expiration,
 		},
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Empty(sresp.Nodes)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestFetchAttestedNodeMissing() {
-	expectedCallCounter := ds_telemetry.StartFetchNodeCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{SpiffeId: "missing"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Nil(fresp.Node)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestFetchStaleNodes() {
@@ -714,28 +616,20 @@ func (s *PluginSuite) TestFetchStaleNodes() {
 		CertNotAfter:        time.Now().Add(-time.Hour).Unix(),
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateNodeCall(s.expectedMetrics)
 	_, err := s.ds.CreateAttestedNode(ctx, &datastore.CreateAttestedNodeRequest{Node: efuture})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartCreateNodeCall(s.expectedMetrics)
 	_, err = s.ds.CreateAttestedNode(ctx, &datastore.CreateAttestedNodeRequest{Node: epast})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	expiration := time.Now().Unix()
-	expectedCallCounter = ds_telemetry.StartListNodeCall(s.expectedMetrics)
 	sresp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{
 		ByExpiresBefore: &wrappers.Int64Value{
 			Value: expiration,
 		},
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.RequireProtoListEqual([]*common.AttestedNode{epast}, sresp.Nodes)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestFetchAttestedNodesWithPagination() {
@@ -932,28 +826,21 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 	uexpires := time.Now().Add(time.Hour * 2).Unix()
 
 	// update non-existing attested node
-	expectedCallCounter := ds_telemetry.StartUpdateNodeCall(s.expectedMetrics)
 	_, err := s.ds.UpdateAttestedNode(ctx, &datastore.UpdateAttestedNodeRequest{
 		SpiffeId:         node.SpiffeId,
 		CertSerialNumber: userial,
 		CertNotAfter:     uexpires,
 	})
-	expectedError := status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedError)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
-	expectedCallCounter = ds_telemetry.StartCreateNodeCall(s.expectedMetrics)
 	_, err = s.ds.CreateAttestedNode(ctx, &datastore.CreateAttestedNodeRequest{Node: node})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartUpdateNodeCall(s.expectedMetrics)
 	uresp, err := s.ds.UpdateAttestedNode(ctx, &datastore.UpdateAttestedNodeRequest{
 		SpiffeId:         node.SpiffeId,
 		CertSerialNumber: userial,
 		CertNotAfter:     uexpires,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	unode := uresp.Node
@@ -964,9 +851,7 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 	s.Equal(userial, unode.CertSerialNumber)
 	s.Equal(uexpires, unode.CertNotAfter)
 
-	expectedCallCounter = ds_telemetry.StartFetchNodeCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{SpiffeId: node.SpiffeId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	fnode := fresp.Node
@@ -976,8 +861,6 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 	s.Equal(node.AttestationDataType, fnode.AttestationDataType)
 	s.Equal(userial, fnode.CertSerialNumber)
 	s.Equal(uexpires, fnode.CertNotAfter)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestDeleteAttestedNode() {
@@ -989,30 +872,19 @@ func (s *PluginSuite) TestDeleteAttestedNode() {
 	}
 
 	// delete it before it exists
-	expectedCallCounter := ds_telemetry.StartDeleteNodeCall(s.expectedMetrics)
 	_, err := s.ds.DeleteAttestedNode(ctx, &datastore.DeleteAttestedNodeRequest{SpiffeId: entry.SpiffeId})
-	expectedError := status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedError)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
-	expectedCallCounter = ds_telemetry.StartCreateNodeCall(s.expectedMetrics)
 	_, err = s.ds.CreateAttestedNode(ctx, &datastore.CreateAttestedNodeRequest{Node: entry})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartDeleteNodeCall(s.expectedMetrics)
 	dresp, err := s.ds.DeleteAttestedNode(ctx, &datastore.DeleteAttestedNodeRequest{SpiffeId: entry.SpiffeId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(entry, dresp.Node)
 
-	expectedCallCounter = ds_telemetry.StartFetchNodeCall(s.expectedMetrics)
 	fresp, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{SpiffeId: entry.SpiffeId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Nil(fresp.Node)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestNodeSelectors() {
@@ -1062,8 +934,6 @@ func (s *PluginSuite) TestNodeSelectors() {
 	// get bar selectors (make sure they weren't impacted by deleting foo)
 	selectors = s.getNodeSelectors("bar", false)
 	s.RequireProtoListEqual(bar, selectors)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestSetNodeSelectorsUnderLoad() {
@@ -1104,9 +974,7 @@ func (s *PluginSuite) TestCreateRegistrationEntry() {
 	s.getTestDataFromJSONFile(filepath.Join("testdata", "valid_registration_entries.json"), &validRegistrationEntries)
 
 	for _, validRegistrationEntry := range validRegistrationEntries {
-		expectedCallCounter := ds_telemetry.StartCreateRegistrationCall(s.expectedMetrics)
 		resp, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{Entry: validRegistrationEntry})
-		expectedCallCounter.Done(nil)
 		s.Require().NoError(err)
 		s.NotNil(resp)
 		s.Require().NotNil(resp.Entry)
@@ -1114,8 +982,6 @@ func (s *PluginSuite) TestCreateRegistrationEntry() {
 		resp.Entry.EntryId = ""
 		s.RequireProtoEqual(resp.Entry, validRegistrationEntry)
 	}
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestCreateInvalidRegistrationEntry() {
@@ -1123,14 +989,10 @@ func (s *PluginSuite) TestCreateInvalidRegistrationEntry() {
 	s.getTestDataFromJSONFile(filepath.Join("testdata", "invalid_registration_entries.json"), &invalidRegistrationEntries)
 
 	for _, invalidRegistrationEntry := range invalidRegistrationEntries {
-		expectedCallCounter := ds_telemetry.StartCreateRegistrationCall(s.expectedMetrics)
 		createRegistrationEntryResponse, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{Entry: invalidRegistrationEntry})
-		expectedCallCounter.Done(&err)
 		s.Require().Error(err)
 		s.Require().Nil(createRegistrationEntryResponse)
 	}
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 
 	// TODO: Check that no entries have been created
 }
@@ -1151,21 +1013,15 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 		},
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateRegistrationCall(s.expectedMetrics)
 	createRegistrationEntryResponse, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{Entry: registeredEntry})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(createRegistrationEntryResponse)
 	createdEntry := createRegistrationEntryResponse.Entry
 
-	expectedCallCounter = ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err := s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: createdEntry.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(fetchRegistrationEntryResponse)
 	s.RequireProtoEqual(createdEntry, fetchRegistrationEntryResponse.Entry)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestPruneRegistrationEntries() {
@@ -1182,68 +1038,48 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 		EntryExpiry: now,
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateRegistrationCall(s.expectedMetrics)
 	createRegistrationEntryResponse, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{Entry: registeredEntry})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(createRegistrationEntryResponse)
 	createdEntry := createRegistrationEntryResponse.Entry
 
 	// Ensure we don't prune valid entries, wind clock back 10s
-	expectedCallCounter = ds_telemetry.StartPruneRegistrationCall(s.expectedMetrics)
 	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
 		ExpiresBefore: now - 10,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err := s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: createdEntry.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(fetchRegistrationEntryResponse)
 	s.Equal(createdEntry, fetchRegistrationEntryResponse.Entry)
 
 	// Ensure we don't prune on the exact ExpiresBefore
-	expectedCallCounter = ds_telemetry.StartPruneRegistrationCall(s.expectedMetrics)
 	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
 		ExpiresBefore: now,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err = s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: createdEntry.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(fetchRegistrationEntryResponse)
 	s.Equal(createdEntry, fetchRegistrationEntryResponse.Entry)
 
 	// Ensure we prune old entries
-	expectedCallCounter = ds_telemetry.StartPruneRegistrationCall(s.expectedMetrics)
 	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
 		ExpiresBefore: now + 10,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err = s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: createdEntry.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Nil(fetchRegistrationEntryResponse.Entry)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestFetchInexistentRegistrationEntry() {
-	expectedCallCounter := ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err := s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: "INEXISTENT"})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Nil(fetchRegistrationEntryResponse.Entry)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestListRegistrationEntries() {
@@ -1271,9 +1107,7 @@ func (s *PluginSuite) TestListRegistrationEntries() {
 		Downstream: true,
 	})
 
-	expectedCallCounter := ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
 	resp, err := s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 
@@ -1283,8 +1117,6 @@ func (s *PluginSuite) TestListRegistrationEntries() {
 	util.SortRegistrationEntries(expectedResponse.Entries)
 	util.SortRegistrationEntries(resp.Entries)
 	s.Equal(expectedResponse, resp)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestListRegistrationEntriesWithPagination() {
@@ -1595,40 +1427,28 @@ func (s *PluginSuite) TestUpdateRegistrationEntry() {
 	entry.Admin = true
 	entry.Downstream = true
 
-	expectedCallCounter := ds_telemetry.StartUpdateRegistrationCall(s.expectedMetrics)
 	updateRegistrationEntryResponse, err := s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
 		Entry: entry,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(updateRegistrationEntryResponse)
 
-	expectedCallCounter = ds_telemetry.StartFetchRegistrationCall(s.expectedMetrics)
 	fetchRegistrationEntryResponse, err := s.ds.FetchRegistrationEntry(ctx, &datastore.FetchRegistrationEntryRequest{EntryId: entry.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(fetchRegistrationEntryResponse)
 	s.Require().NotNil(fetchRegistrationEntryResponse.Entry)
 	s.RequireProtoEqual(entry, fetchRegistrationEntryResponse.Entry)
 
 	entry.EntryId = "badid"
-	expectedCallCounter = ds_telemetry.StartUpdateRegistrationCall(s.expectedMetrics)
 	_, err = s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
 		Entry: entry,
 	})
-	expectedError := status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedError)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestDeleteRegistrationEntry() {
 	// delete non-existing
-	expectedCallCounter := ds_telemetry.StartDeleteRegistrationCall(s.expectedMetrics)
 	_, err := s.ds.DeleteRegistrationEntry(ctx, &datastore.DeleteRegistrationEntryRequest{EntryId: "badid"})
-	expectedError := status.Error(codes.NotFound, _notFoundErrMsg)
-	expectedCallCounter.Done(&expectedError)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
 	entry1 := s.createRegistrationEntry(&common.RegistrationEntry{
@@ -1654,32 +1474,22 @@ func (s *PluginSuite) TestDeleteRegistrationEntry() {
 	})
 
 	// We have two registration entries
-	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
 	entriesResp, err := s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Len(entriesResp.Entries, 2)
 
 	// Make sure we deleted the right one
-	expectedCallCounter = ds_telemetry.StartDeleteRegistrationCall(s.expectedMetrics)
 	delRes, err := s.ds.DeleteRegistrationEntry(ctx, &datastore.DeleteRegistrationEntryRequest{EntryId: entry1.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Equal(entry1, delRes.Entry)
 
 	// Make sure we have now only one registration entry
-	expectedCallCounter = ds_telemetry.StartListRegistrationCall(s.expectedMetrics)
 	entriesResp, err = s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().Len(entriesResp.Entries, 1)
 
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
-
 	// Delete again must fails with Not Found
-	expectedCallCounter = ds_telemetry.StartDeleteRegistrationCall(s.expectedMetrics)
 	delRes, err = s.ds.DeleteRegistrationEntry(ctx, &datastore.DeleteRegistrationEntryRequest{EntryId: entry1.EntryId})
-	expectedCallCounter.Done(nil)
 	s.Require().EqualError(err, "rpc error: code = NotFound desc = datastore-sql: record not found")
 	s.Require().Nil(delRes)
 }
@@ -1925,18 +1735,12 @@ func (s *PluginSuite) TestCreateJoinToken() {
 			Expiry: now,
 		},
 	}
-	expectedCallCounter := ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err := s.ds.CreateJoinToken(ctx, req)
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	// Make sure we can't re-register
-	expectedCallCounter = ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.CreateJoinToken(ctx, req)
-	expectedCallCounter.Done(&err)
 	s.NotNil(err)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestCreateAndFetchJoinToken() {
@@ -1946,23 +1750,17 @@ func (s *PluginSuite) TestCreateAndFetchJoinToken() {
 		Expiry: now,
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err := s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
 		JoinToken: joinToken,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	res, err := s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Equal("foobar", res.JoinToken.Token)
 	s.Equal(now, res.JoinToken.Expiry)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestDeleteJoinToken() {
@@ -1972,11 +1770,9 @@ func (s *PluginSuite) TestDeleteJoinToken() {
 		Expiry: now,
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err := s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
 		JoinToken: joinToken1,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	joinToken2 := &datastore.JoinToken{
@@ -1984,39 +1780,29 @@ func (s *PluginSuite) TestDeleteJoinToken() {
 		Expiry: now,
 	}
 
-	expectedCallCounter = ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
 		JoinToken: joinToken2,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartDeleteJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.DeleteJoinToken(ctx, &datastore.DeleteJoinTokenRequest{
 		Token: joinToken1.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	// Should not be able to fetch after delete
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	resp, err := s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken1.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Nil(resp.JoinToken)
 
 	// Second token should still be present
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	resp, err = s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken2.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(joinToken2, resp.JoinToken)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestPruneJoinTokens() {
@@ -2026,63 +1812,47 @@ func (s *PluginSuite) TestPruneJoinTokens() {
 		Expiry: now,
 	}
 
-	expectedCallCounter := ds_telemetry.StartCreateJoinTokenCall(s.expectedMetrics)
 	_, err := s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
 		JoinToken: joinToken,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
 	// Ensure we don't prune valid tokens, wind clock back 10s
-	expectedCallCounter = ds_telemetry.StartPruneJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.PruneJoinTokens(ctx, &datastore.PruneJoinTokensRequest{
 		ExpiresBefore: now - 10,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	resp, err := s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Equal("foobar", resp.JoinToken.Token)
 
 	// Ensure we don't prune on the exact ExpiresBefore
-	expectedCallCounter = ds_telemetry.StartPruneJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.PruneJoinTokens(ctx, &datastore.PruneJoinTokensRequest{
 		ExpiresBefore: now,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	resp, err = s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Equal("foobar", resp.JoinToken.Token)
 
 	// Ensure we prune old tokens
 	joinToken.Expiry = (now + 10)
-	expectedCallCounter = ds_telemetry.StartPruneJoinTokenCall(s.expectedMetrics)
 	_, err = s.ds.PruneJoinTokens(ctx, &datastore.PruneJoinTokensRequest{
 		ExpiresBefore: now + 10,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 
-	expectedCallCounter = ds_telemetry.StartFetchJoinTokenCall(s.expectedMetrics)
 	resp, err = s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
 		Token: joinToken.Token,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Nil(resp.JoinToken)
-
-	s.Require().Equal(s.expectedMetrics.AllMetrics(), s.m.AllMetrics())
 }
 
 func (s *PluginSuite) TestGetPluginInfo() {
@@ -2359,30 +2129,24 @@ func (s *PluginSuite) getTestDataFromJSONFile(filePath string, jsonValue interfa
 }
 
 func (s *PluginSuite) fetchBundle(trustDomainID string) *common.Bundle {
-	expectedCallCounter := ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	resp, err := s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{
 		TrustDomainId: trustDomainID,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	return resp.Bundle
 }
 
 func (s *PluginSuite) createBundle(trustDomainID string) {
-	expectedCallCounter := ds_telemetry.StartFetchBundleCall(s.expectedMetrics)
 	_, err := s.ds.CreateBundle(ctx, &datastore.CreateBundleRequest{
 		Bundle: bundleutil.BundleProtoFromRootCA(trustDomainID, s.cert),
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 }
 
 func (s *PluginSuite) createRegistrationEntry(entry *common.RegistrationEntry) *common.RegistrationEntry {
-	expectedCallCounter := ds_telemetry.StartCreateRegistrationCall(s.expectedMetrics)
 	resp, err := s.ds.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{
 		Entry: entry,
 	})
-	expectedCallCounter.Done(nil)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().NotNil(resp.Entry)
@@ -2410,8 +2174,6 @@ func makeFederatedRegistrationEntry() *common.RegistrationEntry {
 }
 
 func (s *PluginSuite) getNodeSelectors(spiffeID string, tolerateStale bool) []*common.Selector {
-	callCounter := ds_telemetry.StartGetNodeSelectorsCall(s.expectedMetrics)
-	defer callCounter.Done(nil)
 	resp, err := s.ds.GetNodeSelectors(ctx, &datastore.GetNodeSelectorsRequest{
 		SpiffeId:      spiffeID,
 		TolerateStale: tolerateStale,
@@ -2424,14 +2186,12 @@ func (s *PluginSuite) getNodeSelectors(spiffeID string, tolerateStale bool) []*c
 }
 
 func (s *PluginSuite) setNodeSelectors(spiffeID string, selectors []*common.Selector) {
-	callCounter := ds_telemetry.StartSetNodeSelectorsCall(s.expectedMetrics)
 	resp, err := s.ds.SetNodeSelectors(ctx, &datastore.SetNodeSelectorsRequest{
 		Selectors: &datastore.NodeSelectors{
 			SpiffeId:  spiffeID,
 			Selectors: selectors,
 		},
 	})
-	callCounter.Done(nil)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(&datastore.SetNodeSelectorsResponse{}, resp)
 }
@@ -2475,12 +2235,8 @@ func (s *PluginSuite) TestConfigure() {
 		s.T().Run(tt.desc, func(t *testing.T) {
 			p := New()
 
-			metricsService := metricsservice.New(metricsservice.Config{
-				Metrics: s.m,
-			})
 			var ds datastore.Plugin
-			pluginDone := spiretest.LoadPlugin(t, builtin(p), &ds,
-				spiretest.HostService(proto_services.MetricsServiceHostServiceServer(metricsService)))
+			pluginDone := spiretest.LoadPlugin(t, builtin(p), &ds)
 			defer pluginDone()
 
 			dbPath := filepath.Join(s.dir, "test-datastore-configure.sqlite3")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,7 +96,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 	// until the call to SetDeps() below.
 	agentStore := agentstore.New()
 
-	cat, err := s.loadCatalog(ctx, identityProvider, agentStore, metricsService)
+	cat, err := s.loadCatalog(ctx, metrics, identityProvider, agentStore, metricsService)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (s *Server) setupProfiling(ctx context.Context) (stop func()) {
 	}
 }
 
-func (s *Server) loadCatalog(ctx context.Context, identityProvider hostservices.IdentityProvider, agentStore hostservices.AgentStore,
+func (s *Server) loadCatalog(ctx context.Context, metrics telemetry.Metrics, identityProvider hostservices.IdentityProvider, agentStore hostservices.AgentStore,
 	metricsService common_services.MetricsService) (*catalog.Repository, error) {
 	return catalog.Load(ctx, catalog.Config{
 		Log: s.config.Log.WithField(telemetry.SubsystemName, telemetry.Catalog),
@@ -236,6 +236,7 @@ func (s *Server) loadCatalog(ctx context.Context, identityProvider hostservices.
 			TrustDomain: s.config.TrustDomain.Host,
 		},
 		PluginConfig:     s.config.PluginConfigs,
+		Metrics:          metrics,
 		IdentityProvider: identityProvider,
 		AgentStore:       agentStore,
 		MetricsService:   metricsService,


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
There should be no affected functionality. In terms of metrics observance, there may be a _very_ slight increase in elapsed time for these metrics since the timing now includes the gRPC plugin transport time, which is over in-process pipe for built-ins (i.e. minimal).

**Description of change**
The metrics emitted by the SQL plugin are limited to simple call counters over each RPC. This change moves the metrics emission out of the plugin and into a generic DataStore wrapper that emits the call metrics host-side.

This removes a great deal of mechanics around metric emission from the plugin unittests, which was a maintenance smell. It also makes metrics emission plugin agnostic.

