### PR TITLE
API refactor: implement attest agent #1638

### DIFF
--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -3,26 +3,34 @@ package agent
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
+	"io"
 	"path"
 	"time"
 
+	"github.com/andres-erbsen/clock"
 	"github.com/gofrs/uuid"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/nodeutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"github.com/spiffe/spire/pkg/server/ca"
+	"github.com/spiffe/spire/pkg/server/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
+	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire-next/api/server/agent/v1"
 	"github.com/spiffe/spire/proto/spire-next/types"
 	"github.com/spiffe/spire/proto/spire/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
@@ -33,6 +41,8 @@ func RegisterService(s *grpc.Server, service *Service) {
 
 // Config is the service configuration
 type Config struct {
+	Catalog     catalog.Catalog
+	Clock       clock.Clock
 	DataStore   datastore.DataStore
 	ServerCA    ca.ServerCA
 	TrustDomain spiffeid.TrustDomain
@@ -41,17 +51,21 @@ type Config struct {
 // New creates a new agent service
 func New(config Config) *Service {
 	return &Service{
-		ca: config.ServerCA,
-		ds: config.DataStore,
-		td: config.TrustDomain,
+		cat: config.Catalog,
+		clk: config.Clock,
+		ds:  config.DataStore,
+		ca:  config.ServerCA,
+		td:  config.TrustDomain,
 	}
 }
 
 // Service implements the v1 agent service
 type Service struct {
-	ca ca.ServerCA
-	ds datastore.DataStore
-	td spiffeid.TrustDomain
+	cat catalog.Catalog
+	clk clock.Clock
+	ds  datastore.DataStore
+	ca  ca.ServerCA
+	td  spiffeid.TrustDomain
 }
 
 func (s *Service) ListAgents(ctx context.Context, req *agent.ListAgentsRequest) (*agent.ListAgentsResponse, error) {
@@ -178,8 +192,8 @@ func (s *Service) DeleteAgent(ctx context.Context, req *agent.DeleteAgentRequest
 	}
 
 	if !id.MemberOf(s.td) {
-		log.Error("Invalid request: cannot ban an agent that does not belong to this trust domain")
-		return nil, status.Errorf(codes.InvalidArgument, "cannot ban an agent that does not belong to this trust domain")
+		log.Error("Invalid request: cannot delete an agent that does not belong to this trust domain")
+		return nil, status.Errorf(codes.InvalidArgument, "cannot delete an agent that does not belong to this trust domain")
 	}
 
 	_, err = s.ds.DeleteAttestedNode(ctx, &datastore.DeleteAttestedNodeRequest{
@@ -243,7 +257,128 @@ func (s *Service) BanAgent(ctx context.Context, req *agent.BanAgentRequest) (*em
 }
 
 func (s *Service) AttestAgent(stream agent.Agent_AttestAgentServer) error {
-	return status.Error(codes.Unimplemented, "method not implemented")
+	ctx := stream.Context()
+	log := rpccontext.Logger(ctx)
+
+	if err := rpccontext.RateLimit(ctx, 1); err != nil {
+		log.WithError(err).Error("Rejecting request due to attest agent rate limiting")
+		return err
+	}
+
+	req, err := stream.Recv()
+	if err != nil {
+		log.WithError(err).Error("Failed to receive request from stream")
+		return status.Errorf(codes.InvalidArgument, "failed to receive request from stream: %v", err)
+	}
+
+	// validate
+	params := req.GetParams()
+	if err := validateAttestAgentParams(params); err != nil {
+		log.WithError(err).Error("Invalid request: malformed param")
+		return status.Errorf(codes.InvalidArgument, "malformed param: %v", err)
+	}
+
+	log = log.WithField(telemetry.NodeAttestorType, params.Data.Type)
+
+	// attest
+	var attestResp *nodeattestor.AttestResponse
+	if params.Data.Type == "join_token" {
+		attestResp, err = s.attestJoinToken(ctx, params.Data.Payload)
+		if err != nil {
+			return err
+		}
+	} else {
+		attestResp, err = s.attestChallengeResponse(ctx, stream, params)
+		if err != nil {
+			return err
+		}
+	}
+
+	agentID := attestResp.AgentId
+	agentSpiffeID, err := spiffeid.FromString(agentID)
+	if err != nil {
+		log.WithError(err).Error("Invalid agent id")
+		return status.Error(codes.Internal, "invalid agent id")
+	}
+	log = log.WithField(telemetry.AgentID, agentID)
+
+	// fetch the agent/node to check if it was already attested or banned
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{
+		SpiffeId: agentID,
+	})
+	if err != nil {
+		log.WithError(err).Error("Failed to fetch agent")
+		return status.Error(codes.Internal, "failed to fetch agent")
+	}
+
+	if attestedNode.Node != nil && nodeutil.IsAgentBanned(attestedNode.Node) {
+		log.Error("Failed to attest: agent is banned")
+		return status.Error(codes.PermissionDenied, "failed to attest: agent is banned")
+	}
+
+	// parse and sign CSR
+	svid, err := s.signSvid(ctx, &agentSpiffeID, params.Params.Csr, log)
+	if err != nil {
+		return err
+	}
+
+	// augment selectors with resolver
+	augmentedSels, err := s.augmentSelectors(ctx, agentID, attestResp.Selectors, params.Data.Type)
+	if err != nil {
+		log.WithError(err).Error("Failed to augment selectors")
+		return status.Error(codes.Internal, "failed to augment selectors")
+	}
+	// store augmented selectors
+	_, err = s.ds.SetNodeSelectors(ctx, &datastore.SetNodeSelectorsRequest{
+		Selectors: &datastore.NodeSelectors{
+			SpiffeId:  agentID,
+			Selectors: augmentedSels,
+		},
+	})
+	if err != nil {
+		log.WithError(err).Error("Failed to update selectors")
+		return status.Error(codes.Internal, "failed to update selectors")
+	}
+
+	// create or update attested entry
+	if attestedNode.Node == nil {
+		req := &datastore.CreateAttestedNodeRequest{
+			Node: &common.AttestedNode{
+				AttestationDataType: params.Data.Type,
+				SpiffeId:            agentID,
+				CertNotAfter:        svid[0].NotAfter.Unix(),
+				CertSerialNumber:    svid[0].SerialNumber.String(),
+			}}
+		if _, err := s.ds.CreateAttestedNode(ctx, req); err != nil {
+			log.WithError(err).Error("Failed to create attested agent")
+			return status.Error(codes.Internal, "failed to create attested agent")
+		}
+	} else {
+		req := &datastore.UpdateAttestedNodeRequest{
+			SpiffeId:         agentID,
+			CertNotAfter:     svid[0].NotAfter.Unix(),
+			CertSerialNumber: svid[0].SerialNumber.String(),
+		}
+		if _, err := s.ds.UpdateAttestedNode(ctx, req); err != nil {
+			log.WithError(err).Error("Failed to update attested agent")
+			return status.Error(codes.Internal, "failed to update attested agent")
+		}
+	}
+
+	// build and send response
+	response := getAttestAgentResponse(agentSpiffeID, svid)
+
+	if p, ok := peer.FromContext(ctx); ok {
+		log = log.WithField(telemetry.Address, p.Addr.String())
+	}
+	log.Info("Agent attestation request completed")
+
+	if err := stream.Send(response); err != nil {
+		log.WithError(err).Error("Failed to send response over stream")
+		return status.Errorf(codes.Internal, "failed to send response over stream: %v", err)
+	}
+
+	return nil
 }
 
 func (s *Service) RenewAgent(ctx context.Context, req *agent.RenewAgentRequest) (*agent.RenewAgentResponse, error) {
@@ -266,8 +401,12 @@ func (s *Service) RenewAgent(ctx context.Context, req *agent.RenewAgentRequest) 
 		log.Error("Invalid argument: params cannot be nil")
 		return nil, status.Error(codes.InvalidArgument, "params cannot be nil")
 	}
+	if len(req.Params.Csr) == 0 {
+		log.Error("Invalid argument: missing CSR")
+		return nil, status.Error(codes.InvalidArgument, "missing CSR")
+	}
 
-	agentSVID, err := s.signSvid(ctx, &callerID, req.Params, log)
+	agentSVID, err := s.signSvid(ctx, &callerID, req.Params.Csr, log)
 	if err != nil {
 		return nil, err
 	}
@@ -292,45 +431,6 @@ func (s *Service) RenewAgent(ctx context.Context, req *agent.RenewAgentRequest) 
 			CertChain: x509util.RawCertsFromCertificates(agentSVID),
 		},
 	}, nil
-}
-
-func (s *Service) updateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest, log logrus.FieldLogger) error {
-	_, err := s.ds.UpdateAttestedNode(ctx, req)
-	switch status.Code(err) {
-	case codes.OK:
-		return nil
-	case codes.NotFound:
-		log.WithError(err).Error("Agent not found")
-		return status.Errorf(codes.NotFound, "agent not found: %v", err)
-	default:
-		log.WithError(err).Error("Failed to update agent")
-		return status.Errorf(codes.Internal, "failed to update agent: %v", err)
-	}
-}
-
-func (s *Service) signSvid(ctx context.Context, agentID *spiffeid.ID, params *agent.AgentX509SVIDParams, log logrus.FieldLogger) ([]*x509.Certificate, error) {
-	if len(params.Csr) == 0 {
-		log.Error("Invalid argument: missing CSR")
-		return nil, status.Error(codes.InvalidArgument, "missing CSR")
-	}
-
-	csr, err := x509.ParseCertificateRequest(params.Csr)
-	if err != nil {
-		log.WithError(err).Error("Invalid argument: failed to parse CSR")
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse CSR: %v", err)
-	}
-
-	// Sign a new X509 SVID
-	x509Svid, err := s.ca.SignX509SVID(ctx, ca.X509SVIDParams{
-		SpiffeID:  agentID.String(),
-		PublicKey: csr.PublicKey,
-	})
-	if err != nil {
-		log.WithError(err).Error("Failed to sign X509 SVID")
-		return nil, status.Errorf(codes.Internal, "failed to sign X509 SVID: %v", err)
-	}
-
-	return x509Svid, nil
 }
 
 func (s *Service) CreateJoinToken(ctx context.Context, req *agent.CreateJoinTokenRequest) (*types.JoinToken, error) {
@@ -405,7 +505,183 @@ func (s *Service) createJoinTokenRegistrationEntry(ctx context.Context, token st
 	return nil
 }
 
-func applyMask(a *types.Agent, mask *types.AgentMask) { //nolint: unused,deadcode
+func (s *Service) updateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest, log logrus.FieldLogger) error {
+	_, err := s.ds.UpdateAttestedNode(ctx, req)
+	switch status.Code(err) {
+	case codes.OK:
+		return nil
+	case codes.NotFound:
+		log.WithError(err).Error("Agent not found")
+		return status.Errorf(codes.NotFound, "agent not found: %v", err)
+	default:
+		log.WithError(err).Error("Failed to update agent")
+		return status.Errorf(codes.Internal, "failed to update agent: %v", err)
+	}
+}
+
+func (s *Service) signSvid(ctx context.Context, agentID *spiffeid.ID, csr []byte, log logrus.FieldLogger) ([]*x509.Certificate, error) {
+	parsedCsr, err := x509.ParseCertificateRequest(csr)
+	if err != nil {
+		log.WithError(err).Error("Invalid argument: failed to parse CSR")
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse CSR: %v", err)
+	}
+
+	// Sign a new X509 SVID
+	x509Svid, err := s.ca.SignX509SVID(ctx, ca.X509SVIDParams{
+		SpiffeID:  agentID.String(),
+		PublicKey: parsedCsr.PublicKey,
+	})
+	if err != nil {
+		log.WithError(err).Error("Failed to sign X509 SVID")
+		return nil, status.Errorf(codes.Internal, "failed to sign X509 SVID: %v", err)
+	}
+
+	return x509Svid, nil
+}
+
+func (s *Service) getSelectorsFromAgentID(ctx context.Context, agentID string) ([]*types.Selector, error) {
+	resp, err := s.ds.GetNodeSelectors(ctx, &datastore.GetNodeSelectorsRequest{
+		SpiffeId: agentID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node selectors: %v", err)
+	}
+
+	return api.NodeSelectorsToProto(resp.Selectors)
+}
+
+func (s *Service) attestJoinToken(ctx context.Context, token string) (*nodeattestor.AttestResponse, error) {
+	log := rpccontext.Logger(ctx).WithField(telemetry.NodeAttestorType, "join_token")
+
+	resp, err := s.ds.FetchJoinToken(ctx, &datastore.FetchJoinTokenRequest{
+		Token: token,
+	})
+	switch {
+	case err != nil:
+		log.WithError(err).Error("Failed to fetch join token")
+		return nil, status.Error(codes.Internal, "failed to fetch join token")
+	case resp.JoinToken == nil:
+		log.Error("Failed to attest: join token does not exist or has already been used")
+		return nil, status.Error(codes.InvalidArgument, "failed to attest: join token does not exist or has already been used")
+	}
+
+	_, err = s.ds.DeleteJoinToken(ctx, &datastore.DeleteJoinTokenRequest{
+		Token: token,
+	})
+	switch {
+	case err != nil:
+		log.WithError(err).Error("Failed to delete join token")
+		return nil, status.Error(codes.Internal, "failed to delete join token")
+	case time.Unix(resp.JoinToken.Expiry, 0).Before(s.clk.Now()):
+		log.Error("Join token expired")
+		return nil, status.Error(codes.InvalidArgument, "join token expired")
+	}
+
+	tokenPath := path.Join("spire", "agent", "join_token", token)
+	return &nodeattestor.AttestResponse{
+		AgentId: s.td.NewID(tokenPath).String(),
+	}, nil
+}
+
+func (s *Service) attestChallengeResponse(ctx context.Context, agentStream agent.Agent_AttestAgentServer, params *agent.AttestAgentRequest_Params) (*nodeattestor.AttestResponse, error) {
+	attestorType := params.Data.Type
+	log := rpccontext.Logger(ctx).WithField(telemetry.NodeAttestorType, attestorType)
+
+	nodeAttestor, ok := s.cat.GetNodeAttestorNamed(attestorType)
+	if !ok {
+		log.Error("Could not find node attestor type")
+		return nil, status.Errorf(codes.FailedPrecondition, "could not find node attestor type %q", attestorType)
+	}
+
+	attestorStream, err := nodeAttestor.Attest(ctx)
+	if err != nil {
+		log.WithError(err).Error("Unable to open stream with attestor")
+		return nil, status.Error(codes.Internal, "unable to open stream with attestor")
+	}
+
+	attestRequest := &nodeattestor.AttestRequest{
+		AttestationData: &common.AttestationData{
+			Type: attestorType,
+			Data: []byte(params.Data.Payload),
+		},
+	}
+	var attestResp *nodeattestor.AttestResponse
+
+	for {
+		attestResp, err = attest(attestorStream, attestRequest)
+		if err != nil {
+			log.WithError(err).Error("Failed to attest")
+			return nil, status.Error(codes.Internal, "failed to attest")
+		}
+		// Without a challenge we are done. Otherwise we need to continue the challenge/response flow
+		if attestResp.Challenge == nil {
+			break
+		}
+
+		resp := &agent.AttestAgentResponse{
+			Step: &agent.AttestAgentResponse_Challenge{
+				Challenge: attestResp.Challenge,
+			},
+		}
+		if err := agentStream.Send(resp); err != nil {
+			log.WithError(err).Error("Failed to send challenge to agent")
+			return nil, status.Error(codes.Internal, "failed to send challenge to agent")
+		}
+
+		req, err := agentStream.Recv()
+		if err != nil {
+			log.WithError(err).Error("Failed to receive challenge from agent")
+			return nil, status.Error(codes.Internal, "failed to receive challenge from agent")
+		}
+
+		attestRequest = &nodeattestor.AttestRequest{
+			Response: req.GetChallengeResponse(),
+		}
+	}
+
+	if attestResp.AgentId == "" {
+		log.WithError(err).Error("Failed to attest: AgentID response should not be empty")
+		return nil, status.Error(codes.Internal, "failed to attest: AgentID response should not be empty")
+	}
+
+	if err := attestorStream.CloseSend(); err != nil {
+		log.WithError(err).Error("Failed to close send stream")
+		return nil, status.Errorf(codes.Internal, "failed to close send stream: %v", err)
+	}
+	if _, err := attestorStream.Recv(); err != io.EOF {
+		log.WithError(err).Warn("Expected EOF on attestation stream")
+	}
+
+	return attestResp, nil
+}
+
+func (s *Service) augmentSelectors(ctx context.Context, agentID string, selectors []*common.Selector, attestationType string) ([]*common.Selector, error) {
+	log := rpccontext.Logger(ctx).
+		WithField(telemetry.AgentID, agentID).
+		WithField(telemetry.NodeAttestorType, attestationType)
+
+	// Select node resolver based on request attestation type
+	nodeResolver, ok := s.cat.GetNodeResolverNamed(attestationType)
+	if !ok {
+		log.Debug("Could not find node resolver")
+		return selectors, nil
+	}
+
+	//Call node resolver plugin to get a map of spiffeID=>Selector
+	response, err := nodeResolver.Resolve(ctx, &noderesolver.ResolveRequest{
+		BaseSpiffeIdList: []string{agentID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resolved := response.Map[agentID]; resolved != nil {
+		selectors = append(selectors, resolved.Entries...)
+	}
+
+	return selectors, nil
+}
+
+func applyMask(a *types.Agent, mask *types.AgentMask) {
 	if mask == nil {
 		return
 	}
@@ -430,13 +706,44 @@ func applyMask(a *types.Agent, mask *types.AgentMask) { //nolint: unused,deadcod
 	}
 }
 
-func (s *Service) getSelectorsFromAgentID(ctx context.Context, agentID string) ([]*types.Selector, error) {
-	resp, err := s.ds.GetNodeSelectors(ctx, &datastore.GetNodeSelectorsRequest{
-		SpiffeId: agentID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get node selectors: %v", err)
+func validateAttestAgentParams(params *agent.AttestAgentRequest_Params) error {
+	switch {
+	case params == nil:
+		return errors.New("missing params")
+	case params.Data == nil:
+		return errors.New("missing attestation data")
+	case params.Params == nil:
+		return errors.New("missing X509-SVID parameters")
+	case len(params.Params.Csr) == 0:
+		return errors.New("missing CSR")
+	case params.Data.Type == "":
+		return errors.New("missing attestation data type")
+	case params.Data.Payload == "":
+		return errors.New("missing attestation data payload")
+	default:
+		return nil
+	}
+}
+
+func attest(attestorStream nodeattestor.NodeAttestor_AttestClient, attestRequest *nodeattestor.AttestRequest) (*nodeattestor.AttestResponse, error) {
+	if err := attestorStream.Send(attestRequest); err != nil {
+		return nil, err
+	}
+	return attestorStream.Recv()
+}
+
+func getAttestAgentResponse(spiffeID spiffeid.ID, certificates []*x509.Certificate) *agent.AttestAgentResponse {
+	svid := &types.X509SVID{
+		Id:        api.ProtoFromID(spiffeID),
+		CertChain: x509util.RawCertsFromCertificates(certificates),
+		ExpiresAt: certificates[0].NotAfter.Unix(),
 	}
 
-	return api.NodeSelectorsToProto(resp.Selectors)
+	return &agent.AttestAgentResponse{
+		Step: &agent.AttestAgentResponse_Result_{
+			Result: &agent.AttestAgentResponse_Result{
+				Svid: svid,
+			},
+		},
+	}
 }

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"testing"
 	"time"
@@ -15,23 +16,31 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/api/agent/v1"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
+	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	agentpb "github.com/spiffe/spire/proto/spire-next/api/server/agent/v1"
 	"github.com/spiffe/spire/proto/spire-next/types"
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
+	"github.com/spiffe/spire/test/fakes/fakenoderesolver"
 	"github.com/spiffe/spire/test/fakes/fakeserverca"
+	"github.com/spiffe/spire/test/fakes/fakeservercatalog"
+	"github.com/spiffe/spire/test/fakes/fakeservernodeattestor"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/testkey"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"gotest.tools/assert"
 )
 
 const (
@@ -685,14 +694,14 @@ func TestDeleteAgent(t *testing.T) {
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
-					Message: "Invalid request: cannot ban an agent that does not belong to this trust domain",
+					Message: "Invalid request: cannot delete an agent that does not belong to this trust domain",
 					Data: logrus.Fields{
 						telemetry.SPIFFEID: "spiffe://another.org/spire/agent/node1",
 					},
 				},
 			},
 			code: codes.InvalidArgument,
-			err:  "cannot ban an agent that does not belong to this trust domain",
+			err:  "cannot delete an agent that does not belong to this trust domain",
 			req: &agentpb.DeleteAgentRequest{
 				Id: &types.SPIFFEID{
 					TrustDomain: "another.org",
@@ -1230,27 +1239,555 @@ func TestCreateJoinTokenWithAgentId(t *testing.T) {
 	require.Equal(t, "spiffe://example.org/spire/agent/join_token/"+token.Value, listEntries.Entries[0].Selectors[0].Value)
 }
 
+func TestAttestAgent(t *testing.T) {
+	testCsr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{}, testkey.MustEC256())
+	require.NoError(t, err)
+
+	_, expectedCsrErr := x509.ParseCertificateRequest([]byte("not a csr"))
+	require.Error(t, expectedCsrErr)
+
+	for _, tt := range []struct {
+		name              string
+		retry             bool
+		request           *agentpb.AttestAgentRequest
+		expectedID        spiffeid.ID
+		expectedSelectors []*common.Selector
+		expectedErr       string
+		expectedLogMsgs   []spiretest.LogEntry
+		rateLimiterErr    error
+		code              codes.Code
+		dsError           []error
+	}{
+
+		{
+			name:        "empty request",
+			request:     &agentpb.AttestAgentRequest{},
+			expectedErr: "malformed param: missing params",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid request: malformed param",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "missing params",
+					},
+				},
+			},
+		},
+
+		{
+			name: "empty attestation data",
+			request: &agentpb.AttestAgentRequest{
+				Step: &agentpb.AttestAgentRequest_Params_{
+					Params: &agentpb.AttestAgentRequest_Params{},
+				},
+			},
+			expectedErr: "malformed param: missing attestation data",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid request: malformed param",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "missing attestation data",
+					},
+				},
+			},
+		},
+
+		{
+			name: "missing parameters",
+			request: &agentpb.AttestAgentRequest{
+				Step: &agentpb.AttestAgentRequest_Params_{
+					Params: &agentpb.AttestAgentRequest_Params{
+						Data: &types.AttestationData{
+							Type: "foo type",
+						},
+					},
+				},
+			},
+			expectedErr: "malformed param: missing X509-SVID parameters",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid request: malformed param",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "missing X509-SVID parameters",
+					},
+				},
+			},
+		},
+
+		{
+			name: "missing attestation data type",
+			request: &agentpb.AttestAgentRequest{
+				Step: &agentpb.AttestAgentRequest_Params_{
+					Params: &agentpb.AttestAgentRequest_Params{
+						Data: &types.AttestationData{},
+						Params: &agentpb.AgentX509SVIDParams{
+							Csr: []byte("fake csr"),
+						},
+					},
+				},
+			},
+			expectedErr: "malformed param: missing attestation data type",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid request: malformed param",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "missing attestation data type",
+					},
+				},
+			},
+		},
+
+		{
+			name: "missing csr",
+			request: &agentpb.AttestAgentRequest{
+				Step: &agentpb.AttestAgentRequest_Params_{
+					Params: &agentpb.AttestAgentRequest_Params{
+						Data: &types.AttestationData{
+							Type: "foo type",
+						},
+						Params: &agentpb.AgentX509SVIDParams{},
+					},
+				},
+			},
+			expectedErr: "malformed param: missing CSR",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid request: malformed param",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "missing CSR",
+					},
+				},
+			},
+		},
+
+		{
+			name:           "rate limit fails",
+			request:        &agentpb.AttestAgentRequest{},
+			expectedErr:    "rate limit fails",
+			rateLimiterErr: status.Error(codes.Unknown, "rate limit fails"),
+			code:           codes.Unknown,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Rejecting request due to attest agent rate limiting",
+					Data: logrus.Fields{
+						logrus.ErrorKey: "rpc error: code = Unknown desc = rate limit fails",
+					},
+				},
+			},
+		},
+
+		{
+			name:        "join token does not exist",
+			request:     getAttestAgentRequest("join_token", "bad_token", testCsr),
+			expectedErr: "failed to attest: join token does not exist or has already been used",
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to attest: join token does not exist or has already been used",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+					},
+				},
+			},
+		},
+
+		{
+			name:       "attest with join token",
+			request:    getAttestAgentRequest("join_token", "test_token", testCsr),
+			expectedID: td.NewID("/spire/agent/join_token/test_token"),
+		},
+
+		{
+			name:        "attest with join token is banned",
+			expectedErr: "failed to attest: agent is banned",
+			request:     getAttestAgentRequest("join_token", "banned_token", testCsr),
+			code:        codes.PermissionDenied,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to attest: agent is banned",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/banned_token").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "attest with join token is expired",
+			expectedErr: "join token expired",
+			request:     getAttestAgentRequest("join_token", "expired_token", testCsr),
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Join token expired",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+					},
+				},
+			},
+		},
+
+		{
+			name:        "attest with join token only works once",
+			retry:       true,
+			expectedErr: "failed to attest: join token does not exist or has already been used",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to attest: join token does not exist or has already been used",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+					},
+				},
+			},
+		},
+
+		{
+			name:       "attest with result",
+			request:    getAttestAgentRequest("test_type", "payload_with_result", testCsr),
+			expectedID: td.NewID("/spire/agent/test_type/id_with_result"),
+			expectedSelectors: []*common.Selector{
+				{Type: "test_type", Value: "resolved"},
+				{Type: "test_type", Value: "result"},
+			},
+		},
+
+		{
+			name:       "attest with result twice",
+			retry:      true,
+			request:    getAttestAgentRequest("test_type", "payload_with_result", testCsr),
+			expectedID: td.NewID("/spire/agent/test_type/id_with_result"),
+			expectedSelectors: []*common.Selector{
+				{Type: "test_type", Value: "resolved"},
+				{Type: "test_type", Value: "result"},
+			},
+		},
+
+		{
+			name:       "attest with challenge",
+			request:    getAttestAgentRequest("test_type", "payload_with_challenge", testCsr),
+			expectedID: td.NewID("/spire/agent/test_type/id_with_challenge"),
+			expectedSelectors: []*common.Selector{
+				{Type: "test_type", Value: "challenge"},
+				{Type: "test_type", Value: "resolved_too"},
+			},
+		},
+
+		{
+			name:       "attest already attested",
+			request:    getAttestAgentRequest("test_type", "payload_attested_before", testCsr),
+			expectedID: td.NewID("/spire/agent/test_type/id_attested_before"),
+			expectedSelectors: []*common.Selector{
+				{Type: "test_type", Value: "attested_before"},
+			},
+		},
+
+		{
+			name:        "attest banned",
+			expectedErr: "failed to attest: agent is banned",
+			request:     getAttestAgentRequest("test_type", "payload_banned", testCsr),
+			code:        codes.PermissionDenied,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to attest: agent is banned",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "test_type",
+						telemetry.AgentID:          td.NewID("/spire/agent/test_type/id_banned").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "attest with bad attestor",
+			expectedErr: "could not find node attestor type \"bad_type\"",
+			request:     getAttestAgentRequest("bad_type", "payload_with_result", testCsr),
+			code:        codes.FailedPrecondition,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Could not find node attestor type",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "bad_type",
+					},
+				},
+			},
+		},
+
+		{
+			name:        "attest with bad csr",
+			expectedErr: "failed to parse CSR: ",
+			request:     getAttestAgentRequest("test_type", "payload_with_result", []byte("not a csr")),
+			code:        codes.InvalidArgument,
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid argument: failed to parse CSR",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "test_type",
+						logrus.ErrorKey:            expectedCsrErr.Error(),
+						telemetry.AgentID:          td.NewID("/spire/agent/test_type/id_with_result").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to fetch join token",
+			expectedErr: "failed to fetch join token",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to fetch join token",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						logrus.ErrorKey:            "some error",
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to delete join token",
+			expectedErr: "failed to delete join token",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				nil,
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to delete join token",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						logrus.ErrorKey:            "some error",
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to fetch agent",
+			expectedErr: "failed to fetch agent",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				nil,
+				nil,
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to fetch agent",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						logrus.ErrorKey:            "some error",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to update selectors",
+			expectedErr: "failed to update selectors",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				nil,
+				nil,
+				nil,
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.DebugLevel,
+					Message: "Could not find node resolver",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
+					},
+				},
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to update selectors",
+
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						logrus.ErrorKey:            "some error",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to create attested agent",
+			expectedErr: "failed to create attested agent",
+			request:     getAttestAgentRequest("join_token", "test_token", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				nil,
+				nil,
+				nil,
+				nil,
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.DebugLevel,
+					Message: "Could not find node resolver",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
+					},
+				},
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to create attested agent",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "join_token",
+						logrus.ErrorKey:            "some error",
+						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
+					},
+				},
+			},
+		},
+
+		{
+			name:        "ds: fails to update attested agent",
+			expectedErr: "failed to update attested agent",
+			request:     getAttestAgentRequest("test_type", "payload_attested_before", testCsr),
+			code:        codes.Internal,
+			dsError: []error{
+				nil,
+				nil,
+				errors.New("some error"),
+			},
+			expectedLogMsgs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Failed to update attested agent",
+					Data: logrus.Fields{
+						telemetry.NodeAttestorType: "test_type",
+						logrus.ErrorKey:            "some error",
+						telemetry.AgentID:          td.NewID("/spire/agent/test_type/id_attested_before").String(),
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			// setup
+			test := setupServiceTest(t)
+			defer test.Cleanup()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			test.setupAttestor(t)
+			test.setupResolver(t)
+			test.setupJoinTokens(ctx, t)
+			test.setupNodes(ctx, t)
+
+			test.rateLimiter.count = 1
+			test.rateLimiter.err = tt.rateLimiterErr
+			for _, err := range tt.dsError {
+				test.ds.AppendNextError(err)
+			}
+
+			// exercise
+			stream, err := test.client.AttestAgent(ctx)
+			require.NoError(t, err)
+			result, err := attest(t, stream, tt.request)
+			closeAttestStream(t, stream)
+
+			if tt.retry {
+				// make sure that the first request went well
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				// clear entries from the previous run
+				test.logHook.Reset()
+
+				// attest once more
+				stream, err = test.client.AttestAgent(ctx)
+				require.NoError(t, err)
+				result, err = attest(t, stream, tt.request)
+				closeAttestStream(t, stream)
+			}
+
+			switch {
+			case tt.expectedErr != "":
+				require.Error(t, err)
+				require.Nil(t, result)
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.expectedErr)
+				spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectedLogMsgs)
+			default:
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				test.assertAttestAgentResult(t, tt.expectedID, result)
+				test.assertAgentWasStored(t, tt.expectedID.String(), tt.expectedSelectors)
+			}
+		})
+	}
+}
+
 type serviceTest struct {
-	ca           *fakeserverca.CA
 	client       agentpb.AgentClient
 	done         func()
 	ds           *fakedatastore.DataStore
+	ca           *fakeserverca.CA
+	cat          *fakeservercatalog.Catalog
 	logHook      *test.Hook
 	rateLimiter  *fakeRateLimiter
 	withCallerID bool
+	pluginCloser func()
 }
 
 func (s *serviceTest) Cleanup() {
 	s.done()
+	if s.pluginCloser != nil {
+		s.pluginCloser()
+	}
 }
 
 func setupServiceTest(t *testing.T) *serviceTest {
 	ca := fakeserverca.New(t, td.String(), &fakeserverca.Options{})
 	ds := fakedatastore.New(t)
+	cat := fakeservercatalog.New()
+
 	service := agent.New(agent.Config{
 		ServerCA:    ca,
 		DataStore:   ds,
-		TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
+		TrustDomain: td,
+		Clock:       clock.NewMock(t),
+		Catalog:     cat,
 	})
 
 	log, logHook := test.NewNullLogger()
@@ -1264,6 +1801,7 @@ func setupServiceTest(t *testing.T) *serviceTest {
 	test := &serviceTest{
 		ca:          ca,
 		ds:          ds,
+		cat:         cat,
 		logHook:     logHook,
 		rateLimiter: rateLimiter,
 	}
@@ -1284,6 +1822,131 @@ func setupServiceTest(t *testing.T) *serviceTest {
 	return test
 }
 
+func (s *serviceTest) setupAttestor(t *testing.T) {
+	attestorConfig := fakeservernodeattestor.Config{
+		Data: map[string]string{
+			"payload_attested_before": "id_attested_before",
+			"payload_with_challenge":  "id_with_challenge",
+			"payload_with_result":     "id_with_result",
+			"payload_banned":          "id_banned",
+		},
+		Selectors: map[string][]string{
+			"id_with_result":     {"result"},
+			"id_attested_before": {"attested_before"},
+			"id_with_challenge":  {"challenge"},
+			"id_banned":          {"banned"},
+		},
+	}
+
+	attestorConfig.Challenges = map[string][]string{"id_with_challenge": {"challenge_response"}}
+
+	fakeServerAttestor := fakeservernodeattestor.New("test_type", attestorConfig)
+	fakeServerPlugin := nodeattestor.PluginServer(fakeServerAttestor)
+	fakeCatalogPlugin := catalog.MakePlugin("test_type", fakeServerPlugin)
+
+	loadedPlugin, err := catalog.LoadBuiltInPlugin(context.Background(), catalog.BuiltInPlugin{
+		Log:          nil,
+		Plugin:       fakeCatalogPlugin,
+		HostServices: nil,
+	})
+	require.NoError(t, err, "unable to load plugin")
+
+	var fakeNodeAttestorClient nodeattestor.NodeAttestor
+	if err := loadedPlugin.Fill(&fakeNodeAttestorClient); err != nil {
+		loadedPlugin.Close()
+		require.NoError(t, err, "unable to satisfy plugin client")
+	}
+
+	s.pluginCloser = loadedPlugin.Close
+	s.cat.AddNodeAttestorNamed("test_type", fakeNodeAttestorClient)
+}
+
+func (s *serviceTest) setupResolver(t *testing.T) {
+	resolverConfig := fakenoderesolver.Config{
+		Selectors: map[string][]string{
+			td.NewID("/spire/agent/test_type/id_with_result").String():    {"resolved"},
+			td.NewID("/spire/agent/test_type/id_with_challenge").String(): {"resolved_too"},
+		},
+	}
+
+	fakeServerAttestor := fakenoderesolver.New("test_type", resolverConfig)
+	fakeServerPlugin := noderesolver.PluginServer(fakeServerAttestor)
+	fakeCatalogPlugin := catalog.MakePlugin("test_type", fakeServerPlugin)
+
+	loadedPlugin, err := catalog.LoadBuiltInPlugin(context.Background(), catalog.BuiltInPlugin{
+		Log:          nil,
+		Plugin:       fakeCatalogPlugin,
+		HostServices: nil,
+	})
+	require.NoError(t, err, "unable to load plugin")
+
+	var fakeNodeResolverClient noderesolver.NodeResolver
+	if err := loadedPlugin.Fill(&fakeNodeResolverClient); err != nil {
+		loadedPlugin.Close()
+		require.NoError(t, err, "unable to satisfy plugin client")
+	}
+
+	s.pluginCloser = loadedPlugin.Close
+	s.cat.AddNodeResolverNamed("test_type", fakeNodeResolverClient)
+}
+
+func (s *serviceTest) setupNodes(ctx context.Context, t *testing.T) {
+	req := &datastore.CreateAttestedNodeRequest{
+		Node: &common.AttestedNode{
+			AttestationDataType: "test_type",
+			SpiffeId:            td.NewID("/spire/agent/test_type/id_attested_before").String(),
+			CertSerialNumber:    "test_serial_number",
+		}}
+	_, err := s.ds.CreateAttestedNode(ctx, req)
+	require.NoError(t, err)
+
+	req = &datastore.CreateAttestedNodeRequest{
+		Node: &common.AttestedNode{
+			AttestationDataType: "test_type",
+			SpiffeId:            td.NewID("/spire/agent/test_type/id_banned").String(),
+			CertNotAfter:        0,
+			CertSerialNumber:    "",
+		}}
+	_, err = s.ds.CreateAttestedNode(ctx, req)
+	require.NoError(t, err)
+
+	req = &datastore.CreateAttestedNodeRequest{
+		Node: &common.AttestedNode{
+			AttestationDataType: "join_token",
+			SpiffeId:            td.NewID("/spire/agent/join_token/banned_token").String(),
+			CertNotAfter:        0,
+			CertSerialNumber:    "",
+		}}
+	_, err = s.ds.CreateAttestedNode(ctx, req)
+	require.NoError(t, err)
+}
+
+func (s *serviceTest) setupJoinTokens(ctx context.Context, t *testing.T) {
+	_, err := s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
+		JoinToken: &datastore.JoinToken{
+			Token:  "test_token",
+			Expiry: time.Now().Unix() + int64(60*10),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
+		JoinToken: &datastore.JoinToken{
+			Token:  "banned_token",
+			Expiry: time.Now().Unix() + int64(60*10),
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.ds.CreateJoinToken(ctx, &datastore.CreateJoinTokenRequest{
+		JoinToken: &datastore.JoinToken{
+			Token:  "expired_token",
+			Expiry: time.Now().Unix() - int64(60*10),
+		},
+	})
+	require.NoError(t, err)
+}
+
 func (s *serviceTest) createTestNodes(ctx context.Context, t *testing.T) {
 	for _, testNode := range testNodes {
 		// create the test node
@@ -1294,6 +1957,40 @@ func (s *serviceTest) createTestNodes(ctx context.Context, t *testing.T) {
 		_, err = s.ds.SetNodeSelectors(ctx, &datastore.SetNodeSelectorsRequest{Selectors: testNodeSelectors[testNode.SpiffeId]})
 		require.NoError(t, err)
 	}
+}
+
+func (s *serviceTest) assertAttestAgentResult(t *testing.T, expectedID spiffeid.ID, result *agentpb.AttestAgentResponse_Result) {
+	now := s.ca.Clock().Now().UTC()
+	expiredAt := now.Add(s.ca.X509SVIDTTL())
+
+	require.NotNil(t, result.Svid)
+	expectedIDType := &types.SPIFFEID{TrustDomain: expectedID.TrustDomain().String(), Path: expectedID.Path()}
+	spiretest.AssertProtoEqual(t, expectedIDType, result.Svid.Id)
+	assert.Equal(t, expiredAt.Unix(), result.Svid.ExpiresAt)
+
+	certChain, err := x509util.RawCertsToCertificates(result.Svid.CertChain)
+	require.NoError(t, err)
+	require.NotEmpty(t, certChain)
+
+	x509Svid := certChain[0]
+	assert.Equal(t, expiredAt, x509Svid.NotAfter)
+	require.Equal(t, []*url.URL{expectedID.URL()}, x509Svid.URIs)
+}
+
+func (s *serviceTest) assertAgentWasStored(t *testing.T, expectedID string, expectedSelectors []*common.Selector) {
+	attestedAgent, err := s.ds.FetchAttestedNode(ctx, &datastore.FetchAttestedNodeRequest{
+		SpiffeId: expectedID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, attestedAgent.Node)
+	require.Equal(t, expectedID, attestedAgent.Node.SpiffeId)
+
+	agentSelectors, err := s.ds.GetNodeSelectors(ctx, &datastore.GetNodeSelectorsRequest{
+		SpiffeId: expectedID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, agentSelectors.Selectors)
+	require.EqualValues(t, expectedSelectors, agentSelectors.Selectors.Selectors)
 }
 
 type fakeRateLimiter struct {
@@ -1311,4 +2008,54 @@ func (f *fakeRateLimiter) RateLimit(ctx context.Context, count int) error {
 
 func cloneAttestedNode(aNode *common.AttestedNode) *common.AttestedNode {
 	return proto.Clone(aNode).(*common.AttestedNode)
+}
+
+func getAttestAgentRequest(attType string, payload string, csr []byte) *agentpb.AttestAgentRequest {
+	return &agentpb.AttestAgentRequest{
+		Step: &agentpb.AttestAgentRequest_Params_{
+			Params: &agentpb.AttestAgentRequest_Params{
+				Data: &types.AttestationData{
+					Type:    attType,
+					Payload: payload,
+				},
+				Params: &agentpb.AgentX509SVIDParams{
+					Csr: csr,
+				},
+			},
+		},
+	}
+}
+
+func attest(t *testing.T, stream agentpb.Agent_AttestAgentClient, request *agentpb.AttestAgentRequest) (*agentpb.AttestAgentResponse_Result, error) {
+	var result *agentpb.AttestAgentResponse_Result
+
+	for {
+		// send
+		err := stream.Send(request)
+		require.NoError(t, err)
+
+		// recv
+		resp, err := stream.Recv()
+		challenge := resp.GetChallenge()
+		result = resp.GetResult()
+
+		if challenge != nil {
+			// build new request to be sent
+			request = &agentpb.AttestAgentRequest{
+				Step: &agentpb.AttestAgentRequest_ChallengeResponse{
+					ChallengeResponse: challenge,
+				}}
+
+			continue
+		}
+		return result, err
+	}
+}
+
+func closeAttestStream(t *testing.T, stream agentpb.Agent_AttestAgentClient) {
+	err := stream.Send(&agentpb.AttestAgentRequest{})
+	require.EqualError(t, err, io.EOF.Error())
+
+	err = stream.CloseSend()
+	require.NoError(t, err)
 }

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 
+	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
@@ -131,6 +132,8 @@ func (c *Config) maybeMakeExperimentalServers() *ExperimentalServers {
 			DataStore:   ds,
 			ServerCA:    c.ServerCA,
 			TrustDomain: c.TrustDomain,
+			Catalog:     c.Catalog,
+			Clock:       clock.New(),
 		}),
 		BundleServer: bundlev1.New(bundlev1.Config{
 			TrustDomain: c.TrustDomain,


### PR DESCRIPTION
Signed-off-by: Mariano Kunzi <kunzi.mariano@gmail.com>

**Affected functionality**
API Refactor: Implement Agent.AttestAgent RPC

**Description of change**
This implements Attest Agent as described by the issue with some current caveats:

- Tests for the datastore errors are currently fragile. We might want to make the fake fail in a more convenient way. 

- Join token attestation: This implementation doesn't try to fetch the node to check if it was already attested. It relies on the token being deleted after usage, showing the same error message for non existing tokens, and already used ones. The message being: **"Join token does not exist or has already been used"**.

~~- Currently missing a test case for using a join token more than once.~~

~~- Challenge/response flow: Are there any cases (or do we expect to have in the future) where we need to send more than one challenge?  To put it in a different way, can we get away without relying on a loop, or do we need one because we might need to send more than one challenge in some cases?~~

~~- Join token attestation: I'm open to suggestion regarding improving the code for this particular scenario.~~

~~- I wasn't completely sure about which keys to use for **log.WithField**. Let me know if it can be improved in any way.~~

~~- Testing: WIP.~~


**Which issue this PR fixes**
fixes #1638

