### PR TITLE
Solve node-attestor IT build issue

### DIFF
--- a/test/integration/suites/node-attestation/00-setup
+++ b/test/integration/suites/node-attestation/00-setup
@@ -5,6 +5,8 @@ echo ${ROOTDIR}
 # Move test x509pop certificate and key
 mv conf/agent.key.pem conf/agent/test.key.pem
 mv conf/agent.crt.pem conf/agent/test.crt.pem
+# add read access to prevent error when reading with user 1001
+chmod +x conf/agent/test.key.pem
 
 "${ROOTDIR}/setup/node-attestation/build.sh" "${RUNDIR}/conf/server/node-attestation"
 "${ROOTDIR}/setup/node-attestation/build.sh" "${RUNDIR}/conf/agent/node-attestation"


### PR DESCRIPTION
add read access to x509pop key to prevent error when reading it with test user

Signed-off-by: Marcos Yacob <marcos.yacob@hpe.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

