### PR TITLE
Migrate OIDC Discovery Provider to new APIs

### DIFF
--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -39,12 +39,13 @@ The configuration file is **required** by the provider. It contains
 | `log_level`          | string  | required    | Log level (one of `"error"`,`"warn"`,`"info"`,`"debug"`) | `"info"` |
 | `log_path`           | string  | optional    | Path on disk to write the log.                           |          |
 | `log_requests`       | bool    | optional    | If true, all HTTP requests are logged at the debug level | false    |
-| `registration_api`   | section | required[2] | Provides Registration API details.                       |          |
+| `registration_api`   | section | required[2] | (Deprecated) Provides Registration API details.          |          |
+| `server_api`         | section | required[2] | Provides SPIRE Server API details.                       |          |
 | `workload_api`       | section | required[2] | Provides Workload API details.                           |          |
 
 [1]: One of `acme` or `listen_socket_path` must be defined.
 
-[2]: One of `registration_api` or `workload_api` must be defined. The provider relies on one of these two APIs to obtain the public key material used to construct the JWKS document.
+[2]: One of `server_api` or `workload_api` must be defined. The provider relies on one of these two APIs to obtain the public key material used to construct the JWKS document. The `registration_api` section is deprecated; the `server_api` section should be used in its place.
 
 #### ACME Section
 
@@ -55,11 +56,11 @@ The configuration file is **required** by the provider. It contains
 | `email`            | string  | required    | The email address used to register with the ACME service | |
 | `tos_accepted`     | bool    | required    | Indicates explicit acceptance of the ACME service Terms of Service. Must be true. | |
 
-#### Registration API Section
+#### Server API Section
 
 | Key                | Type     | Required? | Description                              | Default |
 | ------------------ | -------- | --------- | ----------------------------------------- | ------- |
-| `socket_path`      | string   | required  | Path on disk to the Registration API Unix Domain socket. | |
+| `address`          | string   | required  | SPIRE Server API gRPC target address. Only the unix name system is supported. See https://github.com/grpc/grpc/blob/master/doc/naming.md. | |
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
 
 #### Workload API Section
@@ -70,9 +71,16 @@ The configuration file is **required** by the provider. It contains
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
 | `trust_domain`     | string   | required  | Trust domain of the workload. This is used to pick the bundle out of the Workload API response. | |
 
+#### Registration API Section (Deprecated)
+
+| Key                | Type     | Required? | Description                              | Default |
+| ------------------ | -------- | --------- | ----------------------------------------- | ------- |
+| `socket_path`      | string   | required  | Path on disk to the Registration API Unix Domain socket. | |
+| `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
+
 ### Examples
 
-#### Registration API
+#### Server API
 
 ```
 log_level = "debug"
@@ -81,8 +89,8 @@ acme {
     cache_dir = "/some/path/on/disk/to/cache/creds"
     tos_accepted = true
 }
