### PR TITLE
Add index to attested_node_entries expires_at column

### DIFF
--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -475,10 +475,7 @@ func migrateToV14(tx *gorm.DB) error {
 }
 
 func migrateToV15(tx *gorm.DB) error {
-	if err := addAttestedNodeEntriesExpiresAtIndex(tx); err != nil {
-		return err
-	}
-	return nil
+	return addAttestedNodeEntriesExpiresAtIndex(tx)
 }
 
 func addFederatedRegistrationEntriesRegisteredEntryIDIndex(tx *gorm.DB) error {

--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// the latest schema version of the database in the code
-	latestSchemaVersion = 14
+	latestSchemaVersion = 15
 )
 
 var (
@@ -221,39 +221,29 @@ func migrateVersion(tx *gorm.DB, currVersion int, log hclog.Logger) (versionOut 
 	// how to bring the previous version up. The migrations are run
 	// sequentially, each in its own transaction, to move from one version to
 	// the next.
-	switch currVersion {
-	case 0:
-		err = migrateToV1(tx)
-	case 1:
-		err = migrateToV2(tx)
-	case 2:
-		err = migrateToV3(tx)
-	case 3:
-		err = migrateToV4(tx)
-	case 4:
-		err = migrateToV5(tx)
-	case 5:
-		err = migrateToV6(tx)
-	case 6:
-		err = migrateToV7(tx)
-	case 7:
-		err = migrateToV8(tx)
-	case 8:
-		err = migrateToV9(tx)
-	case 9:
-		err = migrateToV10(tx)
-	case 10:
-		err = migrateToV11(tx)
-	case 11:
-		err = migrateToV12(tx)
-	case 12:
-		err = migrateToV13(tx)
-	case 13:
-		err = migrateToV14(tx)
-	default:
-		err = sqlError.New("no migration support for version %d", currVersion)
+	migrations := []func(tx *gorm.DB) error{
+		migrateToV1,
+		migrateToV2,
+		migrateToV3,
+		migrateToV4,
+		migrateToV5,
+		migrateToV6,
+		migrateToV7,
+		migrateToV8,
+		migrateToV9,
+		migrateToV10,
+		migrateToV11,
+		migrateToV12,
+		migrateToV13,
+		migrateToV14,
+		migrateToV15,
 	}
-	if err != nil {
+
+	if currVersion >= len(migrations) {
+		return currVersion, sqlError.New("no migration support for version %d", currVersion)
+	}
+
+	if err := migrations[currVersion](tx); err != nil {
 		return currVersion, err
 	}
 
@@ -484,6 +474,13 @@ func migrateToV14(tx *gorm.DB) error {
 	return nil
 }
 
+func migrateToV15(tx *gorm.DB) error {
+	if err := addAttestedNodeEntriesExpiresAtIndex(tx); err != nil {
+		return err
+	}
+	return nil
+}
+
 func addFederatedRegistrationEntriesRegisteredEntryIDIndex(tx *gorm.DB) error {
 	// GORM creates the federated_registration_entries implicitly with a primary
 	// key tuple (bundle_id, registered_entry_id). Unfortunately, MySQL5 does
@@ -492,6 +489,19 @@ func addFederatedRegistrationEntriesRegisteredEntryIDIndex(tx *gorm.DB) error {
 	// to introduce the index since there is no explicit struct to add tags to
 	// so we have to manually create it.
 	if err := tx.Table("federated_registration_entries").AddIndex("idx_federated_registration_entries_registered_entry_id", "registered_entry_id").Error; err != nil {
+		return sqlError.Wrap(err)
+	}
+	return nil
+}
+
+func addAttestedNodeEntriesExpiresAtIndex(tx *gorm.DB) error {
+	// GORM creates the federated_registration_entries implicitly with a primary
+	// key tuple (bundle_id, registered_entry_id). Unfortunately, MySQL5 does
+	// not use the primary key index efficiently when joining by registered_entry_id
+	// during registration entry list operations. We can't use gorm AutoMigrate
+	// to introduce the index since there is no explicit struct to add tags to
+	// so we have to manually create it.
+	if err := tx.Table("attested_node_entries").AddIndex("idx_attested_node_entries_expires_at", "expires_at").Error; err != nil {
 		return sqlError.Wrap(err)
 	}
 	return nil

--- a/pkg/server/plugin/datastore/sql/migration_test.go
+++ b/pkg/server/plugin/datastore/sql/migration_test.go
@@ -518,7 +518,7 @@ COMMIT;
 		CREATE INDEX idx_federated_registration_entries_registered_entry_id ON "federated_registration_entries"(registered_entry_id) ;
 		COMMIT;
 		`,
-		// future v11 database entry, in which an index was to the attested_nodes_entries expires_at column
+		// future v15 database entry, in which an index was to the attested_nodes_entries expires_at column
 	}
 )
 

--- a/pkg/server/plugin/datastore/sql/migration_test.go
+++ b/pkg/server/plugin/datastore/sql/migration_test.go
@@ -487,7 +487,38 @@ COMMIT;
 		CREATE INDEX idx_federated_registration_entries_registered_entry_id ON "federated_registration_entries"(registered_entry_id) ;
 		COMMIT;
 		`,
-		// future v14 database entry, in which the table 'registered_entries' gained a `revision_number` column
+		// v14 database entry, in which the table 'registered_entries' gained a `revision_number` column
+		`
+		PRAGMA foreign_keys=OFF;
+		BEGIN TRANSACTION;
+		CREATE TABLE IF NOT EXISTS "federated_registration_entries" ("bundle_id" integer,"registered_entry_id" integer, PRIMARY KEY ("bundle_id","registered_entry_id"));
+		CREATE TABLE IF NOT EXISTS "bundles" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"trust_domain" varchar(255) NOT NULL,"data" blob );
+		CREATE TABLE IF NOT EXISTS "attested_node_entries" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"spiffe_id" varchar(255),"data_type" varchar(255),"serial_number" varchar(255),"expires_at" datetime,"new_serial_number" varchar(255),"new_expires_at" datetime );
+		CREATE TABLE IF NOT EXISTS "node_resolver_map_entries" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"spiffe_id" varchar(255),"type" varchar(255),"value" varchar(255) );
+		CREATE TABLE IF NOT EXISTS "registered_entries" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"entry_id" varchar(255),"spiffe_id" varchar(255),"parent_id" varchar(255),"ttl" integer,"admin" bool,"downstream" bool,"expiry" bigint,"revision_number" bigint );
+		CREATE TABLE IF NOT EXISTS "join_tokens" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"token" varchar(255),"expiry" bigint );
+		CREATE TABLE IF NOT EXISTS "selectors" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"registered_entry_id" integer,"type" varchar(255),"value" varchar(255) );
+		CREATE TABLE IF NOT EXISTS "migrations" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"version" integer,"code_version" varchar(255) );
+		INSERT INTO migrations VALUES(1,'2020-10-13 16:29:43.132953291-06:00','2020-10-13 16:29:43.132953291-06:00',14,'0.12.0-dev-19b86b5');
+		CREATE TABLE IF NOT EXISTS "dns_names" ("id" integer primary key autoincrement,"created_at" datetime,"updated_at" datetime,"registered_entry_id" integer,"value" varchar(255) );
+		DELETE FROM sqlite_sequence;
+		INSERT INTO sqlite_sequence VALUES('migrations',1);
+		INSERT INTO sqlite_sequence VALUES('bundles',1);
+		CREATE UNIQUE INDEX uix_bundles_trust_domain ON "bundles"(trust_domain) ;
+		CREATE UNIQUE INDEX uix_attested_node_entries_spiffe_id ON "attested_node_entries"(spiffe_id) ;
+		CREATE UNIQUE INDEX idx_node_resolver_map ON "node_resolver_map_entries"(spiffe_id, "type", "value") ;
+		CREATE INDEX idx_registered_entries_spiffe_id ON "registered_entries"(spiffe_id) ;
+		CREATE INDEX idx_registered_entries_parent_id ON "registered_entries"(parent_id) ;
+		CREATE INDEX idx_registered_entries_expiry ON "registered_entries"("expiry") ;
+		CREATE UNIQUE INDEX uix_registered_entries_entry_id ON "registered_entries"(entry_id) ;
+		CREATE UNIQUE INDEX uix_join_tokens_token ON "join_tokens"("token") ;
+		CREATE INDEX idx_selectors_type_value ON "selectors"("type", "value") ;
+		CREATE UNIQUE INDEX idx_selector_entry ON "selectors"(registered_entry_id, "type", "value") ;
+		CREATE UNIQUE INDEX idx_dns_entry ON "dns_names"(registered_entry_id, "value") ;
+		CREATE INDEX idx_federated_registration_entries_registered_entry_id ON "federated_registration_entries"(registered_entry_id) ;
+		COMMIT;
+		`,
+		// future v11 database entry, in which an index was to the attested_nodes_entries expires_at column
 	}
 )
 

--- a/pkg/server/plugin/datastore/sql/models.go
+++ b/pkg/server/plugin/datastore/sql/models.go
@@ -29,7 +29,7 @@ type AttestedNode struct {
 	SpiffeID        string `gorm:"unique_index"`
 	DataType        string
 	SerialNumber    string
-	ExpiresAt       time.Time
+	ExpiresAt       time.Time `gorm:"index"`
 	NewSerialNumber string
 	NewExpiresAt    *time.Time
 

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -2920,6 +2920,10 @@ func (s *PluginSuite) TestMigration() {
 			s.Require().Empty(resp.Node.NewCertNotAfter)
 		case 13:
 			s.Require().True(s.sqlPlugin.db.Dialect().HasColumn("registered_entries", "revision_number"))
+		case 14:
+			db, err := openSQLite3(dbURI)
+			s.Require().NoError(err)
+			s.Require().True(db.Dialect().HasIndex("attested_node_entries", "idx_attested_node_entries_expires_at"))
 		default:
 			s.T().Fatalf("no migration test added for version %d", i)
 		}


### PR DESCRIPTION
Should improve performance when listing the node selectors against a specific agent validity date for the full entry cache.

Fixes #1910.