### PR TITLE
Log errors in failed user/group name lookup in unix workload attestor

### DIFF
--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/shirou/gopsutil/process"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
@@ -104,6 +105,7 @@ type Plugin struct {
 
 	mu     sync.Mutex
 	config *Configuration
+	log    hclog.Logger
 
 	// hooks for tests
 	hooks struct {
@@ -119,6 +121,10 @@ func New() *Plugin {
 	p.hooks.lookupUserByID = user.LookupId
 	p.hooks.lookupGroupByID = user.LookupGroupId
 	return p
+}
+
+func (p *Plugin) SetLogger(log hclog.Logger) {
+	p.log = log
 }
 
 func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
@@ -241,6 +247,7 @@ func (p *Plugin) getUID(proc processInfo) (string, error) {
 func (p *Plugin) getUserName(uid string) (string, bool) {
 	u, err := p.hooks.lookupUserByID(uid)
 	if err != nil {
+		p.log.Warn("failed to lookup user name by uid", "uid", uid, "error", err)
 		return "", false
 	}
 	return u.Username, true
@@ -265,6 +272,7 @@ func (p *Plugin) getGID(proc processInfo) (string, error) {
 func (p *Plugin) getGroupName(gid string) (string, bool) {
 	g, err := p.hooks.lookupGroupByID(gid)
 	if err != nil {
+		p.log.Warn("failed to lookup group name by gid", "gid", gid, "error", err)
 		return "", false
 	}
 	return g.Name, true

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -247,7 +247,7 @@ func (p *Plugin) getUID(proc processInfo) (string, error) {
 func (p *Plugin) getUserName(uid string) (string, bool) {
 	u, err := p.hooks.lookupUserByID(uid)
 	if err != nil {
-		p.log.Warn("failed to lookup user name by uid", "uid", uid, "error", err)
+		p.log.Warn("Failed to lookup user name by uid", "uid", uid, "error", err)
 		return "", false
 	}
 	return u.Username, true
@@ -272,7 +272,7 @@ func (p *Plugin) getGID(proc processInfo) (string, error) {
 func (p *Plugin) getGroupName(gid string) (string, bool) {
 	g, err := p.hooks.lookupGroupByID(gid)
 	if err != nil {
-		p.log.Warn("failed to lookup group name by gid", "gid", gid, "error", err)
+		p.log.Warn("Failed to lookup group name by gid", "gid", gid, "error", err)
 		return "", false
 	}
 	return g.Name, true


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
`unix` Workload Attestor plugin

**Description of change**
Adding logging in cases where looking up a Unix user name by `uid` or a Unix group name by `gid` fails. Currently, the `unix` attestor swallows these errors without logging or returning them. This makes it difficult to understand workload attestation failures that might be caused by one of the `unix:user` or `unix:group` selectors not being properly identified.

**Which issue this PR fixes**
fixes #2040 

