### PR TITLE
Fix transient failures in mTLS integration tests

### DIFF
--- a/test/integration/suites/envoy-sds-v2/05-check-workload-connectivity
+++ b/test/integration/suites/envoy-sds-v2/05-check-workload-connectivity
@@ -3,10 +3,12 @@
 MAXCHECKSPERPORT=15
 CHECKINTERVAL=1
 
+TRY() { docker-compose exec -T downstream-socat-mtls /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
+VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
+
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking MTLS proxy ($i of $MAXCHECKSPERPORT max)..."
-    docker-compose exec -T downstream-socat-mtls /bin/sh -c "echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001"
-    if docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS ; then
+    if TRY && VERIFY ; then
         MTLS_OK=1
         log-info "MTLS proxy OK"
         break
@@ -14,10 +16,12 @@ for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     sleep "${CHECKINTERVAL}"
 done
 
+TRY() { docker-compose exec -T downstream-socat-tls /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
+VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
+
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking TLS proxy ($i of $MAXCHECKSPERPORT max)..."
-    docker-compose exec -T downstream-socat-tls /bin/sh -c "echo HELLO_TLS | socat -u STDIN TCP:localhost:8002"
-    if docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS ; then
+    if TRY && VERIFY ; then
         TLS_OK=1
         log-info "TLS proxy OK"
         break

--- a/test/integration/suites/envoy-sds-v3/05-check-workload-connectivity
+++ b/test/integration/suites/envoy-sds-v3/05-check-workload-connectivity
@@ -3,10 +3,12 @@
 MAXCHECKSPERPORT=15
 CHECKINTERVAL=1
 
+TRY() { docker-compose exec -T downstream-socat-mtls /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
+VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
+
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking MTLS proxy ($i of $MAXCHECKSPERPORT max)..."
-    docker-compose exec -T downstream-socat-mtls /bin/sh -c "echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001"
-    if docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS ; then
+    if TRY && VERIFY ; then
         MTLS_OK=1
         log-info "MTLS proxy OK"
         break
@@ -14,10 +16,12 @@ for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     sleep "${CHECKINTERVAL}"
 done
 
+TRY() { docker-compose exec -T downstream-socat-tls /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
+VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
+
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking TLS proxy ($i of $MAXCHECKSPERPORT max)..."
-    docker-compose exec -T downstream-socat-tls /bin/sh -c "echo HELLO_TLS | socat -u STDIN TCP:localhost:8002"
-    if docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS ; then
+    if TRY && VERIFY ; then
         TLS_OK=1
         log-info "TLS proxy OK"
         break

--- a/test/integration/suites/ghostunnel-federation/05-check-workload-connectivity
+++ b/test/integration/suites/ghostunnel-federation/05-check-workload-connectivity
@@ -3,14 +3,17 @@
 MAXCHECKSPERPORT=15
 CHECKINTERVAL=1
 
+TRY() { docker-compose exec -T downstream-workload /bin/sh -c 'echo HELLO | socat -u STDIN TCP:localhost:8000'; }
+VERIFY() { docker-compose exec -T upstream-workload cat /tmp/howdy | grep -q HELLO; }
+
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking proxy ($i of $MAXCHECKSPERPORT max)..."
-    docker-compose exec -T downstream-workload /bin/sh -c "echo HELLO | socat -u STDIN TCP:localhost:8000"
-    if docker-compose exec -T upstream-workload cat /tmp/howdy | grep -q HELLO ; then
+    if TRY && VERIFY; then
         log-info "Proxy OK"
         docker-compose exec -T upstream-workload rm /tmp/howdy
         exit 0
     fi
+
     sleep "${CHECKINTERVAL}"
 done
 


### PR DESCRIPTION
This commit fixes spurious test suite failure caused by some racing
components (socat and a proxy). Occasionally (and more frequently on
some platforms) socat is called to write to a socket that doesn't exist
yet. This condition didn't originally affect the outcome of the test,
however a recent bugfix that enforces `set -e` in the test framework
exposed it.

To fix it, move the socat call to a conditional.

Signed-off-by: Evan Gilman <egilman@vmware.com>