### PR TITLE
Plumb rate limit config into node handler

### DIFF
--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -79,6 +79,7 @@ func (c *Config) makeOldAPIServers() (OldAPIServers, error) {
 		ServerCA:                    c.ServerCA,
 		Manager:                     c.Manager,
 		AllowAgentlessNodeAttestors: c.AllowAgentlessNodeAttestors,
+		AttestLimit:                 c.RateLimit.Attestation,
 	})
 	if err != nil {
 		return OldAPIServers{}, err


### PR DESCRIPTION
#1794 introduced a configurable rate limit but there was a bug where the limit was not being plumbed all the way through to the node handler. This causes old agents to fail to attest to new servers.

This PR fixes the issue. The `upgrade` integration tests would have ideally caught this but unfortunately do not freshly attest old agents with new servers. I'll file a separate issue to embellish the `upgrade` integration test to handle this.
