### PR TITLE
Remove SPIFFE ID label from metrics

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -70,9 +70,9 @@ The following metrics are emitted:
 | Call Counter | `registration_api`, `jwt_svid`, `mint` | | The Registration API is minting a JWT SVID.
 | Call Counter | `registration_api`, `x509_svid`, `mint` | | The Registration API is minting an X.509 SVID.
 | Call Counter | `registration_entry`, `manager`, `prune` | | The Registration manager is pruning entries.
-| Counter | `server_ca`, `sign`, `jwt_svid` | `spiffe_id` | The CA has successfully signed a JWT SVID with a given SPIFFE ID.
-| Counter | `server_ca`, `sign`, `x509_ca_svid` | `spiffe_id` | The CA has successfully signed an X.509 CA SVID with a given SPIFFE ID.
-| Counter | `server_ca`, `sign`, `x509_svid` | `spiffe_id` | The CA has successfully signed an X.509 SVID with a given SPIFFE ID.
+| Counter | `server_ca`, `sign`, `jwt_svid` | | The CA has successfully signed a JWT SVID.
+| Counter | `server_ca`, `sign`, `x509_ca_svid` | | The CA has successfully signed an X.509 CA SVID.
+| Counter | `server_ca`, `sign`, `x509_svid` | | The CA has successfully signed an X.509 SVID.
 | Call Counter | `svid`, `rotate` | | The Server's SVID is being rotated.
 | Gauge | `started` | `version` | | The version of the Server.
 

--- a/pkg/common/telemetry/server/ca_manager.go
+++ b/pkg/common/telemetry/server/ca_manager.go
@@ -63,27 +63,21 @@ func IncrManagerPrunedBundleCounter(m telemetry.Metrics) {
 }
 
 // IncrServerCASignJWTSVIDCounter indicate Server CA
-// signed a JWT SVID. Takes SVID's SPIFFE ID
-func IncrServerCASignJWTSVIDCounter(m telemetry.Metrics, id string) {
-	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.JWTSVID}, 1, []telemetry.Label{
-		{Name: telemetry.SPIFFEID, Value: id},
-	})
+// signed a JWT SVID.
+func IncrServerCASignJWTSVIDCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.ServerCA, telemetry.Sign, telemetry.JWTSVID}, 1)
 }
 
 // IncrServerCASignX509CACounter indicate Server CA
-// signed an X509 CA SVID. Takes SVID's SPIFFE ID
-func IncrServerCASignX509CACounter(m telemetry.Metrics, id string) {
-	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509CASVID}, 1, []telemetry.Label{
-		{Name: telemetry.SPIFFEID, Value: id},
-	})
+// signed an X509 CA SVID.
+func IncrServerCASignX509CACounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509CASVID}, 1)
 }
 
 // IncrServerCASignX509Counter indicate Server CA
-// signed an X509 SVID. Takes SVID's SPIFFE ID
-func IncrServerCASignX509Counter(m telemetry.Metrics, id string) {
-	m.IncrCounterWithLabels([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509SVID}, 1, []telemetry.Label{
-		{Name: telemetry.SPIFFEID, Value: id},
-	})
+// signed an X509 SVID.
+func IncrServerCASignX509Counter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.ServerCA, telemetry.Sign, telemetry.X509SVID}, 1)
 }
 
 // End Counters

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -222,7 +222,7 @@ func (ca *CA) SignX509SVID(ctx context.Context, params X509SVIDParams) ([]*x509.
 		telemetry.Expiration: cert.NotAfter.Format(time.RFC3339),
 	}).Debug("Signed X509 SVID")
 
-	telemetry_server.IncrServerCASignX509Counter(ca.c.Metrics, spiffeID)
+	telemetry_server.IncrServerCASignX509Counter(ca.c.Metrics)
 
 	return makeSVIDCertChain(x509CA, cert), nil
 }
@@ -270,7 +270,7 @@ func (ca *CA) SignX509CASVID(ctx context.Context, params X509CASVIDParams) ([]*x
 		telemetry.Expiration: cert.NotAfter.Format(time.RFC3339),
 	}).Debug("Signed X509 CA SVID")
 
-	telemetry_server.IncrServerCASignX509CACounter(ca.c.Metrics, spiffeID)
+	telemetry_server.IncrServerCASignX509CACounter(ca.c.Metrics)
 
 	return makeSVIDCertChain(x509CA, cert), nil
 }
@@ -296,7 +296,7 @@ func (ca *CA) SignJWTSVID(ctx context.Context, params JWTSVIDParams) (string, er
 		return "", errs.New("unable to sign JWT SVID: %v", err)
 	}
 
-	telemetry_server.IncrServerCASignJWTSVIDCounter(ca.c.Metrics, params.SpiffeID)
+	telemetry_server.IncrServerCASignJWTSVIDCounter(ca.c.Metrics)
 	ca.c.Log.WithFields(logrus.Fields{
 		telemetry.Audience:   params.Audience,
 		telemetry.Expiration: expiresAt.Format(time.RFC3339),


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
CA metrics

**Description of change**
There were three remaining counter metrics in the Server CA component
that were including a SPIFFE ID as a metric label. A SPIFFE ID is too
high of cardinality to be used as a metric label because it can cause
indexing problems in metrics backends.

In all three cases, the SPIFFE ID is already being logged in the same
place where the metric is emitted, so this information is still
available through log entries.

