### PR TITLE
Close plugins that fail to configure

### DIFF
--- a/pkg/common/catalog/catalog.go
+++ b/pkg/common/catalog/catalog.go
@@ -202,6 +202,12 @@ func Load(ctx context.Context, config Config) (_ Catalog, err error) {
 			return nil, err
 		}
 
+		// Add the plugin to the plugins list even though it has not been
+		// successfully configured. If anything goes wrong (i.e. failure to
+		// configure, panic, etc.) we want the defer above to close the plugin.
+		// Failure to do so can orphan an external plugin process.
+		cat.plugins = append(cat.plugins, plugin)
+
 		if err := plugin.Configure(ctx, &spi.ConfigureRequest{
 			GlobalConfig:  &config.GlobalConfig,
 			Configuration: c.Data,
@@ -211,7 +217,6 @@ func Load(ctx context.Context, config Config) (_ Catalog, err error) {
 		}
 
 		pluginLog.WithField(telemetry.PluginServices, plugin.serviceNames).Info("Plugin loaded")
-		cat.plugins = append(cat.plugins, plugin)
 	}
 
 	return cat, nil


### PR DESCRIPTION
There is a bug in the catalog that prevents a plugin from being closed if it encounters a failure to configure. Even though spire-server shuts down, this can cause external plugin processes to be orphaned.

This is a little tricky to test via unit-testing but I did do manual verification. However, the catalog tests where orphaning the external test plugin process during the course of the testing. This change fixes that issue.

Fixes #350, fixes #351.