### PR TITLE
Update Validating Webhook for CRD registrar, update README

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,10 +5,10 @@ run:
   skip-dirs:
     - testdata$
     - test/mock
-    - support/k8s/k8s-workload-registrar/mode-crd/api
 
   skip-files:
     - ".*\\.pb\\.go"
+    - support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_types.go
 
 linters:
   enable:

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -172,13 +172,12 @@ The following configuration is required before `"crd"` mode can be used:
    * Additionally a Secret that volume mounts the certificate and key to use for the webhook. See `webhook_cert_dir` configuration option above.
 
 #### CRD mode Security Considerations
-A Validating Webhook is used to provide security when allowing users to manually create SpiffeId custom resources using
-Roles and RoleBindings. It prevents users from creating arbitrary registration entries that can be issued to any workload. The Validating
-Webhook ensures that registration entries created have a namespace selector that matches the namespace the resource was created in.
-This ensures that the manually created entries can only be consumed to workloads within that namespace.
+It is imperative to only grant trusted users access to manually create SpiffeId custom resources. Users with access have the ability to issue any SpiffeId
+to any pod in the namespace.
 
-Care should be taken when granting users access to create SpiffeId custom resources as those users will have the ability to issue SpiffeIDs
-to any pod within the namespace.
+If allowing users to manually create SpiffeId custom resources it is important to use the ValidatingWebhook.  The Validating Webhook ensures that
+registration entries created have a namespace selector that matches the namespace the resource was created in.  This ensures that the manually created
+entries can only be consumed by workloads within that namespace.
 
 ### Webhook Mode Configuration
 The registrar will need access to its server keypair and the CA certificate it uses to verify clients.

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -177,6 +177,9 @@ Roles and RoleBindings. It prevents users from creating arbitrary registration e
 Webhook ensures that registration entries created have a namespace selector that matches the namespace the resource was created in.
 This ensures that the manually created entries can only be consumed to workloads within that namespace.
 
+Care should be taken when granting users access to create SpiffeId custom resources as those users will have the ability to issue SpiffeIDs
+to any pod within the namespace.
+
 ### Webhook Mode Configuration
 The registrar will need access to its server keypair and the CA certificate it uses to verify clients.
 

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -175,7 +175,7 @@ The following configuration is required before `"crd"` mode can be used:
 It is imperative to only grant trusted users access to manually create SpiffeId custom resources. Users with access have the ability to issue any SpiffeId
 to any pod in the namespace.
 
-If allowing users to manually create SpiffeId custom resources it is important to use the ValidatingWebhook.  The Validating Webhook ensures that
+If allowing users to manually create SpiffeId custom resources it is important to use the Validating Webhook.  The Validating Webhook ensures that
 registration entries created have a namespace selector that matches the namespace the resource was created in.  This ensures that the manually created
 entries can only be consumed by workloads within that namespace.
 

--- a/support/k8s/k8s-workload-registrar/config_crd.go
+++ b/support/k8s/k8s-workload-registrar/config_crd.go
@@ -71,6 +71,11 @@ func (c *CRDMode) Run(ctx context.Context) error {
 		return err
 	}
 
+	myNamespace, err := getNamespace()
+	if err != nil {
+		return err
+	}
+
 	log.Info("Initializing SPIFFE ID CRD Mode")
 	err = controllers.NewSpiffeIDReconciler(controllers.SpiffeIDReconcilerConfig{
 		Client:      mgr.GetClient(),
@@ -89,6 +94,7 @@ func (c *CRDMode) Run(ctx context.Context) error {
 			Ctx:         ctx,
 			Log:         log,
 			Mgr:         mgr,
+			Namespace:   myNamespace,
 			R:           registrationClient,
 			TrustDomain: c.TrustDomain,
 		})
@@ -103,7 +109,7 @@ func (c *CRDMode) Run(ctx context.Context) error {
 			Cluster:     c.Cluster,
 			Ctx:         ctx,
 			Log:         log,
-			Namespace:   getNamespace(),
+			Namespace:   myNamespace,
 			Scheme:      mgr.GetScheme(),
 			TrustDomain: c.TrustDomain,
 		}).SetupWithManager(mgr)
@@ -143,11 +149,11 @@ func (c *CRDMode) Run(ctx context.Context) error {
 	return mgr.Start(ctrl.SetupSignalHandler())
 }
 
-func getNamespace() string {
+func getNamespace() (string, error) {
 	content, err := ioutil.ReadFile(namespaceFile)
 	if err != nil {
-		return "default"
+		return "", err
 	}
 
-	return string(content)
+	return string(content), nil
 }

--- a/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
@@ -33,6 +33,7 @@ type SpiffeIDWebhookConfig struct {
 	Ctx         context.Context
 	Log         logrus.FieldLogger
 	Mgr         ctrl.Manager
+	Namespace   string
 	R           registration.RegistrationClient
 	TrustDomain string
 }
@@ -102,9 +103,17 @@ func (s *SpiffeID) validateSpiffeID() error{
 		return errs.New("spec.spiffeId must begin with " + spiffeIDPrefix)
 	}
 
-	// Ensure namespace selector matches namespace of Spiffe ID resource
-	if s.Spec.Selector.Cluster == "" && s.ObjectMeta.Namespace != s.Spec.Selector.Namespace {
-		return errs.New("spec.Selector.Namespace must match namespace of resource")
+	if (s.Spec.Selector.Cluster != "" || s.Spec.Selector.AgentNodeUid != "") {
+		// k8s_psat selectors can only be used from the k8s-workload-registrar namespace
+		if s.ObjectMeta.Namespace != c.Namespace {
+			return errs.New("spec.Selector.Cluster and spec.Selector.AgentNodeUid can " +
+				"only be used by the k8s-workload-registrar")
+		}
+	} else {
+		// Ensure namespace selector matches namespace of Spiffe ID resource for k8s selectors
+		if s.ObjectMeta.Namespace != s.Spec.Selector.Namespace {
+			return errs.New("spec.Selector.Namespace must match namespace of resource")
+		}
 	}
 
 	return nil

--- a/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
@@ -91,7 +91,7 @@ func (s *SpiffeID) ValidateDelete() error {
 }
 
 // validateSpiffeID does basic checks to make sure the SPIFFE ID resource is formatted correctly
-func (s *SpiffeID) validateSpiffeID() error{
+func (s *SpiffeID) validateSpiffeID() error {
 	spiffeIDPrefix := "spiffe://" + c.TrustDomain
 
 	// Validate Spiffe and Parent IDs have the correct format
@@ -103,7 +103,7 @@ func (s *SpiffeID) validateSpiffeID() error{
 		return errs.New("spec.spiffeId must begin with " + spiffeIDPrefix)
 	}
 
-	if (s.Spec.Selector.Cluster != "" || s.Spec.Selector.AgentNodeUid != "") {
+	if s.Spec.Selector.Cluster != "" || s.Spec.Selector.AgentNodeUid != "" {
 		// k8s_psat selectors can only be used from the k8s-workload-registrar namespace
 		if s.ObjectMeta.Namespace != c.Namespace {
 			return errs.New("spec.Selector.Cluster and spec.Selector.AgentNodeUid can " +


### PR DESCRIPTION
1. Patch small security issue in validating webhook that would allow users to create arbitrary spire entries. A user could specify the k8s_psat cluster selector which bypassed the check which restricts spire entries to having the namespace selector populated and mathching the namespace the resource was created in. The webhook now restricts k8s_psat selectors to only be specified from the namespace the registrar lives in so arbitrary users can't use them.
2. Update security warning to be more accurate