### PR TITLE
Fix CRD k8s registrar crash with invalid DNS names

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
@@ -17,9 +17,11 @@ package v1beta1
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/api/registration"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/zeebo/errs"
@@ -113,6 +115,12 @@ func (s *SpiffeID) validateSpiffeID() error {
 		// Ensure namespace selector matches namespace of Spiffe ID resource for k8s selectors
 		if s.ObjectMeta.Namespace != s.Spec.Selector.Namespace {
 			return errs.New("spec.Selector.Namespace must match namespace of resource")
+		}
+	}
+
+	for _, dnsName := range s.Spec.DnsNames {
+		if err := x509util.ValidateDNS(dnsName); err != nil {
+			return fmt.Errorf("invalid DNS name: %v", err)
 		}
 	}
 

--- a/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1/spiffeid_webhook.go
@@ -120,7 +120,7 @@ func (s *SpiffeID) validateSpiffeID() error {
 
 	for _, dnsName := range s.Spec.DnsNames {
 		if err := x509util.ValidateDNS(dnsName); err != nil {
-			return fmt.Errorf("invalid DNS name: %v", err)
+			return fmt.Errorf("invalid DNS name %q: %v", dnsName, err)
 		}
 	}
 

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
@@ -212,15 +212,17 @@ func (r *SpiffeIDReconciler) updateOrCreateSpiffeID(ctx context.Context, spiffeI
 
 // deleteSpiffeID deletes the specified entry on the SPIRE Server
 func (r *SpiffeIDReconciler) deleteSpiffeID(ctx context.Context, spiffeID *spiffeidv1beta1.SpiffeID) error {
-	err := deleteRegistrationEntry(ctx, r.c.R, *spiffeID.Status.EntryId)
-	if err != nil {
-		return err
-	}
+	if spiffeID.Status.EntryId != nil {
+		err := deleteRegistrationEntry(ctx, r.c.R, *spiffeID.Status.EntryId)
+		if err != nil {
+			return err
+		}
 
-	r.c.Log.WithFields(logrus.Fields{
-		"entryID":  spiffeID.Status.EntryId,
-		"spiffeID": spiffeID.Spec.SpiffeId,
-	}).Info("Deleted entry")
+		r.c.Log.WithFields(logrus.Fields{
+			"entryID":  spiffeID.Status.EntryId,
+			"spiffeID": spiffeID.Spec.SpiffeId,
+		}).Info("Deleted entry")
+	}
 
 	return nil
 }

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
@@ -219,7 +219,7 @@ func (r *SpiffeIDReconciler) deleteSpiffeID(ctx context.Context, spiffeID *spiff
 		}
 
 		r.c.Log.WithFields(logrus.Fields{
-			"entryID":  spiffeID.Status.EntryId,
+			"entryID":  *spiffeID.Status.EntryId,
 			"spiffeID": spiffeID.Spec.SpiffeId,
 		}).Info("Deleted entry")
 	}


### PR DESCRIPTION
If a DNS name in SpiffeId CRD was malformed, the SPIRE Server would reject the entry and the EntryId in the SpiffeId CRD would remain nil. Later trying to remove the CRD would lead to a crash because we weren't checking if the CRD had a valid EntryId.

Additionally add checks in the Validating Webhook to ensure DNS names are valid.

