### PR TITLE
Fix file descriptor leak in linux peertracker

### DIFF
--- a/pkg/common/peertracker/tracker_linux.go
+++ b/pkg/common/peertracker/tracker_linux.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strings"
 	"sync"
 	"syscall"
@@ -149,14 +148,9 @@ func parseTaskStat(stat string) ([]string, error) {
 }
 
 func getStarttime(pid int32) (string, error) {
-	statfd, err := os.Open(fmt.Sprintf("/proc/%v/stat", pid))
+	statBytes, err := ioutil.ReadFile(fmt.Sprintf("/proc/%v/stat", pid))
 	if err != nil {
-		return "", fmt.Errorf("could not open caller stats: %v", err)
-	}
-
-	statBytes, err := ioutil.ReadAll(statfd)
-	if err != nil {
-		return "", fmt.Errorf("could not read caller stats: %v", err)
+		return "", fmt.Errorf("could not read caller stat: %v", err)
 	}
 
 	statFields, err := parseTaskStat(string(statBytes))


### PR DESCRIPTION
- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Agent Linux Peertracker


**Description of change**

statfd was never closed, so there was a file descriptor leak that
eventually got cleaned up on garbage collection due to a finalizer
on os.File.

Since the file is only opened to read the contents, the current logic
can be simplified by using `ioutil.ReadFile` which opens the file, reads
the contents, and closes the file.

**Which issue this PR fixes**
fixes #2042

