### PR TITLE
API Refactor: Use all-true mask in datastore RPCs

### DIFF
--- a/pkg/common/protoutil/masks.go
+++ b/pkg/common/protoutil/masks.go
@@ -1,4 +1,4 @@
-package api
+package protoutil
 
 import (
 	"reflect"
@@ -6,12 +6,16 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/spiffe/spire/proto/spire-next/types"
+	"github.com/spiffe/spire/proto/spire/common"
 )
 
 var (
 	AllTrueAgentMask  = MakeAllTrueMask(&types.AgentMask{}).(*types.AgentMask)
 	AllTrueBundleMask = MakeAllTrueMask(&types.BundleMask{}).(*types.BundleMask)
 	AllTrueEntryMask  = MakeAllTrueMask(&types.EntryMask{}).(*types.EntryMask)
+
+	AllTrueCommonBundleMask = MakeAllTrueMask(&common.BundleMask{}).(*common.BundleMask)
+	AllTrueCommonAgentMask  = MakeAllTrueMask(&common.AttestedNodeMask{}).(*common.AttestedNodeMask)
 )
 
 func MakeAllTrueMask(m proto.Message) proto.Message {

--- a/pkg/common/protoutil/masks_test.go
+++ b/pkg/common/protoutil/masks_test.go
@@ -1,9 +1,11 @@
-package api
+package protoutil_test
 
 import (
 	"testing"
 
+	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/proto/spire-next/types"
+	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,14 +16,14 @@ func TestAllTrueMasks(t *testing.T) {
 		X509SvidExpiresAt:    true,
 		Selectors:            true,
 		Banned:               true,
-	}, AllTrueAgentMask)
+	}, protoutil.AllTrueAgentMask)
 
 	assert.Equal(t, &types.BundleMask{
 		X509Authorities: true,
 		JwtAuthorities:  true,
 		RefreshHint:     true,
 		SequenceNumber:  true,
-	}, AllTrueBundleMask)
+	}, protoutil.AllTrueBundleMask)
 
 	assert.Equal(t, &types.EntryMask{
 		SpiffeId:      true,
@@ -33,5 +35,19 @@ func TestAllTrueMasks(t *testing.T) {
 		Downstream:    true,
 		ExpiresAt:     true,
 		DnsNames:      true,
-	}, AllTrueEntryMask)
+	}, protoutil.AllTrueEntryMask)
+
+	assert.Equal(t, &common.BundleMask{
+		RootCas:        true,
+		JwtSigningKeys: true,
+		RefreshHint:    true,
+	}, protoutil.AllTrueCommonBundleMask)
+
+	assert.Equal(t, &common.AttestedNodeMask{
+		AttestationDataType: true,
+		CertSerialNumber:    true,
+		CertNotAfter:        true,
+		NewCertSerialNumber: true,
+		NewCertNotAfter:     true,
+	}, protoutil.AllTrueCommonAgentMask)
 }


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
API Refactor: use all-true mask in datastore RPCs

**Description of change**
A previous PR introduced all-true masks in the `api` package to be used within the new API. Similar masks are also required in the `sql` package to be used in the datastore RPCs. 

This PR 
+ Moves the mask code to a common package: `protoutil`. 
+ Creates a couple of new mask and uses them in datastore RPCs 
 
Signed-off-by: Marcos Yedro <marcosyedro@gmail.com>
