### PR TITLE
Remove grpc-ecosystem middleware deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.4.3
 	github.com/golang/protobuf v1.3.5
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/hashicorp/go-hclog v0.14.0
 	github.com/hashicorp/go-plugin v1.3.0
 	github.com/hashicorp/golang-lru v0.5.1

--- a/pkg/common/catalog/builtin.go
+++ b/pkg/common/catalog/builtin.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"sync"
 
-	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -124,8 +123,8 @@ func LoadBuiltInPlugin(ctx context.Context, builtin BuiltInPlugin) (plugin *Load
 
 func newBuiltInServer() *grpc.Server {
 	return grpc.NewServer(
-		grpc.StreamInterceptor(grpc_recovery.StreamServerInterceptor()),
-		grpc.UnaryInterceptor(grpc_recovery.UnaryServerInterceptor()),
+		grpc.StreamInterceptor(streamPanicInterceptor),
+		grpc.UnaryInterceptor(unaryPanicInterceptor),
 	)
 }
 


### PR DESCRIPTION
grpc-go has implemented chained interceptors for a while. The "recovery" interceptors are trivial to write. No real reason to continue taking this dependency.