### PR TITLE
Use the default_svid_ttl as the default ttl in the spire-server entry command

### DIFF
--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -231,7 +231,7 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.TTL, "ttl", 3600, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
+	f.IntVar(&c.TTL, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
 
 	f.StringVar(&c.Path, "data", "", "Path to a file containing registration JSON (optional)")
 

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -217,7 +217,7 @@ func (UpdateCLI) newConfig(args []string) (*UpdateConfig, error) {
 	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.TTL, "ttl", 3600, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
+	f.IntVar(&c.TTL, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
 
 	f.StringVar(&c.Path, "data", "", "Path to a file containing registration JSON (optional)")
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -98,8 +98,8 @@ Please see the [built-in plugins](#built-in-plugins) section below for informati
 
 ## Federation configuration
 
-SPIRE Server can be configured to federate with others SPIRE Servers living in different trust domains. This allows a trust domain to authenticate identities issued by other SPIFFE authorities, allowing workloads in one trust domain to securely autenticate workloads in a foreign trust domain.  
-A key element to achieve federation is the use of SPIFFE bundle endpoints, these are resources (represented by URLs) that serve a copy of a trust bundle for a trust domain.  
+SPIRE Server can be configured to federate with others SPIRE Servers living in different trust domains. This allows a trust domain to authenticate identities issued by other SPIFFE authorities, allowing workloads in one trust domain to securely autenticate workloads in a foreign trust domain.
+A key element to achieve federation is the use of SPIFFE bundle endpoints, these are resources (represented by URLs) that serve a copy of a trust bundle for a trust domain.
 Using the `federation` section you will be able to configure the bundle endpoints as follows:
 ```hcl
 server {
@@ -234,7 +234,7 @@ Creates registration entries.
 | `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
-| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The value configured in `default_svid_ttl` |
 
 ### `spire-server entry update`
 
@@ -253,7 +253,7 @@ Updates registration entries.
 | `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
-| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The value configured in `default_svid_ttl` |
 
 ### `spire-server entry delete`
 

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"net"
+	"time"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
@@ -39,6 +40,9 @@ type Config struct {
 	// The server's configured trust domain. Used for validation, server SVID, etc.
 	TrustDomain spiffeid.TrustDomain
 
+	// The server's configured default svid ttl. Used for managing entry, etc.
+	SVIDTTL time.Duration
+
 	// Plugin catalog
 	Catalog catalog.Catalog
 
@@ -67,6 +71,7 @@ func (c *Config) makeRegistrationHandler() *registration.Handler {
 		Metrics:     c.Metrics,
 		Catalog:     c.Catalog,
 		TrustDomain: *c.TrustDomain.ID().URL(),
+		SVIDTTL:     c.SVIDTTL,
 		ServerCA:    c.ServerCA,
 	}
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -51,6 +51,7 @@ type Endpoints struct {
 	UDSAddr             *net.UnixAddr
 	SVIDObserver        svid.Observer
 	TrustDomain         spiffeid.TrustDomain
+	SVIDTTL             time.Duration
 	DataStore           datastore.DataStore
 	RegistrationServer  registration_pb.RegistrationServer
 	NodeServer          node_pb.NodeServer
@@ -79,6 +80,7 @@ func New(c Config) (*Endpoints, error) {
 		UDSAddr:             c.UDSAddr,
 		SVIDObserver:        c.SVIDObserver,
 		TrustDomain:         c.TrustDomain,
+		SVIDTTL:             c.SVIDTTL,
 		DataStore:           c.Catalog.GetDataStore(),
 		RegistrationServer:  c.makeRegistrationHandler(),
 		NodeServer:          nodeHandler,

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -56,6 +56,9 @@ func TestNew(t *testing.T) {
 
 	svidObserver := newSVIDObserver(nil)
 
+	svidTTL, err := time.ParseDuration("1h")
+	require.NoError(t, err)
+
 	log, _ := test.NewNullLogger()
 	metrics := fakemetrics.New()
 	ds := fakedatastore.New(t)
@@ -81,6 +84,7 @@ func TestNew(t *testing.T) {
 		UDSAddr:               udsAddr,
 		SVIDObserver:          svidObserver,
 		TrustDomain:           testTD,
+		SVIDTTL:               svidTTL,
 		Catalog:               cat,
 		ServerCA:              serverCA,
 		BundleEndpoint:        bundle.EndpointConfig{Address: tcpAddr},
@@ -94,6 +98,7 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, udsAddr, endpoints.UDSAddr)
 	assert.Equal(t, svidObserver, endpoints.SVIDObserver)
 	assert.Equal(t, testTD, endpoints.TrustDomain)
+	assert.Equal(t, svidTTL, endpoints.SVIDTTL)
 	assert.NotNil(t, endpoints.RegistrationServer)
 	assert.NotNil(t, endpoints.NodeServer)
 	if assert.NotNil(t, endpoints.ExperimentalServers) {

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -41,6 +41,7 @@ type Handler struct {
 	Metrics     telemetry.Metrics
 	Catalog     catalog.Catalog
 	TrustDomain url.URL
+	SVIDTTL     time.Duration
 	ServerCA    ca.ServerCA
 }
 
@@ -835,6 +836,11 @@ func (h *Handler) prepareRegistrationEntry(entry *common.RegistrationEntry, forU
 	entry.SpiffeId, err = idutil.NormalizeSpiffeID(entry.SpiffeId, idutil.AllowTrustDomainWorkload(h.TrustDomain.Host))
 	if err != nil {
 		return nil, err
+	}
+
+	// If ttl is not set, Set `default_svid_ttl` in the server configuration
+	if entry.Ttl == 0 {
+		entry.Ttl = int32(h.SVIDTTL.Seconds())
 	}
 
 	return entry, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -305,6 +305,7 @@ func (s *Server) newEndpointsServer(catalog catalog.Catalog, svidObserver svid.O
 		UDSAddr:                     s.config.BindUDSAddress,
 		SVIDObserver:                svidObserver,
 		TrustDomain:                 spiffeid.RequireTrustDomainFromURI(&s.config.TrustDomain),
+		SVIDTTL:                     s.config.SVIDTTL,
 		Catalog:                     catalog,
 		ServerCA:                    serverCA,
 		Log:                         s.config.Log.WithField(telemetry.SubsystemName, telemetry.Endpoints),


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

The `spire-server entry` command.

**Description of change**
<!-- Please provide a description of the change -->

I added the changes to use the `default_svid_tt`l as the default ttl in the `spire-server entry` command.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

This PR fixes https://github.com/spiffe/spire/issues/1759.
