### PR TITLE
Merge ratelimit changes and changelog into v0.11.1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,17 @@
 # Changelog
 
-## [0.11.1] - 2020-09-24
+## [0.11.1] - 2020-09-29
 
 ### What's New
-- Added AWS PCA support for a locally-supplied upstream bundle (#1574)
-- Added `ratelimit` configurable to server for configuring node attestation rate limit (#1794, #1870)
+- Added AWS PCA configurable allowing operators to provide additional CA certificates for inclusion in the bundle (#1574)
+- Added a configurable to server for disabling rate limiting of node attestation requests (#1794, #1870)
 
 ### What's Changed
 - Fixed Kubernetes Workload Registrar issues (#1814, #1818, #1823)
-- Fixed BatchCreateEntry return value to match docs (#1824)
-- Fixed issue in newly-initialized migration table (#1829)
-- Fixed payload data type for node attestation (#1863)
+- Fixed BatchCreateEntry return value to match docs, returning the contents of an entry if it already exists (#1824)
+- Fixed issue preventing brand new deployments from downgrading successfully (#1829)
+- Fixed a regression introduced in 0.11.0 that caused external node attestor plugins that rely on binary data to fail (#1863)
+
 
 ## [0.11.0] - 2020-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### What's New
 - Added AWS PCA support for a locally-supplied upstream bundle (#1574)
-- Added `attest_limit` configurable to server for configuring node attestation rate limit (#1794)
+- Added `ratelimit` configurable to server for configuring node attestation rate limit (#1794, #1870)
 
 ### What's Changed
 - Fixed Kubernetes Workload Registrar issues (#1814, #1818, #1823)

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -48,9 +48,7 @@ var (
 		Organization: []string{"SPIFFE"},
 	}
 
-	defaultRateLimit = rateLimitConfig{
-		Attestation: 1,
-	}
+	defaultRateLimitAttestation = true
 )
 
 // Config contains all available configurables, arranged by section
@@ -154,7 +152,7 @@ type federatesWithBundleEndpointConfig struct {
 }
 
 type rateLimitConfig struct {
-	Attestation int      `hcl:"attestation"`
+	Attestation *bool    `hcl:"attestation"`
 	UnusedKeys  []string `hcl:",unusedKeys"`
 }
 
@@ -367,10 +365,10 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 	}
 	sc.Log = logger
 
-	if c.Server.RateLimit.Attestation < 0 {
-		return nil, fmt.Errorf("attestation rate limit must be greater than zero")
+	if c.Server.RateLimit.Attestation == nil {
+		c.Server.RateLimit.Attestation = &defaultRateLimitAttestation
 	}
-	sc.RateLimit.Attestation = c.Server.RateLimit.Attestation
+	sc.RateLimit.Attestation = *c.Server.RateLimit.Attestation
 
 	sc.Experimental.AllowAgentlessNodeAttestors = c.Server.Experimental.AllowAgentlessNodeAttestors
 	if c.Server.Federation != nil {
@@ -704,7 +702,6 @@ func defaultConfig() *Config {
 			LogFormat:           log.DefaultFormat,
 			RegistrationUDSPath: defaultSocketPath,
 			Experimental:        experimentalConfig{},
-			RateLimit:           defaultRateLimit,
 		},
 	}
 }

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -807,6 +807,34 @@ func TestNewServerConfig(t *testing.T) {
 				}, c.CASubject)
 			},
 		},
+		{
+			msg: "attestation rate limit is on by default",
+			input: func(c *Config) {
+			},
+			test: func(t *testing.T, c *server.Config) {
+				require.True(t, c.RateLimit.Attestation)
+			},
+		},
+		{
+			msg: "attestation rate limits can be explicitly enabled",
+			input: func(c *Config) {
+				value := false
+				c.Server.RateLimit.Attestation = &value
+			},
+			test: func(t *testing.T, c *server.Config) {
+				require.False(t, c.RateLimit.Attestation)
+			},
+		},
+		{
+			msg: "attestation rate limits can be explicitly disabled",
+			input: func(c *Config) {
+				value := true
+				c.Server.RateLimit.Attestation = &value
+			},
+			test: func(t *testing.T, c *server.Config) {
+				require.True(t, c.RateLimit.Attestation)
+			},
+		},
 	}
 
 	for _, testCase := range cases {

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -816,7 +816,7 @@ func TestNewServerConfig(t *testing.T) {
 			},
 		},
 		{
-			msg: "attestation rate limits can be explicitly enabled",
+			msg: "attestation rate limits can be explicitly disabled",
 			input: func(c *Config) {
 				value := false
 				c.Server.RateLimit.Attestation = &value
@@ -826,7 +826,7 @@ func TestNewServerConfig(t *testing.T) {
 			},
 		},
 		{
-			msg: "attestation rate limits can be explicitly disabled",
+			msg: "attestation rate limits can be explicitly enabled",
 			input: func(c *Config) {
 				value := true
 				c.Server.RateLimit.Attestation = &value

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -102,9 +102,9 @@ server {
 
     # ratelimit: Holds rate limiting configurations.
     # ratelimit = {
-    #     # Maximum node attestations per second that the server can
-    #     # handle from a single IP. Default: 1.
-    #     attestation = 1
+    #     # Controls whether or not node attestation is rate limited to one
+    #     # attempt per-second per-IP. Default: true.
+    #     attestation = true
     # }
 
     # registration_uds_path: Location to bind the registration API socket.

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -48,23 +48,23 @@ SPIRE configuration files may be represented in either HCL or JSON. Please see t
 If the -expandEnv flag is passed to SPIRE, `$VARIABLE` or `${VARIABLE}` style environment variables are expanded before parsing.
 This may be useful for templating configuration files, for example across different trust domains, or for inserting secrets like database connection passwords.
 
-| Configuration               | Description                                                                                     | Default                       |
-|:----------------------------|:------------------------------------------------------------------------------------------------|:------------------------------|
-| `bind_address`              | IP address or DNS name of the SPIRE server                                                      | 0.0.0.0                       |
-| `bind_port`                 | HTTP Port number of the SPIRE server                                                            | 8081                          |
-| `ca_key_type`               | The key type used for the server CA, \<rsa-2048\|rsa-4096\|ec-p256\|ec-p384\>                   | ec-p256 (Both X509 and JWT)   |
-| `ca_subject`                | The Subject that CA certificates should use (see below)                                         |                               |
-| `ca_ttl`                    | The default CA/signing key TTL                                                                  | 24h                           |
-| `data_dir`                  | A directory the server can use for its runtime                                                  |                               |
-| `default_svid_ttl`          | The default SVID TTL                                                                            | 1h                            |
-| `federation`                | Bundle endpoints configuration section used for [federation](#federation-configuration)         |                               |
-| `jwt_issuer`                | The issuer claim used when minting JWT-SVIDs                                                    |                               |
-| `log_file`                  | File to write logs to                                                                           |                               |
-| `log_level`                 | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>                                             | INFO                          |
-| `log_format`                | Format of logs, \<text\|json\>                                                                  | text                          |
-| `ratelimit`                 | Rate limiting configurations, usually used when the sever is behind a load balancer (see below) |                               |
-| `registration_uds_path`     | Location to bind the registration API socket                                                    | /tmp/spire-registration.sock  |
-| `trust_domain`              | The trust domain that this server belongs to                                                    |                               |
+| Configuration               | Description                                                                                      | Default                       |
+|:----------------------------|:-------------------------------------------------------------------------------------------------|:------------------------------|
+| `bind_address`              | IP address or DNS name of the SPIRE server                                                       | 0.0.0.0                       |
+| `bind_port`                 | HTTP Port number of the SPIRE server                                                             | 8081                          |
+| `ca_key_type`               | The key type used for the server CA, \<rsa-2048\|rsa-4096\|ec-p256\|ec-p384\>                    | ec-p256 (Both X509 and JWT)   |
+| `ca_subject`                | The Subject that CA certificates should use (see below)                                          |                               |
+| `ca_ttl`                    | The default CA/signing key TTL                                                                   | 24h                           |
+| `data_dir`                  | A directory the server can use for its runtime                                                   |                               |
+| `default_svid_ttl`          | The default SVID TTL                                                                             | 1h                            |
+| `federation`                | Bundle endpoints configuration section used for [federation](#federation-configuration)          |                               |
+| `jwt_issuer`                | The issuer claim used when minting JWT-SVIDs                                                     |                               |
+| `log_file`                  | File to write logs to                                                                            |                               |
+| `log_level`                 | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>                                              | INFO                          |
+| `log_format`                | Format of logs, \<text\|json\>                                                                   | text                          |
+| `ratelimit`                 | Rate limiting configurations, usually used when the server is behind a load balancer (see below) |                               |
+| `registration_uds_path`     | Location to bind the registration API socket                                                     | /tmp/spire-registration.sock  |
+| `trust_domain`              | The trust domain that this server belongs to                                                     |                               |
 
 | ca_subject                  | Description                    | Default        |
 |:----------------------------|--------------------------------|----------------|
@@ -74,7 +74,7 @@ This may be useful for templating configuration files, for example across differ
 
 | ratelimit                   | Description                    | Default        |
 |:----------------------------|--------------------------------|----------------|
-| `attestation`               | Maximum node attestations per second that the server can handle from a single IP. If the attestation rate is higher, the limiter will put the requests on hold and process them according to the given rate. Notice that if the request queue is too large, some attestation calls could fail due to timeout.| 1 |
+| `attestation`               | Whether or not to rate limit node attestation. If true, node attestation is rate limited to one attempt per second per IP address. | true |
 
 ## Plugin configuration
 

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	Metrics telemetry.Metrics
 
 	// RateLimit holds rate limiting configurations.
-	RateLimit *RateLimitConfig
+	RateLimit RateLimitConfig
 }
 
 func (c *Config) makeOldAPIServers() (OldAPIServers, error) {
@@ -79,7 +79,7 @@ func (c *Config) makeOldAPIServers() (OldAPIServers, error) {
 		ServerCA:                    c.ServerCA,
 		Manager:                     c.Manager,
 		AllowAgentlessNodeAttestors: c.AllowAgentlessNodeAttestors,
-		AttestLimit:                 c.RateLimit.Attestation,
+		RateLimitAttestation:        c.RateLimit.Attestation,
 	})
 	if err != nil {
 		return OldAPIServers{}, err

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -58,7 +58,7 @@ type Endpoints struct {
 	BundleEndpointServer Server
 	Log                  logrus.FieldLogger
 	Metrics              telemetry.Metrics
-	RateLimitConfig      *RateLimitConfig
+	RateLimit            RateLimitConfig
 }
 
 type OldAPIServers struct {
@@ -75,9 +75,8 @@ type APIServers struct {
 
 // RateLimitConfig holds rate limiting configurations.
 type RateLimitConfig struct {
-	// Attestation defines the maximum node attestations per second that
-	// the server can handle from a single IP.
-	Attestation int
+	// Attestation, if true, rate limits attestation
+	Attestation bool
 }
 
 // New creates new endpoints struct
@@ -103,7 +102,7 @@ func New(c Config) (*Endpoints, error) {
 		BundleEndpointServer: c.maybeMakeBundleEndpointServer(),
 		Log:                  c.Log,
 		Metrics:              c.Metrics,
-		RateLimitConfig:      c.RateLimit,
+		RateLimit:            c.RateLimit,
 	}, nil
 }
 
@@ -306,7 +305,7 @@ func (e *Endpoints) makeInterceptors() (grpc.UnaryServerInterceptor, grpc.Stream
 
 	log := e.Log.WithField(telemetry.SubsystemName, "api")
 
-	newUnary, newStream := middleware.Interceptors(Middleware(log, e.Metrics, e.DataStore, clock.New(), e.RateLimitConfig))
+	newUnary, newStream := middleware.Interceptors(Middleware(log, e.Metrics, e.DataStore, clock.New(), e.RateLimit))
 
 	return unaryInterceptorMux(oldUnary, newUnary), streamInterceptorMux(oldStream, newStream)
 }

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -48,7 +48,7 @@ var (
 	agentID      = testTD.NewID("/agent")
 	adminID      = testTD.NewID("/admin")
 	downstreamID = testTD.NewID("/downstream")
-	rateLimit    = &RateLimitConfig{Attestation: 1}
+	rateLimit    = RateLimitConfig{Attestation: true}
 )
 
 func TestNew(t *testing.T) {
@@ -148,7 +148,7 @@ func TestListenAndServe(t *testing.T) {
 		BundleEndpointServer: bundleEndpointServer,
 		Log:                  log,
 		Metrics:              metrics,
-		RateLimitConfig:      rateLimit,
+		RateLimit:            rateLimit,
 	}
 
 	// Prime the datastore with the:

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -28,7 +28,7 @@ import (
 // Number of entries that can be cached
 const entriesCacheSize = 500_000
 
-func Middleware(log logrus.FieldLogger, metrics telemetry.Metrics, ds datastore.DataStore, clk clock.Clock, rlConf *RateLimitConfig) middleware.Middleware {
+func Middleware(log logrus.FieldLogger, metrics telemetry.Metrics, ds datastore.DataStore, clk clock.Clock, rlConf RateLimitConfig) middleware.Middleware {
 	return middleware.Chain(
 		middleware.WithLogger(log),
 		middleware.WithMetrics(metrics),
@@ -186,9 +186,12 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 	})
 }
 
-func RateLimits(conf *RateLimitConfig) map[string]api.RateLimiter {
+func RateLimits(config RateLimitConfig) map[string]api.RateLimiter {
 	noLimit := middleware.NoLimit()
-	attestLimit := middleware.PerIPLimit(conf.Attestation)
+	attestLimit := noLimit
+	if config.Attestation {
+		attestLimit = middleware.PerIPLimit(node_pb.AttestLimit)
+	}
 	csrLimit := middleware.PerIPLimit(node_pb.CSRLimit)
 	jsrLimit := middleware.PerIPLimit(node_pb.JSRLimit)
 	pushJWTKeyLimit := middleware.PerIPLimit(node_pb.PushJWTKeyLimit)

--- a/pkg/server/endpoints/node/handler.go
+++ b/pkg/server/endpoints/node/handler.go
@@ -51,7 +51,9 @@ type HandlerConfig struct {
 	TrustDomain url.URL
 	Clock       clock.Clock
 	Manager     *ca.Manager
-	AttestLimit int
+
+	// RateLimitAttestation, if true, rate limits attestation.
+	RateLimitAttestation bool
 
 	// Allow agentless SPIFFE IDs when doing node attestation
 	AllowAgentlessNodeAttestors bool
@@ -75,7 +77,7 @@ func NewHandler(config HandlerConfig) (*Handler, error) {
 
 	return &Handler{
 		c:                             config,
-		limiter:                       NewLimiter(config.Log, config.AttestLimit),
+		limiter:                       NewLimiter(config.Log, config.RateLimitAttestation),
 		fetchRegistrationEntriesCache: fetchX509SVIDCache,
 	}, nil
 }

--- a/pkg/server/endpoints/node/limiter.go
+++ b/pkg/server/endpoints/node/limiter.go
@@ -27,13 +27,17 @@ type Limiter interface {
 }
 
 // Newlimiter returns a new node api rate.Limiter
-func NewLimiter(l logrus.FieldLogger, attestLimit int) Limiter {
-	return newLimiter(l, attestLimit)
+func NewLimiter(l logrus.FieldLogger, rateLimitAttestation bool) Limiter {
+	return newLimiter(l, rateLimitAttestation)
 }
 
-func newLimiter(l logrus.FieldLogger, attestLimit int) *limiter {
+func newLimiter(l logrus.FieldLogger, rateLimitAttestation bool) *limiter {
+	attestRate := rate.Inf
+	if rateLimitAttestation {
+		attestRate = rate.Limit(node.AttestLimit)
+	}
 	return &limiter{
-		attestRate:   rate.Limit(attestLimit),
+		attestRate:   attestRate,
 		csrRate:      rate.Limit(node.CSRLimit),
 		jsrRate:      rate.Limit(node.JSRLimit),
 		jwtKeyRate:   rate.Limit(node.PushJWTKeyLimit),

--- a/pkg/server/endpoints/node/limiter_test.go
+++ b/pkg/server/endpoints/node/limiter_test.go
@@ -2,12 +2,12 @@ package node
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/proto/spire/api/node"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -15,53 +15,46 @@ import (
 )
 
 func TestLimit(t *testing.T) {
-	limits := []int{1, 5, 10}
-	for _, limit := range limits {
-		limit := limit
-		t.Run(fmt.Sprintf("limit = %d", limit), func(t *testing.T) {
-			l, log := newTestLimiter(limit)
+	l, log := newTestLimiter()
 
-			// Messages under limit are processed "immediately" without logging
-			for i := 1; i <= limit; i++ {
-				ctx, cancel := context.WithTimeout(newTestContext(), 50*time.Millisecond)
-				err := l.Limit(ctx, AttestMsg, 1)
-				assert.NoError(t, err)
+	// Messages under limit are processed "immediately" without logging
+	for i := 1; i <= node.AttestLimit; i++ {
+		ctx, cancel := context.WithTimeout(newTestContext(), 50*time.Millisecond)
+		err := l.Limit(ctx, AttestMsg, 1)
+		assert.NoError(t, err)
 
-				if len(log.Entries) > 0 {
-					msg, _ := log.LastEntry().String()
-					t.Errorf("expected no log lines; got %q", msg)
-				}
-				cancel()
-			}
-
-			// Messages over the limit must wait
-			// Bucket exhausted by above loop
-			ctx, cancel := context.WithTimeout(newTestContext(), 50*time.Millisecond)
-			err := l.Limit(ctx, AttestMsg, 1)
-			assert.Error(t, err)
-
-			if len(log.Entries) != 1 {
-				t.Errorf("expected 1 log entry; got %d", len(log.Entries))
-			}
-			cancel()
-
-			// Can't exceed burst size
-			count := limit + 1
-			err = l.Limit(newTestContext(), AttestMsg, count)
-			assert.Error(t, err)
-		})
+		if len(log.Entries) > 0 {
+			msg, _ := log.LastEntry().String()
+			t.Errorf("expected no log lines; got %v", msg)
+		}
+		cancel()
 	}
+
+	// Messages over the limit must wait
+	// Bucket exhausted by above loop
+	ctx, cancel := context.WithTimeout(newTestContext(), 50*time.Millisecond)
+	err := l.Limit(ctx, AttestMsg, 1)
+	assert.Error(t, err)
+
+	if len(log.Entries) != 1 {
+		t.Errorf("expected 1 log entry; got %v", len(log.Entries))
+	}
+	cancel()
+
+	// Can't exceed burst size
+	count := node.AttestLimit + 1
+	err = l.Limit(newTestContext(), AttestMsg, count)
+	assert.Error(t, err)
 }
 
 func TestLimiterFor(t *testing.T) {
-	limit := 1
-	l, _ := newTestLimiter(limit)
+	l, _ := newTestLimiter()
 
 	// New caller for valid message type gets the right limiter
 	li, err := l.limiterFor(AttestMsg, "evan")
 	require.NoError(t, err)
 	require.NotNil(t, li)
-	assert.Equal(t, limit, li.Burst())
+	assert.Equal(t, node.AttestLimit, li.Burst())
 	assert.Equal(t, l.attestRate, li.Limit())
 
 	// Gets the same limiter when asked for it
@@ -76,7 +69,7 @@ func TestLimiterFor(t *testing.T) {
 }
 
 func TestCallerID(t *testing.T) {
-	l, _ := newTestLimiter(1)
+	l, _ := newTestLimiter()
 	p := newTestPeer()
 
 	id, err := l.callerID(peer.NewContext(context.Background(), p))
@@ -98,7 +91,7 @@ func TestCallerID(t *testing.T) {
 }
 
 func TestNotify(t *testing.T) {
-	l, log := newTestLimiter(1)
+	l, log := newTestLimiter()
 
 	// First time caller gets logged
 	l.notify("evan", AttestMsg)
@@ -120,7 +113,7 @@ func newTestPeer() *peer.Peer {
 	}
 }
 
-func newTestLimiter(limit int) (*limiter, *test.Hook) {
+func newTestLimiter() (*limiter, *test.Hook) {
 	log, hook := test.NewNullLogger()
-	return newLimiter(log, limit), hook
+	return newLimiter(log, true), hook
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -126,7 +126,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 		return err
 	}
 
-	endpointsServer, err := s.newEndpointsServer(cat, svidRotator, serverCA, metrics, caManager, &s.config.RateLimit)
+	endpointsServer, err := s.newEndpointsServer(cat, svidRotator, serverCA, metrics, caManager)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func (s *Server) newSVIDRotator(ctx context.Context, serverCA ca.ServerCA, metri
 	return svidRotator, nil
 }
 
-func (s *Server) newEndpointsServer(catalog catalog.Catalog, svidObserver svid.Observer, serverCA ca.ServerCA, metrics telemetry.Metrics, caManager *ca.Manager, rateLimit *endpoints.RateLimitConfig) (endpoints.Server, error) {
+func (s *Server) newEndpointsServer(catalog catalog.Catalog, svidObserver svid.Observer, serverCA ca.ServerCA, metrics telemetry.Metrics, caManager *ca.Manager) (endpoints.Server, error) {
 	config := endpoints.Config{
 		TCPAddr:                     s.config.BindAddress,
 		UDSAddr:                     s.config.BindUDSAddress,
@@ -311,7 +311,7 @@ func (s *Server) newEndpointsServer(catalog catalog.Catalog, svidObserver svid.O
 		Metrics:                     metrics,
 		Manager:                     caManager,
 		AllowAgentlessNodeAttestors: s.config.Experimental.AllowAgentlessNodeAttestors,
-		RateLimit:                   rateLimit,
+		RateLimit:                   s.config.RateLimit,
 	}
 	if s.config.Federation.BundleEndpoint != nil {
 		config.BundleEndpoint.Address = s.config.Federation.BundleEndpoint.Address

--- a/proto/spire/api/node/limits.go
+++ b/proto/spire/api/node/limits.go
@@ -4,6 +4,7 @@ const (
 	// Max burst values for ratelimiting
 	// Requests containing more than this number of
 	// operations will always be rejected
+	AttestLimit     int = 1
 	CSRLimit        int = 500
 	JSRLimit        int = 500
 	PushJWTKeyLimit int = 500


### PR DESCRIPTION
Cherry-picked #1870 and updated changelog:
```
$ git cherry-pick f54b810a^..3404268a
[tyler/v0.11.1-ratelimit ccf3798e] Replace attest limit configurable with on/off
 Author: Andrew Harding <aharding@vmware.com>
 Date: Mon Sep 28 12:55:11 2020 -0600
 12 files changed, 118 insertions(+), 91 deletions(-)
[tyler/v0.11.1-ratelimit 382b9948] update server_full.conf
 Author: Andrew Harding <aharding@vmware.com>
 Date: Mon Sep 28 13:17:54 2020 -0600
 1 file changed, 3 insertions(+), 3 deletions(-)
[tyler/v0.11.1-ratelimit 0098f259] fix test case naming
 Author: Andrew Harding <aharding@vmware.com>
 Date: Mon Sep 28 14:46:54 2020 -0600
 1 file changed, 2 insertions(+), 2 deletions(-)
```