### PR TITLE
API Refactor: fix entry types conversion

### DIFF
--- a/pkg/agent/client/util.go
+++ b/pkg/agent/client/util.go
@@ -42,19 +42,21 @@ func registrationEntryFromProto(e *types.Entry) (*common.RegistrationEntry, erro
 		return nil, fmt.Errorf("invalid SPIFFE ID: %v", err)
 	}
 
+	var dnsNames []string
 	for _, dnsName := range e.DnsNames {
 		if err := x509util.ValidateDNS(dnsName); err != nil {
 			return nil, fmt.Errorf("invalid DNS name: %v", err)
 		}
+		dnsNames = append(dnsNames, dnsName)
 	}
 
-	// Validate and normalize TDs
-	for i, federatedWith := range e.FederatesWith {
-		td, err := spiffeid.TrustDomainFromString(federatedWith)
+	var federatesWith []string
+	for _, trustDomainName := range e.FederatesWith {
+		td, err := spiffeid.TrustDomainFromString(trustDomainName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid federated trust domain: %v", err)
 		}
-		e.FederatesWith[i] = td.IDString()
+		federatesWith = append(federatesWith, td.IDString())
 	}
 
 	if len(e.Selectors) == 0 {
@@ -82,10 +84,10 @@ func registrationEntryFromProto(e *types.Entry) (*common.RegistrationEntry, erro
 		ParentId:       parentID,
 		SpiffeId:       spiffeID,
 		Admin:          e.Admin,
-		DnsNames:       e.DnsNames,
+		DnsNames:       dnsNames,
 		Downstream:     e.Downstream,
 		EntryExpiry:    e.ExpiresAt,
-		FederatesWith:  e.FederatesWith,
+		FederatesWith:  federatesWith,
 		RevisionNumber: e.RevisionNumber,
 		Selectors:      selectors,
 		Ttl:            e.Ttl,

--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -43,6 +43,15 @@ func RegistrationEntryToProto(e *common.RegistrationEntry) (*types.Entry, error)
 		return nil, err
 	}
 
+	federatesWith := make([]string, 0, len(e.FederatesWith))
+	for _, trustDomainID := range e.FederatesWith {
+		td, err := spiffeid.TrustDomainFromString(trustDomainID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid federated trust domain: %v", err)
+		}
+		federatesWith = append(federatesWith, td.String())
+	}
+
 	var selectors []*types.Selector
 	for _, s := range e.Selectors {
 		selectors = append(selectors, &types.Selector{
@@ -57,11 +66,11 @@ func RegistrationEntryToProto(e *common.RegistrationEntry) (*types.Entry, error)
 		ParentId:       ProtoFromID(parentID),
 		Selectors:      selectors,
 		Ttl:            e.Ttl,
-		FederatesWith:  e.FederatesWith,
+		FederatesWith:  federatesWith,
 		Admin:          e.Admin,
 		Downstream:     e.Downstream,
 		ExpiresAt:      e.EntryExpiry,
-		DnsNames:       e.DnsNames,
+		DnsNames:       append([]string(nil), e.DnsNames...),
 		RevisionNumber: e.RevisionNumber,
 	}, nil
 }
@@ -77,43 +86,73 @@ func ProtoToRegistrationEntry(td spiffeid.TrustDomain, e *types.Entry) (*common.
 // This allows the user to not specify these fields while updating using a mask.
 // All other fields are allowed to be empty (with or without a mask).
 func ProtoToRegistrationEntryWithMask(td spiffeid.TrustDomain, e *types.Entry, mask *types.EntryMask) (*common.RegistrationEntry, error) {
-	var parentIDString string
 	if e == nil {
 		return nil, errors.New("missing entry")
 	}
-	if mask == nil || mask.ParentId {
+
+	if mask == nil {
+		mask = protoutil.AllTrueEntryMask
+	}
+
+	var parentIDString string
+	if mask.ParentId {
 		parentID, err := TrustDomainMemberIDFromProto(td, e.ParentId)
 		if err != nil {
 			return nil, fmt.Errorf("invalid parent ID: %v", err)
 		}
 		parentIDString = parentID.String()
 	}
+
 	var spiffeIDString string
-	if mask == nil || mask.SpiffeId {
+	if mask.SpiffeId {
 		spiffeID, err := TrustDomainWorkloadIDFromProto(td, e.SpiffeId)
 		if err != nil {
 			return nil, fmt.Errorf("invalid spiffe ID: %v", err)
 		}
 		spiffeIDString = spiffeID.String()
 	}
-	for _, dnsName := range e.DnsNames {
-		if err := x509util.ValidateDNS(dnsName); err != nil {
-			return nil, fmt.Errorf("invalid DNS name: %v", err)
+
+	var admin bool
+	if mask.Admin {
+		admin = e.Admin
+	}
+
+	var dnsNames []string
+	if mask.DnsNames {
+		dnsNames = make([]string, 0, len(e.DnsNames))
+		for _, dnsName := range e.DnsNames {
+			if err := x509util.ValidateDNS(dnsName); err != nil {
+				return nil, fmt.Errorf("invalid DNS name: %v", err)
+			}
+			dnsNames = append(dnsNames, dnsName)
 		}
 	}
 
-	// Validate and normalize TDs
-	for i, federatedWith := range e.FederatesWith {
-		td, err := spiffeid.TrustDomainFromString(federatedWith)
-		if err != nil {
-			return nil, fmt.Errorf("invalid federated trust domain: %v", err)
+	var downstream bool
+	if mask.Downstream {
+		downstream = e.Downstream
+	}
+
+	var expiresAt int64
+	if mask.ExpiresAt {
+		expiresAt = e.ExpiresAt
+	}
+
+	var federatesWith []string
+	if mask.FederatesWith {
+		federatesWith = make([]string, 0, len(e.FederatesWith))
+		for _, trustDomainName := range e.FederatesWith {
+			td, err := spiffeid.TrustDomainFromString(trustDomainName)
+			if err != nil {
+				return nil, fmt.Errorf("invalid federated trust domain: %v", err)
+			}
+			federatesWith = append(federatesWith, td.IDString())
 		}
-		e.FederatesWith[i] = td.IDString()
 	}
 
 	var selectors []*common.Selector
 	var err error
-	if mask == nil || mask.Selectors {
+	if mask.Selectors {
 		if len(e.Selectors) == 0 {
 			return nil, errors.New("selector list is empty")
 		}
@@ -123,16 +162,21 @@ func ProtoToRegistrationEntryWithMask(td spiffeid.TrustDomain, e *types.Entry, m
 		}
 	}
 
+	var ttl int32
+	if mask.Ttl {
+		ttl = e.Ttl
+	}
+
 	return &common.RegistrationEntry{
 		EntryId:       e.Id,
 		ParentId:      parentIDString,
 		SpiffeId:      spiffeIDString,
-		Admin:         e.Admin,
-		DnsNames:      e.DnsNames,
-		Downstream:    e.Downstream,
-		EntryExpiry:   e.ExpiresAt,
-		FederatesWith: e.FederatesWith,
+		Admin:         admin,
+		DnsNames:      dnsNames,
+		Downstream:    downstream,
+		EntryExpiry:   expiresAt,
+		FederatesWith: federatesWith,
 		Selectors:     selectors,
-		Ttl:           e.Ttl,
+		Ttl:           ttl,
 	}, nil
 }

--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -375,7 +375,7 @@ func TestGetEntry(t *testing.T) {
 					{Type: "unix", Value: "uid:1000"},
 					{Type: "unix", Value: "gid:1000"},
 				},
-				FederatesWith: []string{federatedTd.IDString()},
+				FederatesWith: []string{federatedTd.String()},
 				Admin:         true,
 				DnsNames:      []string{"dns1", "dns2"},
 				Downstream:    true,
@@ -625,7 +625,7 @@ func TestBatchCreateEntry(t *testing.T) {
 						DnsNames:      []string{"dns1"},
 						Downstream:    true,
 						ExpiresAt:     expiresAt,
-						FederatesWith: []string{"spiffe://domain1.org"},
+						FederatesWith: []string{"domain1.org"},
 						Ttl:           60,
 					},
 				},
@@ -810,7 +810,7 @@ func TestBatchCreateEntry(t *testing.T) {
 			test := setupServiceTest(t, ds)
 			defer test.Cleanup()
 
-			// Create fedeated bundles, that we use on "FederatesWith"
+			// Create federated bundles, that we use on "FederatesWith"
 			createFederatedBundles(t, ds)
 			_ = createTestEntries(t, ds, defaultEntry)
 
@@ -1040,8 +1040,8 @@ func TestGetAuthorizedEntries(t *testing.T) {
 			{Type: "unix", Value: "gid:1000"},
 		},
 		FederatesWith: []string{
-			"spiffe://domain1.com",
-			"spiffe://domain2.com",
+			"domain1.com",
+			"domain2.com",
 		},
 		Admin:      true,
 		ExpiresAt:  time.Now().Add(30 * time.Second).Unix(),
@@ -1058,8 +1058,8 @@ func TestGetAuthorizedEntries(t *testing.T) {
 			{Type: "unix", Value: "gid:1001"},
 		},
 		FederatesWith: []string{
-			"spiffe://domain3.com",
-			"spiffe://domain4.com",
+			"domain3.com",
+			"domain4.com",
 		},
 		ExpiresAt: time.Now().Add(60 * time.Second).Unix(),
 		DnsNames:  []string{"dns3", "dns4"},
@@ -1268,7 +1268,7 @@ func TestBatchUpdateEntry(t *testing.T) {
 			{Type: "unix", Value: "uid:2000"},
 		},
 		FederatesWith: []string{
-			federatedTd.IDString(),
+			federatedTd.String(),
 		},
 		Admin:      true,
 		ExpiresAt:  expiresAt,
@@ -1878,7 +1878,7 @@ func TestBatchUpdateEntry(t *testing.T) {
 							{Type: "unix", Value: "uid:2000"},
 						},
 						FederatesWith: []string{
-							"spiffe://domain1.org",
+							"domain1.org",
 						},
 						Admin:          true,
 						ExpiresAt:      expiresAt,

--- a/pkg/server/api/entry_test.go
+++ b/pkg/server/api/entry_test.go
@@ -35,7 +35,10 @@ func TestRegistrationEntryToProto(t *testing.T) {
 				},
 				FederatesWith: []string{
 					"spiffe://domain1.com",
-					"spiffe://domain2.com",
+					// common registration entries use the trust domain ID but
+					// we should assert that they are normalized to trust
+					// domain name either way.
+					"domain2.com",
 				},
 				Admin:       true,
 				EntryExpiry: expiresAt,
@@ -52,8 +55,8 @@ func TestRegistrationEntryToProto(t *testing.T) {
 					{Type: "unix", Value: "gid:1000"},
 				},
 				FederatesWith: []string{
-					"spiffe://domain1.com",
-					"spiffe://domain2.com",
+					"domain1.com",
+					"domain2.com",
 				},
 				Admin:      true,
 				ExpiresAt:  expiresAt,
@@ -110,7 +113,7 @@ func TestProtoToRegistrationEntryWithMask(t *testing.T) {
 		mask        *types.EntryMask
 	}{
 		{
-			name: "success",
+			name: "mask including all fields",
 			entry: &types.Entry{
 				Id:       "entry1",
 				ParentId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
@@ -121,8 +124,11 @@ func TestProtoToRegistrationEntryWithMask(t *testing.T) {
 					{Type: "unix", Value: "gid:1000"},
 				},
 				FederatesWith: []string{
-					"spiffe://domain1.com",
-					"domain2.com",
+					"domain1.com",
+					// types entries use the trust domain name but we should
+					// assert that they are normalized to trust domain ID
+					// either way.
+					"spiffe://domain2.com",
 				},
 				Admin:      true,
 				ExpiresAt:  expiresAt,
@@ -150,59 +156,22 @@ func TestProtoToRegistrationEntryWithMask(t *testing.T) {
 			mask: protoutil.AllTrueEntryMask,
 		},
 		{
-			name: "success empty spiffe id",
+			name: "mask off all fields",
 			entry: &types.Entry{
-				Id:       "entry1",
-				ParentId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
-				Selectors: []*types.Selector{
-					{Type: "unix", Value: "uid:1000"},
-					{Type: "unix", Value: "gid:1000"},
-				},
+				Id:            "entry1",
+				ParentId:      &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+				Selectors:     []*types.Selector{},
+				DnsNames:      []string{"name1"},
+				FederatesWith: []string{"domain.test"},
+				Ttl:           1,
+				Admin:         true,
+				Downstream:    true,
+				ExpiresAt:     4,
 			},
 			expectEntry: &common.RegistrationEntry{
-				EntryId:  "entry1",
-				ParentId: "spiffe://example.org/foo",
-				SpiffeId: "",
-				Selectors: []*common.Selector{
-					{Type: "unix", Value: "uid:1000"},
-					{Type: "unix", Value: "gid:1000"},
-				},
+				EntryId: "entry1",
 			},
-			mask: &types.EntryMask{
-				SpiffeId:  false,
-				ParentId:  true,
-				Selectors: true,
-			},
-		},
-		{
-			name: "success empty selectors, ignore spiffe id field",
-			entry: &types.Entry{
-				Id:        "entry1",
-				ParentId:  &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
-				Selectors: []*types.Selector{},
-			},
-			expectEntry: &common.RegistrationEntry{
-				EntryId:   "entry1",
-				ParentId:  "spiffe://example.org/foo",
-				Selectors: []*common.Selector{},
-			},
-			mask: &types.EntryMask{
-				SpiffeId:  false,
-				ParentId:  true,
-				Selectors: false,
-			},
-		},
-		{
-			name: "fail bad spiffe id",
-			entry: &types.Entry{
-				Id:       "entry1",
-				ParentId: &types.SPIFFEID{TrustDomain: "", Path: "/foo"},
-				Selectors: []*types.Selector{
-					{Type: "unix", Value: "uid:1000"},
-					{Type: "unix", Value: "gid:1000"},
-				},
-			},
-			err: "invalid parent ID: spiffeid: trust domain is empty",
+			mask: &types.EntryMask{},
 		},
 	} {
 		tt := tt
@@ -243,8 +212,11 @@ func TestProtoToRegistrationEntry(t *testing.T) {
 					{Type: "unix", Value: "gid:1000"},
 				},
 				FederatesWith: []string{
-					"spiffe://domain1.com",
-					"domain2.com",
+					"domain1.com",
+					// types entries use the trust domain name but we should
+					// assert that they are normalized to trust domain ID
+					// either way.
+					"spiffe://domain2.com",
 				},
 				Admin:      true,
 				ExpiresAt:  expiresAt,

--- a/test/fixture/registration/manager_test_entries.json
+++ b/test/fixture/registration/manager_test_entries.json
@@ -73,7 +73,7 @@
                 "spiffe_id": "spiffe://example.org/database",
                 "parent_id": "spiffe://example.org/spire/agent",
                 "ttl": 200,
-                "federates_with": ["otherdomain.test"],
+                "federates_with": ["spiffe://otherdomain.test"],
                 "dns_names": ["name-0003"]
             }
         ]


### PR DESCRIPTION
- Fixes a bug where the trust domain ID was used instead of name when converting the FederatesWith field in from common.RegistrationEntry to types.Entry.
- Fixes slice aliasing of DnsNames
- Fixes mask not being applied to all entry fields