### PR TITLE
Fix file descriptor leak in Linux Agent UDS peer tracker

### DIFF
--- a/pkg/common/peertracker/tracker_linux.go
+++ b/pkg/common/peertracker/tracker_linux.go
@@ -153,6 +153,7 @@ func getStarttime(pid int32) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("could not open caller stats: %v", err)
 	}
+	defer statfd.Close()
 
 	statBytes, err := ioutil.ReadAll(statfd)
 	if err != nil {


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Agent UDS peer tracker on Linux

**Description of change**
The `/proc/<pid>/stat` file descriptor is kept open longer than it needs
to be. This can result in SPIRE Agent opening multiple file descriptors
for the same proc stat file over time. The file descriptors will be kept open
until the garbage collector runs.

Fix by just closing the stat file descriptor at the end of the function
where it is opened and used.

