### PR TITLE
Support re-authenticate against the Vault if the token is not renewable

### DIFF
--- a/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
@@ -107,68 +107,135 @@ func (vcs *VaultClientSuite) Test_NewClientConfig_WithGivenMontPoint() {
 
 func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_CertAuth() {
 	vcs.fakeVaultServer.CertAuthResponseCode = 200
-	vcs.fakeVaultServer.CertAuthResponse = []byte(testCertAuthResponse)
+	for _, c := range []struct {
+		name     string
+		response []byte
+		reusable bool
+	}{
+		{
+			name:     "Cert Authentication success / Token is renewable",
+			response: []byte(testCertAuthResponse),
+			reusable: true,
+		},
+		{
+			name:     "Cert Authentication success / Token is not renewable",
+			response: []byte(testCertAuthResponseNotRenewable),
+		},
+	} {
+		c := c
+		vcs.Run(c.name, func() {
+			vcs.fakeVaultServer.CertAuthResponse = c.response
 
-	s, addr, err := vcs.fakeVaultServer.NewTLSServer()
-	vcs.Require().NoError(err)
+			s, addr, err := vcs.fakeVaultServer.NewTLSServer()
+			vcs.Require().NoError(err)
 
-	s.Start()
-	defer s.Close()
+			s.Start()
+			defer s.Close()
 
-	cp := &ClientParams{
-		VaultAddr:      fmt.Sprintf("https://%v/", addr),
-		CACertPath:     testRootCert,
-		ClientCertPath: testClientCert,
-		ClientKeyPath:  testClientKey,
+			cp := &ClientParams{
+				VaultAddr:      fmt.Sprintf("https://%v/", addr),
+				CACertPath:     testRootCert,
+				ClientCertPath: testClientCert,
+				ClientKeyPath:  testClientKey,
+			}
+			cc, err := NewClientConfig(cp, hclog.Default())
+			vcs.Require().NoError(err)
+
+			_, reusable, err := cc.NewAuthenticatedClient(CERT)
+			vcs.Require().NoError(err)
+			vcs.Require().Equal(c.reusable, reusable)
+		})
 	}
-	cc, err := NewClientConfig(cp, hclog.Default())
-	vcs.Require().NoError(err)
-
-	_, err = cc.NewAuthenticatedClient(CERT)
-	vcs.Require().NoError(err)
 }
 
 func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_TokenAuth() {
-	s, addr, err := vcs.fakeVaultServer.NewTLSServer()
-	vcs.Require().NoError(err)
+	vcs.fakeVaultServer.LookupSelfResponseCode = 200
+	for _, c := range []struct {
+		name     string
+		response []byte
+		reusable bool
+	}{
+		{
+			name:     "Token Authentication success / Token never expire",
+			response: []byte(testLookupSelfResponseNeverExpire),
+			reusable: true,
+		},
+		{
+			name:     "Token Authentication success / Token is renewable",
+			response: []byte(testLookupSelfResponse),
+			reusable: true,
+		},
+		{
+			name:     "Token Authentication success / Token is not renewable",
+			response: []byte(testLookupSelfResponseNotRenewable),
+		},
+	} {
+		c := c
+		vcs.Run(c.name, func() {
+			vcs.fakeVaultServer.LookupSelfResponse = c.response
 
-	s.Start()
-	defer s.Close()
+			s, addr, err := vcs.fakeVaultServer.NewTLSServer()
+			vcs.Require().NoError(err)
 
-	cp := &ClientParams{
-		VaultAddr:  fmt.Sprintf("https://%v/", addr),
-		CACertPath: testRootCert,
-		Token:      "test-token",
+			s.Start()
+			defer s.Close()
+
+			cp := &ClientParams{
+				VaultAddr:  fmt.Sprintf("https://%v/", addr),
+				CACertPath: testRootCert,
+				Token:      "test-token",
+			}
+			cc, err := NewClientConfig(cp, hclog.Default())
+			vcs.Require().NoError(err)
+
+			_, reusable, err := cc.NewAuthenticatedClient(TOKEN)
+			vcs.Require().NoError(err)
+			vcs.Require().Equal(c.reusable, reusable)
+		})
 	}
-	cc, err := NewClientConfig(cp, hclog.Default())
-	vcs.Require().NoError(err)
-
-	client, err := cc.NewAuthenticatedClient(TOKEN)
-	vcs.Require().NoError(err)
-	vcs.Require().Equal("test-token", client.vaultClient.Token())
 }
 
 func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_AppRoleAuth() {
 	vcs.fakeVaultServer.AppRoleAuthResponseCode = 200
-	vcs.fakeVaultServer.AppRoleAuthResponse = []byte(testAppRoleAuthResponse)
+	for _, c := range []struct {
+		name     string
+		response []byte
+		reusable bool
+	}{
+		{
+			name:     "AppRole Authentication success / Token is renewable",
+			response: []byte(testAppRoleAuthResponse),
+			reusable: true,
+		},
+		{
+			name:     "AppRole Authentication success / Token is not renewable",
+			response: []byte(testAppRoleAuthResponseNotRenewable),
+		},
+	} {
+		c := c
+		vcs.Run(c.name, func() {
+			vcs.fakeVaultServer.AppRoleAuthResponse = c.response
 
-	s, addr, err := vcs.fakeVaultServer.NewTLSServer()
-	vcs.Require().NoError(err)
+			s, addr, err := vcs.fakeVaultServer.NewTLSServer()
+			vcs.Require().NoError(err)
 
-	s.Start()
-	defer s.Close()
+			s.Start()
+			defer s.Close()
 
-	cp := &ClientParams{
-		VaultAddr:       fmt.Sprintf("https://%v/", addr),
-		CACertPath:      testRootCert,
-		AppRoleID:       "test-approle-id",
-		AppRoleSecretID: "test-approle-secret-id",
+			cp := &ClientParams{
+				VaultAddr:       fmt.Sprintf("https://%v/", addr),
+				CACertPath:      testRootCert,
+				AppRoleID:       "test-approle-id",
+				AppRoleSecretID: "test-approle-secret-id",
+			}
+			cc, err := NewClientConfig(cp, hclog.Default())
+			vcs.Require().NoError(err)
+
+			_, reusable, err := cc.NewAuthenticatedClient(APPROLE)
+			vcs.Require().NoError(err)
+			vcs.Require().Equal(c.reusable, reusable)
+		})
 	}
-	cc, err := NewClientConfig(cp, hclog.Default())
-	vcs.Require().NoError(err)
-
-	_, err = cc.NewAuthenticatedClient(APPROLE)
-	vcs.Require().NoError(err)
 }
 
 func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_CertAuthFailed() {
@@ -192,7 +259,7 @@ func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_CertAuthFailed() {
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vcs.Require().NoError(err)
 
-	_, err = cc.NewAuthenticatedClient(CERT)
+	_, _, err = cc.NewAuthenticatedClient(CERT)
 	vcs.Require().Error(err)
 }
 
@@ -216,7 +283,7 @@ func (vcs *VaultClientSuite) Test_NewAuthenticatedClient_AppRoleAuthFailed() {
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vcs.Require().NoError(err)
 
-	_, err = cc.NewAuthenticatedClient(APPROLE)
+	_, _, err = cc.NewAuthenticatedClient(APPROLE)
 	vcs.Require().Error(err)
 }
 
@@ -371,7 +438,7 @@ func (vcs *VaultClientSuite) Test_SignIntermediate() {
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vcs.Require().NoError(err)
 
-	client, err := cc.NewAuthenticatedClient(CERT)
+	client, _, err := cc.NewAuthenticatedClient(CERT)
 	vcs.Require().NoError(err)
 
 	testTTL := "0"
@@ -409,7 +476,7 @@ func (vcs *VaultClientSuite) Test_SignIntermediate_ErrorFromEndpoint() {
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vcs.Require().NoError(err)
 
-	client, err := cc.NewAuthenticatedClient(CERT)
+	client, _, err := cc.NewAuthenticatedClient(CERT)
 	vcs.Require().NoError(err)
 
 	testTTL := "0"

--- a/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
@@ -12,6 +12,7 @@ const (
 	defaultAppRoleAuthEndpoint      = "/v1/auth/approle/login"
 	defaultSignIntermediateEndpoint = "/v1/pki/root/sign-intermediate"
 	defaultRenewEndpoint            = "/v1/auth/token/renew-self"
+	defaultLookupSelfEndpoint       = "/v1/auth/token/lookup-self"
 
 	listenAddr = "127.0.0.1:0"
 )
@@ -101,10 +102,41 @@ approle_auth {
   }
 }`
 
+	testCertAuthResponseNotRenewable = `{
+  "auth": {
+    "client_token": "cf95f87d-f95b-47ff-b1f5-ba7bff850425",
+    "policies": [
+      "web",
+      "stage"
+    ],
+    "lease_duration": 3600,
+    "renewable": false
+  }
+}`
+
 	testAppRoleAuthResponse = `{
   "auth": {
     "renewable": true,
     "lease_duration": 1200,
+    "metadata": null,
+    "token_policies": [
+      "default"
+    ],
+    "accessor": "fd6c9a00-d2dc-3b11-0be5-af7ae0e1d374",
+    "client_token": "5b1a0318-679c-9c45-e5c6-d1b9a9035d49"
+  },
+  "warnings": null,
+  "wrap_info": null,
+  "data": null,
+  "lease_duration": 0,
+  "renewable": false,
+  "lease_id": ""
+}`
+
+	testAppRoleAuthResponseNotRenewable = `{
+  "auth": {
+    "renewable": false,
+    "lease_duration": 3600,
     "metadata": null,
     "token_policies": [
       "default"
@@ -157,6 +189,95 @@ approle_auth {
     "renewable": true
   }
 }`
+
+	testLookupSelfResponseNeverExpire = `{
+  "request_id": "90e4b86a-5c61-1aeb-0fc7-50a05056c3b3",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "accessor": "rQuZeGOEdH4IazavJWqwTCRk",
+    "creation_time": 1605502335,
+    "creation_ttl": 0,
+    "display_name": "root",
+    "entity_id": "",
+    "expire_time": null,
+    "explicit_max_ttl": 0,
+    "id": "test-token",
+    "meta": null,
+    "num_uses": 0,
+    "orphan": true,
+    "path": "auth/token/root",
+    "policies": [
+      "root"
+    ],
+    "ttl": 0,
+    "type": "service"
+  },
+  "warnings": null
+}`
+
+	testLookupSelfResponse = `{
+  "request_id": "8dc10d02-797d-1c23-f9f3-c7f07be89150",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "accessor": "sB3mNrjoIr2JscfNsAUM1k0A",
+    "creation_time": 1605502988,
+    "creation_ttl": 2764800,
+    "display_name": "approle",
+    "entity_id": "0bee5a2d-efe5-6fd3-9c5a-972266ecccf4",
+    "expire_time": "2020-12-18T05:03:08.5694729Z",
+    "explicit_max_ttl": 0,
+    "id": "test--token",
+    "issue_time": "2020-11-16T05:03:08.5694807Z",
+    "meta": {
+      "role_name": "test"
+    },
+    "num_uses": 0,
+    "orphan": true,
+    "path": "auth/approle/login",
+    "policies": [
+      "default"
+    ],
+    "renewable": true,
+    "ttl": 2763477,
+    "type": "service"
+  },
+  "warnings": null
+}`
+
+	testLookupSelfResponseNotRenewable = `{
+  "request_id": "ac39fad7-02d7-48df-2f8a-7a1872c41a4b",
+  "lease_id": "",
+  "lease_duration": 0,
+  "renewable": false,
+  "data": {
+    "accessor": "",
+    "creation_time": 1605506361,
+    "creation_ttl": 3600,
+    "display_name": "approle",
+    "entity_id": "0bee5a2d-efe5-6fd3-9c5a-972266ecccf4",
+    "expire_time": "2020-11-16T06:59:21Z",
+    "explicit_max_ttl": 0,
+    "id": "test-token",
+    "issue_time": "2020-11-16T05:59:21Z",
+    "meta": {
+      "role_name": "test"
+    },
+    "num_uses": 0,
+    "orphan": true,
+    "path": "auth/approle/login",
+    "policies": [
+      "default"
+    ],
+    "renewable": false,
+    "ttl": 3517,
+    "type": "batch"
+  },
+  "warnings": null
+}`
 )
 
 type FakeVaultServerConfig struct {
@@ -179,6 +300,10 @@ type FakeVaultServerConfig struct {
 	RenewReqHandler              func(code int, resp []byte) func(http.ResponseWriter, *http.Request)
 	RenewResponseCode            int
 	RenewResponse                []byte
+	LookupSelfReqEndpoint        string
+	LookupSelfReqHandler         func(code int, resp []byte) func(w http.ResponseWriter, r *http.Request)
+	LookupSelfResponseCode       int
+	LookupSelfResponse           []byte
 }
 
 // NewFakeVaultServerConfig returns VaultServerConfig with default values
@@ -193,6 +318,8 @@ func NewFakeVaultServerConfig() *FakeVaultServerConfig {
 		SignIntermediateReqHandler:  defaultReqHandler,
 		RenewReqEndpoint:            defaultRenewEndpoint,
 		RenewReqHandler:             defaultReqHandler,
+		LookupSelfReqEndpoint:       defaultLookupSelfEndpoint,
+		LookupSelfReqHandler:        defaultReqHandler,
 	}
 }
 
@@ -222,6 +349,7 @@ func (v *FakeVaultServerConfig) NewTLSServer() (srv *httptest.Server, addr strin
 	mux.HandleFunc(v.AppRoleAuthReqEndpoint, v.AppRoleAuthReqHandler(v.AppRoleAuthResponseCode, v.AppRoleAuthResponse))
 	mux.HandleFunc(v.SignIntermediateReqEndpoint, v.SignIntermediateReqHandler(v.SignIntermediateResponseCode, v.SignIntermediateResponse))
 	mux.HandleFunc(v.RenewReqEndpoint, v.RenewReqHandler(v.RenewResponseCode, v.RenewResponse))
+	mux.HandleFunc(v.LookupSelfReqEndpoint, v.LookupSelfReqHandler(v.LookupSelfResponseCode, v.LookupSelfResponse))
 
 	srv = httptest.NewUnstartedServer(mux)
 	srv.Listener = l

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -360,6 +360,8 @@ func (vps *VaultPluginSuite) Test_MintX509CA_ErrorFromVault() {
 }
 
 func (vps *VaultPluginSuite) Test_MintX509CA_InvalidVaultResponse() {
+	vps.fakeVaultServer.LookupSelfResponse = []byte(testLookupSelfResponse)
+	vps.fakeVaultServer.LookupSelfResponseCode = 200
 	vps.fakeVaultServer.SignIntermediateReqEndpoint = "/v1/test-pki/root/sign-intermediate"
 	vps.fakeVaultServer.SignIntermediateResponseCode = 200
 	vps.fakeVaultServer.SignIntermediateResponse = []byte(testInvalidSignIntermediateResponse)
@@ -372,6 +374,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidVaultResponse() {
 
 	p := vps.newPlugin()
 	p.cc = vps.getFakeClientConfig(addr)
+	p.authMethod = TOKEN
 
 	vps.LoadPlugin(builtin(p), &vps.plugin)
 	req := vps.loadMintX509CARequestFromTestFile()
@@ -382,6 +385,9 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidVaultResponse() {
 }
 
 func (vps *VaultPluginSuite) Test_MintX509CA_InvalidCSR() {
+	vps.fakeVaultServer.LookupSelfResponse = []byte(testLookupSelfResponse)
+	vps.fakeVaultServer.LookupSelfResponseCode = 200
+
 	s, addr, err := vps.fakeVaultServer.NewTLSServer()
 	vps.Require().NoError(err)
 
@@ -390,6 +396,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidCSR() {
 
 	p := vps.newPlugin()
 	p.cc = vps.getFakeClientConfig(addr)
+	p.authMethod = TOKEN
 
 	vps.LoadPlugin(builtin(p), &vps.plugin)
 	req := vps.loadMintX509CARequestFromTestFile()
@@ -397,6 +404,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidCSR() {
 
 	_, err = vps.mintX509CA(req)
 	vps.Require().Error(err)
+	vps.Require().Contains(err.Error(), "failed to parse CSR data")
 }
 
 func (vps *VaultPluginSuite) mintX509CA(req *upstreamauthority.MintX509CARequest) (*upstreamauthority.MintX509CAResponse, error) {

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -66,11 +66,13 @@ func (vps *VaultPluginSuite) Test_Configure() {
 		name       string
 		configTmpl string
 		err        string
+		wantAuth   AuthMethod
 		envKeyVal  map[string]string
 	}{
 		{
 			name:       "Configure plugin with Client Certificate authentication params given in config file",
 			configTmpl: testTokenAuthConfigTpl,
+			wantAuth:   TOKEN,
 		},
 		{
 			name:       "Configure plugin with Token authentication params given as environment variables",
@@ -78,10 +80,12 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			envKeyVal: map[string]string{
 				envVaultToken: "test-token",
 			},
+			wantAuth: TOKEN,
 		},
 		{
 			name:       "Configure plugin with Client Certificate authentication params given in config file",
 			configTmpl: testCertAuthConfigTpl,
+			wantAuth:   CERT,
 		},
 		{
 			name:       "Configure plugin with Client Certificate authentication params given as environment variables",
@@ -90,10 +94,12 @@ func (vps *VaultPluginSuite) Test_Configure() {
 				envVaultClientCert: "_test_data/keys/EC/client_cert.pem",
 				envVaultClientKey:  "_test_data/keys/EC/client_key.pem",
 			},
+			wantAuth: CERT,
 		},
 		{
 			name:       "Configure plugin with AppRole authenticate params given in config file",
 			configTmpl: testAppRoleAuthConfigTpl,
+			wantAuth:   APPROLE,
 		},
 		{
 			name:       "Configure plugin with AppRole authentication params given as environment variables",
@@ -102,6 +108,7 @@ func (vps *VaultPluginSuite) Test_Configure() {
 				envVaultAppRoleID:       "test-approle-id",
 				envVaultAppRoleSecretID: "test-approle-secret-id",
 			},
+			wantAuth: APPROLE,
 		},
 		{
 			name:       "Multiple authentication methods configured",
@@ -114,6 +121,7 @@ func (vps *VaultPluginSuite) Test_Configure() {
 			envKeyVal: map[string]string{
 				envVaultAddr: fmt.Sprintf("https://%v/", addr),
 			},
+			wantAuth: TOKEN,
 		},
 	} {
 		c := c
@@ -135,7 +143,22 @@ func (vps *VaultPluginSuite) Test_Configure() {
 				vps.Require().EqualError(err, c.err)
 				return
 			}
-			vps.Require().NotNil(p.vc.vaultClient.Token())
+
+			vps.Require().NotNil(p.cc)
+			vps.Require().NotNil(p.cc.clientParams)
+
+			switch c.wantAuth {
+			case TOKEN:
+				vps.Require().NotNil(p.cc.clientParams.Token)
+			case CERT:
+				vps.Require().NotNil(p.cc.clientParams.CertAuthMountPoint)
+				vps.Require().NotNil(p.cc.clientParams.ClientCertPath)
+				vps.Require().NotNil(p.cc.clientParams.ClientKeyPath)
+			case APPROLE:
+				vps.Require().NotNil(p.cc.clientParams.AppRoleAuthMountPoint)
+				vps.Require().NotNil(p.cc.clientParams.AppRoleID)
+				vps.Require().NotNil(p.cc.clientParams.AppRoleSecretID)
+			}
 		})
 	}
 }
@@ -154,36 +177,164 @@ func (vps *VaultPluginSuite) Test_Configure_Error_InvalidConfig() {
 }
 
 func (vps *VaultPluginSuite) Test_MintX509CA() {
-	vps.fakeVaultServer.SignIntermediateReqEndpoint = "/v1/test-pki/root/sign-intermediate"
-	vps.fakeVaultServer.SignIntermediateResponseCode = 200
-	vps.fakeVaultServer.SignIntermediateResponse = []byte(testSignIntermediateResponse)
+	for _, c := range []struct {
+		name            string
+		lookupSelfResp  []byte
+		certAuthResp    []byte
+		appRoleAuthResp []byte
+		config          *PluginConfig
+		authMethod      AuthMethod
+		reuseToken      bool
+		err             string
+	}{
+		{
+			name:           "Mint X509CA SVID with Token authentication",
+			lookupSelfResp: []byte(testLookupSelfResponse),
+			config: &PluginConfig{
+				PKIMountPoint: "test-pki",
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				TokenAuth: &TokenAuthConfig{
+					Token: "test-token",
+				},
+			},
+			authMethod: TOKEN,
+			reuseToken: true,
+		},
+		{
+			name:           "Mint X509CA SVID with Token authentication / Token is not renewable",
+			lookupSelfResp: []byte(testLookupSelfResponseNotRenewable),
+			config: &PluginConfig{
+				PKIMountPoint: "test-pki",
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				TokenAuth: &TokenAuthConfig{
+					Token: "test-token",
+				},
+			},
+			authMethod: TOKEN,
+		},
+		{
+			name:           "Mint X509CA SVID with Token authentication / Token never expire",
+			lookupSelfResp: []byte(testLookupSelfResponseNeverExpire),
+			config: &PluginConfig{
+				PKIMountPoint: "test-pki",
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				TokenAuth: &TokenAuthConfig{
+					Token: "test-token",
+				},
+			},
+			authMethod: TOKEN,
+			reuseToken: true,
+		},
+		{
+			name:         "Mint X509CA SVID with TLS cert authentication",
+			certAuthResp: []byte(testCertAuthResponse),
+			config: &PluginConfig{
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				PKIMountPoint: "test-pki",
+				CertAuth: &CertAuthConfig{
+					CertAuthMountPoint: "test-cert-auth",
+					CertAuthRoleName:   "test",
+					ClientCertPath:     "_test_data/keys/EC/client_cert.pem",
+					ClientKeyPath:      "_test_data/keys/EC/client_key.pem",
+				},
+			},
+			authMethod: CERT,
+			reuseToken: true,
+		},
+		{
+			name:            "Mint X509CA SVID with AppRole authentication",
+			appRoleAuthResp: []byte(testAppRoleAuthResponse),
+			config: &PluginConfig{
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				PKIMountPoint: "test-pki",
+				AppRoleAuth: &AppRoleAuthConfig{
+					AppRoleMountPoint: "test-approle-auth",
+					RoleID:            "test-approle-id",
+					SecretID:          "test-approle-secret-id",
+				},
+			},
+			authMethod: APPROLE,
+			reuseToken: true,
+		},
+		{
+			name:         "Mint X509CA SVID with TLS cert authentication / Token is not renewable",
+			certAuthResp: []byte(testCertAuthResponseNotRenewable),
+			config: &PluginConfig{
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				PKIMountPoint: "test-pki",
+				CertAuth: &CertAuthConfig{
+					CertAuthMountPoint: "test-cert-auth",
+					CertAuthRoleName:   "test",
+					ClientCertPath:     "_test_data/keys/EC/client_cert.pem",
+					ClientKeyPath:      "_test_data/keys/EC/client_key.pem",
+				},
+			},
+			authMethod: CERT,
+		},
+		{
+			name:            "Mint X509CA SVID with AppRole authentication / Token is not renewable",
+			appRoleAuthResp: []byte(testAppRoleAuthResponseNotRenewable),
+			config: &PluginConfig{
+				CACertPath:    "_test_data/keys/EC/root_cert.pem",
+				PKIMountPoint: "test-pki",
+				AppRoleAuth: &AppRoleAuthConfig{
+					AppRoleMountPoint: "test-approle-auth",
+					RoleID:            "test-approle-id",
+					SecretID:          "test-approle-secret-id",
+				},
+			},
+			authMethod: APPROLE,
+		},
+	} {
+		c := c
+		vps.Run(c.name, func() {
+			vps.fakeVaultServer.CertAuthResponseCode = 200
+			vps.fakeVaultServer.CertAuthResponse = c.certAuthResp
+			vps.fakeVaultServer.CertAuthReqEndpoint = "/v1/auth/test-cert-auth/login"
+			vps.fakeVaultServer.AppRoleAuthResponseCode = 200
+			vps.fakeVaultServer.AppRoleAuthResponse = c.appRoleAuthResp
+			vps.fakeVaultServer.AppRoleAuthReqEndpoint = "/v1/auth/test-approle-auth/login"
+			vps.fakeVaultServer.LookupSelfResponse = c.lookupSelfResp
+			vps.fakeVaultServer.LookupSelfResponseCode = 200
+			vps.fakeVaultServer.SignIntermediateResponseCode = 200
+			vps.fakeVaultServer.SignIntermediateResponse = []byte(testSignIntermediateResponse)
+			vps.fakeVaultServer.SignIntermediateReqEndpoint = "/v1/test-pki/root/sign-intermediate"
 
-	s, addr, err := vps.fakeVaultServer.NewTLSServer()
-	vps.Require().NoError(err)
+			s, addr, err := vps.fakeVaultServer.NewTLSServer()
+			vps.Require().NoError(err)
 
-	s.Start()
-	defer s.Close()
+			s.Start()
+			defer s.Close()
 
-	p := vps.newPlugin()
-	p.vc = vps.getFakeVaultClient(addr)
+			p := vps.newPlugin()
+			c.config.VaultAddr = fmt.Sprintf("https://%s", addr)
+			cp := genClientParams(c.authMethod, c.config)
+			cc, err := NewClientConfig(cp, p.logger)
+			vps.Require().NoError(err)
+			p.cc = cc
+			p.authMethod = c.authMethod
 
-	vps.LoadPlugin(builtin(p), &vps.plugin)
-	req := vps.loadMintX509CARequestFromTestFile()
+			vps.LoadPlugin(builtin(p), &vps.plugin)
 
-	res, err := vps.mintX509CA(req)
-	vps.Require().NoError(err)
-	vps.Require().NotNil(res)
+			req := vps.loadMintX509CARequestFromTestFile()
+			res, err := vps.mintX509CA(req)
+			vps.Require().NoError(err)
+			vps.Require().NotNil(res)
 
-	for _, certDER := range res.X509CaChain {
-		cert, err := x509.ParseCertificate(certDER)
-		vps.Require().NoError(err)
-		vps.Require().NotNil(cert)
-	}
+			for _, certDER := range res.X509CaChain {
+				cert, err := x509.ParseCertificate(certDER)
+				vps.Require().NoError(err)
+				vps.Require().NotNil(cert)
+			}
 
-	for _, upstreamDER := range res.UpstreamX509Roots {
-		upstream, err := x509.ParseCertificate(upstreamDER)
-		vps.Require().NoError(err)
-		vps.Require().NotNil(upstream)
+			for _, upstreamDER := range res.UpstreamX509Roots {
+				upstream, err := x509.ParseCertificate(upstreamDER)
+				vps.Require().NoError(err)
+				vps.Require().NotNil(upstream)
+			}
+
+			vps.Require().Equal(c.reuseToken, p.reuseToken)
+		})
 	}
 }
 
@@ -199,7 +350,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_ErrorFromVault() {
 	defer s.Close()
 
 	p := vps.newPlugin()
-	p.vc = vps.getFakeVaultClient(addr)
+	p.cc = vps.getFakeClientConfig(addr)
 
 	vps.LoadPlugin(builtin(p), &vps.plugin)
 	req := vps.loadMintX509CARequestFromTestFile()
@@ -220,7 +371,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidVaultResponse() {
 	defer s.Close()
 
 	p := vps.newPlugin()
-	p.vc = vps.getFakeVaultClient(addr)
+	p.cc = vps.getFakeClientConfig(addr)
 
 	vps.LoadPlugin(builtin(p), &vps.plugin)
 	req := vps.loadMintX509CARequestFromTestFile()
@@ -238,7 +389,7 @@ func (vps *VaultPluginSuite) Test_MintX509CA_InvalidCSR() {
 	defer s.Close()
 
 	p := vps.newPlugin()
-	p.vc = vps.getFakeVaultClient(addr)
+	p.cc = vps.getFakeClientConfig(addr)
 
 	vps.LoadPlugin(builtin(p), &vps.plugin)
 	req := vps.loadMintX509CARequestFromTestFile()
@@ -296,20 +447,17 @@ func (vps *VaultPluginSuite) loadMintX509CARequestFromTestFile() *upstreamauthor
 	}
 }
 
-func (vps *VaultPluginSuite) getFakeVaultClient(addr string) *Client {
+func (vps *VaultPluginSuite) getFakeClientConfig(addr string) *ClientConfig {
 	retry := 0
 	cp := &ClientParams{
 		MaxRetries:    &retry,
 		VaultAddr:     fmt.Sprintf("https://%v/", addr),
 		CACertPath:    testRootCert,
 		PKIMountPoint: "test-pki",
-		Token:         "test-token",
+		Token:         "fake-token",
 	}
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vps.Require().NoError(err)
 
-	client, err := cc.NewAuthenticatedClient(TOKEN)
-	vps.Require().NoError(err)
-
-	return client
+	return cc
 }

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -454,7 +454,7 @@ func (vps *VaultPluginSuite) getFakeClientConfig(addr string) *ClientConfig {
 		VaultAddr:     fmt.Sprintf("https://%v/", addr),
 		CACertPath:    testRootCert,
 		PKIMountPoint: "test-pki",
-		Token:         "fake-token",
+		Token:         "test-token",
 	}
 	cc, err := NewClientConfig(cp, hclog.Default())
 	vps.Require().NoError(err)


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

UpstreamAuthority 'vault' plugin

**Description of change**
<!-- Please provide a description of the change -->

This is able to re-authenticate against the Vault if the token is not renewable and periodic.

- Support non-renewable token (such as the batch type token)
  - A periodic token which is not renewable,  it will be re-authenticated(will not attempts to renew) at every signing request.
- Make it possible to renew the token even if use the Token Auth method .


There is no affect to the environment in which it is currently running.

FYI. https://www.vaultproject.io/docs/concepts/tokens#token-type-comparison

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

