### PR TITLE
Remove periods at the end of log and error messages

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -417,7 +417,7 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 
 	// TODO: remove deprecated configurable in 0.12.0
 	if c.Agent.DeprecatedEnableSDS != nil {
-		ac.Log.Warn("SDS support is now always on. The enable_sds configurable is ignored and should be removed.")
+		ac.Log.Warn("SDS support is now always on. The enable_sds configurable is ignored and should be removed")
 	}
 
 	if !allowUnknownConfig {

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -431,7 +431,7 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 	}
 
 	if !hasExpectedTTLs(sc.CATTL, sc.SVIDTTL) {
-		sc.Log.Warnf("The configured SVID TTL cannot be guaranteed in all cases - SVIDs with shorter TTLs may be issued if the signing key is expiring soon. Set a CA TTL of at least 6x or reduce SVID TTL below 6x to avoid issuing SVIDs with a smaller TTL than specified.")
+		sc.Log.Warnf("The configured SVID TTL cannot be guaranteed in all cases - SVIDs with shorter TTLs may be issued if the signing key is expiring soon. Set a CA TTL of at least 6x or reduce SVID TTL below 6x to avoid issuing SVIDs with a smaller TTL than specified")
 	}
 
 	if c.Server.CAKeyType != "" {

--- a/pkg/agent/attestor/node/node.go
+++ b/pkg/agent/attestor/node/node.go
@@ -141,11 +141,11 @@ func (a *attestor) loadSVID(ctx context.Context) ([]*x509.Certificate, *ecdsa.Pr
 		}
 		return svid, key, nil
 	case privateKeyExists && svidExists && svidIsExpired:
-		a.c.Log.WithField("expiry", svid[0].NotAfter).Warn("Private key recovered, but SVID is expired. Generating new keypair.")
+		a.c.Log.WithField("expiry", svid[0].NotAfter).Warn("Private key recovered, but SVID is expired. Generating new keypair")
 	case privateKeyExists && !svidExists:
-		a.c.Log.Warn("Private key recovered, but no SVID found. Generating new keypair.")
+		a.c.Log.Warn("Private key recovered, but no SVID found. Generating new keypair")
 	case !privateKeyExists && svidExists:
-		a.c.Log.Warn("SVID recovered, but no private key found. Generating new keypair.")
+		a.c.Log.Warn("SVID recovered, but no private key found. Generating new keypair")
 	default:
 		// Neither private key nor SVID were found.
 	}

--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -166,7 +166,7 @@ func Load(ctx context.Context, config Config) (_ Catalog, err error) {
 		})
 
 		if c.Disabled {
-			pluginLog.Debug("Not loading plugin; disabled.")
+			pluginLog.Debug("Not loading plugin; disabled")
 			continue
 		}
 
@@ -198,7 +198,7 @@ func Load(ctx context.Context, config Config) (_ Catalog, err error) {
 			})
 		}
 		if err != nil {
-			pluginLog.WithError(err).Error("Failed to load plugin.")
+			pluginLog.WithError(err).Error("Failed to load plugin")
 			return nil, err
 		}
 
@@ -206,11 +206,11 @@ func Load(ctx context.Context, config Config) (_ Catalog, err error) {
 			GlobalConfig:  &config.GlobalConfig,
 			Configuration: c.Data,
 		}); err != nil {
-			pluginLog.WithError(err).Error("Failed to configure plugin.")
+			pluginLog.WithError(err).Error("Failed to configure plugin")
 			return nil, errs.New("unable to configure plugin %q: %v", c.Name, err)
 		}
 
