### PR TITLE
[#1915] Allow integration test suites to be run in batches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,9 @@ jobs:
       - checkout
       - run:
           name: Execute integration test suites
+          working_directory: test/integration/
           command: |
-            echo $(circleci tests glob "test/integration/suites/*" | circleci tests split)
-            circleci tests glob "test/integration/suites/*" | circleci tests split | xargs -n1 test/integration/test-one.sh
+            circleci tests glob "suites/*" | circleci tests split | xargs ./test.sh
 
   # Publish "unstable" docker images
   publish-unstable-images:

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ else
 endif
 
 integration:
-	$(E)./test/integration/test-all.sh
+	$(E)./test/integration/test.sh
 
 #############################################################################
 # Build Artifact

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -6,8 +6,15 @@ cd "${DIR}" || fail-now "Unable to change to script directory"
 
 . ./common
 
+SUITES=suites/*
+if [[ -n $1 ]]; then
+        SUITES=$@
+fi
+
+echo "Testing $SUITES"
+
 failed=()
-for suite in suites/*; do
+for suite in $SUITES; do
     if ! ./test-one.sh "${suite}"; then
         echo "STATUS=$?"
         failed+=( "$(basename "${suite}")" )


### PR DESCRIPTION
The current integration test harness executes all suites and then
reports which suites have failed as an error message at the end. This is
convenient (and in some ways necessary) as the test suites produce a lot
of output, where errors become needles in a haystack.

The CircleCI configuration parallelizes integration test suites by
splitting the suites up and passing them to `test-one.sh` using `xargs
-n 1`. This approach means that suites which fail get buried in the
output of the rest, and `xargs` doesn't report _which_ invocation
failed.

This commit addresses this problem by allowing our test script to
(optionally) accept a list of suites to test. If no arguments are
passed, the script runs all suites. In making this change, the test
script (previously `test-all.sh`) has been renamed to `test.sh`.

Also included is an update to the CircleCI config to make use of the new
functionality.

Fixes https://github.com/spiffe/spire/issues/1915

Signed-off-by: Evan Gilman <egilman@vmware.com>