### PR TITLE
Fix reconcile mode gets stuck after restart.

### DIFF
--- a/support/k8s/k8s-workload-registrar/config_reconcile.go
+++ b/support/k8s/k8s-workload-registrar/config_reconcile.go
@@ -161,13 +161,13 @@ func (slw SpiffeLogWrapper) Errorf(format string, args ...interface{}) {
 func ServerID(trustDomain string) spiretypes.SPIFFEID {
 	return spiretypes.SPIFFEID{
 		TrustDomain: trustDomain,
-		Path:        path.Join("spire", "server"),
+		Path:        path.Join("/", "spire", "server"),
 	}
 }
 
 func nodeID(trustDomain string, controllerName string, cluster string) spiretypes.SPIFFEID {
 	return spiretypes.SPIFFEID{
 		TrustDomain: trustDomain,
-		Path:        path.Join(controllerName, cluster, "node"),
+		Path:        path.Join("/", controllerName, cluster, "node"),
 	}
 }

--- a/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/node_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/node_controller.go
@@ -81,13 +81,9 @@ func (r *NodeReconciler) getAllEntries(ctx context.Context) ([]*spiretypes.Entry
 		return nil, err
 	}
 	var allNodeEntries []*spiretypes.Entry
-	nodeIDPrefix := spiretypes.SPIFFEID{
-		TrustDomain: r.RootID.TrustDomain,
-		Path:        r.RootID.Path,
-	}
 
 	for _, maybeNodeEntry := range serverChildEntries {
-		if spiffeIDHasPrefix(maybeNodeEntry.SpiffeId, &nodeIDPrefix) {
+		if spiffeIDHasPrefix(maybeNodeEntry.SpiffeId, &r.RootID) {
 			allNodeEntries = append(allNodeEntries, maybeNodeEntry)
 		}
 	}

--- a/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/pod_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/pod_controller.go
@@ -229,14 +229,14 @@ func (r *PodReconciler) makeSpiffeIDForPod(pod *corev1.Pod) *spiretypes.SPIFFEID
 	var spiffeID *spiretypes.SPIFFEID
 	switch r.Mode {
 	case PodReconcilerModeServiceAccount:
-		spiffeID = r.makeID(path.Join("ns", pod.Namespace, "sa", pod.Spec.ServiceAccountName))
+		spiffeID = r.makeID(path.Join("/ns", pod.Namespace, "sa", pod.Spec.ServiceAccountName))
 	case PodReconcilerModeLabel:
 		if val, ok := pod.GetLabels()[r.Value]; ok {
-			spiffeID = r.makeID(val)
+			spiffeID = r.makeID(path.Join("/", val))
 		}
 	case PodReconcilerModeAnnotation:
 		if val, ok := pod.GetAnnotations()[r.Value]; ok {
-			spiffeID = r.makeID(val)
+			spiffeID = r.makeID(path.Join("/", val))
 		}
 	}
 	return spiffeID


### PR DESCRIPTION
Ensure SPIFFEID Paths have leading slash, otherwise we find no existing entries when fetching results.

**Affected functionality**
k8s registrar reconcile mode

**Description of change**
SPIFFEID paths were being incorrectly created without leading slashes. This caused ListEntries to return no results.