### PR TITLE
Introduce Ryan Turner as a CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @evan2645 @amartinezfayo @azdagron @APTy @mcpherrinm
+* @evan2645 @amartinezfayo @azdagron @APTy @rturner3
 
 #documentation
 /README.md      @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup
@@ -24,8 +24,9 @@
 # fast.co
 # @APTy
 
-# Matthew McPherrin
-# @mcpherrinm
+# Ryan Turner
+# Uber Technologies, Inc
+# @rturner3
 
 ##########################################
 # Product Manager
@@ -34,3 +35,11 @@
 # Andres Vega
 # VMware, Inc
 # @anvega
+
+##########################################
+# Community Chair
+##########################################
+
+# Umair Khan
+# Hewlett-Packard Enterprise
+# @umairmkhan


### PR DESCRIPTION
Ryan Turner (@rturner3) has been shadowing the SPIRE maintainers for quite some time. He has demonstrated a strong capability and willingness to serve the SPIRE community. The maintainers have come to consensus, and I now propose, that Ryan Turner be added as a maintainer to the SPIRE project.

Ryan will replace Matt McPherrin. Matt has recently changed jobs and is no longer responsible for workload identity in his new role. As a result, he has decided to step down from SPIRE maintainer-ship. I'd like to thank Matt for his excellent contributions over the years.

While I was in there, I also took the opportunity to add an entry for our Community Chair, Umair Khan (@umairmkhan), who was accepted as the Community Chair some time back.