### PR TITLE
Fix error handling in integration test scaffolding

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -68,8 +68,8 @@ check-synced-entry() {
   CHECKINTERVAL=1
   for ((i=1;i<=MAXCHECKS;i++)); do
       log-info "checking for synced entry ($i of $MAXCHECKS max)..."
-      docker-compose logs $1
-      if docker-compose logs $1 | grep "$2"; then
+      docker-compose logs "$1"
+      if docker-compose logs "$1" | grep "$2"; then
           return 0
       fi
       sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/nested-rotation/10-check-svids
+++ b/test/integration/suites/nested-rotation/10-check-svids
@@ -18,7 +18,7 @@ validateX509SVID() {
       -socketPath /opt/spire/sockets/workload_api.sock \
       -write /tmp || fail-now "x509-SVID check failed"
 
-  docker-compose exec $2 openssl verify -verbose -CAfile /tmp/bundle.0.pem -untrusted /opt/svid.0.pem /opt/svid.0.pem
+  docker-compose exec -T $2 openssl verify -verbose -CAfile /tmp/bundle.0.pem -untrusted /opt/svid.0.pem /opt/svid.0.pem
 }
 
 validateJWTSVID() {

--- a/test/integration/suites/self-test/00-ensure-command-failure-fails-step
+++ b/test/integration/suites/self-test/00-ensure-command-failure-fails-step
@@ -1,0 +1,14 @@
+onexit() {
+    if [ $? != 0 ]; then
+        exit 0
+    else
+        fail-now "Script should have failed."
+    fi
+}
+
+trap onexit EXIT
+
+log-info "Testing that command failure fails step script..."
+false
+log-warn "Should not get here!"
+exit 0

--- a/test/integration/suites/self-test/README.md
+++ b/test/integration/suites/self-test/README.md
@@ -1,0 +1,4 @@
+# Self-Test
+
+This test suite ensures properties about test execution by the integration test
+framework.


### PR DESCRIPTION
The integration test scaffolding has fallen prey to bash-ism whereby `set -e` is NOT honored in subshells, even if set explicitly. This has caused integration tests to continue running when a command in a step script fails when the exit status not explicitly tested, hiding test failures.

The fix is to NOT execute the test in a subshell, but rather invoke a separate instance of bash against a copy of the step code with a preamble containing the common functions which also sets up bash options like errexit and pipefail.

The change also includes a fix to the nested rotation test which had a failed invocation due to a missing docker-compose option disabling the TTY.

There is also included a small self-test suite that ensures that command failure fails step scripts. More tests can be added in the future that ensure various mechanics of the integration test framework are working as expected.