### PR TITLE
[#1930] Add security considerations section to token-based node attestors

### DIFF
--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -1,5 +1,4 @@
 # Server plugin: NodeAttestor "aws_iid"
-
 *Must be used in conjunction with the agent-side aws_iid plugin*
 
 The `aws_iid` plugin automatically attests instances using the AWS Instance
@@ -9,13 +8,25 @@ attested by the aws_iid attestor will be issued a SPIFFE ID like
 `spiffe://example.org/spire/agent/aws_iid/ACCOUNT_ID/REGION/INSTANCE_ID`. Additionally,
 this plugin resolves the agent's AWS IID-based SPIFFE ID into a set of selectors.
 
+## Configuration
 | Configuration       | Description | Default                 |
 | --------------------| ----------- | ----------------------- |
 | `access_key_id`     | AWS access key id     | Value of `AWS_ACCESS_KEY_ID` environment variable |
 | `secret_access_key` | AWS secret access key | Value of `AWS_SECRET_ACCESS_KEY` environment variable |
 | `skip_block_device` | Skip anti-tampering mechanism which checks to make sure that the underlying root volume has not been detached prior to attestation. | false |
 
-The user or role identified by the credentials must have permissions for `ec2:DescribeInstances`.
+A sample configuration:
+
+```
+    NodeAttestor "aws_iid" {
+        plugin_data {
+			access_key_id = "ACCESS_KEY_ID"
+			secret_access_key = "SECRET_ACCESS_KEY"
+        }
+    }
+```
+## AWS IAM Permissions
+The user or role identified by the configured credentials must have permissions for `ec2:DescribeInstances`.
 
 The following is an example for a IAM policy needed to get instance's info from AWS.
 
@@ -35,17 +46,7 @@ The following is an example for a IAM policy needed to get instance's info from 
 
 For more information on security credentials, see https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html.
 
-A sample configuration:
-
-```
-    NodeAttestor "aws_iid" {
-        plugin_data {
-			access_key_id = "ACCESS_KEY_ID"
-			secret_access_key = "SECRET_ACCESS_KEY"
-        }
-    }
-```
-
+## Supported Selectors
 This plugin generates the following selectors related to the instance where the agent is running:
 
 | Selector            | Example                                           | Description                                                      |
@@ -55,7 +56,13 @@ This plugin generates the following selectors related to the instance where the 
 | Security Group Name | `sg:name:blog`                                    | The name of the security group the instance belongs to           |
 | IAM role            | `iamrole:arn:aws:iam::123456789012:role/Blog`     | An IAM role within the instance profile for the instance         |
 
- All of the selectors have the type `aws_iid`.
+All of the selectors have the type `aws_iid`.
 
- The `IAM role` selector is included in the generated set of selectors only if the instance has an IAM Instance Profile associated.
+The `IAM role` selector is included in the generated set of selectors only if the instance has an IAM Instance Profile associated.
 
+## Security Considerations
+The AWS Instance Identity Document, which this attestor leverages to prove node identity, is available to any process running on the node by default. As a result, it is possible for non-agent code running on a node to attest to the SPIRE Server, allowing it to obtain any workload identity that the node is authorized to run.
+
+While many operators choose to configure their systems to block access to the Instance Identity Document, the SPIRE project cannot guarantee this posture. To mitigate the associated risk, the `aws_iid` node attestor implements Trust On First Use (or TOFU) semantics. For any given node, attestation may occur only once. Subsequent attestation attempts will be rejected.
+
+It is still possible for non-agent code to complete node attestation before SPIRE Agent can, however this condition is easily and quickly detectable as SPIRE Agent will fail to start, and both SPIRE Agent and SPIRE Server will log the occurrence. Such cases should be investigated as possible security incidents.

--- a/doc/plugin_server_nodeattestor_azure_msi.md
+++ b/doc/plugin_server_nodeattestor_azure_msi.md
@@ -15,6 +15,8 @@ spiffe://<trust domain>/spire/agent/azure_msi/<tenant_id>/<principal_id>
 The server does not need to be running in Azure in order to perform node
 attestation.
 
+## Configuration
+
 | Configuration   | Description | Default                 |
 | --------------- | ----------- | ----------------------- |
 | `tenants`       | A map of tenants, keyed by tenant ID, that are authorized for attestation. Tokens for unspecified tenants are rejected. | |
@@ -46,3 +48,10 @@ A sample configuration:
         }
     }
 ```
+
+## Security Considerations
+The Azure Managed Service Identity token, which this attestor leverages to prove node identity, is available to any process running on the node by default. As a result, it is possible for non-agent code running on a node to attest to the SPIRE Server, allowing it to obtain any workload identity that the node is authorized to run.
+
+While many operators choose to configure their systems to block access to the Managed Service Identity token, the SPIRE project cannot guarantee this posture. To mitigate the associated risk, the `azure_msi` node attestor implements Trust On First Use (or TOFU) semantics. For any given node, attestation may occur only once. Subsequent attestation attempts will be rejected.
+
+It is still possible for non-agent code to complete node attestation before SPIRE Agent can, however this condition is easily and quickly detectable as SPIRE Agent will fail to start, and both SPIRE Agent and SPIRE Server will log the occurrence. Such cases should be investigated as possible security incidents.

--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -66,3 +66,10 @@ The plugin uses the Application Default Credentials to authenticate with the Goo
 
 The service account must have IAM permissions and Authorization Scopes granting access to the following APIs:
 * [compute.instances.get](https://cloud.google.com/compute/docs/reference/rest/v1/instances/get)
+
+## Security Considerations
+The Instance Identity Token, which this attestor leverages to prove node identity, is available to any process running on the node by default. As a result, it is possible for non-agent code running on a node to attest to the SPIRE Server, allowing it to obtain any workload identity that the node is authorized to run.
+
+While many operators choose to configure their systems to block access to the Instance Identity Token, the SPIRE project cannot guarantee this posture. To mitigate the associated risk, the `gcp_iit` node attestor implements Trust On First Use (or TOFU) semantics. For any given node, attestation may occur only once. Subsequent attestation attempts will be rejected.
+
+It is still possible for non-agent code to complete node attestation before SPIRE Agent can, however this condition is easily and quickly detectable as SPIRE Agent will fail to start, and both SPIRE Agent and SPIRE Server will log the occurrence. Such cases should be investigated as possible security incidents.


### PR DESCRIPTION
Node attestors which rely on instance identity tokens provided by a
cloud provider use TOFU semantics due to the fact that these tokens are
generally available to all code running on the node. This commit adds a
Security Considerations section to the reference documentation of these
attestors, describing the nature of this problem and the need for TOFU.

No other content was added or removed as part of this change, but
headings have been added to documents which previously lacked them

Fixes #1930 

Signed-off-by: Evan Gilman <egilman@vmware.com>