### PR TITLE
Fix Circle-CI GCR login procedure

### DIFF
--- a/.circleci/publish-release-images.sh
+++ b/.circleci/publish-release-images.sh
@@ -8,7 +8,7 @@ echo "Tag    : ${CIRCLE_TAG}"
 echo "Commit : ${CIRCLE_SHA1}"
 echo
 echo "Logging into gcr.io..."
-docker login -u _json_key --password-stdin https://gcr.io < echo "$GCR_API_KEY"
+docker login -u _json_key --password-stdin https://gcr.io <<< "$GCR_API_KEY"
 
 # Strip the leading "v" off of the tag name. SPIRE images are
 # tagged with just the version number.

--- a/.circleci/publish-unstable-images.sh
+++ b/.circleci/publish-unstable-images.sh
@@ -8,7 +8,7 @@ echo "Tag    : ${CIRCLE_TAG}"
 echo "Commit : ${CIRCLE_SHA1}"
 echo
 echo "Logging into gcr.io..."
-docker login -u _json_key --password-stdin https://gcr.io < echo "$GCR_API_KEY"
+docker login -u _json_key --password-stdin https://gcr.io <<< "$GCR_API_KEY"
 
 # Push with commit tag
 docker tag spire-server gcr.io/spiffe-io/spire-server:"${CIRCLE_SHA1}"


### PR DESCRIPTION
I was hoping to keep our GCR credentials off disk and out of the process
table by passing them into `docker login` via stdin. This commit fixes
that line in the relevant helper scripts by using a BASH Here String

```
Logging into gcr.io...
.circleci/publish-unstable-images.sh: line 11: echo: No such file or directory
```

Signed-off-by: Evan Gilman <egilman@vmware.com>