### PR TITLE
Support Vault namespace

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -569,6 +569,10 @@ plugins {
     #         # Default: ${VAULT_ADDR}.
     #         # vault_addr = ""
 
+    #         # namespace: Name of the Vault namespace.
+    #         # Default: ${VAULT_NAMESPACE}.
+    #         # namespace = ""
+
     #         # pki_mount_point: Name of the mount point where PKI secret engine is mounted.
     #         # Default: pki.
     #         # pki_mount_point = ""

--- a/doc/plugin_server_upstreamauthority_vault.md
+++ b/doc/plugin_server_upstreamauthority_vault.md
@@ -10,6 +10,7 @@ The plugin accepts the following configuration options:
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
 | vault_addr  | string |   | The URL of the Vault server. (e.g., https://vault.example.com:8443/) | `${VAULT_ADDR}` |
+| namespace        | string |  | Name of the Vault namespaces. This is only available in the Vault Enterprise. | `${VAULT_NAMESPACE}` |
 | pki_mount_point  | string |  | Name of the mount point where PKI secret engine is mounted | pki |
 | ca_cert_path     | string |  | Path to a CA certificate file used to verify the Vault server certificate. Only PEM format is supported. | `${VAULT_CACERT}` |
 | insecure_skip_verify  | bool |  | If true, vault client accepts any server certificates | false |

--- a/doc/plugin_server_upstreamauthority_vault.md
+++ b/doc/plugin_server_upstreamauthority_vault.md
@@ -10,7 +10,7 @@ The plugin accepts the following configuration options:
 | key | type | required | description | default |
 |:----|:-----|:---------|:------------|:--------|
 | vault_addr  | string |   | The URL of the Vault server. (e.g., https://vault.example.com:8443/) | `${VAULT_ADDR}` |
-| namespace        | string |  | Name of the Vault namespaces. This is only available in the Vault Enterprise. | `${VAULT_NAMESPACE}` |
+| namespace        | string |  | Name of the Vault namespace. This is only available in the Vault Enterprise. | `${VAULT_NAMESPACE}` |
 | pki_mount_point  | string |  | Name of the mount point where PKI secret engine is mounted | pki |
 | ca_cert_path     | string |  | Path to a CA certificate file used to verify the Vault server certificate. Only PEM format is supported. | `${VAULT_CACERT}` |
 | insecure_skip_verify  | bool |  | If true, vault client accepts any server certificates | false |

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/hashicorp/hcl v1.0.1-0.20190430135223-99e2f22d1c94
 	github.com/hashicorp/vault/api v1.0.4
+	github.com/hashicorp/vault/sdk v0.1.13
 	github.com/imdario/mergo v0.3.7
 	github.com/imkira/go-observer v1.0.3
 	github.com/jinzhu/gorm v1.9.9

--- a/pkg/server/plugin/upstreamauthority/vault/vault.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault.go
@@ -50,6 +50,8 @@ type PluginConfig struct {
 	// If true, vault client accepts any server certificates.
 	// It should be used only test environment so on.
 	InsecureSkipVerify bool `hcl:"insecure_skip_verify"`
+	// Name of the Vault namespaces
+	Namespace string `hcl:"namespace"`
 }
 
 // TokenAuth represents parameters for token auth method
@@ -248,6 +250,7 @@ func genClientParams(method AuthMethod, config *PluginConfig) *ClientParams {
 		CACertPath:    getEnvOrDefault(envVaultCACert, config.CACertPath),
 		PKIMountPoint: config.PKIMountPoint,
 		TLSSKipVerify: config.InsecureSkipVerify,
+		Namespace:     getEnvOrDefault(envVaultNamespace, config.Namespace),
 	}
 
 	switch method {

--- a/pkg/server/plugin/upstreamauthority/vault/vault.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault.go
@@ -50,7 +50,7 @@ type PluginConfig struct {
 	// If true, vault client accepts any server certificates.
 	// It should be used only test environment so on.
 	InsecureSkipVerify bool `hcl:"insecure_skip_verify"`
-	// Name of the Vault namespaces
+	// Name of the Vault namespace
 	Namespace string `hcl:"namespace"`
 }
 

--- a/pkg/server/plugin/upstreamauthority/vault/vault_client.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client.go
@@ -87,7 +87,7 @@ type ClientParams struct {
 	// Set to 0 to disable retrying.
 	// If the value is nil, to use the default in hashicorp/vault/api.
 	MaxRetries *int
-	// Name of the Vault namespaces
+	// Name of the Vault namespace
 	Namespace string
 }
 

--- a/pkg/server/plugin/upstreamauthority/vault/vault_client.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client.go
@@ -24,6 +24,7 @@ const (
 	envVaultCACert          = "VAULT_CACERT"
 	envVaultAppRoleID       = "VAULT_APPROLE_ID"
 	envVaultAppRoleSecretID = "VAULT_APPROLE_SECRET_ID" //// #nosec G101
+	envVaultNamespace       = "VAULT_NAMESPACE"
 
 	defaultCertMountPoint    = "cert"
 	defaultPKIMountPoint     = "pki"
@@ -86,6 +87,8 @@ type ClientParams struct {
 	// Set to 0 to disable retrying.
 	// If the value is nil, to use the default in hashicorp/vault/api.
 	MaxRetries *int
+	// Name of the Vault namespaces
+	Namespace string
 }
 
 type Client struct {
@@ -135,6 +138,10 @@ func (c *ClientConfig) NewAuthenticatedClient(method AuthMethod) (client *Client
 	vc, err := vapi.NewClient(config)
 	if err != nil {
 		return nil, false, err
+	}
+
+	if c.clientParams.Namespace != "" {
+		vc.SetNamespace(c.clientParams.Namespace)
 	}
 
 	client = &Client{

--- a/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_fake_test.go
@@ -90,6 +90,15 @@ approle_auth {
 	approle_secret_id  = "test-approle-secret-id"
 }`
 
+	testNamespaceConfigTpl = `
+namespace = "test-ns"
+vault_addr  = "{{ .Addr }}"
+pki_mount_point = "test-pki"
+ca_cert_path = "_test_data/keys/EC/root_cert.pem"
+token_auth {
+   token  = "test-token"
+}
+`
 	testCertAuthResponse = `{
   "auth": {
     "client_token": "cf95f87d-f95b-47ff-b1f5-ba7bff850425",


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

UpstreamAuthority 'vault' plugin

**Description of change**
<!-- Please provide a description of the change -->

This allows to specify the namespace to the HashiCorp Vault.
The namespace feature is available in Vault Enterprise edition.
Even If the namespace is used in normal edition, the Vault will ignore.

FYI. https://www.vaultproject.io/docs/enterprise/namespaces

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

