### PR TITLE
Convert `agent evict` CLI to new API

### DIFF
--- a/pkg/server/api/id.go
+++ b/pkg/server/api/id.go
@@ -54,6 +54,16 @@ func VerifyTrustDomainAgentID(td spiffeid.TrustDomain, id spiffeid.ID) error {
 	return nil
 }
 
+func VerifyAnyTrustDomainAgentID(id spiffeid.ID) error {
+	if id.Path() == "" {
+		return fmt.Errorf("%q is not an agent in a trust domain; path is empty", id)
+	}
+	if !idutil.IsAgentPath(id.Path()) {
+		return fmt.Errorf("%q is not an agent in a trust domain; path is not in the agent namespace", id)
+	}
+	return nil
+}
+
 func TrustDomainWorkloadIDFromProto(td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
 	id, err := idFromProto(protoID)
 	if err != nil {


### PR DESCRIPTION
Converts the `agent evict` CLI to the new API.

Also:
- Replaced the tests with a non-mock based, table-driven test with much better coverage.
- Added a new test method to start up a server on a socket in a temp directory
- Fixed a false-positive failure when shutting down the test gRPC servers due to improper detection of the server shutdown condition