### PR TITLE
Upgrade integration test to kind 0.9.0

### DIFF
--- a/test/integration/suites/k8s-reconcile/00-setup
+++ b/test/integration/suites/k8s-reconcile/00-setup
@@ -5,7 +5,7 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.5.1
+KINDVERSION=v0.9.0
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
 KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"

--- a/test/integration/suites/k8s-reconcile/01-apply-config
+++ b/test/integration/suites/k8s-reconcile/01-apply-config
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 wait-for-rollout() {
     ns=$1

--- a/test/integration/suites/k8s-reconcile/02-check-for-workload-svid
+++ b/test/integration/suites/k8s-reconcile/02-check-for-workload-svid
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 MAXFETCHCHECKS=60
 FETCHCHECKINTERVAL=1

--- a/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2
@@ -17,3 +17,6 @@ nodes:
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl
+  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+- role: worker
+  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb

--- a/test/integration/suites/k8s-reconcile/init-kubectl
+++ b/test/integration/suites/k8s-reconcile/init-kubectl
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+KUBECONFIG="${RUNDIR}/kubeconfig"
+if [ ! -f "${RUNDIR}/kubeconfig" ]; then
+    ./bin/kind get kubeconfig --name=k8stest > "${RUNDIR}/kubeconfig"
+fi
+export KUBECONFIG
+

--- a/test/integration/suites/k8s-reconcile/teardown
+++ b/test/integration/suites/k8s-reconcile/teardown
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 if [ -z "$SUCCESS" ]; then
    ./bin/kubectl -nspire logs deployment/spire-server --all-containers || true

--- a/test/integration/suites/k8s/00-setup
+++ b/test/integration/suites/k8s/00-setup
@@ -5,7 +5,7 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.5.1
+KINDVERSION=v0.9.0
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
 KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"

--- a/test/integration/suites/k8s/01-apply-config
+++ b/test/integration/suites/k8s/01-apply-config
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 wait-for-rollout() {
     ns=$1

--- a/test/integration/suites/k8s/02-check-for-workload-svid
+++ b/test/integration/suites/k8s/02-check-for-workload-svid
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 MAXFETCHCHECKS=60
 FETCHCHECKINTERVAL=1

--- a/test/integration/suites/k8s/conf/kind-config.yaml
+++ b/test/integration/suites/k8s/conf/kind-config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2
@@ -17,3 +17,6 @@ nodes:
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl
+  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
+- role: worker
+  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb

--- a/test/integration/suites/k8s/init-kubectl
+++ b/test/integration/suites/k8s/init-kubectl
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+KUBECONFIG="${RUNDIR}/kubeconfig"
+if [ ! -f "${RUNDIR}/kubeconfig" ]; then
+    ./bin/kind get kubeconfig --name=k8stest > "${RUNDIR}/kubeconfig"
+fi
+export KUBECONFIG
+

--- a/test/integration/suites/k8s/teardown
+++ b/test/integration/suites/k8s/teardown
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-KUBECONFIG="$(./bin/kind get kubeconfig-path --name=k8stest)"
-export KUBECONFIG
+source init-kubectl
 
 if [ -z "$SUCCESS" ]; then
    ./bin/kubectl -nspire logs deployment/spire-server --all-containers || true


### PR DESCRIPTION
The change includes:
- Migrations to the kind config schema
- Pinning to our minimum supported k8s version (i.e. 0.18.x)
- Work around a change in kind CLI around obtaining the kubeconfig. Instead of being able to get a path to the kubeconfig, it just emits the kubeconfig on stdout. So the test harness dumps that in a file in the run directory and sets KUBECONFIG accordingly. A sourceable helper script is used to simply this process for steps that need to use kubectl.