### PR TITLE
Add comment for TTL settings of Vault PKI Secret Engine

### DIFF
--- a/doc/plugin_server_upstreamauthority_vault.md
+++ b/doc/plugin_server_upstreamauthority_vault.md
@@ -23,6 +23,24 @@ The plugin supports **Client Certificate**, **Token** and **AppRole** authentica
 - **Token** method authenticates to Vault using the token in a HTTP Request header.
 - **AppRole** method authenticates to Vault using a RoleID and SecretID that are issued from Vault.
 
+the [`ca_ttl` SPIRE Server configurable](https://github.com/spiffe/spire/blob/master/doc/spire_server.md#server-configuration-file) should be less than or equal to the Vault's PKI secret engine TTL.
+To configure the TTL value, either increase the default TTL of the Engine or set the `max_ttl` in the Role configuration.
+
+e.g. increase the default TTL
+```
+$ vault secrets tune -max-lease-ttl=8760h pki
+```
+
+e.g. configure the max TTL of the Role
+```
+$ vault write pki/roles/my-spire-role \
+    allowed_domains=example.com \
+    allow_subdomains=true \
+    key_type=ec \
+    key_bits=256 \
+    max_ttl=8760h
+```
+
 The configured token needs to be attached to a policy that has at least the following capabilities:
 
 ```hcl


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Update UpstreamAuthority `vault` plugin document

**Description of change**
<!-- Please provide a description of the change -->

Add a comment for the TTL configurable of the PKI Secret Engine.

If `ca_ttl` is larger than the TTL of the PKI Engine, the Vault will issue a certificate with PKI Engine's TTL. (no error occur)

For example, if the `ca_ttl` is `4320h` and the TTL of the PKI engine is `720h`, the TTL of the intermediate CA certificate issued by the PKI engine is set to `720h`.


c.f. 
- https://www.vaultproject.io/docs/secrets/pki#setu
- https://www.vaultproject.io/api/secret/pki#max_ttl
- https://www.vaultproject.io/api/secret/pki#ttl-3

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

