### PR TITLE
Fix fatal error when k8s registrar leader election enabled

### DIFF
--- a/support/k8s/k8s-workload-registrar/config_reconcile.go
+++ b/support/k8s/k8s-workload-registrar/config_reconcile.go
@@ -83,6 +83,7 @@ func (c *ReconcileMode) Run(ctx context.Context) error {
 		Scheme:             scheme,
 		MetricsBindAddress: c.MetricsAddr,
 		LeaderElection:     c.LeaderElection,
+		LeaderElectionID:   fmt.Sprintf("%s-leader-election", c.ControllerName),
 	})
 	if err != nil {
 		setupLog.Error(err, "Unable to start manager")

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/utils.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/utils.go
@@ -43,6 +43,7 @@ func NewManager(leaderElection bool, metricsBindAddr, webhookCertDir string, web
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		CertDir:            webhookCertDir,
 		LeaderElection:     leaderElection,
+		LeaderElectionID:   "spire-k8s-registrar-leader-election",
 		MetricsBindAddress: metricsBindAddr,
 		Port:               webhookPort,
 		Scheme:             scheme,

--- a/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
@@ -58,6 +58,16 @@ rules:
   resources: ["configmaps"]
   resourceNames: ["spire-bundle"]
   verbs: ["get", "patch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["spire-k8s-registrar-leader-election"]
+  verbs: ["update", "get"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
 
 ---
 
@@ -160,6 +170,7 @@ data:
     trust_domain = "example.org"
     cluster = "example-cluster"
     server_socket_path = "/run/spire/sockets/registration.sock"
+    leader_election = true
 
 ---
 


### PR DESCRIPTION
The LeaderElectionID used to have a default in older versions of controller-runtime, but now needs setting explicitly. Without it set the registrar will fatal error when reconcile/crd modes have leader election enabled. Populate it with a sensible value, based on the configured controller name for reconcile mode, or a fixed value for crd mode.

Also enable leader election in the integration test for reconcile, since it's a flag that's unlikely to get adhoc testing otherwise.