### PR TITLE
Leverage t.Cleanup

### DIFF
--- a/api/workload/v2/workload_test.go
+++ b/api/workload/v2/workload_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spiffe/go-spiffe/proto/spiffe/workload"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -187,9 +187,7 @@ type stubbedAPI struct {
 }
 
 func newStubbedAPI(t *testing.T) *stubbedAPI {
-	dir, err := ioutil.TempDir("", "workload-test")
-	require.NoError(t, err)
-
+	dir := spiretest.TempDir(t)
 	return &stubbedAPI{
 		T:          t,
 		SocketPath: path.Join(dir, "workload_api.sock"),

--- a/api/workload/x509_client_test.go
+++ b/api/workload/x509_client_test.go
@@ -156,7 +156,6 @@ func TestStreamX509SVIDBackoffOnFetchFailure(t *testing.T) {
 
 func TestStreamX509SVIDBackoffOnRecvFailure(t *testing.T) {
 	w := fakeworkloadapi.New(t, fakeworkloadapi.FetchX509SVIDErrorAlways(errFake))
-	defer w.Close()
 
 	testStreamX509SVIDBackoff(t, w.Addr())
 }
@@ -208,7 +207,6 @@ func TestStreamX509SVIDFailsOnInvalidArgument(t *testing.T) {
 	w := fakeworkloadapi.New(t, fakeworkloadapi.FetchX509SVIDErrorOnce(
 		status.Error(codes.InvalidArgument, "invalid argument"),
 	))
-	defer w.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
@@ -224,7 +222,6 @@ func TestStreamX509SVIDFailsOnInvalidArgument(t *testing.T) {
 
 func TestStreamX509SVIDFailOnError(t *testing.T) {
 	w := fakeworkloadapi.New(t, fakeworkloadapi.FetchX509SVIDErrorOnce(errFake))
-	defer w.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
@@ -241,7 +238,6 @@ func TestStreamX509SVIDFailOnError(t *testing.T) {
 
 func TestStreamX509SVIDWritesUpdatesToChannel(t *testing.T) {
 	w := fakeworkloadapi.New(t, fakeworkloadapi.FetchX509SVIDResponses(responseA, responseB, responseC))
-	defer w.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()

--- a/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
@@ -88,7 +88,6 @@ Workload API returned rpc error: code = Unavailable desc = connection error: des
 
 func (s *HealthCheckSuite) TestSucceedsOnPermissionDenied() {
 	w := s.makeFailedWorkloadAPI(status.Error(codes.PermissionDenied, "permission denied"))
-	defer w.Close()
 	code := s.cmd.Run([]string{"--socketPath", w.Addr().Name})
 	s.Equal(0, code, "exit code")
 	s.Equal("Agent is healthy.\n", s.stdout.String(), "stdout")
@@ -97,7 +96,6 @@ func (s *HealthCheckSuite) TestSucceedsOnPermissionDenied() {
 
 func (s *HealthCheckSuite) TestSucceedsOnUnknown() {
 	w := s.makeFailedWorkloadAPI(status.Error(codes.Unknown, "unknown"))
-	defer w.Close()
 	code := s.cmd.Run([]string{"--socketPath", w.Addr().Name})
 	s.Equal(0, code, "exit code")
 	s.Equal("Agent is healthy.\n", s.stdout.String(), "stdout")
@@ -106,7 +104,6 @@ func (s *HealthCheckSuite) TestSucceedsOnUnknown() {
 
 func (s *HealthCheckSuite) TestSucceedsOnGoodResponse() {
 	w := s.makeGoodWorkloadAPI()
-	defer w.Close()
 	code := s.cmd.Run([]string{"--socketPath", w.Addr().Name})
 	s.Equal(0, code, "exit code")
 	s.Equal("Agent is healthy.\n", s.stdout.String(), "stdout")
@@ -115,7 +112,6 @@ func (s *HealthCheckSuite) TestSucceedsOnGoodResponse() {
 
 func (s *HealthCheckSuite) TestSucceedsOnGoodResponseVerbose() {
 	w := s.makeGoodWorkloadAPI()
-	defer w.Close()
 	code := s.cmd.Run([]string{"--socketPath", w.Addr().Name, "--verbose"})
 	s.Equal(0, code, "exit code")
 	s.Equal(`Contacting Workload API...

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/x509"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/fakes/fakeregistrationclient"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -189,9 +189,7 @@ func (s *BundleSuite) TestSetCannotLoadBundleFromFile() {
 }
 
 func (s *BundleSuite) TestSetCreatesBundleFromFile() {
-	tmpDir, err := ioutil.TempDir("", "spire-server-cli-test-")
-	s.Require().NoError(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := spiretest.TempDir(s.T())
 
 	bundlePath := filepath.Join(tmpDir, "bundle.pem")
 

--- a/cmd/spire-server/cli/bundle/experimental_bundle_test.go
+++ b/cmd/spire-server/cli/bundle/experimental_bundle_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/x509"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/fakes/fakeregistrationclient"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -194,9 +194,7 @@ func (s *ExperimentalBundleSuite) TestSetCannotLoadBundleFromFile() {
 }
 
 func (s *ExperimentalBundleSuite) TestSetCreatesBundleFromFile() {
-	tmpDir, err := ioutil.TempDir("", "spire-server-cli-test-")
-	s.Require().NoError(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := spiretest.TempDir(s.T())
 
 	bundlePath := filepath.Join(tmpDir, "bundle.pem")
 

--- a/cmd/spire-server/cli/jwt/mint_test.go
+++ b/cmd/spire-server/cli/jwt/mint_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -67,19 +66,15 @@ func TestMintHelp(t *testing.T) {
 }
 
 func TestMintRun(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	svidPath := filepath.Join(dir, "token")
 
 	api := new(FakeRegistrationAPI)
 
-	defaultServerDone := spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, util.DefaultSocketPath), api)
-	defer defaultServerDone()
+	spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, util.DefaultSocketPath), api)
 
-	otherServerDone := spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, "other.sock"), api)
-	defer otherServerDone()
+	spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, "other.sock"), api)
 
 	signer, err := jose.NewSigner(jose.SigningKey{
 		Algorithm: jose.ES256,

--- a/cmd/spire-server/cli/x509/mint_test.go
+++ b/cmd/spire-server/cli/x509/mint_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -77,9 +76,7 @@ func TestMintHelp(t *testing.T) {
 }
 
 func TestMintRun(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	svidPath := filepath.Join(dir, "svid.pem")
 	keyPath := filepath.Join(dir, "key.pem")
@@ -100,11 +97,9 @@ func TestMintRun(t *testing.T) {
 
 	api := new(FakeRegistrationAPI)
 
-	defaultServerDone := spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, util.DefaultSocketPath), api)
-	defer defaultServerDone()
+	spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, util.DefaultSocketPath), api)
 
-	otherServerDone := spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, "other.sock"), api)
-	defer otherServerDone()
+	spiretest.StartRegistrationAPIOnSocket(t, filepath.Join(dir, "other.sock"), api)
 
 	testCases := []struct {
 		name string

--- a/pkg/agent/attestor/node/experimental_test.go
+++ b/pkg/agent/attestor/node/experimental_test.go
@@ -321,18 +321,16 @@ func TestAttestorWithExperimentalAPI(t *testing.T) {
 			require := require.New(t)
 
 			// prepare the temp directory holding the cached bundle/svid
-			svidCachePath, bundleCachePath, removeDir := prepareTestDir(t, testCase.cachedSVID, testCase.cachedBundle)
-			defer removeDir()
+			svidCachePath, bundleCachePath := prepareTestDir(t, testCase.cachedSVID, testCase.cachedBundle)
 
 			// load up the fake agent-side node attestor
-			agentNA, agentNADone := prepareAgentNA(t, fakeagentnodeattestor.Config{
+			agentNA := prepareAgentNA(t, fakeagentnodeattestor.Config{
 				Fail:      testCase.failFetchingAttestationData,
 				Responses: testCase.agentClient.challengeResponses,
 			})
-			defer agentNADone()
 
 			// load up the fake server-side node attestor
-			serverNA, serverNADone := prepareServerNA(t, fakeservernodeattestor.Config{
+			serverNA := prepareServerNA(t, fakeservernodeattestor.Config{
 				TrustDomain: "domain.test",
 				Data: map[string]string{
 					"TEST": "foo",
@@ -341,11 +339,9 @@ func TestAttestorWithExperimentalAPI(t *testing.T) {
 					"foo": testCase.agentClient.challengeResponses,
 				},
 			})
-			defer serverNADone()
 
 			// load up an in-memory key manager
-			km, kmDone := prepareKeyManager(t, testCase.storeKey)
-			defer kmDone()
+			km := prepareKeyManager(t, testCase.storeKey)
 
 			// initialize the catalog
 			catalog := fakeagentcatalog.New()

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -41,8 +41,7 @@ import (
 )
 
 const (
-	tmpSubdirName = "manager-test"
-	trustDomain   = "example.org"
+	trustDomain = "example.org"
 )
 
 var (

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -8,10 +8,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
-	"os"
 	"path"
 	"reflect"
 	"sync"
@@ -33,6 +31,7 @@ import (
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakeagentcatalog"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/require"
 
@@ -56,8 +55,7 @@ var (
 )
 
 func TestInitializationFailure(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
@@ -81,8 +79,7 @@ func TestInitializationFailure(t *testing.T) {
 }
 
 func TestStoreBundleOnStartup(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
@@ -135,8 +132,7 @@ func TestStoreBundleOnStartup(t *testing.T) {
 }
 
 func TestStoreSVIDOnStartup(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
@@ -187,8 +183,7 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 }
 
 func TestStoreKeyOnStartup(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	clk := clock.NewMock(t)
 	ca, cakey := createCA(t, clk, trustDomain)
@@ -242,8 +237,7 @@ func TestStoreKeyOnStartup(t *testing.T) {
 }
 
 func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -332,8 +326,7 @@ func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
 }
 
 func TestSVIDRotation(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -446,8 +439,7 @@ func TestSVIDRotation(t *testing.T) {
 }
 
 func TestSynchronization(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -591,8 +583,7 @@ func TestSynchronization(t *testing.T) {
 }
 
 func TestSynchronizationClearsStaleCacheEntries(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -660,8 +651,7 @@ func TestSynchronizationClearsStaleCacheEntries(t *testing.T) {
 }
 
 func TestSynchronizationUpdatesRegistrationEntries(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -728,8 +718,7 @@ func TestSynchronizationUpdatesRegistrationEntries(t *testing.T) {
 }
 
 func TestSubscribersGetUpToDateBundle(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -794,8 +783,7 @@ func TestSubscribersGetUpToDateBundle(t *testing.T) {
 }
 
 func TestSurvivesCARotation(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -865,8 +853,7 @@ func TestSurvivesCARotation(t *testing.T) {
 }
 
 func TestFetchJWTSVID(t *testing.T) {
-	dir := createTempDir(t)
-	defer removeTempDir(dir)
+	dir := spiretest.TempDir(t)
 
 	l, err := net.Listen("tcp", "localhost:")
 	if err != nil {
@@ -1342,18 +1329,6 @@ func (h *mockNodeAPIHandler) getCertFromCtx(ctx context.Context) (certificate *x
 	}
 
 	return chain[0], nil
-}
-
-func createTempDir(t *testing.T) string {
-	dir, err := ioutil.TempDir("", tmpSubdirName)
-	if err != nil {
-		t.Fatalf("could not create temp dir: %v", err)
-	}
-	return dir
-}
-
-func removeTempDir(dir string) {
-	os.RemoveAll(dir)
 }
 
 func createCA(t *testing.T, clk clock.Clock, trustDomain string) (*x509.Certificate, *ecdsa.PrivateKey) {

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/spiretest"
 )
 
 var (
@@ -23,11 +24,10 @@ var (
 )
 
 func TestDisk_GenerateKeyPair(t *testing.T) {
+	tempDir := spiretest.TempDir(t)
+
 	plugin := New()
-	tempDir, err := ioutil.TempDir("", "km-disk-test")
-	require.NoError(t, err)
 	plugin.dir = tempDir
-	defer os.RemoveAll(tempDir)
 
 	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
 	require.NoError(t, err)
@@ -46,11 +46,10 @@ func TestDisk_GenerateKeyPair(t *testing.T) {
 }
 
 func TestDisk_FetchPrivateKey(t *testing.T) {
+	tempDir := spiretest.TempDir(t)
+
 	plugin := New()
-	tempDir, err := ioutil.TempDir("", "km-disk-test")
-	require.NoError(t, err)
 	plugin.dir = tempDir
-	defer os.RemoveAll(tempDir)
 
 	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
 	require.NoError(t, err)
@@ -63,10 +62,7 @@ func TestDisk_FetchPrivateKey(t *testing.T) {
 }
 
 func TestDisk_Configure(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "km-disk-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
+	tempDir := spiretest.TempDir(t)
 	keysDir := filepath.Join(tempDir, "keys")
 
 	plugin := New()

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
@@ -44,16 +44,10 @@ type AttestorSuite struct {
 }
 
 func (s *AttestorSuite) SetupTest() {
-	var err error
-	s.dir, err = ioutil.TempDir("", "spire-k8s-psat-test-")
-	s.Require().NoError(err)
+	s.dir = s.TempDir()
 
 	s.newAttestor()
 	s.configure(AttestorConfig{})
-}
-
-func (s *AttestorSuite) TearDownTest() {
-	os.RemoveAll(s.dir)
 }
 
 func (s *AttestorSuite) TestFetchAttestationDataNotConfigured() {

--- a/pkg/agent/plugin/workloadattestor/docker/docker_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_test.go
@@ -374,15 +374,13 @@ func doAttest(t *testing.T, p *Plugin, req *workloadattestor.AttestRequest) (*wo
 
 func doAttestWithContext(ctx context.Context, t *testing.T, p *Plugin, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
 	var wp workloadattestor.Plugin
-	done := spiretest.LoadPlugin(t, builtin(p), &wp)
-	defer done()
+	spiretest.LoadPlugin(t, builtin(p), &wp)
 	return wp.Attest(ctx, req)
 }
 
 func doConfigure(t *testing.T, p *Plugin, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
 	var wp workloadattestor.Plugin
-	done := spiretest.LoadPlugin(t, builtin(p), &wp)
-	defer done()
+	spiretest.LoadPlugin(t, builtin(p), &wp)
 	return wp.Configure(context.Background(), req)
 }
 

--- a/pkg/common/diskutil/file_test.go
+++ b/pkg/common/diskutil/file_test.go
@@ -6,13 +6,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAtomicWriteFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	tests := []struct {
 		name string

--- a/pkg/common/peertracker/listener_test.go
+++ b/pkg/common/peertracker/listener_test.go
@@ -3,15 +3,14 @@ package peertracker
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net"
-	"os"
 	"path"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,20 +34,15 @@ func TestListenerTestSuite(t *testing.T) {
 type ListenerTestSuite struct {
 	suite.Suite
 
-	tempDir  string
 	ul       *Listener
 	unixAddr *net.UnixAddr
 }
 
 func (p *ListenerTestSuite) SetupTest() {
-	var err error
-
-	p.tempDir, err = ioutil.TempDir("", "spire-listener-test")
-	p.Require().NoError(err)
-
+	tempDir := spiretest.TempDir(p.T())
 	p.unixAddr = &net.UnixAddr{
 		Net:  "unix",
-		Name: path.Join(p.tempDir, "test.sock"),
+		Name: path.Join(tempDir, "test.sock"),
 	}
 }
 
@@ -59,8 +53,6 @@ func (p *ListenerTestSuite) TearDownTest() {
 		p.NoError(err)
 		p.ul = nil
 	}
-	err := os.Remove(p.tempDir)
-	p.NoError(err)
 }
 
 func (p *ListenerTestSuite) TestAcceptDoesntFailWhenTrackerFails() {

--- a/pkg/common/plugin/k8s/apiserver/client_test.go
+++ b/pkg/common/plugin/k8s/apiserver/client_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -146,14 +145,11 @@ func (s *ClientSuite) SetupTest() {
 	s.mockAuthV1 = mock_authv1.NewMockAuthenticationV1Interface(s.mockCtrl)
 	s.mockTokenReviews = mock_tokenreview.NewMockTokenReviewInterface(s.mockCtrl)
 
-	var err error
-	s.dir, err = ioutil.TempDir("", "spire-k8s-client-test-")
-	s.Require().NoError(err)
+	s.dir = s.TempDir()
 }
 
 func (s *ClientSuite) TearDownTest() {
 	s.mockCtrl.Finish()
-	os.RemoveAll(s.dir)
 }
 
 func (s *ClientSuite) TestGetPodFailsIfNamespaceIsEmpty() {

--- a/pkg/server/ca/journal_test.go
+++ b/pkg/server/ca/journal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -102,18 +103,12 @@ func TestJournal(t *testing.T) {
 }
 
 type JournalSuite struct {
-	suite.Suite
+	spiretest.Suite
 	dir string
 }
 
 func (s *JournalSuite) SetupTest() {
-	dir, err := ioutil.TempDir("", "spire-server-ca-journal")
-	s.Require().NoError(err)
-	s.dir = dir
-}
-
-func (s *JournalSuite) TearDownTest() {
-	os.RemoveAll(s.dir)
+	s.dir = s.TempDir()
 }
 
 func (s *JournalSuite) TestNew() {

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -146,11 +146,10 @@ func (s *ManagerSuite) TestSelfSigning() {
 }
 
 func (s *ManagerSuite) TestUpstreamSigned() {
-	upstreamAuthority, fakeUA, upDone := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
+	upstreamAuthority, fakeUA := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
 		TrustDomain:           testTrustDomain,
 		DisallowPublishJWTKey: true,
 	})
-	defer upDone()
 
 	s.initUpstreamSignedManager(upstreamAuthority)
 
@@ -178,12 +177,11 @@ func (s *ManagerSuite) TestUpstreamSigned() {
 }
 
 func (s *ManagerSuite) TestUpstreamIntermediateSigned() {
-	upstreamAuthority, fakeUA, upDone := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
+	upstreamAuthority, fakeUA := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
 		TrustDomain:           testTrustDomain,
 		DisallowPublishJWTKey: true,
 		UseIntermediate:       true,
 	})
-	defer upDone()
 	s.initUpstreamSignedManager(upstreamAuthority)
 
 	// X509 CA should be set up to be an intermediate and have two certs in
@@ -214,10 +212,9 @@ func (s *ManagerSuite) TestUpstreamAuthorityWithPublishJWTKeyImplemented() {
 	bundle := s.createBundle()
 	s.Require().Len(bundle.JwtSigningKeys, 0)
 
-	upstreamAuthority, ua, upDone := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
+	upstreamAuthority, ua := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
 		TrustDomain: testTrustDomain,
 	})
-	defer upDone()
 	s.initUpstreamSignedManager(upstreamAuthority)
 
 	s.AssertProtoListEqual(ua.JWTKeys(), s.fetchBundle().JwtSigningKeys)
@@ -529,10 +526,9 @@ func (s *ManagerSuite) TestActivationThreshholdCap() {
 }
 
 func (s *ManagerSuite) TestAlternateKeyTypes() {
-	ua, _, upDone := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
+	ua, _ := fakeupstreamauthority.Load(s.T(), fakeupstreamauthority.Config{
 		TrustDomain: testTrustDomain,
 	})
-	defer upDone()
 
 	upstreamAuthority := fakeservercatalog.UpstreamAuthority(
 		"fakeupstreamauthority", ua)

--- a/pkg/server/endpoints/bundle/server_test.go
+++ b/pkg/server/endpoints/bundle/server_test.go
@@ -152,8 +152,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestACMEAuth(t *testing.T) {
-	dir, err := ioutil.TempDir("", "spire-server-endpoints-bundle-acme-")
-	require.NoError(t, err)
+	dir := spiretest.TempDir(t)
 
 	bundle := bundleutil.New("spiffe://domain.test")
 	km := memory.New()

--- a/pkg/server/endpoints/node/handler_test.go
+++ b/pkg/server/endpoints/node/handler_test.go
@@ -134,8 +134,7 @@ func (s *HandlerSuite) setupTest(upstreamAuthorityConfig *fakeupstreamauthority.
 	s.catalog = fakeservercatalog.New()
 	s.catalog.SetDataStore(s.ds)
 	if upstreamAuthorityConfig != nil {
-		upstreamAuthority, _, uaDone := fakeupstreamauthority.Load(s.T(), *upstreamAuthorityConfig)
-		s.AppendCloser(uaDone)
+		upstreamAuthority, _ := fakeupstreamauthority.Load(s.T(), *upstreamAuthorityConfig)
 		s.catalog.SetUpstreamAuthority(fakeservercatalog.UpstreamAuthority(
 			"fakeupstreamauthority",
 			upstreamAuthority,

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -2808,8 +2808,7 @@ func (s *PluginSuite) TestConfigure() {
 			p := New()
 
 			var ds datastore.Plugin
-			pluginDone := spiretest.LoadPlugin(t, builtin(p), &ds)
-			defer pluginDone()
+			spiretest.LoadPlugin(t, builtin(p), &ds)
 
 			dbPath := filepath.Join(s.dir, "test-datastore-configure.sqlite3")
 

--- a/pkg/server/plugin/keymanager/disk/disk_test.go
+++ b/pkg/server/plugin/keymanager/disk/disk_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager/base"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager/test"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -35,15 +36,9 @@ type Suite struct {
 func (s *Suite) SetupTest() {
 	// initialize a temp directory and a subdirectory within (to aid with
 	// persistence failure testing)
-	var err error
-	s.tmpDir, err = ioutil.TempDir("", "server-keymanager-disk-")
-	s.Require().NoError(err)
+	s.tmpDir = spiretest.TempDir(s.T())
 	s.Require().NoError(os.MkdirAll(s.keysDir(), 0755))
 	s.createManager()
-}
-
-func (s *Suite) TearDownTest() {
-	os.RemoveAll(s.tmpDir)
 }
 
 func (s *Suite) createManager() {

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/big"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -106,16 +105,11 @@ func (s *AttestorSuite) SetupSuite() {
 	}, nil)
 	s.Require().NoError(err)
 
-	s.dir, err = ioutil.TempDir("", "spire-server-nodeattestor-k8s-sat-")
-	s.Require().NoError(err)
+	s.dir = s.TempDir()
 
 	// generate a self-signed certificate for signing tokens
 	s.Require().NoError(createAndWriteSelfSignedCert("FOO", s.fooKey, s.fooCertPath()))
 	s.Require().NoError(createAndWriteSelfSignedCert("BAR", s.barKey, s.barCertPath()))
-}
-
-func (s *AttestorSuite) TearDownSuite() {
-	os.RemoveAll(s.dir)
 }
 
 func (s *AttestorSuite) SetupTest() {

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
@@ -84,9 +84,8 @@ func TestConfigure(t *testing.T) {
 
 			raw := New()
 			var plugin notifier.Plugin
-			pluginDone := spiretest.LoadPlugin(t, builtIn(raw), &plugin,
+			spiretest.LoadPlugin(t, builtIn(raw), &plugin,
 				spiretest.HostService(hostservices.IdentityProviderHostServiceServer(idp)))
-			defer pluginDone()
 
 			resp, err := plugin.Configure(context.Background(), &spi.ConfigureRequest{Configuration: tt.config})
 			if tt.code != codes.OK {
@@ -238,9 +237,8 @@ func testUpdateBundleObject(t *testing.T, notify func(plugin notifier.Plugin) er
 
 			// Load the instance as a plugin
 			var plugin notifier.Plugin
-			pluginDone := spiretest.LoadPlugin(t, builtIn(raw), &plugin,
+			spiretest.LoadPlugin(t, builtIn(raw), &plugin,
 				spiretest.HostService(hostservices.IdentityProviderHostServiceServer(idp)))
-			defer pluginDone()
 
 			if !tt.skipConfigure {
 				_, err := plugin.Configure(context.Background(), &spi.ConfigureRequest{

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -60,7 +60,6 @@ type handler struct {
 }
 
 type whandler struct {
-	dir        string
 	socketPath string
 }
 

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -9,8 +9,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -64,7 +62,6 @@ type handler struct {
 type whandler struct {
 	dir        string
 	socketPath string
-	server     *grpc.Server
 }
 
 type testHandler struct {
@@ -79,25 +76,8 @@ func (h *testHandler) startTestServers(t *testing.T) {
 	h.wapiServer.startWAPITestServer(t)
 }
 
-func (h *testHandler) stopTestServers() {
-	h.napiServer.server.Stop()
-	os.RemoveAll(h.wapiServer.dir)
-}
-
 func (w *whandler) startWAPITestServer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "upstreamca-spire-test-")
-	require.NoError(t, err)
-	w.dir = dir
-	w.socketPath = filepath.Join(dir, "test.sock")
-
-	w.server = grpc.NewServer()
-
-	w_pb.RegisterSpiffeWorkloadAPIServer(w.server, w)
-
-	l, err := net.Listen("unix", w.socketPath)
-	require.NoError(t, err)
-
-	go func() { _ = w.server.Serve(l) }()
+	w.socketPath = spiretest.StartWorkloadAPIOnTempSocket(t, w)
 }
 
 func (w *whandler) FetchX509SVID(_ *w_pb.X509SVIDRequest, stream w_pb.SpiffeWorkloadAPI_FetchX509SVIDServer) error {
@@ -289,8 +269,7 @@ func TestSpirePlugin_Configure(t *testing.T) {
 }
 
 func TestSpirePlugin_GetPluginInfo(t *testing.T) {
-	m, done := newWithDefault(t, "", "")
-	defer done()
+	m := newWithDefault(t, "", "")
 
 	res, err := m.GetPluginInfo(ctx, &spi.GetPluginInfoRequest{})
 	require.NoError(t, err)
@@ -344,9 +323,7 @@ func TestSpirePlugin_MintX509CA(t *testing.T) {
 			// Setup servers
 			server := testHandler{}
 			server.startTestServers(t)
-			defer server.stopTestServers()
-			p, done := newWithDefault(t, server.napiServer.addr, server.wapiServer.socketPath)
-			defer done()
+			p := newWithDefault(t, server.napiServer.addr, server.wapiServer.socketPath)
 
 			// Send initial request and get stream
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -401,9 +378,7 @@ func TestSpirePlugin_PublishJWTKey(t *testing.T) {
 	// Setup servers
 	server := testHandler{}
 	server.startTestServers(t)
-	defer server.stopTestServers()
-	p, done := newWithDefault(t, server.napiServer.addr, server.wapiServer.socketPath)
-	defer done()
+	p := newWithDefault(t, server.napiServer.addr, server.wapiServer.socketPath)
 
 	// Send initial request and get stream
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -445,7 +420,7 @@ func TestSpirePlugin_PublishJWTKey(t *testing.T) {
 	require.Contains(t, err.Error(), "rpc error: code = Canceled desc = context canceled")
 }
 
-func newWithDefault(t *testing.T, addr string, socketPath string) (upstreamauthority.Plugin, func()) {
+func newWithDefault(t *testing.T, addr string, socketPath string) upstreamauthority.Plugin {
 	host, port, _ := net.SplitHostPort(addr)
 
 	config := Configuration{
@@ -463,13 +438,12 @@ func newWithDefault(t *testing.T, addr string, socketPath string) (upstreamautho
 	}
 
 	var plugin upstreamauthority.Plugin
-	done := spiretest.LoadPlugin(t, BuiltIn(), &plugin)
+	spiretest.LoadPlugin(t, BuiltIn(), &plugin)
 	if _, err = plugin.Configure(ctx, pluginConfig); err != nil {
-		done()
 		require.NoError(t, err)
 	}
 
 	clk = mockClock
 
-	return plugin, done
+	return plugin
 }

--- a/support/k8s/k8s-workload-registrar/config_test.go
+++ b/support/k8s/k8s-workload-registrar/config_test.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,13 +20,11 @@ var (
 func TestLoadConfig(t *testing.T) {
 	require := require.New(t)
 
-	dir, err := ioutil.TempDir("", "spire-adm-webhook-config-")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	confPath := filepath.Join(dir, "test.conf")
 
-	_, err = LoadConfig(confPath)
+	_, err := LoadConfig(confPath)
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 

--- a/support/k8s/k8s-workload-registrar/server_test.go
+++ b/support/k8s/k8s-workload-registrar/server_test.go
@@ -22,6 +22,7 @@ import (
 
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,9 +37,7 @@ xrHoko3NlsLMmZn282gMYb+0Au9R+IXllaYy8+vuW9R7VctQwmaAgGU4
 )
 
 func TestServer(t *testing.T) {
-	dir, err := ioutil.TempDir("", "k8s-workload-registrar-server-")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	keyPath := filepath.Join(dir, "key.pem")
 	certPath := filepath.Join(dir, "cert.pem")

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,13 +26,11 @@ var (
 func TestLoadConfig(t *testing.T) {
 	require := require.New(t)
 
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := spiretest.TempDir(t)
 
 	confPath := filepath.Join(dir, "test.conf")
 
-	_, err = LoadConfig(confPath)
+	_, err := LoadConfig(confPath)
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 

--- a/support/oidc-discovery-provider/registration_api_test.go
+++ b/support/oidc-discovery-provider/registration_api_test.go
@@ -21,9 +21,7 @@ func TestRegistrationAPISource(t *testing.T) {
 
 	api := &fakeRegistrationAPIServer{}
 
-	// Create a temporary directory to host the socket
-	socketPath, closeServer := spiretest.StartRegistrationAPIOnTempSocket(t, api)
-	defer closeServer()
+	socketPath := spiretest.StartRegistrationAPIOnTempSocket(t, api)
 
 	log, _ := test.NewNullLogger()
 	clock := clock.NewMock(t)

--- a/support/oidc-discovery-provider/workload_api_test.go
+++ b/support/oidc-discovery-provider/workload_api_test.go
@@ -21,9 +21,7 @@ func TestWorkloadAPISource(t *testing.T) {
 
 	api := &fakeWorkloadAPIServer{}
 
-	// Create a temporary directory to host the socket
-	socketPath, closeServer := spiretest.StartWorkloadAPIOnTempSocket(t, api)
-	defer closeServer()
+	socketPath := spiretest.StartWorkloadAPIOnTempSocket(t, api)
 
 	log, _ := test.NewNullLogger()
 	clock := clock.NewMock(t)

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -29,9 +29,7 @@ var _ datastore.DataStore = (*DataStore)(nil)
 
 func New(tb testing.TB) *DataStore {
 	var ds datastore.Plugin
-
-	// TODO: clean up plugin when we move to go1.14.
-	_ = spiretest.LoadPlugin(tb, sql.BuiltIn(), &ds)
+	spiretest.LoadPlugin(tb, sql.BuiltIn(), &ds)
 
 	_, err := ds.Configure(context.Background(), &spi.ConfigureRequest{
 		Configuration: fmt.Sprintf(`

--- a/test/fakes/fakeupstreamauthority/plugin.go
+++ b/test/fakes/fakeupstreamauthority/plugin.go
@@ -10,17 +10,17 @@ import (
 	"github.com/spiffe/spire/test/spiretest"
 )
 
-func Load(t *testing.T, config Config) (upstreamauthority.UpstreamAuthority, *UpstreamAuthority, func()) {
+func Load(t *testing.T, config Config) (upstreamauthority.UpstreamAuthority, *UpstreamAuthority) {
 	fake := New(t, config)
 
 	var ua upstreamauthority.UpstreamAuthority
-	uaDone := spiretest.LoadPlugin(t, catalog.MakePlugin("fake",
+	spiretest.LoadPlugin(t, catalog.MakePlugin("fake",
 		upstreamauthority.PluginServer(&upstreamAuthorityPlugin{
 			UpstreamAuthority: fake,
 		}),
 	), &ua)
 
-	return ua, fake, uaDone
+	return ua, fake
 }
 
 type upstreamAuthorityPlugin struct {

--- a/test/fakes/fakeworkloadapi/workloadapi.go
+++ b/test/fakes/fakeworkloadapi/workloadapi.go
@@ -3,16 +3,13 @@ package fakeworkloadapi
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/proto/spiffe/workload"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -52,9 +49,7 @@ func FetchX509SVIDResponses(responses ...*workload.X509SVIDResponse) Result {
 }
 
 type WorkloadAPI struct {
-	dir    string
-	addr   *net.UnixAddr
-	server *grpc.Server
+	addr *net.UnixAddr
 
 	mu                   sync.Mutex
 	fetchX509SVIDResults []fetchX509SVIDResult
@@ -72,36 +67,12 @@ func New(t *testing.T, results ...Result) *WorkloadAPI {
 		}
 	}
 
-	var err error
-	w.dir, err = ioutil.TempDir("", "api-workload-tests")
-	if err != nil {
-		w.Close()
-		require.NoError(t, err)
-	}
 	w.addr = &net.UnixAddr{
 		Net:  "unix",
-		Name: filepath.Join(w.dir, "agent.sock"),
+		Name: spiretest.StartWorkloadAPIOnTempSocket(t, w),
 	}
 
-	listener, err := net.Listen("unix", w.addr.Name)
-	if err != nil {
-		w.Close()
-		require.NoError(t, err)
-	}
-
-	w.server = grpc.NewServer()
-	workload.RegisterSpiffeWorkloadAPIServer(w.server, w)
-	go func() { _ = w.server.Serve(listener) }()
 	return w
-}
-
-func (w *WorkloadAPI) Close() {
-	if w.server != nil {
-		w.server.Stop()
-	}
-	if w.dir != "" {
-		os.RemoveAll(w.dir)
-	}
 }
 
 func (w *WorkloadAPI) Addr() *net.UnixAddr {

--- a/test/spiretest/dir.go
+++ b/test/spiretest/dir.go
@@ -1,0 +1,23 @@
+package spiretest
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TempDir creates a temporary directory that is cleaned up when the test
+// finishes.
+// TODO: remove when go1.15 is out, which introduces a new method on
+// *testing.T for this purpose.
+func TempDir(tb testing.TB) string {
+	dir, err := ioutil.TempDir("", "spire-test-")
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		assert.NoError(tb, os.RemoveAll(dir))
+	})
+	return dir
+}

--- a/test/spiretest/plugin.go
+++ b/test/spiretest/plugin.go
@@ -36,7 +36,7 @@ func HostService(hostService catalog.HostServiceServer) PluginOption {
 	})
 }
 
-func LoadPlugin(tb testing.TB, plugin catalog.Plugin, x interface{}, opts ...PluginOption) (done func()) {
+func LoadPlugin(tb testing.TB, plugin catalog.Plugin, x interface{}, opts ...PluginOption) {
 	config := &pluginConfig{}
 	for _, opt := range opts {
 		opt.setOption(config)
@@ -48,10 +48,9 @@ func LoadPlugin(tb testing.TB, plugin catalog.Plugin, x interface{}, opts ...Plu
 		HostServices: config.hostServices,
 	})
 	require.NoError(tb, err, "unable to load plugin")
+	tb.Cleanup(p.Close)
 
 	if err := p.Fill(x); err != nil {
-		p.Close()
 		require.NoError(tb, err, "unable to satisfy plugin client")
 	}
-	return p.Close
 }


### PR DESCRIPTION
Go 1.14 introduced the Cleanup method on *testing.T which facilitates cleanup of resources when tests finish. This change leverages the method to clean up a bunch of test teardown code.