### PR TITLE
Fix error message when attestation is disabled

### DIFF
--- a/pkg/server/api/middleware/ratelimit_test.go
+++ b/pkg/server/api/middleware/ratelimit_test.go
@@ -31,6 +31,17 @@ func TestNoLimit(t *testing.T) {
 	assert.Equal(t, 0, limiters.Count)
 }
 
+func TestDisabledLimit(t *testing.T) {
+	limiters := NewFakeLimiters()
+
+	// DisabledLimit() does not do rate limiting and should succeed.
+	m := DisabledLimit()
+	require.NoError(t, m.RateLimit(context.Background(), 99))
+
+	// There should be no rate limiters configured as DisabledLimit() doesn't use one.
+	assert.Equal(t, 0, limiters.Count)
+}
+
 func TestPerCallLimit(t *testing.T) {
 	limiters := NewFakeLimiters()
 
@@ -189,7 +200,24 @@ func TestRateLimits(t *testing.T) {
 			},
 		},
 		{
-			name:       "does not when rate limiter not used by unlimited handler",
+			name:           "does not log when handler with disabled limit tries to rate limit",
+			method:         "/fake.Service/DisabledLimit",
+			rateLimitCount: 1,
+			expectCode:     codes.OK,
+		},
+		{
+			name:       "logs when handler with disabled limit does not rate limit",
+			method:     "/fake.Service/DisabledLimit",
+			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Disabled rate limiter went unused; this is a bug",
+				},
+			},
+		},
+		{
+			name:       "does not log when rate limiter not used by unlimited handler",
 			method:     "/fake.Service/NoLimit",
 			expectCode: codes.OK,
 		},
@@ -230,8 +258,9 @@ func TestRateLimits(t *testing.T) {
 			unaryInterceptor := UnaryInterceptor(Chain(
 				WithRateLimits(
 					map[string]api.RateLimiter{
-						"/fake.Service/NoLimit":   NoLimit(),
-						"/fake.Service/WithLimit": PerCallLimit(2),
+						"/fake.Service/NoLimit":       NoLimit(),
+						"/fake.Service/DisabledLimit": DisabledLimit(),
+						"/fake.Service/WithLimit":     PerCallLimit(2),
 					},
 				),
 				// Install a middleware downstream so that we can test what

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -234,7 +234,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 
 func RateLimits(config RateLimitConfig) map[string]api.RateLimiter {
 	noLimit := middleware.NoLimit()
-	attestLimit := noLimit
+	attestLimit := middleware.DisabledLimit()
 	if config.Attestation {
 		attestLimit = middleware.PerIPLimit(node_pb.AttestLimit)
 	}


### PR DESCRIPTION

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Server no longer logs a misleading and incorrect error message on attestation attempts when attestation limits are disabled.

**Description of change**
When attestation rate limiting is disabled in the middleware, the AttestAgent RPC is still invoking the rate limiter. This causes the
middleware to log that there is a bug, since an RPC was either not limited (and not expected to invoke the limiter) or was limited (and expected to invoke the limiter).

This change introduces a new kind of limit, the "disabled" limit and fixes the middleware layer to still expect the rate limiter to be
invoked by the RPC for disabled limits.

It then changes the rate limiting configuration to use the "disabled" limit for Agent.AttestAgent when attestation rate limiting is disabled.

**Which issue this PR fixes**
Fixes #1898 

