### PR TITLE
Bring down the agent when it needs to re-attest

### DIFF
--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -311,7 +311,7 @@ func (c *client) fetchEntries(ctx context.Context) ([]*types.Entry, error) {
 	if err != nil {
 		c.release(connection)
 		c.c.Log.WithError(err).Error("Failed to fetch authorized entries")
-		return nil, fmt.Errorf("failed to fetch authorized entries: %v", err)
+		return nil, err
 	}
 
 	return resp.Entries, err

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -311,7 +311,7 @@ func (c *client) fetchEntries(ctx context.Context) ([]*types.Entry, error) {
 	if err != nil {
 		c.release(connection)
 		c.c.Log.WithError(err).Error("Failed to fetch authorized entries")
-		return nil, err
+		return nil, fmt.Errorf("failed to fetch authorized entries: %w", err)
 	}
 
 	return resp.Entries, err
@@ -370,7 +370,7 @@ func (c *client) fetchSVIDs(ctx context.Context, params []*svidpb.NewX509SVIDPar
 	if err != nil {
 		c.release(connection)
 		c.c.Log.WithError(err).Error("failed to batch new X509 SVID(s)")
-		return nil, fmt.Errorf("failed to batch new X509 SVID(s): %v", err)
+		return nil, fmt.Errorf("failed to batch new X509 SVID(s): %w", err)
 	}
 
 	okStatus := int32(codes.OK)

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -168,7 +168,8 @@ func (c *client) RenewSVID(ctx context.Context, csr []byte) (*node.X509SVID, err
 	})
 	if err != nil {
 		c.release(connection)
-		return nil, err
+		c.c.Log.WithError(err).Error("Failed to renew agent")
+		return nil, fmt.Errorf("failed to renew agent: %w", err)
 	}
 
 	var certChain []byte
@@ -241,8 +242,8 @@ func (c *client) NewJWTSVID(ctx context.Context, jsr *node.JSR, entryID string) 
 	})
 	if err != nil {
 		c.release(connection)
-		c.c.Log.WithError(err).Errorf("Failure fetching JWT SVID")
-		return nil, fmt.Errorf("failure fetching JWT SVID: %v", err)
+		c.c.Log.WithError(err).Error("Failed to fetch JWT SVID")
+		return nil, fmt.Errorf("failed to fetch JWT SVID: %w", err)
 	}
 
 	svid := resp.Svid
