### PR TITLE
Add information about KeyUsage

### DIFF
--- a/doc/plugin_agent_nodeattestor_x509pop.md
+++ b/doc/plugin_agent_nodeattestor_x509pop.md
@@ -17,7 +17,7 @@ spiffe://<trust domain>/spire/agent/x509pop/<fingerprint>
 | Configuration | Description | Default                 |
 | ------------- | ----------- | ----------------------- |
 | `private_key_path` | The path to the private key on disk (PEM encoded PKCS1 or PKCS8) | |
-| `certificate_path` | The path to the certificate bundle on disk. The file must contain one or more PEM blocks, starting with the identity certificate followed by any intermediate certificates necessary for chain-of-trust validation. | |
+| `certificate_path` | The path to the certificate bundle on disk. The file must contain one or more PEM blocks, starting with the identity certificate followed by any intermediate certificates necessary for chain-of-trust validation. The identity certificate must contain the `digitalSignature` in the [X509v3 KeyUsage](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) | |
 | `intermediates_path` | Optional. The path to a chain of intermediate certificates on disk. The file must contain one or more PEM blocks, corresponding to intermediate certificates necessary for chain-of-trust validation. If the file pointed by `certificate_path` contains more than one certificate, this chain of certificates will be appended to it. | |
 
 A sample configuration:


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Documentation about `x509pop`

**Description of change**
<!-- Please provide a description of the change -->

Add information about KeyUsage required for Agent certificates.

If digitalSignature is not set, we get the error as below.
```
error="rpc error: code = Unknown desc = unable to generate challenge: certificate not intended for digital signature use" method=AttestAgent node_attestor_type=x509pop service=agent.v1.Agent subsystem_name=api
```

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

