### PR TITLE
Code version is not initialized in a pristine database.

### DIFF
--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -185,7 +185,10 @@ func initDB(db *gorm.DB, dbType string, log hclog.Logger) (err error) {
 		return sqlError.Wrap(err)
 	}
 
-	if err := tx.Assign(Migration{Version: latestSchemaVersion}).FirstOrCreate(&Migration{}).Error; err != nil {
+	if err := tx.Assign(Migration{
+		Version:     latestSchemaVersion,
+		CodeVersion: codeVersion.String(),
+	}).FirstOrCreate(&Migration{}).Error; err != nil {
 		tx.Rollback()
 		return sqlError.Wrap(err)
 	}

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -2665,6 +2665,13 @@ func (s *PluginSuite) TestMigration() {
 	}
 }
 
+func (s *PluginSuite) TestPristineDatabaseMigrationValues() {
+	var m Migration
+	s.Require().NoError(s.sqlPlugin.db.First(&m).Error)
+	s.Equal(latestSchemaVersion, m.Version)
+	s.Equal(codeVersion.String(), m.CodeVersion)
+}
+
 func (s *PluginSuite) TestRace() {
 	next := int64(0)
 	exp := time.Now().Add(time.Hour).Unix()


### PR DESCRIPTION
The code version is not set in the migration table when the database is newly initialized. If the server is shut down and a version with an older schema is started, it will fail to start even if it is within the +/- minor version compatibility boundary, since the "code version" stored in the database will be effectively 0.0.0.

This change fixes the pristine database initialization code to initialize the code version column appropriately.