### PR TITLE
Add `ExpiresAt` to `entry show` output

### DIFF
--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -226,6 +226,7 @@ Parent ID     : spiffe://example.org/parent
 Revision      : 0
 Downstream    : true
 TTL           : 60
+ExpiresAt     : 1552410266
 Selector      : zebra:zebra:2000
 Selector      : alpha:alpha:2000
 FederatesWith : spiffe://domaina.test

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -2,7 +2,9 @@ package entry
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/spiffe/spire/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire/proto/spire/types"
@@ -220,22 +222,22 @@ func TestCreate(t *testing.T) {
 				},
 			},
 			fakeResp: fakeRespOKFromCmd,
-			expOut: `Entry ID      : entry-id
-SPIFFE ID     : spiffe://example.org/workload
-Parent ID     : spiffe://example.org/parent
-Revision      : 0
-Downstream    : true
-TTL           : 60
-ExpiresAt     : 1552410266
-Selector      : zebra:zebra:2000
-Selector      : alpha:alpha:2000
-FederatesWith : spiffe://domaina.test
-FederatesWith : spiffe://domainb.test
-DNS name      : unu1000
-DNS name      : ung1000
-Admin         : true
+			expOut: fmt.Sprintf(`Entry ID         : entry-id
+SPIFFE ID        : spiffe://example.org/workload
+Parent ID        : spiffe://example.org/parent
+Revision         : 0
+Downstream       : true
+TTL              : 60
+Expiration time  : %s
+Selector         : zebra:zebra:2000
+Selector         : alpha:alpha:2000
+FederatesWith    : spiffe://domaina.test
+FederatesWith    : spiffe://domainb.test
+DNS name         : unu1000
+DNS name         : ung1000
+Admin            : true
 
-`,
+`, time.Unix(1552410266, 0).UTC()),
 		},
 		{
 			name: "Create succeeds using data file",
@@ -260,20 +262,20 @@ Admin         : true
 				},
 			},
 			fakeResp: fakeRespOKFromFile,
-			expOut: `Entry ID      : entry-id-1
-SPIFFE ID     : spiffe://example.org/Blog
-Parent ID     : spiffe://example.org/spire/agent/join_token/TokenBlog
-Revision      : 0
-TTL           : 200
-Selector      : unix:uid:1111
-Admin         : true
+			expOut: `Entry ID         : entry-id-1
+SPIFFE ID        : spiffe://example.org/Blog
+Parent ID        : spiffe://example.org/spire/agent/join_token/TokenBlog
+Revision         : 0
+TTL              : 200
+Selector         : unix:uid:1111
+Admin            : true
 
-Entry ID      : entry-id-2
-SPIFFE ID     : spiffe://example.org/Database
-Parent ID     : spiffe://example.org/spire/agent/join_token/TokenDatabase
-Revision      : 0
-TTL           : 200
-Selector      : unix:uid:1111
+Entry ID         : entry-id-2
+SPIFFE ID        : spiffe://example.org/Database
+Parent ID        : spiffe://example.org/spire/agent/join_token/TokenDatabase
+Revision         : 0
+TTL              : 200
+Selector         : unix:uid:1111
 
 `,
 		},
@@ -289,12 +291,12 @@ Selector      : unix:uid:1111
 			}},
 			fakeResp: fakeRespErr,
 			expOut: `FAILED to create the following entry:
-Entry ID      : 
-SPIFFE ID     : spiffe://example.org/already-exist
-Parent ID     : spiffe://example.org/spire/server
-Revision      : 0
-TTL           : default
-Selector      : unix:uid:1
+Entry ID         : 
+SPIFFE ID        : spiffe://example.org/already-exist
+Parent ID        : spiffe://example.org/spire/server
+Revision         : 0
+TTL              : default
+Selector         : unix:uid:1
 
 similar entry already exists
 `,

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -3,6 +3,7 @@ package entry
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/spiffe/spire/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire/proto/spire/types"
@@ -254,45 +255,45 @@ func getEntries(count int) []*types.Entry {
 func getPrintedEntry(idx int) string {
 	switch idx {
 	case 0:
-		return `Entry ID      : 00000000-0000-0000-0000-000000000000
-SPIFFE ID     : spiffe://example.org/son
-Parent ID     : spiffe://example.org/father
-Revision      : 0
-TTL           : default
-Selector      : foo:bar
+		return `Entry ID         : 00000000-0000-0000-0000-000000000000
+SPIFFE ID        : spiffe://example.org/son
+Parent ID        : spiffe://example.org/father
+Revision         : 0
+TTL              : default
+Selector         : foo:bar
 
 `
 	case 1:
