### PR TITLE
Update CODEOWNERS to remove documentation exceptions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,5 @@
 * @evan2645 @amartinezfayo @azdagron @APTy @rturner3
 
-#documentation
-/README.md      @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup
-/doc/           @evan2645 @amartinezfayo @azdagron @APTy @marcosy @ajessup
-
 ##########################################
 # Maintainers
 ##########################################


### PR DESCRIPTION
SPIRE maintainers own the docs, and have for quite some time now. This
commit removes the special-casing of documentation maintenance in the
CODEOWNERS file.

Signed-off-by: Evan Gilman <egilman@vmware.com>