### PR TITLE
Stop logging JWT-SVIDs that fail validation

### DIFF
--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -155,10 +155,7 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 
 	spiffeID, claims, err := jwtsvid.ValidateToken(ctx, req.Svid, keyStore, []string{req.Audience})
 	if err != nil {
-		log.WithFields(logrus.Fields{
-			telemetry.Error: err.Error(),
-			telemetry.SVID:  req.Svid,
-		}).Warn("Failed to validate JWT")
+		log.WithError(err).Warn("Failed to validate JWT")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 	log.WithField(telemetry.SPIFFEID, spiffeID).Debug("Successfully validated JWT")


### PR DESCRIPTION
While reworking the workload handler unit-tests, I noticed that we are logging JWT-SVIDs that fail validation. This is a security concern since it means that those who are able to inspect the agent log can get their hands on JWT-SVIDs, which might otherwise be valid even though the agent rejected them (e.g. mismatched audience values, workload not federated
with the JWT-SVID trust domain).

Looks like this was added by #1059 while expanding the logging around telemetry emission.

This change removes the logging of the SVID.