### PR TITLE
Load SQL datastore directly

### DIFF
--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -113,7 +113,7 @@ type Repository struct {
 }
 
 func Load(ctx context.Context, config Config) (*Repository, error) {
-	pluginConfig, err := catalog.PluginConfigFromHCL(config.PluginConfig)
+	pluginConfig, err := catalog.PluginConfigsFromHCL(config.PluginConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -104,6 +104,13 @@ type Catalog interface {
 	//       BetweenThreeAndFive []nodeattestor.NodeAttestor `catalog:"min=3,max=5"`
 	//   }
 	//
+	//   You can also add a `catalog:"-"` tag to a field to have it be ignored
+	//   by the catalog:
+	//
+	//   struct {
+	//       IgnoreMe int `catalog:"-"`
+	//   }
+	//
 	Fill(x interface{}) error
 
 	// Close() closes the catalog, shutting down servers and killing external

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -320,12 +320,21 @@ func (s *CatalogSuite) TestPluginsFill() {
 			},
 		},
 		{
+			"ignore struct tag",
+			func(r *require.Assertions) {
+				c := &struct {
+					IgnoreMe struct{} `catalog:"-"`
+				}{}
+				r.NoError(ps.Fill(c))
+			},
+		},
+		{
 			"bad struct tag",
 			func(r *require.Assertions) {
 				c := &struct {
 					Plugins []catalogtest.Plugin `catalog:"BAD"`
 				}{}
-				r.EqualError(ps.Fill(c), `unable to set catalog field "Plugins": expected key=value for catalog tag value "BAD"`)
+				r.EqualError(ps.Fill(c), `unable to set catalog field "Plugins": unrecognized catalog tag key "BAD"`)
 			},
 		},
 		{

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -329,6 +329,15 @@ func (s *CatalogSuite) TestPluginsFill() {
 			},
 		},
 		{
+			"unexpected value on ignore tag",
+			func(r *require.Assertions) {
+				c := &struct {
+					IgnoreMe struct{} `catalog:"-=bad"`
+				}{}
+				r.EqualError(ps.Fill(c), `unable to set catalog field "IgnoreMe": not expecting key=value for catalog tag value "-=bad"`)
+			},
+		},
+		{
 			"bad struct tag",
 			func(r *require.Assertions) {
 				c := &struct {
@@ -347,6 +356,15 @@ func (s *CatalogSuite) TestPluginsFill() {
 			},
 		},
 		{
+			"min struct tag without value",
+			func(r *require.Assertions) {
+				c := &struct {
+					Plugins []catalogtest.Plugin `catalog:"min"`
+				}{}
+				r.EqualError(ps.Fill(c), `unable to set catalog field "Plugins": expected key=value for catalog tag value "min"`)
+			},
+		},
+		{
 			"negative min struct tag",
 			func(r *require.Assertions) {
 				c := &struct {
@@ -362,6 +380,15 @@ func (s *CatalogSuite) TestPluginsFill() {
 					Plugins []catalogtest.Plugin `catalog:"max=BAD"`
 				}{}
 				r.EqualError(ps.Fill(c), `unable to set catalog field "Plugins": invalid catalog tag max value "BAD"`)
+			},
+		},
+		{
+			"max struct tag without value",
+			func(r *require.Assertions) {
+				c := &struct {
+					Plugins []catalogtest.Plugin `catalog:"max"`
+				}{}
+				r.EqualError(ps.Fill(c), `unable to set catalog field "Plugins": expected key=value for catalog tag value "max"`)
 			},
 		},
 		{

--- a/pkg/common/catalog/config_test.go
+++ b/pkg/common/catalog/config_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParsePluginConfigFromHCLFailure(t *testing.T) {
-	_, err := ParsePluginConfigFromHCL(`NOT-VALID-HCL`)
+func TestParsePluginConfigsFromHCLFailure(t *testing.T) {
+	_, err := ParsePluginConfigsFromHCL(`NOT-VALID-HCL`)
 	require.Error(t, err)
 }
 
-func TestParsePluginConfigFromHCLSuccess(t *testing.T) {
-	config, err := ParsePluginConfigFromHCL(`
+func TestParsePluginConfigsFromHCLSuccess(t *testing.T) {
+	config, err := ParsePluginConfigsFromHCL(`
 	TYPE1 "NAME1" {
 		plugin_cmd = "CMD1"
 		plugin_data = "DATA1"

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
@@ -230,7 +231,7 @@ func loadSQLDataStore(ctx context.Context, log logrus.FieldLogger, datastoreConf
 
 	sqlHCLConfig, ok := datastoreConfig[ds_sql.PluginName]
 	if !ok {
-		return nil, errors.New("pluggability for the DataStore is deprecated; only the built-in SQL plugin is supported")
+		return nil, fmt.Errorf("pluggability for the DataStore is deprecated; only the built-in %q plugin is supported", ds_sql.PluginName)
 	}
 
 	sqlConfig, err := catalog.PluginConfigFromHCL(datastore.Type, ds_sql.PluginName, sqlHCLConfig)
@@ -240,7 +241,7 @@ func loadSQLDataStore(ctx context.Context, log logrus.FieldLogger, datastoreConf
 
 	// Is the plugin external?
 	if sqlConfig.Path != "" {
-		return nil, errors.New("pluggability for the DataStore is deprecated; only the built-in SQL plugin is supported")
+		return nil, fmt.Errorf("pluggability for the DataStore is deprecated; only the built-in %q plugin is supported", ds_sql.PluginName)
 	}
 
 	ds := ds_sql.New()

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -44,6 +44,8 @@ var (
 )
 
 const (
+	PluginName = "sql"
+
 	// MySQL database type
 	MySQL = "mysql"
 	// PostgreSQL database type
@@ -57,7 +59,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin("sql",
+	return catalog.MakePlugin(PluginName,
 		datastore.PluginServer(p),
 	)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 
 	healthChecks := health.NewChecker(s.config.HealthChecks, s.config.Log)
 
-	s.config.Log.Info("plugins started")
+	s.config.Log.Info("Plugins started")
 
 	err = s.validateTrustDomain(ctx, cat.GetDataStore())
 	if err != nil {


### PR DESCRIPTION
This changes the server catalog code to load and configure the SQL datastore directly instead of going through the catalog machinery. This removes the gRPC layer between the core and the datastore code.

Bypassing gRPC gets rid of the 4MB response limit that currently exists, allowing us to simplify some of the interactions with the datastore. Namely it allows us to remove the paging support added to ListNodeSelectors (which is currently broken).

Most of the change consists of adding support to the common catalog "Fill()" code to support a struct tag that causes the catalog code to ignore a struct field during "filling".