### PR TITLE
Prepare v0.11.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.11.2] - 2020-10-29
+
+### What's New
+ - Added rate limiting to logging that occurs under certain misconfigurations (#1901)
+
+### What's Changed
+- Fixed an issue in the Upstream Authority plugin that could result in stale data being used (#1917)
+- Fixed error messages when attestation is disabled (#1899)
+- Fixed some incorrectly-formatted log messages (#1920)
+
+
 ## [0.11.1] - 2020-09-29
 
 ### What's New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [0.11.2] - 2020-10-29
 
 ### What's New
- - Added rate limiting to logging that occurs under certain misconfigurations (#1901)
+ - Error messages related to a specific class of software bugs are now rate limited (#1901)
 
 ### What's Changed
-- Fixed an issue in the Upstream Authority plugin that could result in stale data being used (#1917)
+- Fixed an issue in the Upstream Authority plugin that could result in a delay in the propagation of bundle updates/changes (#1917)
 - Fixed error messages when attestation is disabled (#1899)
 - Fixed some incorrectly-formatted log messages (#1920)
 

--- a/pkg/common/version/version.go
+++ b/pkg/common/version/version.go
@@ -8,7 +8,7 @@ const (
 	// IMPORTANT: When updating, make sure to reconcile the versions list that
 	// is part of the upgrade integration test. See
 	// test/integration/suites/upgrade/README.md for details.
-	Base = "0.11.0"
+	Base = "0.11.2"
 )
 
 var (

--- a/pkg/server/api/middleware/authorization.go
+++ b/pkg/server/api/middleware/authorization.go
@@ -51,7 +51,7 @@ func (m *authorizationMiddleware) Preprocess(ctx context.Context, methodName str
 
 	authorizer, ok := m.authorizers[methodName]
 	if !ok {
-		rpccontext.Logger(ctx).Error("Authorization misconfigured (method not registered); this is a bug")
+		logMisconfiguration(ctx, "Authorization misconfigured (method not registered); this is a bug")
 		return nil, status.Errorf(codes.Internal, "authorization misconfigured for %q (method not registered)", methodName)
 	}
 	return authorizer.AuthorizeCaller(ctx)

--- a/pkg/server/api/middleware/authorize_any_of.go
+++ b/pkg/server/api/middleware/authorize_any_of.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -41,7 +40,7 @@ func (a anyOfAuthorizer) Name() string {
 
 func (a anyOfAuthorizer) AuthorizeCaller(ctx context.Context) (context.Context, error) {
 	if len(a.authorizers) == 0 {
-		rpccontext.Logger(ctx).Error("Authorization misconfigured (no authorizers); this is a bug")
+		logMisconfiguration(ctx, "Authorization misconfigured (no authorizers); this is a bug")
 		return nil, status.Error(codes.Internal, "authorization misconfigured (no authorizers)")
 	}
 

--- a/pkg/server/api/middleware/common.go
+++ b/pkg/server/api/middleware/common.go
@@ -1,0 +1,1 @@
+package middleware

--- a/pkg/server/api/middleware/metrics.go
+++ b/pkg/server/api/middleware/metrics.go
@@ -31,7 +31,7 @@ func (m metricsMiddleware) Preprocess(ctx context.Context, fullMethod string) (c
 func (m metricsMiddleware) Postprocess(ctx context.Context, fullMethod string, handlerInvoked bool, rpcErr error) {
 	counter, ok := rpccontext.CallCounter(ctx).(*telemetry.CallCounter)
 	if !ok {
-		rpccontext.Logger(ctx).Error("Metrics misconfigured; this is a bug")
+		logMisconfiguration(ctx, "Metrics misconfigured; this is a bug")
 		return
 	}
 	counter.Done(&rpcErr)

--- a/pkg/server/api/middleware/misconfig.go
+++ b/pkg/server/api/middleware/misconfig.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+)
+
+var (
+	misconfigLogMtx   sync.Mutex
+	misconfigLogTimes = make(map[string]time.Time)
+)
+
+const misconfigLogEvery = time.Minute
+
+// logMisconfiguration logs a misconfiguration for the RPC. It assumes that the
+// context has been embellished with the names for the RPC. This method should
+// not be called under normal operation and only when there is an
+// implementation bug. As such there is no attempt at a time/space efficient
+// implementation. In any case, the number of distinct misconfiguration
+// messages intersected with the number of RPCs should not produce any amount
+// of real memory use. Contention on the global mutex should also be
+// reasonable.
+func logMisconfiguration(ctx context.Context, msg string) {
+	if shouldLogMisconfiguration(ctx, msg) {
+		rpccontext.Logger(ctx).Error(msg)
+	}
+}
+
+func shouldLogMisconfiguration(ctx context.Context, msg string) bool {
+	names, _ := rpccontext.Names(ctx)
+	key := names.Service + "|" + names.Method + "|" + msg
+
+	now := clk.Now()
+
+	misconfigLogMtx.Lock()
+	defer misconfigLogMtx.Unlock()
+	last, ok := misconfigLogTimes[key]
+	if !ok || now.Sub(last) >= misconfigLogEvery {
+		misconfigLogTimes[key] = now
+		return true
+	}
+	return false
+}

--- a/pkg/server/api/middleware/misconfig_test.go
+++ b/pkg/server/api/middleware/misconfig_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/test/spiretest"
+)
+
+func TestLogMisconfiguration(t *testing.T) {
+	mockClk, done := setupClock(t)
+	defer done()
+
+	log, hook := test.NewNullLogger()
+
+	baseCtx := context.Background()
+	baseCtx = rpccontext.WithLogger(baseCtx, log)
+	ctx1 := rpccontext.WithNames(baseCtx, api.Names{Service: "service", Method: "method1"})
+	ctx2 := rpccontext.WithNames(baseCtx, api.Names{Service: "service", Method: "method2"})
+
+	// Log various messages from various method contexts and make sure no
+	// repeated messages are logged.
+	logMisconfiguration(ctx1, "message1a")
+	logMisconfiguration(ctx1, "message1a")
+	logMisconfiguration(ctx1, "message1a")
+	logMisconfiguration(ctx1, "message1b")
+	logMisconfiguration(ctx1, "message1b")
+	logMisconfiguration(ctx1, "message1b")
+	logMisconfiguration(ctx2, "message2a")
+	logMisconfiguration(ctx2, "message2a")
+	logMisconfiguration(ctx2, "message2a")
+	logMisconfiguration(ctx2, "message2b")
+	logMisconfiguration(ctx2, "message2b")
+	logMisconfiguration(ctx2, "message2b")
+	spiretest.AssertLogs(t, hook.AllEntries(), []spiretest.LogEntry{
+		{Level: logrus.ErrorLevel, Message: "message1a"},
+		{Level: logrus.ErrorLevel, Message: "message1b"},
+		{Level: logrus.ErrorLevel, Message: "message2a"},
+		{Level: logrus.ErrorLevel, Message: "message2b"},
+	})
+
+	// Now advance the clock and ensure that the messages are logged again
+	hook.Reset()
+	mockClk.Add(misconfigLogEvery)
+	logMisconfiguration(ctx1, "message1a")
+	logMisconfiguration(ctx1, "message1b")
+	logMisconfiguration(ctx2, "message2a")
+	logMisconfiguration(ctx2, "message2b")
+	spiretest.AssertLogs(t, hook.AllEntries(), []spiretest.LogEntry{
+		{Level: logrus.ErrorLevel, Message: "message1a"},
+		{Level: logrus.ErrorLevel, Message: "message1b"},
+		{Level: logrus.ErrorLevel, Message: "message2a"},
+		{Level: logrus.ErrorLevel, Message: "message2b"},
+	})
+}

--- a/pkg/server/api/middleware/ratelimit.go
+++ b/pkg/server/api/middleware/ratelimit.go
@@ -192,7 +192,7 @@ type rateLimitsMiddleware struct {
 func (i rateLimitsMiddleware) Preprocess(ctx context.Context, fullMethod string) (context.Context, error) {
 	rateLimiter, ok := i.limiters[fullMethod]
 	if !ok {
-		rpccontext.Logger(ctx).Error("Rate limiting misconfigured; this is a bug")
+		logMisconfiguration(ctx, "Rate limiting misconfigured; this is a bug")
 		return nil, status.Errorf(codes.Internal, "rate limiting misconfigured for %q", fullMethod)
 	}
 	return rpccontext.WithRateLimiter(ctx, &rateLimiterWrapper{rateLimiter: rateLimiter}), nil
@@ -210,7 +210,7 @@ func (i rateLimitsMiddleware) Postprocess(ctx context.Context, fullMethod string
 	if !ok {
 		// This shouldn't be the case unless Preprocess is broken and fails to
 		// inject the rate limiter into the context.
-		rpccontext.Logger(ctx).Error("Rate limiting misconfigured; this is a bug")
+		logMisconfiguration(ctx, "Rate limiting misconfigured; this is a bug")
 		return
 	}
 
@@ -218,7 +218,7 @@ func (i rateLimitsMiddleware) Postprocess(ctx context.Context, fullMethod string
 	if !ok {
 		// This shouldn't be the case unless Preprocess is broken and fails to
 		// wrap the rate limiter.
-		rpccontext.Logger(ctx).Error("Rate limiting misconfigured; this is a bug")
+		logMisconfiguration(ctx, "Rate limiting misconfigured; this is a bug")
 		return
 	}
 
@@ -232,7 +232,7 @@ func logLimiterMisuse(ctx context.Context, rateLimiter api.RateLimiter, used boo
 		// misconfiguration. Either the RPC is wrong, or the middleware is
 		// wrong as to whether or not the RPC should rate limit.
 		if used {
-			rpccontext.Logger(ctx).Error("Rate limiter used unexpectedly; this is a bug")
+			logMisconfiguration(ctx, "Rate limiter used unexpectedly; this is a bug")
 		}
 	case disabledLimit:
 		// RPC should invoke the rate limiter since is an RPC that is normally
@@ -240,13 +240,13 @@ func logLimiterMisuse(ctx context.Context, rateLimiter api.RateLimiter, used boo
 		// limits but we want to make sure the RPC will be applying limits
 		// under normal conditions.
 		if !used {
-			rpccontext.Logger(ctx).Error("Disabled rate limiter went unused; this is a bug")
+			logMisconfiguration(ctx, "Disabled rate limiter went unused; this is a bug")
 		}
 	default:
 		// All other rate limiters should definitely be invoked by the RPC or
 		// it is a bug.
 		if !used {
-			rpccontext.Logger(ctx).Error("Rate limiter went unused; this is a bug")
+			logMisconfiguration(ctx, "Rate limiter went unused; this is a bug")
 		}
 	}
 }

--- a/pkg/server/api/middleware/ratelimit_test.go
+++ b/pkg/server/api/middleware/ratelimit_test.go
@@ -31,6 +31,17 @@ func TestNoLimit(t *testing.T) {
 	assert.Equal(t, 0, limiters.Count)
 }
 
+func TestDisabledLimit(t *testing.T) {
+	limiters := NewFakeLimiters()
+
+	// DisabledLimit() does not do rate limiting and should succeed.
+	m := DisabledLimit()
+	require.NoError(t, m.RateLimit(context.Background(), 99))
+
+	// There should be no rate limiters configured as DisabledLimit() doesn't use one.
+	assert.Equal(t, 0, limiters.Count)
+}
+
 func TestPerCallLimit(t *testing.T) {
 	limiters := NewFakeLimiters()
 
@@ -189,7 +200,24 @@ func TestRateLimits(t *testing.T) {
 			},
 		},
 		{
-			name:       "does not when rate limiter not used by unlimited handler",
+			name:           "does not log when handler with disabled limit tries to rate limit",
+			method:         "/fake.Service/DisabledLimit",
+			rateLimitCount: 1,
+			expectCode:     codes.OK,
+		},
+		{
+			name:       "logs when handler with disabled limit does not rate limit",
+			method:     "/fake.Service/DisabledLimit",
+			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Disabled rate limiter went unused; this is a bug",
+				},
+			},
+		},
+		{
+			name:       "does not log when rate limiter not used by unlimited handler",
 			method:     "/fake.Service/NoLimit",
 			expectCode: codes.OK,
 		},
@@ -230,8 +258,9 @@ func TestRateLimits(t *testing.T) {
 			unaryInterceptor := UnaryInterceptor(Chain(
 				WithRateLimits(
 					map[string]api.RateLimiter{
-						"/fake.Service/NoLimit":   NoLimit(),
-						"/fake.Service/WithLimit": PerCallLimit(2),
+						"/fake.Service/NoLimit":       NoLimit(),
+						"/fake.Service/DisabledLimit": DisabledLimit(),
+						"/fake.Service/WithLimit":     PerCallLimit(2),
 					},
 				),
 				// Install a middleware downstream so that we can test what

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -188,7 +188,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 
 func RateLimits(config RateLimitConfig) map[string]api.RateLimiter {
 	noLimit := middleware.NoLimit()
-	attestLimit := noLimit
+	attestLimit := middleware.DisabledLimit()
 	if config.Attestation {
 		attestLimit = middleware.PerIPLimit(node_pb.AttestLimit)
 	}

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -181,7 +181,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 				telemetry.SVIDSerialNumber: agentSVID.SerialNumber.String(),
 				telemetry.SerialNumber:     resp.Node.CertSerialNumber,
 			}).Error("Agent SVID is not active")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, resp.Node.CertSerialNumber, agentSVID.SerialNumber)
+			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, resp.Node.CertSerialNumber, agentSVID.SerialNumber.String())
 		}
 	})
 }

--- a/pkg/server/endpoints/middleware_test.go
+++ b/pkg/server/endpoints/middleware_test.go
@@ -210,7 +210,7 @@ func TestAgentAuthorizer(t *testing.T) {
 				CertSerialNumber: "NEW",
 			},
 			expectedCode:   codes.PermissionDenied,
-			expectedMsg:    fmt.Sprintf(`agent "spiffe://domain.test/agent" expected to have serial number "NEW"; has %q`, agentSVID.SerialNumber),
+			expectedMsg:    fmt.Sprintf(`agent "spiffe://domain.test/agent" expected to have serial number "NEW"; has %q`, agentSVID.SerialNumber.String()),
 			expectedReason: types.PermissionDeniedDetails_AGENT_NOT_ACTIVE,
 			expectedLogs: []spiretest.LogEntry{
 				{

--- a/pkg/server/plugin/upstreamauthority/spire/spire.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire.go
@@ -206,10 +206,8 @@ func (m *Plugin) pollBundleUpdates(ctx context.Context) {
 		resp, err := m.serverClient.getBundle(ctx)
 		if err != nil {
 			m.log.Warn("Failed to fetch bundle while polling", "error", err)
-		}
-
-		if m.bundleVersion == preFetchCallVersion && resp != nil {
-			m.setBundle(resp)
+		} else {
+			m.setBundleIfVersionMatches(resp, preFetchCallVersion)
 		}
 
 		select {
@@ -222,11 +220,13 @@ func (m *Plugin) pollBundleUpdates(ctx context.Context) {
 	}
 }
 
-func (m *Plugin) setBundle(b *types.Bundle) {
+func (m *Plugin) setBundleIfVersionMatches(b *types.Bundle, expectedVersion uint64) {
 	m.bundleMtx.Lock()
 	defer m.bundleMtx.Unlock()
 
-	m.currentBundle = *b
+	if m.bundleVersion == expectedVersion {
+		m.currentBundle = *b
+	}
 }
 
 func (m *Plugin) getBundle() types.Bundle {


### PR DESCRIPTION
This PR:

1. Updates `version` var
2. Updates the `CHANGELOG`
3. Cherry-picks PRs from the [0.11.2 Release](https://github.com/spiffe/spire/projects/8) project (#1917, #1899, #1901, and #1920)

Fixes #1926