### PR TITLE
Append h2 to the NextProtos on the TLS config returned by GetConfigForClient

### DIFF
--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -39,6 +39,8 @@ import (
 // route to the server in the case of a change in DNS membership.
 const defaultMaxConnectionAge = 3 * time.Minute
 
+const alpnProtoH2 = "h2"
+
 // Server manages gRPC and HTTP endpoint lifecycle
 type Server interface {
 	// ListenAndServe starts all endpoint servers and blocks until the context
@@ -253,6 +255,8 @@ func (e *Endpoints) getTLSConfig(ctx context.Context) func(*tls.ClientHelloInfo)
 			ClientCAs:    roots,
 
 			MinVersion: tls.VersionTLS12,
+
+			NextProtos: []string{alpnProtoH2},
 		}, nil
 	}
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -38,8 +39,6 @@ import (
 // the server sends a hangup request. This enables agents to more dynamically
 // route to the server in the case of a change in DNS membership.
 const defaultMaxConnectionAge = 3 * time.Minute
-
-const alpnProtoH2 = "h2"
 
 // Server manages gRPC and HTTP endpoint lifecycle
 type Server interface {
@@ -256,7 +255,7 @@ func (e *Endpoints) getTLSConfig(ctx context.Context) func(*tls.ClientHelloInfo)
 
 			MinVersion: tls.VersionTLS12,
 
-			NextProtos: []string{alpnProtoH2},
+			NextProtos: []string{http2.NextProtoTLS},
 		}, nil
 	}
 }


### PR DESCRIPTION
SPIRE server is passing a `tls.Config` that does not have the `h2` protocol appended. This is causing problems for non-go languages (found the issue using a java TLS client). This PR adds `h2` to the `NextProtos` property in the TLS Configuration for Client.

Fixes [#1966](https://github.com/spiffe/spire/issues/1966)