### PR TITLE
Use the default_svid_ttl as the default TTL in the spire-server entry command

### DIFF
--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -231,7 +231,7 @@ func (CreateCLI) newConfig(args []string) (*CreateConfig, error) {
 	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.TTL, "ttl", 3600, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
+	f.IntVar(&c.TTL, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
 
 	f.StringVar(&c.Path, "data", "", "Path to a file containing registration JSON (optional)")
 

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -217,7 +217,7 @@ func (UpdateCLI) newConfig(args []string) (*UpdateConfig, error) {
 	f.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
 	f.StringVar(&c.ParentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.SpiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.TTL, "ttl", 3600, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
+	f.IntVar(&c.TTL, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry")
 
 	f.StringVar(&c.Path, "data", "", "Path to a file containing registration JSON (optional)")
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -234,7 +234,7 @@ Creates registration entries.
 | `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
-| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
 ### `spire-server entry update`
 
@@ -253,7 +253,7 @@ Updates registration entries.
 | `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
-| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | 3600           |
+| `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
 ### `spire-server entry delete`
 
@@ -370,7 +370,7 @@ Mints an X509-SVID.
 | `-dns`        | A DNS name that will be included in SVID. Can be used more than once | |
 | `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-spiffeID`   | The SPIFFE ID of the X509-SVID                                     | |
-| `-ttl`        | The TTL of the X509-SVID                                           | |
+| `-ttl`        | The TTL of the X509-SVID                                           | The TTL configured with `default_svid_ttl` |
 | `-write`      | Directory to write output to instead of stdout                     | |
 
 ### `spire-server jwt mint`


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

The `spire-server entry` command.

**Description of change**
<!-- Please provide a description of the change -->

I changed the default TTL of the `spire-server entry` command to 0.
By changing the default TTL to 0, the `default_svid_ttl` is used as the default TTL.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

This PR fixes #1759.