### PR TITLE
Make it possible to set role name at authentication

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -568,6 +568,11 @@ plugins {
     #             # where TLS certificate auth method is mounted. Default: cert.
     #             # cert_auth_mount_point = ""
 
+    #             # cert_auth_role_name: Name of the Vault role
+    #             # If given, the plugin authenticates against only the named role.
+    #             # Default to trying all roles.
+    #             # cert_auth_role_name = ""
+
     #             # client_cert_path: Path to a client certificate file.
     #             # Only PEM format is supported. Default: ${VAULT_CLIENT_CERT}.
     #             # client_cert_path = ""

--- a/doc/plugin_server_upstreamauthority_vault.md
+++ b/doc/plugin_server_upstreamauthority_vault.md
@@ -54,6 +54,7 @@ path "pki/root/sign-intermediate" {
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
 | cert_auth_mount_point | string |  | Name of the mount point where TLS certificate auth method is mounted | cert |
+| cert_auth_role_name | string | | Name of the Vault role. If given, the plugin authenticates against only the named role. Default to trying all roles. | |
 | client_cert_path | string | | Path to a client certificate file. Only PEM format is supported. | `${VAULT_CLIENT_CERT}` |
 | client_key_path  | string | | Path to a client private key file. Only PEM format is supported. | `${VAULT_CLIENT_KEY}` |
 
@@ -68,6 +69,14 @@ path "pki/root/sign-intermediate" {
                 client_cert_path = "/path/to/client-cert.pem"
                 client_key_path  = "/path/to/client-key.pem"
             }
+            // If specify the role to authenticate with
+            // cert_auth {
+            //     cert_auth_mount_point = "test-tls-cert-auth"
+            //     cert_auth_role_name = "test"
+            //     client_cert_path = "/path/to/client-cert.pem"
+            //     client_key_path  = "/path/to/client-key.pem"
+            // }
+       
             // If specify the key-pair as an environment variable and use the modified mount point
             // cert_auth {
             //    cert_auth_mount_point = "test-tls-cert-auth"

--- a/pkg/server/plugin/upstreamauthority/vault/vault.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault.go
@@ -63,6 +63,9 @@ type CertAuthConfig struct {
 	// Name of the mount point where Client Certificate Auth method is mounted. (e.g., /auth/<mount_point>/login)
 	// If the value is empty, use default mount point (/auth/cert)
 	CertAuthMountPoint string `hcl:"cert_auth_mount_point"`
+	// Name of the Vault role.
+	// If given, the plugin authenticates against only the named role.
+	CertAuthRoleName string `hcl:"cert_auth_role_name"`
 	// Path to a client certificate file.
 	// Only PEM format is supported.
 	ClientCertPath string `hcl:"client_cert_path"`
@@ -238,6 +241,7 @@ func genClientParams(method AuthMethod, config *PluginConfig) *ClientParams {
 		cp.Token = getEnvOrDefault(envVaultToken, config.TokenAuth.Token)
 	case CERT:
 		cp.CertAuthMountPoint = config.CertAuth.CertAuthMountPoint
+		cp.CertAuthRoleName = config.CertAuth.CertAuthRoleName
 		cp.ClientCertPath = getEnvOrDefault(envVaultClientCert, config.CertAuth.ClientCertPath)
 		cp.ClientKeyPath = getEnvOrDefault(envVaultClientKey, config.CertAuth.ClientKeyPath)
 	case APPROLE:

--- a/pkg/server/plugin/upstreamauthority/vault/vault_client.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client.go
@@ -55,6 +55,9 @@ type ClientParams struct {
 	Token string
 	// Name of mount point where TLS Cert auth method is mounted. (e.g., /auth/<mount_point>/login )
 	CertAuthMountPoint string
+	// Name of the Vault role.
+	// If given, the plugin authenticates against only the named role
+	CertAuthRoleName string
 	// Path to a client certificate file to be used when auth method is 'cert'
 	ClientCertPath string
 	// Path to a client private key file to be used when auth method is 'cert'
@@ -134,7 +137,9 @@ func (c *ClientConfig) NewAuthenticatedClient(method AuthMethod) (*Client, error
 		client.SetToken(c.clientParams.Token)
 	case CERT:
 		path := fmt.Sprintf("auth/%v/login", c.clientParams.CertAuthMountPoint)
-		sec, err := client.Auth(path, map[string]interface{}{})
+		sec, err := client.Auth(path, map[string]interface{}{
+			"name": c.clientParams.CertAuthRoleName,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
@@ -30,6 +30,7 @@ pki_mount_point = "test-pki"
 ca_cert_path = "_test_data/keys/EC/root_cert.pem"
 cert_auth {
    cert_auth_mount_point = "test-cert-auth"
+   cert_auth_role_name = "test"
    client_cert_path = "_test_data/keys/EC/client_cert.pem"
    client_key_path  = "_test_data/keys/EC/client_key.pem"
 }`


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

UpstreamAuthority `vault` plugin.

**Description of change**
<!-- Please provide a description of the change -->

This PR adds the ability to identify a role when performing authentication.
The vault defaults to trying all certificate roles and returning any one that matches.
If set, Authenticate against only the named certificate role. 

c.f. https://www.vaultproject.io/api/auth/cert#parameters-7

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

