### PR TITLE
Clarify batch RPC result ordering

### DIFF
--- a/proto/spire/api/server/bundle/v1/bundle.pb.go
+++ b/proto/spire/api/server/bundle/v1/bundle.pb.go
@@ -445,7 +445,7 @@ func (m *BatchCreateFederatedBundleRequest) GetOutputMask() *types.BundleMask {
 }
 
 type BatchCreateFederatedBundleResponse struct {
-	// Result for each bundle in the request.
+	// Result for each bundle in the request (order is maintained).
 	Results              []*BatchCreateFederatedBundleResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                     `json:"-"`
 	XXX_unrecognized     []byte                                       `json:"-"`
@@ -596,7 +596,7 @@ func (m *BatchUpdateFederatedBundleRequest) GetOutputMask() *types.BundleMask {
 }
 
 type BatchUpdateFederatedBundleResponse struct {
-	// Result for each bundle in the request.
+	// Result for each bundle in the request (order is maintained).
 	Results              []*BatchUpdateFederatedBundleResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                     `json:"-"`
 	XXX_unrecognized     []byte                                       `json:"-"`
@@ -738,7 +738,7 @@ func (m *BatchSetFederatedBundleRequest) GetOutputMask() *types.BundleMask {
 }
 
 type BatchSetFederatedBundleResponse struct {
-	// Result for each bundle in the request.
+	// Result for each bundle in the request (order is maintained).
 	Results              []*BatchSetFederatedBundleResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                  `json:"-"`
 	XXX_unrecognized     []byte                                    `json:"-"`
@@ -878,7 +878,7 @@ func (m *BatchDeleteFederatedBundleRequest) GetMode() BatchDeleteFederatedBundle
 }
 
 type BatchDeleteFederatedBundleResponse struct {
-	// Result for each bundle in the request.
+	// Result for each trust domain name in the request (order is maintained).
 	Results              []*BatchDeleteFederatedBundleResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                                     `json:"-"`
 	XXX_unrecognized     []byte                                       `json:"-"`

--- a/proto/spire/api/server/bundle/v1/bundle.proto
+++ b/proto/spire/api/server/bundle/v1/bundle.proto
@@ -133,7 +133,7 @@ message BatchCreateFederatedBundleResponse {
         spire.types.Bundle bundle = 2;
     }
 
-    // Result for each bundle in the request.
+    // Result for each bundle in the request (order is maintained).
     repeated Result results = 1;
 }
 
@@ -157,7 +157,7 @@ message BatchUpdateFederatedBundleResponse {
         spire.types.Bundle bundle = 2;
     }
 
-    // Result for each bundle in the request.
+    // Result for each bundle in the request (order is maintained).
     repeated Result results = 1;
 }
 
@@ -178,7 +178,7 @@ message BatchSetFederatedBundleResponse {
         spire.types.Bundle bundle = 2;
     }
 
-    // Result for each bundle in the request.
+    // Result for each bundle in the request (order is maintained).
     repeated Result results = 1;
 }
 
@@ -211,6 +211,6 @@ message BatchDeleteFederatedBundleResponse {
         string trust_domain = 2;
     }
 
-    // Result for each bundle in the request.
+    // Result for each trust domain name in the request (order is maintained).
     repeated Result results = 1;
 }

--- a/proto/spire/api/server/entry/v1/entry.pb.go
+++ b/proto/spire/api/server/entry/v1/entry.pb.go
@@ -299,7 +299,7 @@ func (m *BatchCreateEntryRequest) GetOutputMask() *types.EntryMask {
 }
 
 type BatchCreateEntryResponse struct {
-	// Result for each entry in the request.
+	// Result for each entry in the request (order is maintained).
 	Results              []*BatchCreateEntryResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
 	XXX_unrecognized     []byte                             `json:"-"`
@@ -451,7 +451,7 @@ func (m *BatchUpdateEntryRequest) GetOutputMask() *types.EntryMask {
 }
 
 type BatchUpdateEntryResponse struct {
-	// Result for each entry in the request.
+	// Result for each entry in the request (order is maintained).
 	Results              []*BatchUpdateEntryResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
 	XXX_unrecognized     []byte                             `json:"-"`
@@ -582,7 +582,7 @@ func (m *BatchDeleteEntryRequest) GetIds() []string {
 }
 
 type BatchDeleteEntryResponse struct {
-	// Result for each entry in the request.
+	// Result for each entry ID in the request (order is maintained).
 	Results              []*BatchDeleteEntryResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
 	XXX_unrecognized     []byte                             `json:"-"`

--- a/proto/spire/api/server/entry/v1/entry.proto
+++ b/proto/spire/api/server/entry/v1/entry.proto
@@ -103,7 +103,7 @@ message BatchCreateEntryResponse {
         spire.types.Entry entry = 2;
     }
 
-    // Result for each entry in the request.
+    // Result for each entry in the request (order is maintained).
     repeated Result results = 1;
 }
 
@@ -129,7 +129,7 @@ message BatchUpdateEntryResponse {
         spire.types.Entry entry = 2;
     }
 
-    // Result for each entry in the request.
+    // Result for each entry in the request (order is maintained).
     repeated Result results = 1;
 }
 
@@ -147,7 +147,7 @@ message BatchDeleteEntryResponse {
         string id = 2;
     }
 
-    // Result for each entry in the request.
+    // Result for each entry ID in the request (order is maintained).
     repeated Result results = 1;
 }
 

--- a/proto/spire/api/server/svid/v1/svid.pb.go
+++ b/proto/spire/api/server/svid/v1/svid.pb.go
@@ -263,7 +263,7 @@ func (m *BatchNewX509SVIDRequest) GetParams() []*NewX509SVIDParams {
 }
 
 type BatchNewX509SVIDResponse struct {
-	// Result for each X509-SVID requested.
+	// Result for each X509-SVID requested (order is maintained).
 	Results              []*BatchNewX509SVIDResponse_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
 	XXX_unrecognized     []byte                             `json:"-"`

--- a/proto/spire/api/server/svid/v1/svid.proto
+++ b/proto/spire/api/server/svid/v1/svid.proto
@@ -92,7 +92,7 @@ message BatchNewX509SVIDResponse {
         spire.types.X509SVID svid = 2;
     }
 
-    // Result for each X509-SVID requested.
+    // Result for each X509-SVID requested (order is maintained).
     repeated Result results = 1;
 }
 


### PR DESCRIPTION
It wasn't immediately clear that results from batch operations were in the same order as the batched items in the request. This PR adds some clarifying language to the result comments.
