### PR TITLE
Fix logging big.Int value

### DIFF
--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -229,7 +229,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 				telemetry.SVIDSerialNumber: agentSVID.SerialNumber.String(),
 				telemetry.SerialNumber:     resp.Node.CertSerialNumber,
 			}).Error("Agent SVID is not active")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, resp.Node.CertSerialNumber, agentSVID.SerialNumber)
+			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, resp.Node.CertSerialNumber, agentSVID.SerialNumber.String())
 		}
 	})
 }

--- a/pkg/server/endpoints/middleware_test.go
+++ b/pkg/server/endpoints/middleware_test.go
@@ -205,7 +205,7 @@ func TestAgentAuthorizer(t *testing.T) {
 				CertSerialNumber: "NEW",
 			},
 			expectedCode:   codes.PermissionDenied,
-			expectedMsg:    fmt.Sprintf(`agent "spiffe://domain.test/agent" expected to have serial number "NEW"; has %q`, agentSVID.SerialNumber),
+			expectedMsg:    fmt.Sprintf(`agent "spiffe://domain.test/agent" expected to have serial number "NEW"; has %q`, agentSVID.SerialNumber.String()),
 			expectedReason: types.PermissionDeniedDetails_AGENT_NOT_ACTIVE,
 			expectedLogs: []spiretest.LogEntry{
 				{


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

SPIRE Server middleware

**Description of change**
<!-- Please provide a description of the change -->

This PR fixes the broken logging.
Before this commit, the bit.Int wasn't properly output.

```
 time="2020-10-16T07:43:08Z" level=error msg="Failed to fetch authorized entries" error="rpc error: code = PermissionDenied desc = agent \"spiffe://example.org/spire/agent/sshpop/${hostname}\" expected to have serial number \"173519580944580228740697109256257631213\"; has %!q(big.Int=107959714025526768817333596538168335315)" subsystem_name=manager
```

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

