### PR TITLE
Remove pagination from hydration of entries cache

### DIFF
--- a/pkg/server/cache/entrycache/fullcache_ds.go
+++ b/pkg/server/cache/entrycache/fullcache_ds.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	agentPageSize = 500
-	entryPageSize = 500
 )
 
 var (
@@ -28,11 +27,10 @@ func BuildFromDataStore(ctx context.Context, ds datastore.DataStore) (*FullEntry
 }
 
 type entryIteratorDS struct {
-	ds              datastore.DataStore
-	entries         []*types.Entry
-	next            int
-	err             error
-	paginationToken string
+	ds      datastore.DataStore
+	entries []*types.Entry
+	next    int
+	err     error
 }
 
 func makeEntryIteratorDS(ds datastore.DataStore) EntryIterator {
@@ -45,13 +43,9 @@ func (it *entryIteratorDS) Next(ctx context.Context) bool {
 	if it.err != nil {
 		return false
 	}
-	if it.entries == nil || (it.next >= len(it.entries) && it.paginationToken != "") {
+	if it.entries == nil {
 		req := &datastore.ListRegistrationEntriesRequest{
 			TolerateStale: true,
-			Pagination: &datastore.Pagination{
-				Token:    it.paginationToken,
-				PageSize: entryPageSize,
-			},
 		}
 
 		resp, err := it.ds.ListRegistrationEntries(ctx, req)
@@ -60,7 +54,6 @@ func (it *entryIteratorDS) Next(ctx context.Context) bool {
 			return false
 		}
 
-		it.paginationToken = resp.Pagination.Token
 		it.next = 0
 		it.entries, err = api.RegistrationEntriesToProto(resp.Entries)
 		if err != nil {

--- a/pkg/server/cache/entrycache/fullcache_ds_test.go
+++ b/pkg/server/cache/entrycache/fullcache_ds_test.go
@@ -27,7 +27,7 @@ func TestEntryIteratorDS(t *testing.T) {
 		assert.NoError(t, it.Err())
 	})
 
-	const numEntries = entryPageSize + 1
+	const numEntries = 10
 	const parentID = "spiffe://example.org/parent"
 	const spiffeIDPrefix = "spiffe://example.org/entry"
 	selectors := []*common.Selector{
@@ -50,7 +50,7 @@ func TestEntryIteratorDS(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	t.Run("multiple pages", func(t *testing.T) {
+	t.Run("existing entries", func(t *testing.T) {
 		it := makeEntryIteratorDS(ds)
 		var entries []*types.Entry
 		for i := 0; i < numEntries; i++ {
@@ -67,13 +67,8 @@ func TestEntryIteratorDS(t *testing.T) {
 		assert.ElementsMatch(t, expectedEntries, entries)
 	})
 
-	t.Run("multiple pages with datastore error in-between pages", func(t *testing.T) {
+	t.Run("datastore error", func(t *testing.T) {
 		it := makeEntryIteratorDS(ds)
-		for i := 0; i < entryPageSize; i++ {
-			assert.True(t, it.Next(ctx))
-			require.NoError(t, it.Err())
-		}
-
 		dsErr := errors.New("some datastore error")
 		ds.SetNextError(dsErr)
 		assert.False(t, it.Next(ctx))


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
In-memory registration entry cache, authorized registration entry sync between Agent and Server

**Description of change**
Pagination was previously used because there was a gRPC layer separating
SPIRE core from the sql datastore plugin. That gRPC boundary no longer
exists, so there are no longer concerns about query result exceeding the
maximum response message size of gRPC. It is more performant to do the
full table scan in one go rather than through sequential piecemeal
paginated requests.

