### PR TITLE
Solve downstream RPC IT when running on linux

### DIFF
--- a/test/integration/setup/downstreamclient/build.sh
+++ b/test/integration/setup/downstreamclient/build.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd "${DIR}" && GOOS=linux go build -o $1
+cd "${DIR}" && CGO_ENABLED=0 GOOS=linux go build -o $1


### PR DESCRIPTION
Add `CGO_ENABLED=0` when building client to be able to run client on alpine when builded on xenon 

Signed-off-by: Marcos Yacob <marcos.yacob@hpe.com>
