### PR TITLE
Buffer "first result" channels

### DIFF
--- a/pkg/server/ca/upstream_client.go
+++ b/pkg/server/ca/upstream_client.go
@@ -79,7 +79,7 @@ func (u *UpstreamClient) MintX509CA(ctx context.Context, csr []byte, ttl time.Du
 		PreferredTtl: int32(ttl / time.Second),
 	}
 
-	firstResultCh := make(chan mintX509CAResult)
+	firstResultCh := make(chan mintX509CAResult, 1)
 	u.mintX509CAStream.Start(func(streamCtx context.Context) {
 		u.runMintX509CAStream(streamCtx, req, firstResultCh)
 	})
@@ -123,7 +123,7 @@ func (u *UpstreamClient) PublishJWTKey(ctx context.Context, jwtKey *common.Publi
 		JwtKey: jwtKey,
 	}
 
-	firstResultCh := make(chan publishJWTKeyResult)
+	firstResultCh := make(chan publishJWTKeyResult, 1)
 	u.publishJWTKeyStream.Start(func(streamCtx context.Context) {
 		u.runPublishJWTKeyStream(streamCtx, req, firstResultCh)
 	})


### PR DESCRIPTION
The Upstream Authority uses channels to capture the first result coming off of the X509 or JWT authority stream. They block starting the streams before selecting from the first result channel. If there is a failure to start up the streams, the result is written to the first result channel which deadlocks because there is no receiver and it is unbuffered.

This PR makes the first result channels buffered to prevent the deadlock.