-		pluginLog.WithField(telemetry.PluginServices, plugin.serviceNames).Info("Plugin loaded.")
+		pluginLog.WithField(telemetry.PluginServices, plugin.serviceNames).Info("Plugin loaded")
 		cat.plugins = append(cat.plugins, plugin)
 	}
 

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -157,7 +157,7 @@ func (s *CatalogSuite) TestNoKnownService() {
 	// assert we logged a message about the unknown service
 	s.assertHasLogEntry(testLogEntry{
 		Level:   logrus.WarnLevel,
-		Message: "Unknown service type.",
+		Message: "Unknown service type",
 		Data: logrus.Fields{
 			telemetry.PluginService: "Service",
 		},
@@ -177,7 +177,7 @@ func (s *CatalogSuite) TestHostServiceNotAvailable() {
 	s.assertHasLogEntries([]testLogEntry{
 		{
 			Level:   logrus.WarnLevel,
-			Message: "Host service not available.",
+			Message: "Host service not available",
 			Data: logrus.Fields{
 				"@module":        "pluginimpl",
 				"hostservice":    "HostService",
@@ -186,7 +186,7 @@ func (s *CatalogSuite) TestHostServiceNotAvailable() {
 		},
 		{
 			Level:   logrus.WarnLevel,
-			Message: "Host service not available.",
+			Message: "Host service not available",
 			Data: logrus.Fields{
 				"@module":        "serviceimpl",
 				"hostservice":    "HostService",
@@ -810,7 +810,7 @@ func extInitLogs(module string) []testLogEntry {
 	return []testLogEntry{
 		{
 			Level:   logrus.InfoLevel,
-			Message: "Configure called.",
+			Message: "Configure called",
 			Data: logrus.Fields{
 				"@module":               module,
 				"config":                "CONFIG",
@@ -820,7 +820,7 @@ func extInitLogs(module string) []testLogEntry {
 		},
 		{
 			Level:   logrus.InfoLevel,
-			Message: "Plugin loaded.",
+			Message: "Plugin loaded",
 			Data: logrus.Fields{
 				telemetry.PluginBuiltIn:  false,
 				telemetry.PluginName:     "testext",

--- a/pkg/common/catalog/init.go
+++ b/pkg/common/catalog/init.go
@@ -55,7 +55,7 @@ func newCatalogPlugin(ctx context.Context, c *grpc.ClientConn, config catalogPlu
 		for _, typ := range resp.PluginServices {
 			service, ok := servicesMap[typ]
 			if !ok {
-				config.Log.WithField(telemetry.PluginService, typ).Warn("Unknown service type.")
+				config.Log.WithField(telemetry.PluginService, typ).Warn("Unknown service type")
 				continue
 			}
 			serviceImpls = append(serviceImpls, service.NewServiceClient(c))

--- a/pkg/common/catalog/test/pluginimpl.go
+++ b/pkg/common/catalog/test/pluginimpl.go
@@ -32,7 +32,7 @@ func (s *testPlugin) BrokerHostServices(broker catalog.HostServiceBroker) error 
 	}
 	if !has && s.log != nil {
 		// s.log will only be nil if this is not used within the new plugin framework (i.e. old plugin test)
-		s.log.Warn("Host service not available.", "hostservice", "HostService")
+		s.log.Warn("Host service not available", "hostservice", "HostService")
 	}
 	return nil
 }
@@ -44,7 +44,7 @@ func (s *testPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (
 	}
 	if s.log != nil {
 		// s.log will only be nil if this is not used within the new plugin framework (i.e. old plugin test)
-		s.log.Info("Configure called.", "trustdomain", trustDomain, "config", req.Configuration)
+		s.log.Info("Configure called", "trustdomain", trustDomain, "config", req.Configuration)
 	}
 	if req.Configuration == "BAD" {
 		return nil, status.Error(codes.InvalidArgument, "BAD configuration")

--- a/pkg/common/catalog/test/serviceimpl.go
+++ b/pkg/common/catalog/test/serviceimpl.go
@@ -28,7 +28,7 @@ func (s *testService) BrokerHostServices(broker catalog.HostServiceBroker) error
 		return err
 	}
 	if !has {
-		s.log.Warn("Host service not available.", "hostservice", "HostService")
+		s.log.Warn("Host service not available", "hostservice", "HostService")
 	}
 	return nil
 }

--- a/pkg/common/cli/umask.go
+++ b/pkg/common/cli/umask.go
@@ -17,7 +17,7 @@ func SetUmask(log logrus.FieldLogger) {
 	if (currentUmask & minimumUmask) != minimumUmask {
 		badUmask := currentUmask
 		currentUmask |= minimumUmask
-		log.Warnf("Current umask %#04o is too permissive; setting umask %#04o.", badUmask, currentUmask)
+		log.Warnf("Current umask %#04o is too permissive; setting umask %#04o", badUmask, currentUmask)
 	}
 	setUmask(currentUmask)
 }

--- a/pkg/common/cli/umask_test.go
+++ b/pkg/common/cli/umask_test.go
@@ -25,14 +25,14 @@ func TestUmask(t *testing.T) {
 		// Current umask is too permissive. Set to minimum.
 		{
 			Initial: 0, Expected: 0027, Logs: []string{
-				"Current umask 0000 is too permissive; setting umask 0027.",
+				"Current umask 0000 is too permissive; setting umask 0027",
 			},
 		},
 		// Current umask is too permissive. Set to minimum making sure bits
 		// are OR'd.
 		{
 			Initial: 0125, Expected: 0127, Logs: []string{
-				"Current umask 0125 is too permissive; setting umask 0127.",
+				"Current umask 0125 is too permissive; setting umask 0127",
 			},
 		},
 	}

--- a/pkg/common/peertracker/listener.go
+++ b/pkg/common/peertracker/listener.go
@@ -78,14 +78,14 @@ func (l *Listener) Accept() (net.Conn, error) {
 		}
 
 		if err != nil {
-			l.log.WithError(err).Warn("Connection failed during accept.")
+			l.log.WithError(err).Warn("Connection failed during accept")
 			conn.Close()
 			continue
 		}
 
 		watcher, err := l.Tracker.NewWatcher(caller)
 		if err != nil {
-			l.log.WithError(err).Warn("Connection failed during accept.")
+			l.log.WithError(err).Warn("Connection failed during accept")
 			conn.Close()
 			continue
 		}

--- a/pkg/common/peertracker/listener_test.go
+++ b/pkg/common/peertracker/listener_test.go
@@ -109,7 +109,7 @@ func (p *ListenerTestSuite) TestAcceptDoesntFailWhenTrackerFails() {
 	select {
 	case logEntry := <-logCh:
 		p.Require().NotNil(logEntry)
-		p.Require().Equal("Connection failed during accept.", logEntry.Message)
+		p.Require().Equal("Connection failed during accept", logEntry.Message)
 		logErr := logEntry.Data["error"]
 		p.Require().IsType(errors.New(""), logErr)
 		p.Require().EqualError(logErr.(error), "create new watcher failed")

--- a/pkg/common/telemetry/inmem.go
+++ b/pkg/common/telemetry/inmem.go
@@ -41,7 +41,7 @@ func newInmemRunner(c *MetricsConfig) (sinkRunner, error) {
 	if logger, ok := c.Logger.(interface{ Writer() *io.PipeWriter }); ok {
 		runner.w = logger.Writer()
 	} else {
-		c.Logger.Warn("Unknown logging subsystem; disabling telemetry signaling.")
+		c.Logger.Warn("Unknown logging subsystem; disabling telemetry signaling")
 		return runner, nil
 	}
 
@@ -88,7 +88,7 @@ func (i *inmemRunner) startConfigWarning(ctx context.Context, wg *sync.WaitGroup
 			select {
 			case <-sigChannel:
 				i.log.Warn("The in-memory telemetry sink will be disabled by default in a future release." +
-					" If you wish to continue using it, please enable it in the telemetry configuration.")
+					" If you wish to continue using it, please enable it in the telemetry configuration")
 			case <-ctx.Done():
 				signal.Stop(sigChannel)
 				return

--- a/pkg/common/telemetry/inmem_test.go
+++ b/pkg/common/telemetry/inmem_test.go
@@ -100,7 +100,7 @@ func TestWarnOnFutureDisable(t *testing.T) {
 
 			if entry := hook.LastEntry(); entry != nil {
 				assert.Equal(t, "The in-memory telemetry sink will be disabled by default in a future release."+
-					" If you wish to continue using it, please enable it in the telemetry configuration.", entry.Message)
+					" If you wish to continue using it, please enable it in the telemetry configuration", entry.Message)
 				return
 			}
 		}

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -45,7 +45,7 @@ func newPrometheusRunner(c *MetricsConfig) (sinkRunner, error) {
 	}
 
 	if runner.c.Host != "localhost" {
-		runner.log.Warnf("Agent is now configured to accept remote network connections for Prometheus stats collection. Please ensure access to this port is tightly controlled.")
+		runner.log.Warnf("Agent is now configured to accept remote network connections for Prometheus stats collection. Please ensure access to this port is tightly controlled")
 	}
 
 	runner.server = &http.Server{

--- a/pkg/server/endpoints/bundle/acme_auth.go
+++ b/pkg/server/endpoints/bundle/acme_auth.go
@@ -52,7 +52,7 @@ func ACMEAuth(log logrus.FieldLogger, km keymanager.KeyManager, config ACMEConfi
 	}
 
 	if !config.ToSAccepted {
-		log.Warn("ACME Terms of Service have not been accepted. See the `tos_accepted` configurable.")
+		log.Warn("ACME Terms of Service have not been accepted. See the `tos_accepted` configurable")
 	}
 
 	return &acmeAuth{
@@ -67,7 +67,7 @@ func ACMEAuth(log logrus.FieldLogger, km keymanager.KeyManager, config ACMEConfi
 					tosLog.Info("ACME Terms of Service accepted")
 					return true
 				}
-				tosLog.Warn("ACME Terms of Service have not been accepted. See the `tos_accepted` configurable.")
+				tosLog.Warn("ACME Terms of Service have not been accepted. See the `tos_accepted` configurable")
 				return false
 			},
 			Email:      config.Email,

--- a/pkg/server/endpoints/bundle/server_test.go
+++ b/pkg/server/endpoints/bundle/server_test.go
@@ -192,7 +192,7 @@ func TestACMEAuth(t *testing.T) {
 		require.Error(t, err)
 
 		if entry := hook.LastEntry(); assert.NotNil(t, entry) {
-			assert.Equal(t, "ACME Terms of Service have not been accepted. See the `tos_accepted` configurable.", entry.Message)
+			assert.Equal(t, "ACME Terms of Service have not been accepted. See the `tos_accepted` configurable", entry.Message)
 			assert.Equal(t, logrus.WarnLevel, entry.Level)
 			assert.Equal(t, logrus.Fields{
 				"directory_url": ca.URL,

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -195,7 +195,7 @@ func (e *Endpoints) runTCPServer(ctx context.Context, server *grpc.Server) error
 		e.Log.Info("Stopping TCP server")
 		server.Stop()
 		<-errChan
-		e.Log.Info("TCP server has stopped.")
+		e.Log.Info("TCP server has stopped")
 		return nil
 	}
 }
@@ -228,7 +228,7 @@ func (e *Endpoints) runUDSServer(ctx context.Context, server *grpc.Server) error
 		e.Log.Info("Stopping UDS server")
 		server.Stop()
 		<-errChan
-		e.Log.Info("UDS server has stopped.")
+		e.Log.Info("UDS server has stopped")
 		return nil
 	}
 }

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -156,10 +156,10 @@ func authorizedEntryFetcherWithFullCache(log logrus.FieldLogger, metrics telemet
 			end := nowFn()
 			rebuildLog := log.WithField(telemetry.ElapsedTime, end.Sub(start))
 			if err != nil {
-				rebuildLog.WithError(err).Error("Failed to reload entry cache.")
+				rebuildLog.WithError(err).Error("Failed to reload entry cache")
 				return nil, err
 			}
-			rebuildLog.Debug("Reloaded entry cache.")
+			rebuildLog.Debug("Reloaded entry cache")
 			cache = newCache
 			loaded = end
 		}

--- a/pkg/server/plugin/datastore/sql/migration.go
+++ b/pkg/server/plugin/datastore/sql/migration.go
@@ -69,7 +69,7 @@ func migrateDB(db *gorm.DB, dbType string, disableMigration bool, log hclog.Logg
 	log = log.With(telemetry.VersionInfo, dbCodeVersion.String())
 
 	if schemaVersion == latestSchemaVersion {
-		log.Debug("Code and DB schema versions are the same. No migration needed.")
+		log.Debug("Code and DB schema versions are the same. No migration needed")
 
 		// same DB schema; if current code version greater than stored, store newer code version
 		if codeVersion.GT(dbCodeVersion) {
@@ -125,7 +125,7 @@ func migrateDB(db *gorm.DB, dbType string, disableMigration bool, log hclog.Logg
 		}
 	}
 
-	log.Info("Done running migrations.")
+	log.Info("Done running migrations")
 	return nil
 }
 
@@ -163,7 +163,7 @@ func isCompatibleCodeVersion(dbCodeVersion semver.Version) bool {
 }
 
 func initDB(db *gorm.DB, dbType string, log hclog.Logger) (err error) {
-	log.Info("Initializing new database.")
+	log.Info("Initializing new database")
 	tx := db.Begin()
 	if err := tx.Error; err != nil {
 		return sqlError.Wrap(err)

--- a/pkg/server/plugin/datastore/sql/sqlite.go
+++ b/pkg/server/plugin/datastore/sql/sqlite.go
@@ -17,7 +17,7 @@ type sqliteDB struct {
 
 func (s sqliteDB) connect(cfg *configuration, isReadOnly bool) (db *gorm.DB, version string, supportsCTE bool, err error) {
 	if isReadOnly {
-		s.log.Warn("Read-only connection is not applicable for sqlite3. Falling back to primary connection.")
+		s.log.Warn("Read-only connection is not applicable for sqlite3. Falling back to primary connection")
 	}
 
 	db, err = openSQLite3(cfg.ConnectionString)

--- a/pkg/server/plugin/upstreamauthority/awspca/pca.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca.go
@@ -107,7 +107,7 @@ func (m *PCAPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*
 	}
 
 	// Perform a check for the presence of the CA
-	m.log.Info("Looking up certificate authority from ACM.", "certificate_authority_arn", config.CertificateAuthorityARN)
+	m.log.Info("Looking up certificate authority from ACM", "certificate_authority_arn", config.CertificateAuthorityARN)
 	describeResponse, err := m.pcaClient.DescribeCertificateAuthorityWithContext(ctx, &acmpca.DescribeCertificateAuthorityInput{
 		CertificateAuthorityArn: aws.String(config.CertificateAuthorityARN),
 	})
@@ -118,7 +118,7 @@ func (m *PCAPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*
 	// Ensure the CA is set to ACTIVE
 	caStatus := aws.StringValue(describeResponse.CertificateAuthority.Status)
 	if caStatus != "ACTIVE" {
-		m.log.Warn("Certificate is in an invalid state for issuance.",
+		m.log.Warn("Certificate is in an invalid state for issuance",
 			"certificate_authority_arn", config.CertificateAuthorityARN,
 			"status", caStatus)
 	}
@@ -129,7 +129,7 @@ func (m *PCAPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*
 		m.signingAlgorithm = config.SigningAlgorithm
 	} else {
 		signingAlgortithm := aws.StringValue(describeResponse.CertificateAuthority.CertificateAuthorityConfiguration.SigningAlgorithm)
-		m.log.Info("No signing algorithm specified, using the CA default.", "signing_algorithm", signingAlgortithm)
+		m.log.Info("No signing algorithm specified, using the CA default", "signing_algorithm", signingAlgortithm)
 		m.signingAlgorithm = signingAlgortithm
 	}
 
@@ -138,7 +138,7 @@ func (m *PCAPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*
 	if config.CASigningTemplateARN != "" {
 		m.caSigningTemplateArn = config.CASigningTemplateARN
 	} else {
-		m.log.Info("No CA signing template ARN specified, using the default.", "ca_signing_template_arn", defaultCASigningTemplateArn)
+		m.log.Info("No CA signing template ARN specified, using the default", "ca_signing_template_arn", defaultCASigningTemplateArn)
 		m.caSigningTemplateArn = defaultCASigningTemplateArn
 	}
 
@@ -167,7 +167,7 @@ func (m *PCAPlugin) MintX509CA(request *upstreamauthority.MintX509CARequest, str
 	}
 
 	// Have ACM sign the certificate
-	m.log.Info("Submitting CSR to ACM.", "signing_algorithm", m.signingAlgorithm)
+	m.log.Info("Submitting CSR to ACM", "signing_algorithm", m.signingAlgorithm)
 	validityPeriod := time.Second * time.Duration(request.PreferredTtl)
 	issueResponse, err := m.pcaClient.IssueCertificateWithContext(ctx, &acmpca.IssueCertificateInput{
 		CertificateAuthorityArn: aws.String(m.certificateAuthorityArn),
@@ -188,7 +188,7 @@ func (m *PCAPlugin) MintX509CA(request *upstreamauthority.MintX509CARequest, str
 	// the certificate has been issued
 	certificateArn := issueResponse.CertificateArn
 
-	m.log.Info("Waiting for issuance from ACM.", "certificate_arn", aws.StringValue(certificateArn))
+	m.log.Info("Waiting for issuance from ACM", "certificate_arn", aws.StringValue(certificateArn))
 	getCertificateInput := &acmpca.GetCertificateInput{
 		CertificateAuthorityArn: aws.String(m.certificateAuthorityArn),
 		CertificateArn:          certificateArn,
@@ -197,10 +197,10 @@ func (m *PCAPlugin) MintX509CA(request *upstreamauthority.MintX509CARequest, str
 	if err != nil {
 		return err
 	}
-	m.log.Info("Certificate issued.", "certificate_arn", aws.StringValue(certificateArn))
+	m.log.Info("Certificate issued", "certificate_arn", aws.StringValue(certificateArn))
 
 	// Finally get the certificate contents
-	m.log.Info("Retrieving certificate and chain from ACM.", "certificate_arn", aws.StringValue(certificateArn))
+	m.log.Info("Retrieving certificate and chain from ACM", "certificate_arn", aws.StringValue(certificateArn))
 	getResponse, err := m.pcaClient.GetCertificateWithContext(ctx, getCertificateInput)
 	if err != nil {
 		return err
@@ -217,7 +217,7 @@ func (m *PCAPlugin) MintX509CA(request *upstreamauthority.MintX509CARequest, str
 	if err != nil {
 		return err
 	}
-	m.log.Info("Certificate and chain received.", "certificate_arn", aws.StringValue(certificateArn))
+	m.log.Info("Certificate and chain received", "certificate_arn", aws.StringValue(certificateArn))
 
 	// ACM's API outputs the certificate chain from a GetCertificate call in the following
 	// order: A (signed by B) -> B (signed by ROOT) -> ROOT.

--- a/support/k8s/k8s-workload-registrar/config_reconcile.go
+++ b/support/k8s/k8s-workload-registrar/config_reconcile.go
@@ -70,7 +70,7 @@ func (c *ReconcileMode) Run(ctx context.Context) error {
 		setupLog.Error(err, "Unable to connect to SPIRE registration API")
 		return err
 	}
-	setupLog.Info("Connected to spire server.")
+	setupLog.Info("Connected to spire server")
 
 	rootID := nodeID(c.TrustDomain, c.ControllerName, c.Cluster)
 


### PR DESCRIPTION
Signed-off-by: Matteus Silva <silvamatteus@lsd.ufcg.edu.br>


**Pull Request checklist**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Changes in log and error messages.

**Description of change**

According to CONTRIBUTING.md, section [Logs and Errors](https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md#logs-and-errors), log messages and error messages should not end with periods.

