### PR TITLE
Tweak the timeout value in Upstream Authority plugin unit-test

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -43,6 +43,8 @@ const (
 	"server_port":"_test_data/keys/cert.pem",
 	"server_agent_address":"8090"
 }`
+
+	testTimeout = time.Minute
 )
 
 var (
@@ -440,7 +442,7 @@ func TestSpirePlugin_MintX509CA(t *testing.T) {
 			p := newWithDefault(t, serverAddr, socketPath)
 
 			// Send initial request and get stream
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 			csr, pubKey := c.getCSR()
 			stream, err := p.MintX509CA(ctx, &upstreamauthority.MintX509CARequest{Csr: csr})
 			require.NoError(t, err)
@@ -501,7 +503,7 @@ func TestSpirePlugin_PublishJWTKey(t *testing.T) {
 	p := newWithDefault(t, server.sAPIServer.addr, server.wAPIServer.socketPath)
 
 	// Send initial request and get stream
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	stream, err := p.PublishJWTKey(ctx, &upstreamauthority.PublishJWTKeyRequest{
 		JwtKey: &common.PublicKey{
 			Kid: "kid-2",
@@ -539,7 +541,7 @@ func TestSpirePlugin_PublishJWTKey(t *testing.T) {
 	require.Nil(t, resp)
 	require.Contains(t, err.Error(), "rpc error: code = Canceled desc = context canceled")
 
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 	server.sAPIServer.err = errors.New("some error")
 	stream, err = p.PublishJWTKey(ctx, &upstreamauthority.PublishJWTKeyRequest{


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Upstream Authority plugin unit-test

**Description of change**
<!-- Please provide a description of the change -->

I tweaked the timeout value from 10s to 1m in Upstream Authority plugin unit-test.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

This PR fixes https://github.com/spiffe/spire/issues/1820.