### PR TITLE
Add documentation in CONTRIBUTING.md about periods in log and error messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,8 @@ Log messages should make use of logging fields to convey additional information,
 using string formatting which increases the cardinality of messages for log watchers to
 look for and hinders aggregation.
 
+Log messages and error messages should not end with periods.
+
 ## Mocks
 
 Unit tests should avoid mock tests as much as possible. When necessary we should inject mocked


### PR DESCRIPTION
Signed-off-by: silvamatteus <silvamatteus@lsd.ufcg.edu.br>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request checklist**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Update in CONTRIBUTING.md about error messages and log messages.

**Description of change**

The recent documentation on log messages and error messages did not
clarify what the recommendations were about periods at the end of
the sentences. This change clarifies that.

