### PR TITLE
Set TLS 1.2 minimum for all endpoints

### DIFF
--- a/pkg/server/endpoints/bundle/server.go
+++ b/pkg/server/endpoints/bundle/server.go
@@ -57,9 +57,13 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 		return errs.Wrap(err)
 	}
 
+	// Set up the TLS config, setting TLS 1.2 as the minimum.
+	tlsConfig := s.c.ServerAuth.GetTLSConfig()
+	tlsConfig.MinVersion = tls.VersionTLS12
+
 	server := &http.Server{
 		Handler:   http.HandlerFunc(s.serveHTTP),
-		TLSConfig: s.c.ServerAuth.GetTLSConfig(),
+		TLSConfig: tlsConfig,
 	}
 
 	errCh := make(chan error, 1)

--- a/support/k8s/k8s-workload-registrar/server.go
+++ b/support/k8s/k8s-workload-registrar/server.go
@@ -37,6 +37,7 @@ func NewServer(config ServerConfig) (*Server, error) {
 
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
 	}
 	if !config.InsecureSkipClientVerification {
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert


### PR DESCRIPTION
The server API endpoint already enforces TLS 1.2 as the minimum TLS
version. However, the bundle endpoint and k8s registrar endpoints still
accept TLS 1.0/1.1 clients. This change updates those servers to also
enforce at least TLS 1.2.

Fixes: #2024