@@ -331,7 +332,7 @@ func (c *client) fetchBundles(ctx context.Context, federatedBundles []string) ([
 	if err != nil {
 		c.release(connection)
 		c.c.Log.WithError(err).Error("Failed to fetch bundle")
-		return nil, fmt.Errorf("failed to fetch bundle: %v", err)
+		return nil, fmt.Errorf("failed to fetch bundle: %w", err)
 	}
 	bundles = append(bundles, bundle)
 
@@ -350,7 +351,7 @@ func (c *client) fetchBundles(ctx context.Context, federatedBundles []string) ([
 			c.c.Log.WithError(err).WithField(telemetry.FederatedBundle, b).Warn("Federated bundle not found")
 		default:
 			c.c.Log.WithError(err).WithField(telemetry.FederatedBundle, b).Error("Failed to fetch federated bundle")
-			return nil, err
+			return nil, fmt.Errorf("failed to fetch federated bundle: %w", err)
 		}
 	}
 

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -173,13 +173,13 @@ func TestRenewSVID(t *testing.T) {
 				CertChain: [][]byte{{1, 2, 3}},
 				ExpiresAt: 12345,
 			},
-			err: "malformed param",
+			err: "failed to renew agent: malformed param",
 		},
 		{
 			name:     "renew agent fails",
 			csr:      []byte{0, 1, 2},
 			agentErr: errors.New("renew fails"),
-			err:      "renew fails",
+			err:      "failed to renew agent: renew fails",
 		},
 	} {
 		tt := tt
@@ -655,7 +655,7 @@ func TestFetchJWTSVID(t *testing.T) {
 			setupTest: func(err error) {
 				tc.svidClient.newJWTSVID = err
 			},
-			err:      "failure fetching JWT SVID: client fails",
+			err:      "failed to fetch JWT SVID: client fails",
 			fetchErr: errors.New("client fails"),
 		},
 		{

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -539,7 +539,7 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToFetch(t *testing.T) {
 			setupTest: func(tc *testClient) {
 				tc.entryClient.err = errors.New("an error")
 			},
-			err: "an error",
+			err: "failed to fetch authorized entries: an error",
 		},
 		{
 			name: "Agent bundle",

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -539,7 +539,7 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToFetch(t *testing.T) {
 			setupTest: func(tc *testClient) {
 				tc.entryClient.err = errors.New("an error")
 			},
-			err: "failed to fetch authorized entries: an error",
+			err: "an error",
 		},
 		{
 			name: "Agent bundle",

--- a/pkg/agent/manager/storage.go
+++ b/pkg/agent/manager/storage.go
@@ -71,3 +71,9 @@ func StoreSVID(svidCachePath string, svidChain []*x509.Certificate) error {
 	}
 	return diskutil.AtomicWriteFile(svidCachePath, data.Bytes(), 0600)
 }
+
+// DeleteSVID deletes the svid from disk at svidCachePath. Returns nil if all went
+// fine, otherwise it returns an error.
+func DeleteSVID(svidCachePath string) error {
+	return os.Remove(svidCachePath)
+}

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -67,7 +67,7 @@ func (r *rotator) runRotation(ctx context.Context) error {
 		err := r.rotateSVID(ctx)
 
 		switch {
-		case err != nil && nodeutil.IsShutdownError(err):
+		case err != nil && nodeutil.ShouldAgentReattest(err):
 			r.c.Log.WithError(err).Error("Could not rotate agent SVID")
 			return err
 		case err != nil:

--- a/pkg/common/nodeutil/node.go
+++ b/pkg/common/nodeutil/node.go
@@ -2,10 +2,31 @@ package nodeutil
 
 import (
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/proto/spire/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // IsAgentBanned determines if a given attested node is banned or not.
 // An agent is considered as "banned" if its X509 SVID serial number is empty.
 func IsAgentBanned(node *common.AttestedNode) bool {
 	return node.CertSerialNumber == ""
+}
+
+// IsShutdownError returns true if the Server returned an error worth rebooting the Agent
+func IsShutdownError(err error) bool {
+	errStatus := status.Convert(err)
+	if errStatus.Code() != codes.PermissionDenied {
+		return false
+	}
+
+	for _, errDetail := range errStatus.Details() {
+		errReason, _ := errDetail.(*types.PermissionDeniedDetails)
+		if errReason.Reason == types.PermissionDeniedDetails_AGENT_EXPIRED ||
+			errReason.Reason == types.PermissionDeniedDetails_AGENT_NOT_ACTIVE ||
+			errReason.Reason == types.PermissionDeniedDetails_AGENT_NOT_ATTESTED {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/common/nodeutil/node_test.go
+++ b/pkg/common/nodeutil/node_test.go
@@ -5,10 +5,32 @@ import (
 
 	"github.com/spiffe/spire/pkg/common/nodeutil"
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/proto/spire/types"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestIsAgentBanned(t *testing.T) {
 	require.True(t, nodeutil.IsAgentBanned(&common.AttestedNode{}))
 	require.False(t, nodeutil.IsAgentBanned(&common.AttestedNode{CertSerialNumber: "non-empty-serial"}))
+}
+
+func TestIsShutdownError(t *testing.T) {
+	require.True(t, nodeutil.IsShutdownError(getError(t, codes.PermissionDenied, types.PermissionDeniedDetails_AGENT_EXPIRED)))
+	require.True(t, nodeutil.IsShutdownError(getError(t, codes.PermissionDenied, types.PermissionDeniedDetails_AGENT_NOT_ACTIVE)))
+	require.True(t, nodeutil.IsShutdownError(getError(t, codes.PermissionDenied, types.PermissionDeniedDetails_AGENT_NOT_ATTESTED)))
+	require.False(t, nodeutil.IsShutdownError(getError(t, codes.PermissionDenied, types.PermissionDeniedDetails_AGENT_BANNED)))
+	require.False(t, nodeutil.IsShutdownError(getError(t, codes.Unknown, types.PermissionDeniedDetails_AGENT_EXPIRED)))
+	require.False(t, nodeutil.IsShutdownError(getError(t, codes.Unknown, types.PermissionDeniedDetails_AGENT_NOT_ACTIVE)))
+	require.False(t, nodeutil.IsShutdownError(getError(t, codes.Unknown, types.PermissionDeniedDetails_AGENT_NOT_ATTESTED)))
+}
+
+func getError(t *testing.T, code codes.Code, reason types.PermissionDeniedDetails_Reason) error {
+	st := status.New(code, "some error")
+	detailed, err := st.WithDetails(&types.PermissionDeniedDetails{
+		Reason: reason,
+	})
+	require.NoError(t, err)
+	return detailed.Err()
 }


### PR DESCRIPTION
Signed-off-by: Mariano Kunzi <kunzi.mariano@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Agent shutting down when meeting conditions that require re-attestation.

**Description of change**
<!-- Please provide a description of the change -->
When making calls to the server, and getting `PermissionDenied`, and the reason being one of the next `[PermissionDeniedDetails_AGENT_EXPIRED, PermissionDeniedDetails_AGENT_NOT_ACTIVE, PermissionDeniedDetails_AGENT_NOT_ATTESTED]`, the agent will shutdown and delete the SVID in order to execute a re attestation.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
fixes #1644 

