### PR TITLE
Upgrade golangci-lint to 1.27.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ go_bin_dir := $(go_dir)/bin
 go_url = https://storage.googleapis.com/golang/go$(go_version).$(os1)-$(arch2).tar.gz
 go := PATH="$(go_bin_dir):$(PATH)" go
 
-golangci_lint_version = v1.23.6
+golangci_lint_version = v1.27.0
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 

--- a/cmd/spire-agent/cli/api/fetch_x509.go
+++ b/cmd/spire-agent/cli/api/fetch_x509.go
@@ -156,7 +156,7 @@ func (c *fetchX509Command) writeKey(filename string, privateKey crypto.PrivateKe
 
 // writeFile creates or truncates filename, and writes data to it
 func (c *fetchX509Command) writeFile(filename string, data []byte) error {
-	return ioutil.WriteFile(filename, data, 0644)
+	return ioutil.WriteFile(filename, data, 0644) // nolint: gosec // expected permission
 }
 
 type X509SVID struct {

--- a/cmd/spire-agent/cli/api/fetch_x509.go
+++ b/cmd/spire-agent/cli/api/fetch_x509.go
@@ -151,12 +151,12 @@ func (c *fetchX509Command) writeKey(filename string, privateKey crypto.PrivateKe
 		Bytes: data,
 	}
 
-	return c.writeFile(filename, pem.EncodeToMemory(b))
+	return ioutil.WriteFile(filename, pem.EncodeToMemory(b), 0600)
 }
 
 // writeFile creates or truncates filename, and writes data to it
 func (c *fetchX509Command) writeFile(filename string, data []byte) error {
-	return ioutil.WriteFile(filename, data, 0644) // nolint: gosec // expected permission
+	return ioutil.WriteFile(filename, data, 0644) // nolint: gosec // expected permission for certificates
 }
 
 type X509SVID struct {

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -195,7 +195,7 @@ func (s *BundleSuite) TestSetCreatesBundleFromFile() {
 
 	bundlePath := filepath.Join(tmpDir, "bundle.pem")
 
-	s.Require().NoError(ioutil.WriteFile(bundlePath, []byte(cert1PEM), 0644))
+	s.Require().NoError(ioutil.WriteFile(bundlePath, []byte(cert1PEM), 0600))
 	s.assertBundleSet("-path", bundlePath)
 }
 

--- a/cmd/spire-server/cli/bundle/experimental_bundle_test.go
+++ b/cmd/spire-server/cli/bundle/experimental_bundle_test.go
@@ -200,7 +200,7 @@ func (s *ExperimentalBundleSuite) TestSetCreatesBundleFromFile() {
 
 	bundlePath := filepath.Join(tmpDir, "bundle.pem")
 
-	s.Require().NoError(ioutil.WriteFile(bundlePath, []byte(otherDomainJWKS), 0644))
+	s.Require().NoError(ioutil.WriteFile(bundlePath, []byte(otherDomainJWKS), 0600))
 	s.assertBundleSet("-id", "spiffe://otherdomain.test", "-path", bundlePath)
 }
 

--- a/cmd/spire-server/cli/x509/mint.go
+++ b/cmd/spire-server/cli/x509/mint.go
@@ -165,7 +165,7 @@ func (c *mintCommand) run() error {
 		keyPath := c.env.JoinPath(c.write, "key.pem")
 		bundlePath := c.env.JoinPath(c.write, "bundle.pem")
 
-		if err := ioutil.WriteFile(svidPath, svidPEM.Bytes(), 0644); err != nil {
+		if err := ioutil.WriteFile(svidPath, svidPEM.Bytes(), 0644); err != nil { // nolint: gosec // expected permission
 			return fmt.Errorf("unable to write SVID: %v", err)
 		}
 		if err := c.env.Printf("X509-SVID written to %s\n", svidPath); err != nil {
@@ -179,7 +179,7 @@ func (c *mintCommand) run() error {
 			return err
 		}
 
-		if err := ioutil.WriteFile(bundlePath, bundlePEM.Bytes(), 0644); err != nil {
+		if err := ioutil.WriteFile(bundlePath, bundlePEM.Bytes(), 0644); err != nil { // nolint: gosec // expected permission
 			return fmt.Errorf("unable to write bundle: %v", err)
 		}
 		if err := c.env.Printf("Root CAs written to %s\n", bundlePath); err != nil {

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
@@ -162,7 +162,7 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	valuePath := s.joinPath(path)
 	err := os.MkdirAll(filepath.Dir(valuePath), 0755)
 	s.Require().NoError(err)
-	err = ioutil.WriteFile(valuePath, []byte(data), 0644)
+	err = ioutil.WriteFile(valuePath, []byte(data), 0600)
 	s.Require().NoError(err)
 	return valuePath
 }

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -139,7 +139,7 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	valuePath := s.joinPath(path)
 	err := os.MkdirAll(filepath.Dir(valuePath), 0755)
 	s.Require().NoError(err)
-	err = ioutil.WriteFile(valuePath, []byte(data), 0644)
+	err = ioutil.WriteFile(valuePath, []byte(data), 0600)
 	s.Require().NoError(err)
 	return valuePath
 }

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -185,6 +185,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		}
 
 		for _, item := range list.Items {
+			item := item
 			status, lookup := lookUpContainerInPod(containerID, item.Status)
 			switch lookup {
 			case containerInPod:

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -641,7 +641,7 @@ func (s *Suite) setServer(server *httptest.Server) {
 func (s *Suite) writeFile(path, data string) {
 	realPath := filepath.Join(s.dir, path)
 	s.Require().NoError(os.MkdirAll(filepath.Dir(realPath), 0755))
-	s.Require().NoError(ioutil.WriteFile(realPath, []byte(data), 0644))
+	s.Require().NoError(ioutil.WriteFile(realPath, []byte(data), 0600))
 }
 
 func (s *Suite) serveHTTP(w http.ResponseWriter, req *http.Request) {

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -217,7 +217,7 @@ func (s *Suite) configure(config string) {
 }
 
 func (s *Suite) writeFile(path string, data []byte) {
-	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, path), data, 0644))
+	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, path), data, 0600))
 }
 
 type fakeProcess struct {

--- a/pkg/common/peertracker/credentials.go
+++ b/pkg/common/peertracker/credentials.go
@@ -38,7 +38,8 @@ func (c *grpcCredentials) Info() credentials.ProtocolInfo {
 }
 
 func (c *grpcCredentials) Clone() credentials.TransportCredentials {
-	return &(*c) // nolint: staticcheck // cloning
+	copy := *c
+	return &copy
 }
 
 func (c *grpcCredentials) OverrideServerName(_ string) error {

--- a/pkg/common/peertracker/credentials.go
+++ b/pkg/common/peertracker/credentials.go
@@ -38,7 +38,7 @@ func (c *grpcCredentials) Info() credentials.ProtocolInfo {
 }
 
 func (c *grpcCredentials) Clone() credentials.TransportCredentials {
-	return &(*c) // nolint: staticcheck // clonning
+	return &(*c) // nolint: staticcheck // cloning
 }
 
 func (c *grpcCredentials) OverrideServerName(_ string) error {

--- a/pkg/common/peertracker/credentials.go
+++ b/pkg/common/peertracker/credentials.go
@@ -38,7 +38,7 @@ func (c *grpcCredentials) Info() credentials.ProtocolInfo {
 }
 
 func (c *grpcCredentials) Clone() credentials.TransportCredentials {
-	return &(*c)
+	return &(*c) // nolint: staticcheck // clonning
 }
 
 func (c *grpcCredentials) OverrideServerName(_ string) error {

--- a/pkg/common/plugin/k8s/apiserver/client_test.go
+++ b/pkg/common/plugin/k8s/apiserver/client_test.go
@@ -375,18 +375,18 @@ func createTokenReview(audience []string) *authv1.TokenReview {
 
 func (s *ClientSuite) createSampleKubeConfigFile(kubeConfigPath string) {
 	caPath := filepath.Join(s.dir, "ca.crt")
-	err := ioutil.WriteFile(caPath, kubeConfigCA, 0644)
+	err := ioutil.WriteFile(caPath, kubeConfigCA, 0600)
 	s.Require().NoError(err)
 
 	clientCrtPath := filepath.Join(s.dir, "client.crt")
-	err = ioutil.WriteFile(clientCrtPath, kubeConfigClientCert, 0644)
+	err = ioutil.WriteFile(clientCrtPath, kubeConfigClientCert, 0600)
 	s.Require().NoError(err)
 
 	clientKeyPath := filepath.Join(s.dir, "client.key")
-	err = ioutil.WriteFile(clientKeyPath, kubeConfigClientKey, 0644)
+	err = ioutil.WriteFile(clientKeyPath, kubeConfigClientKey, 0600)
 	s.Require().NoError(err)
 
 	kubeConfigContent := []byte(fmt.Sprintf(kubeConfig, caPath, clientCrtPath, clientKeyPath))
-	err = ioutil.WriteFile(kubeConfigPath, kubeConfigContent, 0644)
+	err = ioutil.WriteFile(kubeConfigPath, kubeConfigContent, 0600)
 	s.Require().NoError(err)
 }

--- a/pkg/server/ca/journal_test.go
+++ b/pkg/server/ca/journal_test.go
@@ -295,7 +295,7 @@ func (s *JournalSuite) writeString(path, data string) {
 }
 
 func (s *JournalSuite) writeBytes(path string, data []byte) {
-	s.Require().NoError(ioutil.WriteFile(path, data, 0644))
+	s.Require().NoError(ioutil.WriteFile(path, data, 0600))
 }
 
 func (s *JournalSuite) now() time.Time {

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -453,7 +453,7 @@ func (s *ManagerSuite) TestMigration() {
 	// assert that we migrate on load by writing junk data to the old JSON file
 	// and making sure initialization fails. The journal tests exercise this
 	// code more carefully.
-	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, "certs.json"), []byte("NOTJSON"), 0644))
+	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, "certs.json"), []byte("NOTJSON"), 0600))
 	s.m = NewManager(s.selfSignedConfig())
 	err := s.m.Initialize(context.Background())
 	s.RequireErrorContains(err, "failed to migrate old JSON data: unable to decode JSON")

--- a/pkg/server/plugin/nodeattestor/k8s/psat/psat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/psat/psat_test.go
@@ -389,9 +389,9 @@ func (s *AttestorSuite) TestConfigure() {
 
 	// cluster missing service account whitelist
 	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		Configuration: fmt.Sprint(`clusters = {
+		Configuration: `clusters = {
 			"FOO" = {}
-		}`),
+		}`,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
 	s.RequireGRPCStatus(err, codes.Unknown, `k8s-psat: cluster "FOO" configuration must have at least one service account whitelisted`)
@@ -447,7 +447,7 @@ func (s *AttestorSuite) configureAttestor() nodeattestor.Plugin {
 	attestor := New()
 
 	resp, err := attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		Configuration: fmt.Sprint(`
+		Configuration: `
 		clusters = {
 			"FOO" = {
 				service_account_whitelist = ["NS1:SA1"]
@@ -461,7 +461,7 @@ func (s *AttestorSuite) configureAttestor() nodeattestor.Plugin {
 				audience = ["AUDIENCE"]
 			}
 		}
-		`),
+		`,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
 	s.Require().NoError(err)
@@ -528,7 +528,7 @@ func createAndWriteSelfSignedCert(cn string, signer crypto.Signer, path string) 
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644); err != nil {
+	if err := ioutil.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -347,11 +347,11 @@ func (s *AttestorSuite) TestConfigure() {
 
 	// cluster missing service account whitelist (token review validation config)
 	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		Configuration: fmt.Sprint(`clusters = {
+		Configuration: `clusters = {
 				"BAR" = {
 					use_token_review_api_validation = true
 				}
-			}`),
+			}`,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
 	s.RequireGRPCStatus(err, codes.Unknown, `k8s-sat: cluster "BAR" configuration must have at least one service account whitelisted`)
@@ -371,7 +371,7 @@ func (s *AttestorSuite) TestConfigure() {
 	s.Require().Nil(resp)
 
 	// no keys in PEM file
-	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, "nokeys.pem"), []byte{}, 0644))
+	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, "nokeys.pem"), []byte{}, 0600))
 	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: fmt.Sprintf(`clusters = {
 				"FOO" = {
@@ -394,7 +394,7 @@ func (s *AttestorSuite) TestServiceAccountKeyFileAlternateEncodings() {
 	s.Require().NoError(ioutil.WriteFile(fooPKCS1KeyPath, pem.EncodeToMemory(&pem.Block{
 		Type:  "RSA PUBLIC KEY",
 		Bytes: fooPKCS1Bytes,
-	}), 0644))
+	}), 0600))
 
 	fooPKIXKeyPath := filepath.Join(s.dir, "foo-pkix.pem")
 	fooPKIXBytes, err := x509.MarshalPKIXPublicKey(s.fooKey.Public())
@@ -402,7 +402,7 @@ func (s *AttestorSuite) TestServiceAccountKeyFileAlternateEncodings() {
 	s.Require().NoError(ioutil.WriteFile(fooPKIXKeyPath, pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",
 		Bytes: fooPKIXBytes,
-	}), 0644))
+	}), 0600))
 
 	barPKIXKeyPath := filepath.Join(s.dir, "bar-pkix.pem")
 	barPKIXBytes, err := x509.MarshalPKIXPublicKey(s.barKey.Public())
@@ -410,7 +410,7 @@ func (s *AttestorSuite) TestServiceAccountKeyFileAlternateEncodings() {
 	s.Require().NoError(ioutil.WriteFile(barPKIXKeyPath, pem.EncodeToMemory(&pem.Block{
 		Type:  "PUBLIC KEY",
 		Bytes: barPKIXBytes,
-	}), 0644))
+	}), 0600))
 
 	_, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: fmt.Sprintf(`clusters = {
@@ -554,7 +554,7 @@ func createAndWriteSelfSignedCert(cn string, signer crypto.Signer, path string) 
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644); err != nil {
+	if err := ioutil.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -36,7 +36,7 @@ func TestLoadConfig(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 
-	err = ioutil.WriteFile(confPath, []byte(minimalRegistrationAPIConfig), 0644)
+	err = ioutil.WriteFile(confPath, []byte(minimalRegistrationAPIConfig), 0600)
 	require.NoError(err)
 
 	config, err := LoadConfig(confPath)

--- a/test/fixture/nodeattestor/x509pop/generate.go
+++ b/test/fixture/nodeattestor/x509pop/generate.go
@@ -94,6 +94,6 @@ func writeCerts(path string, certs ...*x509.Certificate) {
 		})
 		panice(err)
 	}
-	err := ioutil.WriteFile(path, data.Bytes(), 0644)
+	err := ioutil.WriteFile(path, data.Bytes(), 0600)
 	panice(err)
 }

--- a/tools/plugintest/main.go
+++ b/tools/plugintest/main.go
@@ -44,7 +44,7 @@ func run(ctx context.Context) error {
 	}
 
 	pluginPath := args[0]
-	pid, err := strconv.Atoi(args[1])
+	pid, err := strconv.Atoi(args[1]) // nolint: gosec
 	if err != nil {
 		return errors.New("pid argument is malformed")
 	}

--- a/tools/spire-plugingen/main.go
+++ b/tools/spire-plugingen/main.go
@@ -331,7 +331,7 @@ func (g *generator) generate() (err error) {
 			return errs.Wrap(err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(outDir, strings.ToLower(client.Name)+".go"), outBytes, 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outDir, strings.ToLower(client.Name)+".go"), outBytes, 0644); err != nil { // nolint: gosec // expected permission
 			return errs.New("unable to write generated code for %s: %v", client.Name, err)
 		}
 	}


### PR DESCRIPTION
Upgrade golangci-lint to 1.27.0
it upgraded gosec to 2.0, most of lint found are related with code using `644` instead of `600` for certificates, 
I updated it only in tests but keep 644 on code.
There are some lints that we can add and may be useful:
- **prealloc**: Finds slice declarations that could potentially be preallocated
- **goerr113**: Golang linter to check the errors handling expressions
- **testpackage**: linter that makes you use a separate _test package (this will require several changes in tests)
- **nolintlint**: Reports ill-formed or insufficient nolint directives