-		return `Entry ID      : 00000000-0000-0000-0000-000000000001
-SPIFFE ID     : spiffe://example.org/daughter
-Parent ID     : spiffe://example.org/father
-Revision      : 0
-TTL           : default
-Selector      : bar:baz
-Selector      : foo:bar
+		return `Entry ID         : 00000000-0000-0000-0000-000000000001
+SPIFFE ID        : spiffe://example.org/daughter
+Parent ID        : spiffe://example.org/father
+Revision         : 0
+TTL              : default
+Selector         : bar:baz
+Selector         : foo:bar
 
 `
 	case 2:
-		return `Entry ID      : 00000000-0000-0000-0000-000000000002
-SPIFFE ID     : spiffe://example.org/daughter
-Parent ID     : spiffe://example.org/mother
-Revision      : 0
-TTL           : default
-Selector      : bar:baz
-Selector      : baz:bat
-FederatesWith : spiffe://domain.test
+		return `Entry ID         : 00000000-0000-0000-0000-000000000002
+SPIFFE ID        : spiffe://example.org/daughter
+Parent ID        : spiffe://example.org/mother
+Revision         : 0
+TTL              : default
+Selector         : bar:baz
+Selector         : baz:bat
+FederatesWith    : spiffe://domain.test
 
 `
 	case 3:
-		return `Entry ID      : 00000000-0000-0000-0000-000000000003
-SPIFFE ID     : spiffe://example.org/son
-Parent ID     : spiffe://example.org/mother
-Revision      : 0
-TTL           : default
-ExpiresAt     : 1552410266
-Selector      : baz:bat
+		return fmt.Sprintf(`Entry ID         : 00000000-0000-0000-0000-000000000003
+SPIFFE ID        : spiffe://example.org/son
+Parent ID        : spiffe://example.org/mother
+Revision         : 0
+TTL              : default
+Expiration time  : %s
+Selector         : baz:bat
 
-`
+`, time.Unix(1552410266, 0).UTC())
 	default:
 		return "index should be lower than 4"
 	}

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -238,6 +238,7 @@ func getEntries(count int) []*types.Entry {
 			ParentId:  &types.SPIFFEID{TrustDomain: "example.org", Path: "/mother"},
 			SpiffeId:  &types.SPIFFEID{TrustDomain: "example.org", Path: "/son"},
 			Selectors: []*types.Selector{selectors[2]},
+			ExpiresAt: 1552410266,
 			Id:        "00000000-0000-0000-0000-000000000003",
 		},
 	}
@@ -288,6 +289,7 @@ SPIFFE ID     : spiffe://example.org/son
 Parent ID     : spiffe://example.org/mother
 Revision      : 0
 TTL           : default
+ExpiresAt     : 1552410266
 Selector      : baz:bat
 
 `

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -2,7 +2,9 @@ package entry
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/spiffe/spire/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire/proto/spire/types"
@@ -207,22 +209,22 @@ func TestUpdate(t *testing.T) {
 				Entries: []*types.Entry{entry1},
 			},
 			fakeResp: fakeRespOKFromCmd,
-			expOut: `Entry ID      : entry-id
-SPIFFE ID     : spiffe://example.org/workload
-Parent ID     : spiffe://example.org/parent
-Revision      : 0
-Downstream    : true
-TTL           : 60
-ExpiresAt     : 1552410266
-Selector      : zebra:zebra:2000
-Selector      : alpha:alpha:2000
-FederatesWith : spiffe://domaina.test
-FederatesWith : spiffe://domainb.test
-DNS name      : unu1000
-DNS name      : ung1000
-Admin         : true
+			expOut: fmt.Sprintf(`Entry ID         : entry-id
+SPIFFE ID        : spiffe://example.org/workload
+Parent ID        : spiffe://example.org/parent
+Revision         : 0
+Downstream       : true
+TTL              : 60
+Expiration time  : %s
+Selector         : zebra:zebra:2000
+Selector         : alpha:alpha:2000
+FederatesWith    : spiffe://domaina.test
+FederatesWith    : spiffe://domainb.test
+DNS name         : unu1000
+DNS name         : ung1000
+Admin            : true
 
-`,
+`, time.Unix(1552410266, 0).UTC()),
 		},
 		{
 			name: "Update succeeds using data file",
@@ -233,20 +235,20 @@ Admin         : true
 				Entries: []*types.Entry{entry2, entry3},
 			},
 			fakeResp: fakeRespOKFromFile,
-			expOut: `Entry ID      : entry-id-1
-SPIFFE ID     : spiffe://example.org/Blog
-Parent ID     : spiffe://example.org/spire/agent/join_token/TokenBlog
-Revision      : 0
-TTL           : 200
-Selector      : unix:uid:1111
-Admin         : true
+			expOut: `Entry ID         : entry-id-1
+SPIFFE ID        : spiffe://example.org/Blog
+Parent ID        : spiffe://example.org/spire/agent/join_token/TokenBlog
+Revision         : 0
+TTL              : 200
+Selector         : unix:uid:1111
+Admin            : true
 
-Entry ID      : entry-id-2
-SPIFFE ID     : spiffe://example.org/Database
-Parent ID     : spiffe://example.org/spire/agent/join_token/TokenDatabase
-Revision      : 0
-TTL           : 200
-Selector      : unix:uid:1111
+Entry ID         : entry-id-2
+SPIFFE ID        : spiffe://example.org/Database
+Parent ID        : spiffe://example.org/spire/agent/join_token/TokenDatabase
+Revision         : 0
+TTL              : 200
+Selector         : unix:uid:1111
 
 `,
 		},
