### PR TITLE
docs: Document `container_id_cgroup_matchers` docker attestor config

### DIFF
--- a/doc/plugin_agent_workloadattestor_docker.md
+++ b/doc/plugin_agent_workloadattestor_docker.md
@@ -8,6 +8,18 @@ the docker daemon for the container's labels.
 | ------------- | ----------- |
 | docker_socket_path | The location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix). |
 | docker_version | The API version of the docker daemon. If not specified, the version is negotiated by the client.           |
+| container_id_cgroup_matchers | A list of patterns used to discover container IDs from cgroup entries. |
+
+A sample configuration:
+
+```
+    WorkloadAttestor "docker" {
+        plugin_data {
+        }
+    }
+```
+
+### Workload Selectors
 
 Since selectors are created dynamically based on the container's docker labels, there isn't a list of known selectors.
 Instead, each of the container's labels are used in creating the list of selectors.
@@ -18,14 +30,31 @@ Instead, each of the container's labels are used in creating the list of selecto
 | `docker:env`      | `docker:env:VAR=val`                | The raw string value of each of the container's environment variables. |
 | `docker:image_id` | `docker:image_id:77af4d6b9913`      | The image id of the container.                                         |
 
-A sample configuration:
+### Container ID CGroup Matchers
 
+The patterns provided should use the wildcard `*` matching token and `<id>` capture token
+to describe how a container id should be extracted from a cgroup entry. The
+given patterns MUST NOT be ambiguous and an error will be returned if multiple
+patterns can match the same input.
+
+Valid Example:
 ```
-    WorkloadAttestor "docker" {
-        plugin_data {
-        }
-    }
+    container_id_cgroup_matchers = [
+        "/docker/<id>",
+        "/my.slice/*/<id>/*"
+    ]
 ```
+
+Invalid Example:
+```
+    container_id_cgroup_matchers = [
+        "/a/b/<id>",
+        "/*/b/<id>"
+    ]
+```
+
+Note: The pattern provided is *not* a regular expression. It is a simplified matching
+language that enforces a forward slash-delimited schema.
 
 ## Example
 ### Labels

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -64,7 +64,8 @@ type dockerPluginConfig struct {
 	DockerSocketPath string `hcl:"docker_socket_path"`
 	// DockerVersion is the API version of the docker daemon. If not specified, the version is negotiated by the client.
 	DockerVersion string `hcl:"docker_version"`
-	// ContainerIDCGroupMatchers
+	// ContainerIDCGroupMatchers is a list of patterns used to discover container IDs from cgroup entries.
+	// See the documentation for cgroup.NewContainerIDFinder in the cgroup subpackage for more information.
 	ContainerIDCGroupMatchers []string `hcl:"container_id_cgroup_matchers"`
 }
 


### PR DESCRIPTION
Fixes #2023