### PR TITLE
Unset the environment variables referenced by the Vault plugin before testing

### DIFF
--- a/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
@@ -17,6 +17,13 @@ const (
 )
 
 var (
+	testConfigWithVaultAddrEnvTpl = `
+pki_mount_point = "test-pki"
+ca_cert_path = "_test_data/keys/EC/root_cert.pem"
+token_auth {
+   token  = "test-token"
+}`
+
 	testCertAuthConfigTpl = `
 vault_addr  = "{{ .Addr }}"
 pki_mount_point = "test-pki"

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/spiffe/spire/test/spiretest"
 )
 
+func init() {
+	os.Unsetenv(envVaultAddr)
+	os.Unsetenv(envVaultToken)
+	os.Unsetenv(envVaultClientCert)
+	os.Unsetenv(envVaultClientKey)
+	os.Unsetenv(envVaultCACert)
+	os.Unsetenv(envVaultAppRoleID)
+	os.Unsetenv(envVaultAppRoleSecretID)
+}
+
 func TestVaultPlugin(t *testing.T) {
 	spiretest.Run(t, new(VaultPluginSuite))
 }
@@ -97,6 +107,13 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			name:       "Multiple authentication methods configured",
 			configTmpl: testMultipleAuthConfigsTpl,
 			err:        "only one authentication method can be configured",
+		},
+		{
+			name:       "Pass VaultAddr via the environment variable",
+			configTmpl: testConfigWithVaultAddrEnvTpl,
+			envKeyVal: map[string]string{
+				envVaultAddr: fmt.Sprintf("https://%v/", addr),
+			},
 		},
 	} {
 		c := c

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -76,7 +76,7 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			name:       "Configure plugin with Token authentication params given as environment variables",
 			configTmpl: testTokenAuthConfigWithEnvTpl,
 			envKeyVal: map[string]string{
-				"VAULT_TOKEN": "test-token",
+				envVaultToken: "test-token",
 			},
 		},
 		{
@@ -87,8 +87,8 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			name:       "Configure plugin with Client Certificate authentication params given as environment variables",
 			configTmpl: testCertAuthConfigWithEnvTpl,
 			envKeyVal: map[string]string{
-				"VAULT_CLIENT_CERT": "_test_data/keys/EC/client_cert.pem",
-				"VAULT_CLIENT_KEY":  "_test_data/keys/EC/client_key.pem",
+				envVaultClientCert: "_test_data/keys/EC/client_cert.pem",
+				envVaultClientKey:  "_test_data/keys/EC/client_key.pem",
 			},
 		},
 		{
@@ -99,8 +99,8 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			name:       "Configure plugin with AppRole authentication params given as environment variables",
 			configTmpl: testAppRoleAuthConfigWithEnvTpl,
 			envKeyVal: map[string]string{
-				"VAULT_APPROLE_ID":        "test-approle-id",
-				"VAULT_APPROLE_SECRET_ID": "test-approle-secret-id",
+				envVaultAppRoleID:       "test-approle-id",
+				envVaultAppRoleSecretID: "test-approle-secret-id",
 			},
 		},
 		{


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

UpstreamAuthority 'vault' plugin 

**Description of change**
<!-- Please provide a description of the change -->

Fix  UpstreamAuthority vault plugin test failure when VAULT_ADDR  is set in the user's environment.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

#1713 