@@ -263,12 +265,12 @@ Selector      : unix:uid:1111
 			}},
 			fakeResp: fakeRespErr,
 			expOut: `FAILED to update the following entry:
-Entry ID      : non-existent-id
-SPIFFE ID     : spiffe://example.org/workload
-Parent ID     : spiffe://example.org/parent
-Revision      : 0
-TTL           : default
-Selector      : unix:uid:1
+Entry ID         : non-existent-id
+SPIFFE ID        : spiffe://example.org/workload
+Parent ID        : spiffe://example.org/parent
+Revision         : 0
+TTL              : default
+Selector         : unix:uid:1
 
 failed to update entry: datastore-sql: record not found
 `,

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -213,6 +213,7 @@ Parent ID     : spiffe://example.org/parent
 Revision      : 0
 Downstream    : true
 TTL           : 60
+ExpiresAt     : 1552410266
 Selector      : zebra:zebra:2000
 Selector      : alpha:alpha:2000
 FederatesWith : spiffe://domaina.test

--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -47,6 +47,10 @@ func printEntry(e *types.Entry, env *common_cli.Env) {
 		env.Printf("TTL           : %d\n", e.Ttl)
 	}
 
+	if e.ExpiresAt != 0 {
+		env.Printf("ExpiresAt     : %d\n", e.ExpiresAt)
+	}
+
 	for _, s := range e.Selectors {
 		env.Printf("Selector      : %s:%s\n", s.Type, s.Value)
 	}

--- a/cmd/spire-server/cli/entry/util.go
+++ b/cmd/spire-server/cli/entry/util.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
@@ -32,39 +33,39 @@ func parseSelector(str string) (*types.Selector, error) {
 }
 
 func printEntry(e *types.Entry, env *common_cli.Env) {
-	env.Printf("Entry ID      : %s\n", e.Id)
-	env.Printf("SPIFFE ID     : %s\n", protoToIDString(e.SpiffeId))
-	env.Printf("Parent ID     : %s\n", protoToIDString(e.ParentId))
-	env.Printf("Revision      : %d\n", e.RevisionNumber)
+	env.Printf("Entry ID         : %s\n", e.Id)
+	env.Printf("SPIFFE ID        : %s\n", protoToIDString(e.SpiffeId))
+	env.Printf("Parent ID        : %s\n", protoToIDString(e.ParentId))
+	env.Printf("Revision         : %d\n", e.RevisionNumber)
 
 	if e.Downstream {
-		env.Printf("Downstream    : %t\n", e.Downstream)
+		env.Printf("Downstream       : %t\n", e.Downstream)
 	}
 
 	if e.Ttl == 0 {
-		env.Printf("TTL           : default\n")
+		env.Printf("TTL              : default\n")
 	} else {
-		env.Printf("TTL           : %d\n", e.Ttl)
+		env.Printf("TTL              : %d\n", e.Ttl)
 	}
 
 	if e.ExpiresAt != 0 {
-		env.Printf("ExpiresAt     : %d\n", e.ExpiresAt)
+		env.Printf("Expiration time  : %s\n", time.Unix(e.ExpiresAt, 0).UTC())
 	}
 
 	for _, s := range e.Selectors {
-		env.Printf("Selector      : %s:%s\n", s.Type, s.Value)
+		env.Printf("Selector         : %s:%s\n", s.Type, s.Value)
 	}
 	for _, id := range e.FederatesWith {
-		env.Printf("FederatesWith : %s\n", id)
+		env.Printf("FederatesWith    : %s\n", id)
 	}
 	for _, dnsName := range e.DnsNames {
-		env.Printf("DNS name      : %s\n", dnsName)
+		env.Printf("DNS name         : %s\n", dnsName)
 	}
 
 	// admin is rare, so only show admin if true to keep
 	// from muddying the output.
 	if e.Admin {
-		env.Printf("Admin         : %t\n", e.Admin)
+		env.Printf("Admin            : %t\n", e.Admin)
 	}
 
 	env.Println()


### PR DESCRIPTION
Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Description of change**
Adds `ExpiresAt` field to the `entry show` output when the field is other than zero. 

**Which issue this PR fixes**
Fixes #1971 
