### PR TITLE
Remove debug logging around cache rebuild

### DIFF
--- a/pkg/server/endpoints/entryfetcher.go
+++ b/pkg/server/endpoints/entryfetcher.go
@@ -58,7 +58,6 @@ func (a *AuthorizedEntryFetcherWithFullCache) RunRebuildCacheTask(ctx context.Co
 		if err != nil {
 			a.log.WithError(err).Error("Failed to reload entry cache")
 		} else {
-			a.log.Debug("Reloaded entry cache")
 			a.mu.Lock()
 			a.cache = cache
 			a.mu.Unlock()


### PR DESCRIPTION
The cache rebuild happens every five seconds. The debug logging was useful when it first went in to make sure things were happening. However, the log line is incredibly verbose in server logs and the noise trumps utility. Telemetry that is emitted on each reload can help augment observability when diagnosing entry cache related issues.

This change removes the debug logging around cache rebuild.