### PR TITLE
Fix broken link to federation in spire-tutorials repo

### DIFF
--- a/doc/scaling_spire.md
+++ b/doc/scaling_spire.md
@@ -63,7 +63,7 @@ These multiple trust domain and interoperability use cases both require a well-d
 
 For additional detail on how this is achieved, refer to the following SPIFFE spec that describes the mechanism: https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#5-spiffe-bundle-endpoint
 
-For a tutorial on configuring Federated SPIRE, refer to: https://github.com/spiffe/spire-tutorials/tree/master/federation
+For a tutorial on configuring Federated SPIRE, refer to: https://github.com/spiffe/spire-tutorials/tree/master/docker-compose/federation
 
 # Interaction with External Systems
 


### PR DESCRIPTION
The path to the federation tutorial changed as a result of this PR:
https://github.com/spiffe/spire-tutorials/pull/50
A new docker-compose directory was added and the federation tutorial
was moved into that.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [n/a] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Doc change only.

**Description of change**
Fix broken link in doc.

**Which issue this PR fixes**
n/a
