### PR TITLE
Return an error if an SDS client asks for resources that don't exist.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
   integration-test:
     # Run in the machine executor since we have to execute a bunch of
     # docker containers to do the tests
-    machine: true
+    machine:
+      image: ubuntu-2004:202010-01
     parallelism: 4
     resource_class: medium
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,8 +102,8 @@ jobs:
     steps:
       - setup_remote_docker: {}
       - checkout
-      - run: make images
-      - run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local | gzip > images.tar.gz
+      - run: make images scratch-images
+      - run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > images.tar.gz
       - persist_to_workspace:
           root: ./
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - setup_remote_docker: {}
       - checkout
       - run: make images scratch-images
-      - run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > images.tar.gz
+      - run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local | gzip > images.tar.gz
       - persist_to_workspace:
           root: ./
           paths:

--- a/pkg/agent/endpoints/sdsv2/handler.go
+++ b/pkg/agent/endpoints/sdsv2/handler.go
@@ -243,10 +243,7 @@ func (h *Handler) buildResponse(versionInfo string, req *api_v2.DiscoveryRequest
 			names[name] = true
 		}
 	}
-	var returnAllEntries = false
-	if len(names) == 0 {
-		returnAllEntries = true
-	}
+	returnAllEntries := len(names) == 0
 
 	// TODO: verify the type url
 	if upd.Bundle != nil {

--- a/pkg/agent/endpoints/sdsv2/handler_test.go
+++ b/pkg/agent/endpoints/sdsv2/handler_test.go
@@ -478,7 +478,7 @@ func (s *HandlerSuite) TestFetchSecrets() {
 	s.requireSecrets(resp, workloadTLSCertificate1)
 
 	// Fetch non-existent resource
-	resp, err = s.handler.FetchSecrets(context.Background(), &api_v2.DiscoveryRequest{
+	_, err = s.handler.FetchSecrets(context.Background(), &api_v2.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/other"},
 	})
 	s.Require().Error(err)

--- a/pkg/agent/endpoints/sdsv2/handler_test.go
+++ b/pkg/agent/endpoints/sdsv2/handler_test.go
@@ -287,9 +287,8 @@ func (s *HandlerSuite) TestStreamSecretsUnknownResource() {
 	s.sendAndWait(stream, &api_v2.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/WHATEVER"},
 	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp)
+	_, err = stream.Recv()
+	s.Require().Error(err)
 }
 
 func (s *HandlerSuite) TestStreamSecretsStreaming() {
@@ -482,11 +481,7 @@ func (s *HandlerSuite) TestFetchSecrets() {
 	resp, err = s.handler.FetchSecrets(context.Background(), &api_v2.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/other"},
 	})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.requireSecrets(resp)
+	s.Require().Error(err)
 }
 
 func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -241,10 +241,7 @@ func (h *Handler) buildResponse(versionInfo string, req *discovery_v3.DiscoveryR
 			names[name] = true
 		}
 	}
-	var returnAllEntries = false
-	if len(names) == 0 {
-		returnAllEntries = true
-	}
+	returnAllEntries := len(names) == 0
 
 	// TODO: verify the type url
 	if upd.Bundle != nil {

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -241,50 +241,63 @@ func (h *Handler) buildResponse(versionInfo string, req *discovery_v3.DiscoveryR
 			names[name] = true
 		}
 	}
+	var returnAllEntries = false
+	if len(names) == 0 {
+		returnAllEntries = true
+	}
 
 	// TODO: verify the type url
 	if upd.Bundle != nil {
 		switch {
-		case len(names) == 0 || names[upd.Bundle.TrustDomainID()]:
+		case returnAllEntries || names[upd.Bundle.TrustDomainID()]:
 			validationContext, err := buildValidationContext(upd.Bundle, "")
 			if err != nil {
 				return nil, err
 			}
+			delete(names, upd.Bundle.TrustDomainID())
 			resp.Resources = append(resp.Resources, validationContext)
 		case names[h.c.DefaultBundleName]:
 			validationContext, err := buildValidationContext(upd.Bundle, h.c.DefaultBundleName)
 			if err != nil {
 				return nil, err
 			}
+			delete(names, h.c.DefaultBundleName)
 			resp.Resources = append(resp.Resources, validationContext)
 		}
 	}
 
 	for _, federatedBundle := range upd.FederatedBundles {
-		if len(names) == 0 || names[federatedBundle.TrustDomainID()] {
+		if returnAllEntries || names[federatedBundle.TrustDomainID()] {
 			validationContext, err := buildValidationContext(federatedBundle, "")
 			if err != nil {
 				return nil, err
 			}
+			delete(names, federatedBundle.TrustDomainID())
 			resp.Resources = append(resp.Resources, validationContext)
 		}
 	}
 
 	for i, identity := range upd.Identities {
 		switch {
-		case len(names) == 0 || names[identity.Entry.SpiffeId]:
+		case returnAllEntries || names[identity.Entry.SpiffeId]:
 			tlsCertificate, err := buildTLSCertificate(identity, "")
 			if err != nil {
 				return nil, err
 			}
+			delete(names, identity.Entry.SpiffeId)
 			resp.Resources = append(resp.Resources, tlsCertificate)
 		case i == 0 && names[h.c.DefaultSVIDName]:
 			tlsCertificate, err := buildTLSCertificate(identity, h.c.DefaultSVIDName)
 			if err != nil {
 				return nil, err
 			}
+			delete(names, h.c.DefaultSVIDName)
 			resp.Resources = append(resp.Resources, tlsCertificate)
 		}
+	}
+
+	if len(names) > 0 {
+		return nil, errs.New("unable to retrieve all requested identities, missing %v", names)
 	}
 
 	return resp, nil

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -287,9 +287,8 @@ func (s *HandlerSuite) TestStreamSecretsUnknownResource() {
 	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/WHATEVER"},
 	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp)
+	_, err = stream.Recv()
+	s.Require().Error(err)
 }
 
 func (s *HandlerSuite) TestStreamSecretsStreaming() {
@@ -482,11 +481,7 @@ func (s *HandlerSuite) TestFetchSecrets() {
 	resp, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/other"},
 	})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.requireSecrets(resp)
+	s.Require().Error(err)
 }
 
 func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -478,7 +478,7 @@ func (s *HandlerSuite) TestFetchSecrets() {
 	s.requireSecrets(resp, workloadTLSCertificate1)
 
 	// Fetch non-existent resource
-	resp, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
+	_, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
 		ResourceNames: []string{"spiffe://domain.test/other"},
 	})
 	s.Require().Error(err)


### PR DESCRIPTION
This will reject an SDS client if it requests resource names that don't exist.

This is a solution for SDS clients getting "stuck" if attestation fails temporarily due to some local problem (e.g. k8s attestation taking too long.)

This may cause problems if anyone is relying on a configuration where it is expected to request multiple identities/bundles in the same SDS session, some of which do not exist (yet.)

fixes #1230 