-registration_api {
-    socket_path = "/run/spire/sockets/registration.sock"
+server_api {
+    address = "unix:///run/spire/sockets/registration.sock"
 }
 ```
 

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -39,36 +39,7 @@ func run(configPath string) error {
 	}
 	defer log.Close()
 
-	var source JWKSSource
-	switch {
-	case config.RegistrationAPI != nil:
-		log.Warn("The registration_api configuration is deprecated in favor of server_api; please update your configuration")
-		address, err := addressFromSocketPath(config.RegistrationAPI.SocketPath)
-		if err != nil {
-			return err
-		}
-		source, err = NewServerAPISource(ServerAPISourceConfig{
-			Log:          log,
-			Address:      address,
-			PollInterval: config.RegistrationAPI.PollInterval,
-		})
-	case config.ServerAPI != nil:
-		source, err = NewServerAPISource(ServerAPISourceConfig{
-			Log:          log,
-			Address:      config.ServerAPI.Address,
-			PollInterval: config.ServerAPI.PollInterval,
-		})
-	case config.WorkloadAPI != nil:
-		source, err = NewWorkloadAPISource(WorkloadAPISourceConfig{
-			Log:          log,
-			SocketPath:   config.WorkloadAPI.SocketPath,
-			PollInterval: config.WorkloadAPI.PollInterval,
-			TrustDomain:  config.WorkloadAPI.TrustDomain,
-		})
-	default:
-		// This is defensive; LoadConfig should prevent this from happening.
-		err = errs.New("no source has been configured")
-	}
+	source, err := newSource(log, config)
 	if err != nil {
 		return err
 	}
@@ -103,7 +74,39 @@ func run(configPath string) error {
 	return http.Serve(listener, handler)
 }
 
-func acmeListener(logger *log.Logger, config *Config) net.Listener {
+func newSource(log logrus.FieldLogger, config *Config) (JWKSSource, error) {
+	switch {
+	case config.RegistrationAPI != nil:
+		log.Warn("The registration_api configuration is deprecated in favor of server_api and will be removed in a future release; please update your configuration")
+		address, err := addressFromSocketPath(config.RegistrationAPI.SocketPath)
+		if err != nil {
+			return nil, err
+		}
+		return NewServerAPISource(ServerAPISourceConfig{
+			Log:          log,
+			Address:      address,
+			PollInterval: config.RegistrationAPI.PollInterval,
+		})
+	case config.ServerAPI != nil:
+		return NewServerAPISource(ServerAPISourceConfig{
+			Log:          log,
+			Address:      config.ServerAPI.Address,
+			PollInterval: config.ServerAPI.PollInterval,
+		})
+	case config.WorkloadAPI != nil:
+		return NewWorkloadAPISource(WorkloadAPISourceConfig{
+			Log:          log,
+			SocketPath:   config.WorkloadAPI.SocketPath,
+			PollInterval: config.WorkloadAPI.PollInterval,
+			TrustDomain:  config.WorkloadAPI.TrustDomain,
+		})
+	default:
+		// This is defensive; LoadConfig should prevent this from happening.
+		return nil, errs.New("no source has been configured")
+	}
+}
+
+func acmeListener(log logrus.FieldLogger, config *Config) net.Listener {
 	var cache autocert.Cache
 	if config.ACME.CacheDir != "" {
 		cache = autocert.DirCache(config.ACME.CacheDir)
@@ -118,7 +121,7 @@ func acmeListener(logger *log.Logger, config *Config) net.Listener {
 		Email:      config.ACME.Email,
 		HostPolicy: autocert.HostWhitelist(config.Domain),
 		Prompt: func(tosURL string) bool {
-			logger.WithField("url", tosURL).Info("ACME Terms Of Service accepted")
+			log.WithField("url", tosURL).Info("ACME Terms Of Service accepted")
 			return true
 		},
 	}

--- a/support/oidc-discovery-provider/server_api.go
+++ b/support/oidc-discovery-provider/server_api.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
-	"github.com/spiffe/spire/proto/spire/api/registration"
-	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/proto/spire/api/server/bundle/v1"
+	"github.com/spiffe/spire/proto/spire/types"
 	"github.com/zeebo/errs"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -17,43 +17,43 @@ import (
 )
 
 const (
-	DefaultRegistrationAPIPollInterval = time.Second * 10
+	DefaultServerAPIPollInterval = time.Second * 10
 )
 
-type RegistrationAPISourceConfig struct {
+type ServerAPISourceConfig struct {
 	Log          logrus.FieldLogger
-	SocketPath   string
+	Address      string
 	PollInterval time.Duration
 	Clock        clock.Clock
 }
 
-type RegistrationAPISource struct {
+type ServerAPISource struct {
 	log    logrus.FieldLogger
 	clock  clock.Clock
 	cancel context.CancelFunc
 
 	mu      sync.RWMutex
 	wg      sync.WaitGroup
-	bundle  *common.Bundle
+	bundle  *types.Bundle
 	jwks    *jose.JSONWebKeySet
 	modTime time.Time
 }
 
-func NewRegistrationAPISource(config RegistrationAPISourceConfig) (*RegistrationAPISource, error) {
+func NewServerAPISource(config ServerAPISourceConfig) (*ServerAPISource, error) {
 	if config.PollInterval <= 0 {
-		config.PollInterval = DefaultRegistrationAPIPollInterval
+		config.PollInterval = DefaultServerAPIPollInterval
 	}
 	if config.Clock == nil {
 		config.Clock = clock.New()
 	}
 
-	conn, err := grpc.Dial("unix://"+config.SocketPath, grpc.WithInsecure())
+	conn, err := grpc.Dial(config.Address, grpc.WithInsecure())
 	if err != nil {
 		return nil, errs.Wrap(err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := &RegistrationAPISource{
+	s := &ServerAPISource{
 		log:    config.Log,
 		clock:  config.Clock,
 		cancel: cancel,
@@ -63,13 +63,13 @@ func NewRegistrationAPISource(config RegistrationAPISourceConfig) (*Registration
 	return s, nil
 }
 
-func (s *RegistrationAPISource) Close() error {
+func (s *ServerAPISource) Close() error {
 	s.cancel()
 	s.wg.Wait()
 	return nil
 }
 
-func (s *RegistrationAPISource) FetchKeySet() (*jose.JSONWebKeySet, time.Time, bool) {
+func (s *ServerAPISource) FetchKeySet() (*jose.JSONWebKeySet, time.Time, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	if s.jwks == nil {
@@ -78,12 +78,12 @@ func (s *RegistrationAPISource) FetchKeySet() (*jose.JSONWebKeySet, time.Time, b
 	return s.jwks, s.modTime, true
 }
 
-func (s *RegistrationAPISource) pollEvery(ctx context.Context, conn *grpc.ClientConn, interval time.Duration) {
+func (s *ServerAPISource) pollEvery(ctx context.Context, conn *grpc.ClientConn, interval time.Duration) {
 	s.wg.Add(1)
 	defer s.wg.Done()
 
 	defer conn.Close()
-	client := registration.NewRegistrationClient(conn)
+	client := bundle.NewBundleClient(conn)
 
 	s.log.WithField("interval", interval).Debug("Polling started")
 	for {
@@ -97,26 +97,25 @@ func (s *RegistrationAPISource) pollEvery(ctx context.Context, conn *grpc.Client
 	}
 }
 
-func (s *RegistrationAPISource) pollOnce(ctx context.Context, client registration.RegistrationClient) {
+func (s *ServerAPISource) pollOnce(ctx context.Context, client bundle.BundleClient) {
 	// Ensure the stream gets cleaned up
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resp, err := client.FetchBundle(ctx, &common.Empty{})
+	bundle, err := client.GetBundle(ctx, &bundle.GetBundleRequest{
+		OutputMask: &types.BundleMask{
+			JwtAuthorities: true,
+		},
+	})
 	if err != nil {
 		s.log.WithError(err).Warn("Failed to fetch bundle")
 		return
 	}
 
-	s.parseBundle(resp.Bundle)
+	s.parseBundle(bundle)
 }
 
-func (s *RegistrationAPISource) parseBundle(bundle *common.Bundle) {
-	if bundle == nil {
-		s.log.Error("Received an empty bundle from the Registration API")
-		return
-	}
-
+func (s *ServerAPISource) parseBundle(bundle *types.Bundle) {
 	// If the bundle hasn't changed, don't bother continuing
 	s.mu.RLock()
 	if s.bundle != nil && proto.Equal(s.bundle, bundle) {
@@ -126,16 +125,16 @@ func (s *RegistrationAPISource) parseBundle(bundle *common.Bundle) {
 	s.mu.RUnlock()
 
 	jwks := new(jose.JSONWebKeySet)
-	for _, key := range bundle.JwtSigningKeys {
-		publicKey, err := x509.ParsePKIXPublicKey(key.PkixBytes)
+	for _, key := range bundle.JwtAuthorities {
+		publicKey, err := x509.ParsePKIXPublicKey(key.PublicKey)
 		if err != nil {
-			s.log.WithError(err).WithField("kid", key.Kid).Warn("Malformed public key in bundle")
+			s.log.WithError(err).WithField("kid", key.KeyId).Warn("Malformed public key in bundle")
 			continue
 		}
 
 		jwks.Keys = append(jwks.Keys, jose.JSONWebKey{
 			Key:   publicKey,
-			KeyID: key.Kid,
+			KeyID: key.KeyId,
 		})
 	}
 


### PR DESCRIPTION
This change updates the OIDC Discovery Provider to use the new server APIs (namely the Bundle API) instead of the deprecated Registration API.

The `registration_api` configuration section is deprecated in favor of a new `server_api` configuration section. The only difference between the two sections is that instead of a socket path configurable, the `server_api` configuration section has an address configurable, which is a gRPC target address. Only the unix name system is supported.

The change to `address` is forward thinking to a future point where we might allow the bundle to be fetched over the TCP listener of the server, since the Bundle.GetBundle RPC is unauthenticated. I'm punting on adding that support now to keep this change scoped to simply moving away from the deprecated APIs (adding support now would neccesitate code to bootstrap the provider with a bundle to authenticate the server X509-SVID).