### PR TITLE
Back fake datastore with sqlite3 datastore impl

### DIFF
--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -74,7 +74,7 @@ func (s *BundleSuite) SetupTest() {
 	s.stdout = new(bytes.Buffer)
 	s.stderr = new(bytes.Buffer)
 
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 	s.registrationClient = fakeregistrationclient.New(s.T(), "spiffe://example.test", s.ds, nil)
 
 	testEnv := &env{
@@ -340,7 +340,7 @@ func (s *BundleSuite) TestDeleteWithRestrictMode() {
 	})
 
 	s.Require().Equal(1, s.deleteCmd.Run([]string{"-id", "spiffe://domain1.test"}))
-	s.Require().Equal("rpc error: code = Internal desc = cannot delete bundle; federated with 1 registration entries\n", s.stderr.String())
+	s.Require().Equal("rpc error: code = Internal desc = rpc error: code = Unknown desc = datastore-sql: cannot delete bundle; federated with 1 registration entries\n", s.stderr.String())
 
 	_, err := s.ds.FetchBundle(context.Background(), &datastore.FetchBundleRequest{
 		TrustDomainId: "spiffe://domain1.test",

--- a/cmd/spire-server/cli/bundle/experimental_bundle_test.go
+++ b/cmd/spire-server/cli/bundle/experimental_bundle_test.go
@@ -84,7 +84,7 @@ func (s *ExperimentalBundleSuite) SetupTest() {
 	s.stdout = new(bytes.Buffer)
 	s.stderr = new(bytes.Buffer)
 
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 	s.registrationClient = fakeregistrationclient.New(s.T(), "spiffe://example.test", s.ds, nil)
 
 	testEnv := &env{

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	github.com/imdario/mergo v0.3.7
 	github.com/imkira/go-observer v1.0.3
 	github.com/jinzhu/gorm v1.9.9
+	github.com/lib/pq v1.1.1
+	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/mitchellh/cli v1.0.0
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -25,7 +25,7 @@ func (c *serviceTest) Cleanup() {
 }
 
 func setupServiceTest(t *testing.T) *serviceTest { //nolint: unused,deadcode
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 	service := agent.New(agent.Config{
 		Datastore: ds,
 	})

--- a/pkg/server/api/bundle/v1/service.go
+++ b/pkg/server/api/bundle/v1/service.go
@@ -304,14 +304,14 @@ func (s *Service) createFederatedBundle(ctx context.Context, b *types.Bundle, ou
 			Status: api.CreateStatus(codes.InvalidArgument, "failed to convert bundle: %v", err),
 		}
 	}
+
 	resp, err := s.ds.CreateBundle(ctx, &datastore.CreateBundleRequest{
 		Bundle: dsBundle,
 	})
-
 	switch status.Code(err) {
 	case codes.OK:
 	case codes.AlreadyExists:
-		log.WithError(err).Error("Bundle already exists")
+		log.Error("Bundle already exists")
 		return &bundle.BatchCreateFederatedBundleResponse_Result{
 			Status: api.CreateStatus(codes.AlreadyExists, "bundle already exists"),
 		}
@@ -436,9 +436,9 @@ func (s *Service) updateFederatedBundle(ctx context.Context, b *types.Bundle, in
 	switch status.Code(err) {
 	case codes.OK:
 	case codes.NotFound:
-		log.WithError(err).Error("Bundle not found")
+		log.Error("Bundle not found")
 		return &bundle.BatchUpdateFederatedBundleResponse_Result{
-			Status: api.CreateStatus(codes.NotFound, "bundle not found: %v", err),
+			Status: api.CreateStatus(codes.NotFound, "bundle not found"),
 		}
 	default:
 		log.WithError(err).Error("Unable to update bundle")
@@ -519,7 +519,7 @@ func (s *Service) deleteFederatedBundle(ctx context.Context, trustDomain string)
 		}
 	case codes.NotFound:
 		return &bundle.BatchDeleteFederatedBundleResponse_Result{
-			Status:      api.StatusFromError(err),
+			Status:      api.CreateStatus(codes.NotFound, "bundle not found"),
 			TrustDomain: trustDomain,
 		}
 	default:

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -1098,7 +1098,7 @@ func setupServiceTest(t *testing.T) *serviceTest {
 	ca := fakeserverca.New(t, trustDomain.String(), &fakeserverca.Options{})
 	ef := &entryFetcher{}
 	downstream := &entryFetcher{}
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 
 	rateLimiter := &fakeRateLimiter{}
 	service := svid.New(svid.Config{

--- a/pkg/server/bundle/client/manager_test.go
+++ b/pkg/server/bundle/client/manager_test.go
@@ -71,7 +71,7 @@ func TestManager(t *testing.T) {
 
 func startManager(t *testing.T, clock clock.Clock, updater BundleUpdater) func() {
 	log, _ := test.NewNullLogger()
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 
 	trustDomainConfig := TrustDomainConfig{
 		EndpointAddress:  "ENDPOINT_ADDRESS",

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -73,7 +73,7 @@ func TestBundleUpdater(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			ds := fakedatastore.New()
+			ds := fakedatastore.New(t)
 
 			if testCase.localBundle != nil {
 				_, err := ds.CreateBundle(context.Background(), &datastore.CreateBundleRequest{

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -73,7 +73,7 @@ func (s *ManagerSuite) SetupTest() {
 	s.ca = new(fakeCA)
 	s.log, s.logHook = test.NewNullLogger()
 	s.km = memory.New()
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 
 	s.cat = fakeservercatalog.New()
 	s.cat.SetKeyManager(s.km)
@@ -474,7 +474,7 @@ func (s *ManagerSuite) TestPrune() {
 	// advance beyond the second expiration time, prune, and assert nothing
 	// changes because we can't prune out the whole bundle.
 	s.clock.Set(secondExpiresTime.Add(time.Minute + safetyThreshold))
-	s.Require().EqualError(s.m.pruneBundle(context.Background()), "unable to prune bundle: prune failed: would prune all certificates")
+	s.Require().EqualError(s.m.pruneBundle(context.Background()), "unable to prune bundle: rpc error: code = Unknown desc = prune failed: would prune all certificates")
 	s.requireBundleRootCAs(secondX509CA.Certificate)
 	s.requireBundleJWTKeys(secondJWTKey)
 }

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -27,7 +27,7 @@ func TestLoad(t *testing.T) {
 	builtIns = []catalog.Plugin{
 		// Fake Datastore
 		catalog.MakePlugin("fake_ds",
-			datastore.PluginServer(fakedatastore.New())),
+			datastore.PluginServer(fakedatastore.New(t))),
 		// Fake key manager
 		catalog.MakePlugin("fake_km",
 			keymanager.PluginServer(&fakeKeyManager{})),

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -47,7 +47,7 @@ type EndpointsTestSuite struct {
 }
 
 func (s *EndpointsTestSuite) SetupTest() {
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 
 	log, _ := test.NewNullLogger()
 	ip := net.ParseIP("127.0.0.1")

--- a/pkg/server/endpoints/node/cache_test.go
+++ b/pkg/server/endpoints/node/cache_test.go
@@ -16,7 +16,7 @@ func TestFetchBundleCache(t *testing.T) {
 	req := &datastore.FetchBundleRequest{TrustDomainId: "spiffe://domain.test"}
 	bundle1 := &common.Bundle{TrustDomainId: "spiffe://domain.test", RefreshHint: 1}
 	bundle2 := &common.Bundle{TrustDomainId: "spiffe://domain.test", RefreshHint: 2}
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 	clock := clock.NewMock(t)
 	cache := newDatastoreCache(ds, clock)
 

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -72,6 +72,8 @@ var (
 		TrustDomainId: otherDomainID,
 	}
 
+	irrelevantSelectors = []*common.Selector{{Type: "not", Value: "relevant"}}
+
 	testKey, _ = pemutil.ParseECPrivateKey([]byte(`
 -----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgUdF3LNDNZWKYQHFj
@@ -127,7 +129,7 @@ func (s *HandlerSuite) setupTest(upstreamAuthorityConfig *fakeupstreamauthority.
 
 	s.limiter = new(fakeLimiter)
 
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 	s.catalog = fakeservercatalog.New()
 	s.catalog.SetDataStore(s.ds)
 	if upstreamAuthorityConfig != nil {
@@ -358,6 +360,7 @@ func (s *HandlerSuite) testAttestSuccess(csr []byte) {
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:      agentID,
 		SpiffeId:      workloadID,
+		Selectors:     irrelevantSelectors,
 		FederatesWith: []string{otherDomainID},
 	})
 
@@ -607,9 +610,9 @@ func (s *HandlerSuite) TestAttestWithBothAttestorAndResolverSelectors() {
 		Csr:             s.makeCSR(agentID),
 	}, agentID)
 
-	s.Equal([]*common.Selector{
-		{Type: "test", Value: "test-resolver-value"},
+	s.ElementsMatch([]*common.Selector{
 		{Type: "test", Value: "test-attestor-value"},
+		{Type: "test", Value: "test-resolver-value"},
 	}, s.getNodeSelectors())
 
 	s.Equal(s.expectedMetrics.AllMetrics(), s.metrics.AllMetrics())
@@ -674,6 +677,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithNoCSRs() {
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:      agentID,
 		SpiffeId:      workloadID,
+		Selectors:     irrelevantSelectors,
 		FederatesWith: []string{otherDomainID},
 	})
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{})
@@ -689,6 +693,7 @@ func (s *HandlerSuite) TestFetchX509SVIDWithCache() {
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:      agentID,
 		SpiffeId:      workloadID,
+		Selectors:     irrelevantSelectors,
 		FederatesWith: []string{otherDomainID},
 	})
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{})
@@ -886,6 +891,7 @@ func (s *HandlerSuite) TestFetchX509CASVID() {
 	s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:   trustDomainID,
 		SpiffeId:   agentID,
+		Selectors:  irrelevantSelectors,
 		Downstream: true,
 		// add a DNS name. we'll assert it does not influence the CA certificate.
 		DnsNames: []string{"ca-dns1"},
@@ -910,8 +916,9 @@ func (s *HandlerSuite) TestFetchX509SVIDWithWorkloadCSR() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -927,8 +934,9 @@ func (s *HandlerSuite) TestFetchX509SVIDWithWorkloadCSRLegacy() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -946,9 +954,10 @@ func (s *HandlerSuite) TestFetchX509SVIDWithSingleDNS() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
-		DnsNames: dnsList,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
+		DnsNames:  dnsList,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -968,9 +977,10 @@ func (s *HandlerSuite) TestFetchX509SVIDWithSingleDNSLegacy() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
-		DnsNames: dnsList,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
+		DnsNames:  dnsList,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -990,9 +1000,10 @@ func (s *HandlerSuite) TestFetchX509SVIDWithMultipleDNS() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
-		DnsNames: dnsList,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
+		DnsNames:  dnsList,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -1012,9 +1023,10 @@ func (s *HandlerSuite) TestFetchX509SVIDWithMultipleDNSLegacy() {
 	s.attestAgent()
 
 	entry := s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
-		DnsNames: dnsList,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
+		DnsNames:  dnsList,
 	})
 
 	upd := s.requireFetchX509SVIDSuccess(&node.FetchX509SVIDRequest{
@@ -1096,8 +1108,9 @@ func (s *HandlerSuite) TestFetchJWTSVIDWithWorkloadID() {
 	s.attestAgent()
 
 	s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: agentID,
-		SpiffeId: workloadID,
+		ParentId:  agentID,
+		SpiffeId:  workloadID,
+		Selectors: irrelevantSelectors,
 	})
 
 	svid := s.requireFetchJWTSVIDSuccess(&node.FetchJWTSVIDRequest{
@@ -1142,6 +1155,7 @@ UigDxnLeJxW17hsOD8xO8J7WdHMaIhXvrTx7EhxWC1hpCXCsxn6UVlLL
 	s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:   trustDomainID,
 		SpiffeId:   agentID,
+		Selectors:  irrelevantSelectors,
 		Downstream: true,
 	})
 
@@ -1181,6 +1195,7 @@ func (s *HandlerSuite) TestPushJWTKeyUpstreamWithUpstreamAuthority() {
 	s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:   trustDomainID,
 		SpiffeId:   agentID,
+		Selectors:  irrelevantSelectors,
 		Downstream: true,
 	})
 
@@ -1207,6 +1222,7 @@ func (s *HandlerSuite) TestPushJWTKeyUpstreamUnimplemented() {
 	s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:   trustDomainID,
 		SpiffeId:   agentID,
+		Selectors:  irrelevantSelectors,
 		Downstream: true,
 	})
 
@@ -1270,6 +1286,7 @@ func (s *HandlerSuite) TestAuthorizeCallForFetchX509CASVID() {
 	downstreamEntry := s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:   agentID,
 		SpiffeId:   downstreamID,
+		Selectors:  irrelevantSelectors,
 		Downstream: true,
 	})
 	ctx, err = s.handler.AuthorizeCall(peerCtx, fullMethod)

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -79,7 +79,7 @@ type HandlerSuite struct {
 func (s *HandlerSuite) SetupTest() {
 	log, _ := test.NewNullLogger()
 
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 	s.serverCA = fakeserverca.New(s.T(), "example.org", nil)
 
 	catalog := fakeservercatalog.New()
@@ -124,7 +124,7 @@ func (s *HandlerSuite) TestCreateFederatedBundle() {
 		{TrustDomainID: "spiffe://example.org", CaCerts: nil, Err: "federated bundle id cannot match server trust domain"},
 		{TrustDomainID: "spiffe://otherdomain.org/spire/agent", CaCerts: nil, Err: `"spiffe://otherdomain.org/spire/agent" is not a valid trust domain SPIFFE ID: path is not empty`},
 		{TrustDomainID: "spiffe://otherdomain.org", CaCerts: rootCA1DER, Err: ""},
-		{TrustDomainID: "spiffe://otherdomain.org", CaCerts: rootCA1DER, Err: "bundle already exists"},
+		{TrustDomainID: "spiffe://otherdomain.org", CaCerts: rootCA1DER, Err: "UNIQUE constraint failed: bundles.trust_domain"},
 	}
 
 	for _, testCase := range testCases {
@@ -241,7 +241,7 @@ func (s *HandlerSuite) TestUpdateFederatedBundle() {
 	}{
 		{TrustDomainID: "spiffe://example.org", CaCerts: nil, Err: "federated bundle id cannot match server trust domain"},
 		{TrustDomainID: "spiffe://otherdomain.org/spire/agent", CaCerts: nil, Err: `"spiffe://otherdomain.org/spire/agent" is not a valid trust domain SPIFFE ID: path is not empty`},
-		{TrustDomainID: "spiffe://unknowndomain.org", CaCerts: rootCA1DER, Err: "no such bundle"},
+		{TrustDomainID: "spiffe://unknowndomain.org", CaCerts: rootCA1DER, Err: "record not found"},
 		{TrustDomainID: "spiffe://otherdomain.org", CaCerts: rootCA1DER, Err: ""},
 		{TrustDomainID: "spiffe://otherdomain.org", CaCerts: rootCA2DER, Err: ""},
 	}
@@ -278,7 +278,7 @@ func (s *HandlerSuite) TestDeleteFederatedBundle() {
 		{TrustDomainID: "spiffe://example.org", Err: "federated bundle id cannot match server trust domain"},
 		{TrustDomainID: "spiffe://otherdomain.org/spire/agent", Err: `"spiffe://otherdomain.org/spire/agent" is not a valid trust domain SPIFFE ID: path is not empty`},
 		{TrustDomainID: "spiffe://otherdomain.org", Err: ""},
-		{TrustDomainID: "spiffe://otherdomain.org", Err: "no such bundle"},
+		{TrustDomainID: "spiffe://otherdomain.org", Err: "record not found"},
 	}
 
 	s.createBundle(&common.Bundle{
@@ -317,14 +317,22 @@ func (s *HandlerSuite) TestCreateEntryAndCreateEntryIfNotExists() {
 		Err   string
 	}{
 		{
-			Name:  "Parent ID is malformed",
-			Entry: &common.RegistrationEntry{ParentId: "FOO"},
-			Err:   `"FOO" is not a valid trust domain member SPIFFE ID`,
+			Name: "Parent ID is malformed",
+			Entry: &common.RegistrationEntry{
+				ParentId:  "FOO",
+				SpiffeId:  "spiffe://example.org/child",
+				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
+			},
+			Err: `"FOO" is not a valid trust domain member SPIFFE ID`,
 		},
 		{
-			Name:  "SPIFFE ID is malformed",
-			Entry: &common.RegistrationEntry{ParentId: "spiffe://example.org/parent", SpiffeId: "FOO"},
-			Err:   `"FOO" is not a valid workload SPIFFE ID`,
+			Name: "SPIFFE ID is malformed",
+			Entry: &common.RegistrationEntry{
+				ParentId:  "spiffe://example.org/parent",
+				SpiffeId:  "FOO",
+				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
+			},
+			Err: `"FOO" is not a valid workload SPIFFE ID`,
 		},
 		{
 			Name: "Bad DNS",
@@ -471,55 +479,54 @@ func (s *HandlerSuite) TestCreateEntryIfNotExists() {
 }
 
 func (s *HandlerSuite) TestUpdateEntry() {
-	entry := s.createRegistrationEntry(&common.RegistrationEntry{
+	original := s.createRegistrationEntry(&common.RegistrationEntry{
 		ParentId:  "spiffe://example.org/foo",
 		SpiffeId:  "spiffe://example.org/bar",
 		Selectors: []*common.Selector{{Type: "A", Value: "a"}},
 	})
 
 	testCases := []struct {
-		Name  string
-		Entry *common.RegistrationEntry
-		Err   string
+		Name         string
+		PrepareEntry func(e *common.RegistrationEntry)
+		Err          string
 	}{
 		{
 			Name: "Missing entry",
 			Err:  "missing entry to update",
 		},
 		{
-			Name:  "Parent ID is malformed",
-			Entry: &common.RegistrationEntry{EntryId: "X", ParentId: "FOO"},
-			Err:   `"FOO" is not a valid trust domain member SPIFFE ID`,
+			Name: "Parent ID is malformed",
+			PrepareEntry: func(e *common.RegistrationEntry) {
+				e.ParentId = "FOO"
+			},
+			Err: `"FOO" is not a valid trust domain member SPIFFE ID`,
 		},
 		{
-			Name:  "SPIFFE ID is malformed",
-			Entry: &common.RegistrationEntry{EntryId: "X", ParentId: "spiffe://example.org/parent", SpiffeId: "FOO"},
-			Err:   `"FOO" is not a valid workload SPIFFE ID`,
+			Name: "SPIFFE ID is malformed",
+			PrepareEntry: func(e *common.RegistrationEntry) {
+				e.SpiffeId = "FOO"
+			},
+			Err: `"FOO" is not a valid workload SPIFFE ID`,
 		},
 		{
-			Name:  "Registration entry does not exist",
-			Entry: &common.RegistrationEntry{EntryId: "X", ParentId: "spiffe://example.org/parent", SpiffeId: "spiffe://example.org/child"},
-			Err:   "no such registration entry",
+			Name: "Registration entry does not exist",
+			PrepareEntry: func(e *common.RegistrationEntry) {
+				e.EntryId = "X"
+			},
+			Err: "record not found",
 		},
 		{
 			Name: "Bad DNS",
-			Entry: &common.RegistrationEntry{
-				EntryId:   entry.EntryId,
-				ParentId:  "spiffe://example.org/parent",
-				SpiffeId:  "spiffe://example.org/child",
-				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
-				DnsNames:  []string{" "},
+			PrepareEntry: func(e *common.RegistrationEntry) {
+				e.DnsNames = []string{" "}
 			},
 			Err: "empty or only whitespace",
 		},
 		{
 			Name: "Success",
-			Entry: &common.RegistrationEntry{
-				EntryId:   entry.EntryId,
-				ParentId:  "spiffe://example.org/parent",
-				SpiffeId:  "spiffe://example.org/child",
-				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
-				DnsNames:  []string{"wxyz.2-a"},
+			PrepareEntry: func(e *common.RegistrationEntry) {
+				e.Selectors = []*common.Selector{{Type: "B", Value: "b"}}
+				e.DnsNames = []string{"wxyz.2-a"}
 			},
 		},
 	}
@@ -527,17 +534,21 @@ func (s *HandlerSuite) TestUpdateEntry() {
 	for _, testCase := range testCases {
 		testCase := testCase // alias loop variable as it is used in the closure
 		s.T().Run(testCase.Name, func(t *testing.T) {
+			var entry *common.RegistrationEntry
+			if testCase.PrepareEntry != nil {
+				entry = proto.Clone(original).(*common.RegistrationEntry)
+				testCase.PrepareEntry(entry)
+			}
 			resp, err := s.handler.UpdateEntry(context.Background(), &registration.UpdateEntryRequest{
-				Entry: testCase.Entry,
+				Entry: entry,
 			})
-
 			if testCase.Err != "" {
 				requireErrorContains(t, err, testCase.Err)
 				return
 			}
 			require.NoError(t, err)
-			t.Logf("actual=%+v expected=%+v", resp, testCase.Entry)
-			require.True(t, proto.Equal(resp, testCase.Entry))
+			t.Logf("actual=%+v expected=%+v", resp, entry)
+			require.True(t, proto.Equal(resp, entry))
 		})
 	}
 }
@@ -560,7 +571,7 @@ func (s *HandlerSuite) TestDeleteEntry() {
 		},
 		{
 			Name: "Registration entry does not exist",
-			Err:  "no such registration entry",
+			Err:  "record not found",
 		},
 	}
 
@@ -1302,7 +1313,7 @@ func (s *HandlerSuite) TestGetNodeSelectors() {
 	req := &registration.GetNodeSelectorsRequest{SpiffeId: spiffeID}
 	resp, err := s.handler.GetNodeSelectors(ctx, req)
 	s.Require().NoError(err)
-	s.Equal(resp.Selectors, expectedNodeSelectors)
+	spiretest.RequireProtoEqual(s.T(), resp.Selectors, expectedNodeSelectors)
 }
 
 func (s *HandlerSuite) createAttestedNode(spiffeID string) *common.AttestedNode {
@@ -1342,9 +1353,10 @@ func (s *HandlerSuite) TestAuthorizeCall() {
 	}
 
 	s.createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: "spiffe://example.org/parent",
-		SpiffeId: "spiffe://example.org/admin",
-		Admin:    true,
+		ParentId:  "spiffe://example.org/parent",
+		SpiffeId:  "spiffe://example.org/admin",
+		Selectors: []*common.Selector{{Type: "A", Value: "a"}},
+		Admin:     true,
 	})
 
 	testCases := []struct {

--- a/pkg/server/hostservices/agentstore/agentstore_test.go
+++ b/pkg/server/hostservices/agentstore/agentstore_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAgentStore(t *testing.T) {
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 	_, err := ds.CreateAttestedNode(context.Background(), &datastore.CreateAttestedNodeRequest{
 		Node: &common.AttestedNode{
 			SpiffeId: "spiffe://domain.test/spire/agent/test/foo",

--- a/pkg/server/hostservices/identityprovider/identityprovider_test.go
+++ b/pkg/server/hostservices/identityprovider/identityprovider_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -41,7 +42,7 @@ func TestFetchX509IdentitySuccess(t *testing.T) {
 		TrustDomainId: "spiffe://domain.test",
 	}
 
-	ds := fakedatastore.New()
+	ds := fakedatastore.New(t)
 	_, err := ds.CreateBundle(context.Background(), &datastore.CreateBundleRequest{
 		Bundle: bundle,
 	})
@@ -76,5 +77,5 @@ func TestFetchX509IdentitySuccess(t *testing.T) {
 	require.NotNil(t, resp.Identity)
 	require.Equal(t, [][]byte{{1}, {2}}, resp.Identity.CertChain)
 	require.Equal(t, privateKeyBytes, resp.Identity.PrivateKey)
-	require.Equal(t, bundle, resp.Bundle)
+	spiretest.RequireProtoEqual(t, bundle, resp.Bundle)
 }

--- a/pkg/server/plugin/datastore/sql/dialect.go
+++ b/pkg/server/plugin/datastore/sql/dialect.go
@@ -1,0 +1,8 @@
+package sql
+
+import "github.com/jinzhu/gorm"
+
+type dialect interface {
+	connect(cfg *configuration, isReadOnly bool) (db *gorm.DB, version string, supportsCTE bool, err error)
+	isConstraintViolation(err error) bool
+}

--- a/pkg/server/plugin/datastore/sql/mysql.go
+++ b/pkg/server/plugin/datastore/sql/mysql.go
@@ -15,7 +15,6 @@ import (
 	// gorm mysql dialect init registration
 	// also needed for GCP Cloud SQL Proxy
 	_ "github.com/jinzhu/gorm/dialects/mysql"
-	_ "github.com/spiffe/spire/pkg/server/plugin/datastore"
 )
 
 type mysqlDB struct{}
@@ -66,8 +65,13 @@ func (my mysqlDB) supportsCTE(gormDB *gorm.DB) (bool, error) {
 }
 
 func (my mysqlDB) isParseError(err error) bool {
-	mysqlError, ok := err.(*mysql.MySQLError)
-	return ok && mysqlError.Number == 1064
+	e, ok := err.(*mysql.MySQLError)
+	return ok && e.Number == 1064 // ER_PARSE_ERROR
+}
+
+func (my mysqlDB) isConstraintViolation(err error) bool {
+	e, ok := err.(*mysql.MySQLError)
+	return ok && e.Number == 1062 // ER_DUP_ENTRY
 }
 
 // configureConnection modifies the connection string to support features that

--- a/pkg/server/plugin/datastore/sql/postgres.go
+++ b/pkg/server/plugin/datastore/sql/postgres.go
@@ -2,10 +2,10 @@ package sql
 
 import (
 	"github.com/jinzhu/gorm"
+	"github.com/lib/pq"
 
 	// gorm postgres dialect init registration
 	_ "github.com/jinzhu/gorm/dialects/postgres"
-	_ "github.com/spiffe/spire/pkg/server/plugin/datastore"
 )
 
 type postgresDB struct{}
@@ -24,4 +24,10 @@ func (p postgresDB) connect(cfg *configuration, isReadOnly bool) (db *gorm.DB, v
 	// Supported versions of PostgreSQL all support CTE so unconditionally
 	// return true.
 	return db, version, true, nil
+}
+
+func (p postgresDB) isConstraintViolation(err error) bool {
+	e, ok := err.(*pq.Error)
+	// "23xxx" is the constraint violation class for PostgreSQL
+	return ok && e.Code.Class() == "23"
 }

--- a/pkg/server/registration/manager_test.go
+++ b/pkg/server/registration/manager_test.go
@@ -34,7 +34,7 @@ type ManagerSuite struct {
 func (s *ManagerSuite) SetupTest() {
 	s.clock = clock.NewMock(s.T())
 	s.log, s.logHook = test.NewNullLogger()
-	s.ds = fakedatastore.New()
+	s.ds = fakedatastore.New(s.T())
 	s.metrics = fakemetrics.New()
 }
 

--- a/pkg/server/util/regentryutil/fetch_test.go
+++ b/pkg/server/util/regentryutil/fetch_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -16,7 +17,8 @@ var (
 
 func TestFetchRegistrationEntries(t *testing.T) {
 	assert := assert.New(t)
-	dataStore := fakedatastore.New()
+	require := require.New(t)
+	dataStore := fakedatastore.New(t)
 
 	cache, err := NewFetchX509SVIDCache(10)
 	assert.NoError(err)
@@ -25,7 +27,7 @@ func TestFetchRegistrationEntries(t *testing.T) {
 		resp, err := dataStore.CreateRegistrationEntry(ctx, &datastore.CreateRegistrationEntryRequest{
 			Entry: entry,
 		})
-		assert.NoError(err)
+		require.NoError(err)
 		return resp.Entry
 	}
 
@@ -59,18 +61,21 @@ func TestFetchRegistrationEntries(t *testing.T) {
 	// node resolvers map from 2 to 4
 
 	oneEntry := createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: rootID,
-		SpiffeId: oneID,
+		ParentId:  rootID,
+		SpiffeId:  oneID,
+		Selectors: []*common.Selector{{Type: "not", Value: "relevant"}},
 	})
 
 	twoEntry := createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: rootID,
-		SpiffeId: twoID,
+		ParentId:  rootID,
+		SpiffeId:  twoID,
+		Selectors: []*common.Selector{{Type: "not", Value: "relevant"}},
 	})
 
 	threeEntry := createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: twoID,
-		SpiffeId: threeID,
+		ParentId:  twoID,
+		SpiffeId:  threeID,
+		Selectors: []*common.Selector{{Type: "not", Value: "relevant"}},
 	})
 
 	fourEntry := createRegistrationEntry(&common.RegistrationEntry{
@@ -79,8 +84,9 @@ func TestFetchRegistrationEntries(t *testing.T) {
 	})
 
 	fiveEntry := createRegistrationEntry(&common.RegistrationEntry{
-		ParentId: fourID,
-		SpiffeId: fiveID,
+		ParentId:  fourID,
+		SpiffeId:  fiveID,
+		Selectors: []*common.Selector{{Type: "not", Value: "relevant"}},
 	})
 
 	setNodeSelectors(twoID, a1, b2)

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -4,755 +4,261 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
-	"time"
+	"sync/atomic"
+	"testing"
 
-	"github.com/hashicorp/go-hclog"
+	"github.com/stretchr/testify/require"
 
-	"github.com/gofrs/uuid"
-	"github.com/golang/protobuf/proto"
-	"github.com/spiffe/spire/pkg/common/bundleutil"
-	"github.com/spiffe/spire/pkg/common/selector"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
-	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore/sql"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/spiffe/spire/test/spiretest"
 )
 
 var (
-	ErrBundleAlreadyExists       = status.Error(codes.AlreadyExists, "bundle already exists")
-	ErrAttestedNodeAlreadyExists = status.Error(codes.AlreadyExists, "attested node entry already exists")
-	ErrTokenAlreadyExists        = status.Error(codes.AlreadyExists, "token already exists")
-
-	ErrNoSuchBundle            = status.Error(codes.NotFound, "no such bundle")
-	ErrNoSuchAttestedNode      = status.Error(codes.NotFound, "no such attested node entry")
-	ErrNoSuchRegistrationEntry = status.Error(codes.NotFound, "no such registration entry")
-	ErrNoSuchToken             = status.Error(codes.NotFound, "no such token")
+	nextID uint32
 )
 
 type DataStore struct {
-	mu sync.Mutex
-
-	bundles             map[string]*common.Bundle
-	attestedNodes       map[string]*common.AttestedNode
-	nodeSelectors       map[string][]*common.Selector
-	registrationEntries map[string]*common.RegistrationEntry
-	tokens              map[string]*datastore.JoinToken
-
-	// relates bundles with entries that federate with them
-	bundleEntries map[string]map[string]bool
-
-	// expect error when calling functions
-	expectErr error
+	ds   datastore.DataStore
+	errs []error
 }
 
 var _ datastore.DataStore = (*DataStore)(nil)
 
-func New() *DataStore {
+func New(tb testing.TB) *DataStore {
+	var ds datastore.Plugin
+
+	// TODO: clean up plugin when we move to go1.14.
+	_ = spiretest.LoadPlugin(tb, sql.BuiltIn(), &ds)
+
+	_, err := ds.Configure(context.Background(), &spi.ConfigureRequest{
+		Configuration: fmt.Sprintf(`
+			database_type = "sqlite3"
+			connection_string = "file:memdb%d?mode=memory&cache=shared"
+		`, atomic.AddUint32(&nextID, 1)),
+	})
+	require.NoError(tb, err)
+
 	return &DataStore{
-		bundles:             make(map[string]*common.Bundle),
-		attestedNodes:       make(map[string]*common.AttestedNode),
-		nodeSelectors:       make(map[string][]*common.Selector),
-		registrationEntries: make(map[string]*common.RegistrationEntry),
-		tokens:              make(map[string]*datastore.JoinToken),
-		bundleEntries:       make(map[string]map[string]bool),
+		ds: ds,
 	}
 }
 
-// CreateBundle stores the given bundle
 func (s *DataStore) CreateBundle(ctx context.Context, req *datastore.CreateBundleRequest) (*datastore.CreateBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	bundle := req.Bundle
-
-	if _, ok := s.bundles[bundle.TrustDomainId]; ok {
-		return nil, ErrBundleAlreadyExists
-	}
-
-	s.bundles[bundle.TrustDomainId] = cloneBundle(bundle)
-
-	return &datastore.CreateBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.CreateBundle(ctx, req)
 }
 
-// UpdateBundle updates an existing bundle with the given CAs. Overwrites any
-// existing certificates.
 func (s *DataStore) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	newBundle := req.Bundle
-	bundle, ok := s.bundles[newBundle.TrustDomainId]
-	if !ok {
-		return nil, ErrNoSuchBundle
-	}
-
-	if req.InputMask == nil {
-		s.bundles[newBundle.TrustDomainId] = cloneBundle(newBundle)
-
-		return &datastore.UpdateBundleResponse{
-			Bundle: cloneBundle(newBundle),
-		}, nil
-	}
-
-	if req.InputMask.JwtSigningKeys {
-		bundle.JwtSigningKeys = newBundle.JwtSigningKeys
-	}
-	if req.InputMask.RootCas {
-		bundle.RootCas = newBundle.RootCas
-	}
-	if req.InputMask.RefreshHint {
-		bundle.RefreshHint = newBundle.RefreshHint
-	}
-
-	return &datastore.UpdateBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.UpdateBundle(ctx, req)
 }
 
-// SetBundle sets bundle contents. If no bundle exists for the trust domain, it is created.
 func (s *DataStore) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (*datastore.SetBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	bundle := req.Bundle
-
-	s.bundles[bundle.TrustDomainId] = cloneBundle(bundle)
-
-	return &datastore.SetBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.SetBundle(ctx, req)
 }
 
-// AppendBundle updates an existing bundle with the given CAs. Overwrites any
-// existing certificates.
 func (s *DataStore) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	bundle := req.Bundle
-
-	if existingBundle, ok := s.bundles[bundle.TrustDomainId]; ok {
-		bundle, _ = bundleutil.MergeBundles(existingBundle, bundle)
-	}
-
-	s.bundles[bundle.TrustDomainId] = cloneBundle(bundle)
-
-	return &datastore.AppendBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.AppendBundle(ctx, req)
 }
 
-// DeleteBundle deletes the bundle with the matching TrustDomainId. Any CACert data passed is ignored.
 func (s *DataStore) DeleteBundle(ctx context.Context, req *datastore.DeleteBundleRequest) (*datastore.DeleteBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	bundle, ok := s.bundles[req.TrustDomainId]
-	if !ok {
-		return nil, ErrNoSuchBundle
-	}
-
-	if bundleEntries := s.bundleEntries[req.TrustDomainId]; len(bundleEntries) > 0 {
-		switch req.Mode {
-		case datastore.DeleteBundleRequest_DELETE:
-			for entryID := range bundleEntries {
-				delete(s.registrationEntries, entryID)
-			}
-		case datastore.DeleteBundleRequest_DISSOCIATE:
-			for entryID := range bundleEntries {
-				if entry := s.registrationEntries[entryID]; entry != nil {
-					entry.FederatesWith = removeString(entry.FederatesWith, req.TrustDomainId)
-				}
-			}
-		default:
-			return nil, fmt.Errorf("cannot delete bundle; federated with %d registration entries", len(bundleEntries))
-		}
-	}
-	delete(s.bundles, req.TrustDomainId)
-
-	return &datastore.DeleteBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.DeleteBundle(ctx, req)
 }
 
-// FetchBundle returns the bundle matching the specified Trust Domain.
 func (s *DataStore) FetchBundle(ctx context.Context, req *datastore.FetchBundleRequest) (*datastore.FetchBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	bundle, ok := s.bundles[req.TrustDomainId]
-	if !ok {
-		return &datastore.FetchBundleResponse{}, nil
-	}
-
-	return &datastore.FetchBundleResponse{
-		Bundle: cloneBundle(bundle),
-	}, nil
+	return s.ds.FetchBundle(ctx, req)
 }
 
-// ListBundles can be used to fetch all existing bundles.
 func (s *DataStore) ListBundles(ctx context.Context, req *datastore.ListBundlesRequest) (*datastore.ListBundlesResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// get an ordered list of keys so tests can rely on ordering for stability
-	keys := make([]string, 0, len(s.bundles))
-	for key := range s.bundles {
-		keys = append(keys, key)
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	sort.Strings(keys)
-
-	resp := new(datastore.ListBundlesResponse)
-
-	p := req.Pagination
-	// in case pagination is defined and page size greater than zero apply pagination
-	if p != nil && p.PageSize > 0 {
-		// as default start in first position
-		init := 0
-
-		// If token is defined set index of initial element
-		if p.Token != "" {
-			init = sort.StringSlice(keys).Search(p.Token) + 1
-		}
-
-		// set end as initial element + page size, if end is greater to entries size use length as end
-		length := len(keys)
-		end := init + int(p.PageSize)
-		if end > length {
-			end = length
-		}
-
-		// create a new array with paged bundles
-		keys = keys[init:end]
-		if len(keys) > 0 {
-			lastIndex := len(keys) - 1
-			// change token to latests bundle key
-			resp.Pagination = &datastore.Pagination{
-				PageSize: p.PageSize,
-				Token:    keys[lastIndex],
-			}
-		}
+	resp, err := s.ds.ListBundles(ctx, req)
+	if err == nil {
+		// Sorting helps unit-tests have deterministic assertions.
+		sort.Slice(resp.Bundles, func(i, j int) bool {
+			return resp.Bundles[i].TrustDomainId < resp.Bundles[j].TrustDomainId
+		})
 	}
-
-	for _, key := range keys {
-		resp.Bundles = append(resp.Bundles, cloneBundle(s.bundles[key]))
-	}
-
-	return resp, nil
+	return resp, err
 }
 
-// PruneBundle removes expired certs from a bundle
 func (s *DataStore) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (*datastore.PruneBundleResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	oldBundle, ok := s.bundles[req.TrustDomainId]
-	if !ok {
-		// No bundle to prune
-		return &datastore.PruneBundleResponse{}, nil
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	newBundle, changed, err := bundleutil.PruneBundle(oldBundle, time.Unix(req.ExpiresBefore, 0), hclog.NewNullLogger())
-	if err != nil {
-		return nil, fmt.Errorf("prune failed: %v", err)
-	}
-
-	// If any cert was pruned, then update the bundle
-	if changed {
-		s.bundles[req.TrustDomainId] = newBundle
-	}
-
-	return &datastore.PruneBundleResponse{BundleChanged: changed}, nil
+	return s.ds.PruneBundle(ctx, req)
 }
 
 func (s *DataStore) CreateAttestedNode(ctx context.Context, req *datastore.CreateAttestedNodeRequest) (*datastore.CreateAttestedNodeResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	node := req.Node
-
-	if _, ok := s.attestedNodes[node.SpiffeId]; ok {
-		return nil, ErrAttestedNodeAlreadyExists
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	s.attestedNodes[node.SpiffeId] = cloneAttestedNode(node)
-	return &datastore.CreateAttestedNodeResponse{
-		Node: cloneAttestedNode(node),
-	}, nil
+	return s.ds.CreateAttestedNode(ctx, req)
 }
 
 func (s *DataStore) FetchAttestedNode(ctx context.Context, req *datastore.FetchAttestedNodeRequest) (*datastore.FetchAttestedNodeResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	resp := new(datastore.FetchAttestedNodeResponse)
-	node, ok := s.attestedNodes[req.SpiffeId]
-	if !ok {
-		return resp, nil
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	resp.Node = cloneAttestedNode(node)
-
-	return resp, nil
+	return s.ds.FetchAttestedNode(ctx, req)
 }
 
 func (s *DataStore) ListAttestedNodes(ctx context.Context, req *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// get an ordered list of keys so tests can rely on ordering for stability
-	keys := make([]string, 0, len(s.attestedNodes))
-	for key := range s.attestedNodes {
-		keys = append(keys, key)
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	sort.Strings(keys)
-
-	resp := new(datastore.ListAttestedNodesResponse)
-	for _, key := range keys {
-		attestedNodeEntry := s.attestedNodes[key]
-		if req.ByExpiresBefore != nil {
-			if attestedNodeEntry.CertNotAfter >= req.ByExpiresBefore.Value {
-				continue
-			}
-		}
-		resp.Nodes = append(resp.Nodes, cloneAttestedNode(attestedNodeEntry))
-	}
-
-	return resp, nil
+	return s.ds.ListAttestedNodes(ctx, req)
 }
 
 func (s *DataStore) UpdateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	node, ok := s.attestedNodes[req.SpiffeId]
-	if !ok {
-		return nil, ErrNoSuchAttestedNode
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	node.CertSerialNumber = req.CertSerialNumber
-	node.CertNotAfter = req.CertNotAfter
-	node.NewCertSerialNumber = req.NewCertSerialNumber
-	node.NewCertNotAfter = req.NewCertNotAfter
-
-	return &datastore.UpdateAttestedNodeResponse{
-		Node: cloneAttestedNode(node),
-	}, nil
+	return s.ds.UpdateAttestedNode(ctx, req)
 }
 
 func (s *DataStore) DeleteAttestedNode(ctx context.Context, req *datastore.DeleteAttestedNodeRequest) (*datastore.DeleteAttestedNodeResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	node, ok := s.attestedNodes[req.SpiffeId]
-	if !ok {
-		return nil, ErrNoSuchAttestedNode
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	delete(s.attestedNodes, req.SpiffeId)
-
-	return &datastore.DeleteAttestedNodeResponse{
-		Node: cloneAttestedNode(node),
-	}, nil
+	return s.ds.DeleteAttestedNode(ctx, req)
 }
 
 func (s *DataStore) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.nodeSelectors[req.Selectors.SpiffeId] = cloneSelectors(req.Selectors.Selectors)
-	return &datastore.SetNodeSelectorsResponse{}, nil
+	if err := s.getNextError(); err != nil {
+		return nil, err
+	}
+	return s.ds.SetNodeSelectors(ctx, req)
 }
 
 func (s *DataStore) GetNodeSelectors(ctx context.Context, req *datastore.GetNodeSelectorsRequest) (*datastore.GetNodeSelectorsResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	selectors := s.nodeSelectors[req.SpiffeId]
-
-	return &datastore.GetNodeSelectorsResponse{
-		Selectors: &datastore.NodeSelectors{
-			SpiffeId:  req.SpiffeId,
-			Selectors: cloneSelectors(selectors),
-		},
-	}, nil
+	if err := s.getNextError(); err != nil {
+		return nil, err
+	}
+	resp, err := s.ds.GetNodeSelectors(ctx, req)
+	if err == nil {
+		// Sorting helps unit-tests have deterministic assertions.
+		util.SortSelectors(resp.Selectors.Selectors)
+	}
+	return resp, err
 }
 
 func (s *DataStore) CreateRegistrationEntry(ctx context.Context, req *datastore.CreateRegistrationEntryRequest) (*datastore.CreateRegistrationEntryResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	entryID, err := newRegistrationEntryID()
-	if err != nil {
+	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-
-	entry := cloneRegistrationEntry(req.Entry)
-	entry.EntryId = entryID
-	s.registrationEntries[entryID] = entry
-
-	if err := s.addBundleLinks(entryID, req.Entry.FederatesWith); err != nil {
-		return nil, err
-	}
-
-	return &datastore.CreateRegistrationEntryResponse{
-		Entry: cloneRegistrationEntry(entry),
-	}, nil
+	return s.ds.CreateRegistrationEntry(ctx, req)
 }
 
 func (s *DataStore) FetchRegistrationEntry(ctx context.Context, req *datastore.FetchRegistrationEntryRequest) (*datastore.FetchRegistrationEntryResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	resp := new(datastore.FetchRegistrationEntryResponse)
-	entry, ok := s.registrationEntries[req.EntryId]
-	if !ok {
-		return resp, nil
-	}
-	resp.Entry = cloneRegistrationEntry(entry)
-
-	return resp, nil
+	return s.ds.FetchRegistrationEntry(ctx, req)
 }
 
 func (s *DataStore) ListRegistrationEntries(ctx context.Context, req *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	// add the registration entries to the map
-	entriesSet := make(map[string]*common.RegistrationEntry)
-	for _, entry := range s.registrationEntries {
-		if req.ByParentId != nil && entry.ParentId != req.ByParentId.Value {
-			continue
-		}
-		if req.BySpiffeId != nil && entry.SpiffeId != req.BySpiffeId.Value {
-			continue
-		}
-
-		entriesSet[entry.EntryId] = entry
+	resp, err := s.ds.ListRegistrationEntries(ctx, req)
+	if err == nil {
+		// Sorting helps unit-tests have deterministic assertions.
+		util.SortRegistrationEntries(resp.Entries)
 	}
-
-	if req.BySelectors != nil && len(req.BySelectors.Selectors) > 0 {
-		var selectorsList [][]*common.Selector
-		selectorSet := selector.NewSetFromRaw(req.BySelectors.Selectors)
-		switch req.BySelectors.Match {
-		case datastore.BySelectors_MATCH_EXACT:
-			selectorsList = append(selectorsList, selectorSet.Raw())
-		case datastore.BySelectors_MATCH_SUBSET:
-			for combination := range selectorSet.Power() {
-				selectorsList = append(selectorsList, combination.Raw())
-			}
-		default:
-			return nil, fmt.Errorf("unhandled match behavior %q", req.BySelectors.Match)
-		}
-
-		// filter entries that don't match at least one selector set
-		for entryID, entry := range entriesSet {
-			matchesOne := false
-			for _, selectors := range selectorsList {
-				if !matchesSelectors(entry.Selectors, selectors) {
-					continue
-				}
-				if len(entry.Selectors) != len(selectors) {
-					continue
-				}
-				matchesOne = true
-				break
-			}
-			if !matchesOne {
-				delete(entriesSet, entryID)
-			}
-		}
-	}
-
-	// clone and sort entries from the set
-	entries := make([]*common.RegistrationEntry, 0, len(entriesSet))
-	for _, entry := range entriesSet {
-		entries = append(entries, cloneRegistrationEntry(entry))
-	}
-	util.SortRegistrationEntries(entries)
-
-	p := req.Pagination
-	// in case pagination is defined and page size greater than zero apply pagination
-	if p != nil && p.PageSize > 0 {
-		// as default start in first position
-		init := 0
-
-		// If token is defined set index of initial element
-		if p.Token != "" {
-			init = indexOf(p.Token, entries) + 1
-		}
-
-		// set end as initial element + page size, if end is greater to entries size use length as end
-		length := len(entries)
-		end := init + int(p.PageSize)
-		if end > length {
-			end = length
-		}
-
-		// create a new array with paged entries
-		pagedEntries := entries[init:end]
-		var token string
-		if len(pagedEntries) > 0 {
-			lastIndex := len(pagedEntries) - 1
-			// change token to latests element entryId
-			token = pagedEntries[lastIndex].EntryId
-		}
-		return &datastore.ListRegistrationEntriesResponse{
-			Entries: pagedEntries,
-			Pagination: &datastore.Pagination{
-				Token:    token,
-				PageSize: p.PageSize,
-			},
-		}, nil
-	}
-
-	return &datastore.ListRegistrationEntriesResponse{
-		Entries:    entries,
-		Pagination: p,
-	}, nil
-}
-
-func indexOf(element string, entries []*common.RegistrationEntry) int {
-	for k, e := range entries {
-		if element == e.EntryId {
-			return k
-		}
-	}
-	return -1
+	return resp, err
 }
 
 func (s *DataStore) UpdateRegistrationEntry(ctx context.Context, req *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	oldEntry, ok := s.registrationEntries[req.Entry.EntryId]
-	if !ok {
-		return nil, ErrNoSuchRegistrationEntry
-	}
-
-	s.removeBundleLinks(oldEntry.EntryId, oldEntry.FederatesWith)
-
-	entry := cloneRegistrationEntry(req.Entry)
-	s.registrationEntries[req.Entry.EntryId] = entry
-
-	if err := s.addBundleLinks(entry.EntryId, req.Entry.FederatesWith); err != nil {
+	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-
-	return &datastore.UpdateRegistrationEntryResponse{
-		Entry: cloneRegistrationEntry(entry),
-	}, nil
+	return s.ds.UpdateRegistrationEntry(ctx, req)
 }
 
 func (s *DataStore) DeleteRegistrationEntry(ctx context.Context, req *datastore.DeleteRegistrationEntryRequest) (*datastore.DeleteRegistrationEntryResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.expectErr != nil {
-		return nil, s.expectErr
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	registrationEntry, ok := s.registrationEntries[req.EntryId]
-	if !ok {
-		return nil, ErrNoSuchRegistrationEntry
-	}
-	delete(s.registrationEntries, req.EntryId)
-
-	s.removeBundleLinks(req.EntryId, registrationEntry.FederatesWith)
-
-	return &datastore.DeleteRegistrationEntryResponse{
-		Entry: cloneRegistrationEntry(registrationEntry),
-	}, nil
+	return s.ds.DeleteRegistrationEntry(ctx, req)
 }
 
 func (s *DataStore) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (*datastore.PruneRegistrationEntriesResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for key, entry := range s.registrationEntries {
-		if entry.EntryExpiry != 0 && entry.EntryExpiry < req.ExpiresBefore {
-			delete(s.registrationEntries, key)
-		}
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	return &datastore.PruneRegistrationEntriesResponse{}, nil
+	return s.ds.PruneRegistrationEntries(ctx, req)
 }
 
-// CreateJoinToken takes a Token message and stores it
 func (s *DataStore) CreateJoinToken(ctx context.Context, req *datastore.CreateJoinTokenRequest) (*datastore.CreateJoinTokenResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.tokens[req.JoinToken.Token]; ok {
-		return nil, ErrTokenAlreadyExists
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	s.tokens[req.JoinToken.Token] = cloneJoinToken(req.JoinToken)
-
-	return &datastore.CreateJoinTokenResponse{
-		JoinToken: cloneJoinToken(req.JoinToken),
-	}, nil
+	return s.ds.CreateJoinToken(ctx, req)
 }
 
-// FetchToken takes a Token message and returns one, populating the fields
-// we have knowledge of
 func (s *DataStore) FetchJoinToken(ctx context.Context, req *datastore.FetchJoinTokenRequest) (*datastore.FetchJoinTokenResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	joinToken, ok := s.tokens[req.Token]
-	if !ok {
-		return &datastore.FetchJoinTokenResponse{}, nil
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	return &datastore.FetchJoinTokenResponse{
-		JoinToken: cloneJoinToken(joinToken),
-	}, nil
+	return s.ds.FetchJoinToken(ctx, req)
 }
 
 func (s *DataStore) DeleteJoinToken(ctx context.Context, req *datastore.DeleteJoinTokenRequest) (*datastore.DeleteJoinTokenResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	joinToken, ok := s.tokens[req.Token]
-	if !ok {
-		return nil, ErrNoSuchToken
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-	delete(s.tokens, req.Token)
-
-	return &datastore.DeleteJoinTokenResponse{
-		JoinToken: cloneJoinToken(joinToken),
-	}, nil
+	return s.ds.DeleteJoinToken(ctx, req)
 }
 
 func (s *DataStore) PruneJoinTokens(ctx context.Context, req *datastore.PruneJoinTokensRequest) (*datastore.PruneJoinTokensResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for key, token := range s.tokens {
-		if token.Expiry < req.ExpiresBefore {
-			delete(s.tokens, key)
-		}
+	if err := s.getNextError(); err != nil {
+		return nil, err
 	}
-
-	return &datastore.PruneJoinTokensResponse{}, nil
+	return s.ds.PruneJoinTokens(ctx, req)
 }
 
-func (s *DataStore) SetError(err error) {
-	s.expectErr = err
+func (s *DataStore) SetNextError(err error) {
+	s.errs = []error{err}
+}
+
+func (s *DataStore) AppendNextError(err error) {
+	s.errs = append(s.errs, err)
+}
+
+func (s *DataStore) getNextError() error {
+	if len(s.errs) == 0 {
+		return nil
+	}
+	err := s.errs[0]
+	s.errs = s.errs[1:]
+	return err
 }
 
 func (s *DataStore) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	return &spi.ConfigureResponse{}, nil
 }
 
-func (*DataStore) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+func (s *DataStore) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
 	return &spi.GetPluginInfoResponse{}, nil
-}
-
-func (s *DataStore) addBundleLinks(entryID string, bundleIDs []string) error {
-	for _, bundleID := range bundleIDs {
-		if _, ok := s.bundles[bundleID]; !ok {
-			return ErrNoSuchBundle
-		}
-		bundleEntries := s.bundleEntries[bundleID]
-		if bundleEntries == nil {
-			bundleEntries = make(map[string]bool)
-			s.bundleEntries[bundleID] = bundleEntries
-		}
-		bundleEntries[entryID] = true
-	}
-	return nil
-}
-
-func (s *DataStore) removeBundleLinks(entryID string, bundleIDs []string) {
-	for _, bundleID := range bundleIDs {
-		delete(s.bundleEntries[bundleID], entryID)
-	}
-}
-
-func cloneBundle(bundle *common.Bundle) *common.Bundle {
-	return proto.Clone(bundle).(*common.Bundle)
-}
-
-func cloneAttestedNode(attestedNodeEntry *common.AttestedNode) *common.AttestedNode {
-	return proto.Clone(attestedNodeEntry).(*common.AttestedNode)
-}
-
-func cloneSelectors(selectors []*common.Selector) []*common.Selector {
-	return proto.Clone(&common.Selectors{Entries: selectors}).(*common.Selectors).Entries
-}
-
-func cloneRegistrationEntry(registrationEntry *common.RegistrationEntry) *common.RegistrationEntry {
-	return proto.Clone(registrationEntry).(*common.RegistrationEntry)
-}
-
-func cloneJoinToken(token *datastore.JoinToken) *datastore.JoinToken {
-	return proto.Clone(token).(*datastore.JoinToken)
-}
-
-func newRegistrationEntryID() (string, error) {
-	u, err := uuid.NewV4()
-	if err != nil {
-		return "", err
-	}
-	return u.String(), nil
-}
-
-func matchesSelectors(a, b []*common.Selector) bool {
-	a = append([]*common.Selector{}, a...)
-	util.SortSelectors(a)
-	b = append([]*common.Selector{}, b...)
-	util.SortSelectors(b)
-	if len(a) != len(b) {
-		return false
-	}
-	for i := 0; i < len(a); i++ {
-		if !proto.Equal(a[i], b[i]) {
-			return false
-		}
-	}
-	return true
-}
-
-func removeString(list []string, s string) []string {
-	out := make([]string, 0, len(list))
-	for _, entry := range list {
-		if entry != s {
-			out = append(out, entry)
-		}
-	}
-	return out
 }

--- a/test/fakes/fakeregistrationclient/client.go
+++ b/test/fakes/fakeregistrationclient/client.go
@@ -31,7 +31,7 @@ type Client struct {
 
 func New(t *testing.T, trustDomain string, ds datastore.DataStore, nowFn func() time.Time) *Client {
 	if ds == nil {
-		ds = fakedatastore.New()
+		ds = fakedatastore.New(t)
 	}
 	if nowFn == nil {
 		nowFn = time.Now


### PR DESCRIPTION
The current datastore is a distinct in-memory implementation. The semantics don't always line up with that returned by the SQL datastore. This has caused subtle bugs that aren't caught by unit-tests.

This change rips out the fake datastore internals and replaces them with the SQL datastore plugin using an in-memory SQLite3 database.