### PR TITLE
Migrate agent units to using go-spiffe-v2 types

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -21,12 +21,12 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/cli"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/health"
-	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -354,11 +354,11 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 	serverHostPort := net.JoinHostPort(c.Agent.ServerAddress, strconv.Itoa(c.Agent.ServerPort))
 	ac.ServerAddress = fmt.Sprintf("dns:///%s", serverHostPort)
 
-	td, err := idutil.ParseSpiffeID("spiffe://"+c.Agent.TrustDomain, idutil.AllowAnyTrustDomain())
+	td, err := spiffeid.TrustDomainFromString(c.Agent.TrustDomain)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse trust_domain %q: %v", c.Agent.TrustDomain, err)
 	}
-	ac.TrustDomain = *td
+	ac.TrustDomain = td
 
 	ac.BindAddress = &net.UnixAddr{
 		Name: c.Agent.SocketPath,

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -634,7 +634,7 @@ func TestNewAgentConfig(t *testing.T) {
 				c.Agent.TrustDomain = "foo"
 			},
 			test: func(t *testing.T, c *agent.Config) {
-				require.Equal(t, "spiffe://foo", c.TrustDomain.String())
+				require.Equal(t, "spiffe://foo", c.TrustDomain.IDString())
 			},
 		},
 		{

--- a/pkg/agent/api/debug/v1/service_test.go
+++ b/pkg/agent/api/debug/v1/service_test.go
@@ -35,7 +35,7 @@ func TestGetInfo(t *testing.T) {
 	// Create root CA
 	ca := testca.New(t, td)
 	cachedBundleCert := ca.Bundle().X509Authorities()[0]
-	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://example.org")
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
 	cachedBundle := bundleutil.BundleFromRootCA(trustDomain, cachedBundleCert)
 
 	x509SVID := ca.CreateX509SVID(td.NewID("/spire/agent/foo"))

--- a/pkg/agent/api/debug/v1/service_test.go
+++ b/pkg/agent/api/debug/v1/service_test.go
@@ -35,7 +35,8 @@ func TestGetInfo(t *testing.T) {
 	// Create root CA
 	ca := testca.New(t, td)
 	cachedBundleCert := ca.Bundle().X509Authorities()[0]
-	cachedBundle := bundleutil.BundleFromRootCA("spiffe://example.org", cachedBundleCert)
+	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://example.org")
+	cachedBundle := bundleutil.BundleFromRootCA(trustDomain, cachedBundleCert)
 
 	x509SVID := ca.CreateX509SVID(td.NewID("/spire/agent/foo"))
 

--- a/pkg/agent/attestor/node/node_test.go
+++ b/pkg/agent/attestor/node/node_test.go
@@ -327,16 +327,13 @@ func TestAttestor(t *testing.T) {
 			// create the attestor
 			log, _ := test.NewNullLogger()
 			attestor := attestor.New(&attestor.Config{
-				Catalog:         catalog,
-				Metrics:         telemetry.Blackhole{},
-				JoinToken:       testCase.agentService.joinToken,
-				SVIDCachePath:   svidCachePath,
-				BundleCachePath: bundleCachePath,
-				Log:             log,
-				TrustDomain: url.URL{
-					Scheme: "spiffe",
-					Host:   trustDomain.String(),
-				},
+				Catalog:           catalog,
+				Metrics:           telemetry.Blackhole{},
+				JoinToken:         testCase.agentService.joinToken,
+				SVIDCachePath:     svidCachePath,
+				BundleCachePath:   bundleCachePath,
+				Log:               log,
+				TrustDomain:       trustDomain,
 				TrustBundle:       makeTrustBundle(testCase.bootstrapBundle),
 				InsecureBootstrap: testCase.insecureBootstrap,
 				ServerAddress:     listener.Addr().String(),

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net/url"
 	"sync"
 	"time"
 
@@ -57,7 +56,7 @@ type Client interface {
 type Config struct {
 	Addr        string
 	Log         logrus.FieldLogger
-	TrustDomain url.URL
+	TrustDomain spiffeid.TrustDomain
 	// KeysAndBundle is a callback that must return the keys and bundle used by the client
 	// to connect via mTLS to Addr.
 	KeysAndBundle func() ([]*x509.Certificate, *ecdsa.PrivateKey, []*x509.Certificate)
@@ -286,7 +285,7 @@ func (c *client) release(conn *nodeConn) {
 func (c *client) dial(ctx context.Context) (*grpc.ClientConn, error) {
 	return DialServer(ctx, DialServerConfig{
 		Address:     c.c.Addr,
-		TrustDomain: c.c.TrustDomain.Host,
+		TrustDomain: c.c.TrustDomain,
 		GetBundle: func() []*x509.Certificate {
 			_, _, bundle := c.c.KeysAndBundle()
 			return bundle

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -5,12 +5,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"errors"
-	"net/url"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	agentpb "github.com/spiffe/spire/proto/spire/api/server/agent/v1"
 	bundlepb "github.com/spiffe/spire/proto/spire/api/server/bundle/v1"
 	entrypb "github.com/spiffe/spire/proto/spire/api/server/entry/v1"
@@ -26,7 +26,7 @@ import (
 var (
 	log, _ = test.NewNullLogger()
 
-	trustDomainURL = url.URL{Scheme: "spiffe", Host: "example.org"}
+	trustDomain = spiffeid.RequireTrustDomainFromString("example.org")
 
 	testEntries = []*common.RegistrationEntry{
 		{
@@ -565,7 +565,7 @@ func TestFetchUpdatesReleaseConnectionIfItFails(t *testing.T) {
 func TestNewAgentClientFailsDial(t *testing.T) {
 	client := newClient(&Config{
 		KeysAndBundle: keysAndBundle,
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	agentClient, conn, err := client.newAgentClient(context.Background())
 	require.Error(t, err)
@@ -577,7 +577,7 @@ func TestNewAgentClientFailsDial(t *testing.T) {
 func TestNewBundleClientFailsDial(t *testing.T) {
 	client := newClient(&Config{
 		KeysAndBundle: keysAndBundle,
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	agentClient, conn, err := client.newBundleClient(context.Background())
 	require.Error(t, err)
@@ -589,7 +589,7 @@ func TestNewBundleClientFailsDial(t *testing.T) {
 func TestNewEntryClientFailsDial(t *testing.T) {
 	client := newClient(&Config{
 		KeysAndBundle: keysAndBundle,
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	agentClient, conn, err := client.newEntryClient(context.Background())
 	require.Error(t, err)
@@ -601,7 +601,7 @@ func TestNewEntryClientFailsDial(t *testing.T) {
 func TestNewSVIDClientFailsDial(t *testing.T) {
 	client := newClient(&Config{
 		KeysAndBundle: keysAndBundle,
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	agentClient, conn, err := client.newSVIDClient(context.Background())
 	require.Error(t, err)
@@ -720,7 +720,7 @@ func createClient() (*client, *testClient) {
 		Log:           log,
 		KeysAndBundle: keysAndBundle,
 		RotMtx:        new(sync.RWMutex),
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	client.createNewAgentClient = func(conn grpc.ClientConnInterface) agentpb.AgentClient {
 		return tc.agentClient

--- a/pkg/agent/client/dial.go
+++ b/pkg/agent/client/dial.go
@@ -28,8 +28,7 @@ type DialServerConfig struct {
 	// Address is the SPIRE server address
 	Address string
 
-	// TrustDomain is the trust domain ID for the agent/server
-	TrustDomain string
+	TrustDomain spiffeid.TrustDomain
 
 	// GetBundle is a required callback that returns the current trust bundle
 	// for used to authenticate the server certificate.
@@ -44,12 +43,8 @@ type DialServerConfig struct {
 }
 
 func DialServer(ctx context.Context, config DialServerConfig) (*grpc.ClientConn, error) {
-	td, err := spiffeid.TrustDomainFromString(config.TrustDomain)
-	if err != nil {
-		return nil, err
-	}
-	bundleSource := newBundleSource(td, config.GetBundle)
-	serverID := td.NewID(idutil.ServerIDPath)
+	bundleSource := newBundleSource(config.TrustDomain, config.GetBundle)
+	serverID := idutil.ServerID(config.TrustDomain)
 	authorizer := tlsconfig.AuthorizeID(serverID)
 
 	var tlsConfig *tls.Config

--- a/pkg/agent/client/nodeconn_test.go
+++ b/pkg/agent/client/nodeconn_test.go
@@ -27,7 +27,7 @@ func newTestConn(t *testing.T) *grpc.ClientConn {
 	client := newClient(&Config{
 		Log:           log,
 		KeysAndBundle: keysAndBundle,
-		TrustDomain:   trustDomainURL,
+		TrustDomain:   trustDomain,
 	})
 	client.dialContext = func(ctx context.Context, addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 		// make a normal grpc dial but without any of the provided options that may cause it to fail

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -3,10 +3,10 @@ package agent
 import (
 	"crypto/x509"
 	"net"
-	"net/url"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -46,7 +46,7 @@ type Config struct {
 	SyncInterval time.Duration
 
 	// Trust domain and associated CA bundle
-	TrustDomain url.URL
+	TrustDomain spiffeid.TrustDomain
 	TrustBundle []*x509.Certificate
 
 	// Join token to use for attestation, if needed

--- a/pkg/agent/endpoints/sdsv2/handler_test.go
+++ b/pkg/agent/endpoints/sdsv2/handler_test.go
@@ -14,6 +14,7 @@ import (
 	core_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	sds_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/common/api/middleware"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
@@ -28,7 +29,7 @@ import (
 )
 
 var (
-	tdBundle = bundleutil.BundleFromRootCA("spiffe://domain.test", &x509.Certificate{
+	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://domain.test"), &x509.Certificate{
 		Raw: []byte("BUNDLE"),
 	})
 	tdValidationContext = &auth_v2.Secret{
@@ -57,7 +58,7 @@ var (
 		},
 	}
 
-	fedBundle = bundleutil.BundleFromRootCA("spiffe://otherdomain.test", &x509.Certificate{
+	fedBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("otherdomain.test"), &x509.Certificate{
 		Raw: []byte("FEDBUNDLE"),
 	})
 	fedValidationContext = &auth_v2.Secret{

--- a/pkg/agent/endpoints/sdsv2/handler_test.go
+++ b/pkg/agent/endpoints/sdsv2/handler_test.go
@@ -499,8 +499,8 @@ func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {
 				},
 			},
 			Bundle: tdBundle,
-			FederatedBundles: map[string]*bundleutil.Bundle{
-				"spiffe://otherdomain.test": fedBundle,
+			FederatedBundles: map[spiffeid.TrustDomain]*bundleutil.Bundle{
+				spiffeid.RequireTrustDomainFromString("otherdomain.test"): fedBundle,
 			},
 		}
 	}

--- a/pkg/agent/endpoints/sdsv2/handler_test.go
+++ b/pkg/agent/endpoints/sdsv2/handler_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://domain.test"), &x509.Certificate{
+	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("domain.test"), &x509.Certificate{
 		Raw: []byte("BUNDLE"),
 	})
 	tdValidationContext = &auth_v2.Secret{

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -499,8 +499,8 @@ func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {
 				},
 			},
 			Bundle: tdBundle,
-			FederatedBundles: map[string]*bundleutil.Bundle{
-				"spiffe://otherdomain.test": fedBundle,
+			FederatedBundles: map[spiffeid.TrustDomain]*bundleutil.Bundle{
+				spiffeid.RequireTrustDomainFromString("otherdomain.test"): fedBundle,
 			},
 		}
 	}

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://domain.test"), &x509.Certificate{
+	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("domain.test"), &x509.Certificate{
 		Raw: []byte("BUNDLE"),
 	})
 	tdValidationContext = &tls_v3.Secret{
@@ -58,7 +58,7 @@ var (
 		},
 	}
 
-	fedBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://otherdomain.test"), &x509.Certificate{
+	fedBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("otherdomain.test"), &x509.Certificate{
 		Raw: []byte("FEDBUNDLE"),
 	})
 	fedValidationContext = &tls_v3.Secret{

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -14,6 +14,7 @@ import (
 	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/common/api/middleware"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
@@ -28,7 +29,7 @@ import (
 )
 
 var (
-	tdBundle = bundleutil.BundleFromRootCA("spiffe://domain.test", &x509.Certificate{
+	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://domain.test"), &x509.Certificate{
 		Raw: []byte("BUNDLE"),
 	})
 	tdValidationContext = &tls_v3.Secret{
@@ -57,7 +58,7 @@ var (
 		},
 	}
 
-	fedBundle = bundleutil.BundleFromRootCA("spiffe://otherdomain.test", &x509.Certificate{
+	fedBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("spiffe://otherdomain.test"), &x509.Certificate{
 		Raw: []byte("FEDBUNDLE"),
 	})
 	fedValidationContext = &tls_v3.Secret{

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 		id, err := spiffeid.FromString(spiffeID)
 		if err != nil {
 			log.WithError(err).Errorf("Invalid requested SPIFFE ID: %s", spiffeID)
-			return nil, fmt.Errorf("invalid requested SPIFFE ID: %w", err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid requested SPIFFE ID: %v", err)
 		}
 
 		svid, err = h.c.Manager.FetchJWTSVID(ctx, id, req.Audience)

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -93,8 +93,10 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 
 		id, err := spiffeid.FromString(spiffeID)
 		if err != nil {
-			return nil, err
+			log.WithError(err).Errorf("Invalid requested SPIFFE ID: %s", spiffeID)
+			return nil, fmt.Errorf("invalid requested SPIFFE ID: %w", err)
 		}
+
 		svid, err = h.c.Manager.FetchJWTSVID(ctx, id, req.Audience)
 		if err != nil {
 			log.WithError(err).Error("Could not fetch JWT-SVID")
@@ -257,8 +259,8 @@ func composeX509SVIDResponse(update *cache.WorkloadUpdate) (*workload.X509SVIDRe
 
 	bundle := marshalBundle(update.Bundle.RootCAs())
 
-	for id, federatedBundle := range update.FederatedBundles {
-		resp.FederatedBundles[id] = marshalBundle(federatedBundle.RootCAs())
+	for td, federatedBundle := range update.FederatedBundles {
+		resp.FederatedBundles[td.IDString()] = marshalBundle(federatedBundle.RootCAs())
 	}
 
 	for _, identity := range update.Identities {

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/api/rpccontext"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
@@ -29,7 +30,7 @@ import (
 type Manager interface {
 	SubscribeToCacheChanges(cache.Selectors) cache.Subscriber
 	MatchingIdentities([]*common.Selector) []cache.Identity
-	FetchJWTSVID(ctx context.Context, spiffeID string, audience []string) (*client.JWTSVID, error)
+	FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audience []string) (*client.JWTSVID, error)
 	FetchWorkloadUpdate([]*common.Selector) *cache.WorkloadUpdate
 }
 
@@ -89,7 +90,12 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 		loopLog := log.WithField(telemetry.SPIFFEID, spiffeID)
 
 		var svid *client.JWTSVID
-		svid, err = h.c.Manager.FetchJWTSVID(ctx, spiffeID, req.Audience)
+
+		id, err := spiffeid.FromString(spiffeID)
+		if err != nil {
+			return nil, err
+		}
+		svid, err = h.c.Manager.FetchJWTSVID(ctx, id, req.Audience)
 		if err != nil {
 			log.WithError(err).Error("Could not fetch JWT-SVID")
 			return nil, status.Errorf(codes.Unavailable, "could not fetch JWT-SVID: %v", err)

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -106,8 +106,8 @@ func TestFetchX509SVID(t *testing.T) {
 					identityFromX509SVID(x509SVID1),
 				},
 				Bundle: utilBundleFromBundle(t, bundle),
-				FederatedBundles: map[string]*bundleutil.Bundle{
-					federatedBundle.TrustDomain().IDString(): utilBundleFromBundle(t, federatedBundle),
+				FederatedBundles: map[spiffeid.TrustDomain]*bundleutil.Bundle{
+					federatedBundle.TrustDomain(): utilBundleFromBundle(t, federatedBundle),
 				},
 			}},
 			expectCode: codes.OK,
@@ -395,8 +395,8 @@ func TestFetchJWTBundles(t *testing.T) {
 						identityFromX509SVID(x509SVID),
 					},
 					Bundle: utilBundleFromBundle(t, bundle),
-					FederatedBundles: map[string]*bundleutil.Bundle{
-						federatedBundle.TrustDomain().IDString(): utilBundleFromBundle(t, federatedBundle),
+					FederatedBundles: map[spiffeid.TrustDomain]*bundleutil.Bundle{
+						federatedBundle.TrustDomain(): utilBundleFromBundle(t, federatedBundle),
 					},
 				},
 			},
@@ -446,8 +446,8 @@ func TestValidateJWTSVID(t *testing.T) {
 
 	updatesWithFederatedBundle := []*cache.WorkloadUpdate{{
 		Bundle: utilBundleFromBundle(t, bundle),
-		FederatedBundles: map[string]*bundleutil.Bundle{
-			federatedBundle.TrustDomain().IDString(): utilBundleFromBundle(t, federatedBundle),
+		FederatedBundles: map[spiffeid.TrustDomain]*bundleutil.Bundle{
+			federatedBundle.TrustDomain(): utilBundleFromBundle(t, federatedBundle),
 		},
 	}}
 

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -661,8 +661,8 @@ func (m *FakeManager) MatchingIdentities(selectors []*common.Selector) []cache.I
 	return m.identities
 }
 
-func (m *FakeManager) FetchJWTSVID(ctx context.Context, spiffeID string, audience []string) (*client.JWTSVID, error) {
-	svid := m.ca.CreateJWTSVID(spiffeid.RequireFromString(spiffeID), audience)
+func (m *FakeManager) FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audience []string) (*client.JWTSVID, error) {
+	svid := m.ca.CreateJWTSVID(spiffeID, audience)
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/pkg/agent/manager/cache/bundle_cache.go
+++ b/pkg/agent/manager/cache/bundle_cache.go
@@ -2,20 +2,21 @@ package cache
 
 import (
 	"github.com/imkira/go-observer"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 )
 
 type BundleCache struct {
-	trustDomainID string
-	bundles       observer.Property
+	trustDomain spiffeid.TrustDomain
+	bundles     observer.Property
 }
 
-func NewBundleCache(trustDomainID string, bundle *Bundle) *BundleCache {
+func NewBundleCache(trustDomain spiffeid.TrustDomain, bundle *Bundle) *BundleCache {
 	bundles := map[string]*Bundle{
-		trustDomainID: bundle,
+		trustDomain.IDString(): bundle,
 	}
 	return &BundleCache{
-		trustDomainID: trustDomainID,
-		bundles:       observer.NewProperty(bundles),
+		trustDomain: trustDomain,
+		bundles:     observer.NewProperty(bundles),
 	}
 }
 
@@ -26,7 +27,7 @@ func (c *BundleCache) Update(bundles map[string]*Bundle) {
 }
 
 func (c *BundleCache) Bundle() *Bundle {
-	return c.Bundles()[c.trustDomainID]
+	return c.Bundles()[c.trustDomain.IDString()]
 }
 
 func (c *BundleCache) Bundles() map[string]*Bundle {

--- a/pkg/agent/manager/cache/bundle_cache.go
+++ b/pkg/agent/manager/cache/bundle_cache.go
@@ -11,8 +11,8 @@ type BundleCache struct {
 }
 
 func NewBundleCache(trustDomain spiffeid.TrustDomain, bundle *Bundle) *BundleCache {
-	bundles := map[string]*Bundle{
-		trustDomain.IDString(): bundle,
+	bundles := map[spiffeid.TrustDomain]*Bundle{
+		trustDomain: bundle,
 	}
 	return &BundleCache{
 		trustDomain: trustDomain,
@@ -20,18 +20,18 @@ func NewBundleCache(trustDomain spiffeid.TrustDomain, bundle *Bundle) *BundleCac
 	}
 }
 
-func (c *BundleCache) Update(bundles map[string]*Bundle) {
+func (c *BundleCache) Update(bundles map[spiffeid.TrustDomain]*Bundle) {
 	// the bundle map must be copied so that the source can be mutated
 	// afterwards.
 	c.bundles.Update(copyBundleMap(bundles))
 }
 
 func (c *BundleCache) Bundle() *Bundle {
-	return c.Bundles()[c.trustDomain.IDString()]
+	return c.Bundles()[c.trustDomain]
 }
 
-func (c *BundleCache) Bundles() map[string]*Bundle {
-	return c.bundles.Value().(map[string]*Bundle)
+func (c *BundleCache) Bundles() map[spiffeid.TrustDomain]*Bundle {
+	return c.bundles.Value().(map[spiffeid.TrustDomain]*Bundle)
 }
 
 func (c *BundleCache) SubscribeToBundleChanges() *BundleStream {
@@ -50,8 +50,8 @@ func NewBundleStream(stream observer.Stream) *BundleStream {
 }
 
 // Value returns the current value for this stream.
-func (b *BundleStream) Value() map[string]*Bundle {
-	return b.stream.Value().(map[string]*Bundle)
+func (b *BundleStream) Value() map[spiffeid.TrustDomain]*Bundle {
+	return b.stream.Value().(map[spiffeid.TrustDomain]*Bundle)
 }
 
 // Changes returns the channel that is closed when a new value is available.
@@ -61,8 +61,8 @@ func (b *BundleStream) Changes() chan struct{} {
 
 // Next advances this stream to the next state.
 // You should never call this unless Changes channel is closed.
-func (b *BundleStream) Next() map[string]*Bundle {
-	value, _ := b.stream.Next().(map[string]*Bundle)
+func (b *BundleStream) Next() map[spiffeid.TrustDomain]*Bundle {
+	value, _ := b.stream.Next().(map[spiffeid.TrustDomain]*Bundle)
 	return value
 }
 
@@ -73,8 +73,8 @@ func (b *BundleStream) HasNext() bool {
 
 // WaitNext waits for Changes to be closed, advances the stream and returns
 // the current value.
-func (b *BundleStream) WaitNext() map[string]*Bundle {
-	value, _ := b.stream.WaitNext().(map[string]*Bundle)
+func (b *BundleStream) WaitNext() map[spiffeid.TrustDomain]*Bundle {
+	value, _ := b.stream.WaitNext().(map[spiffeid.TrustDomain]*Bundle)
 	return value
 }
 
@@ -89,12 +89,12 @@ func (b *BundleStream) Clone() *BundleStream {
 }
 
 // copyBundleMap does a shallow copy of the bundle map.
-func copyBundleMap(bundles map[string]*Bundle) map[string]*Bundle {
+func copyBundleMap(bundles map[spiffeid.TrustDomain]*Bundle) map[spiffeid.TrustDomain]*Bundle {
 	if bundles == nil {
 		return nil
 	}
 
-	out := make(map[string]*Bundle, len(bundles))
+	out := make(map[spiffeid.TrustDomain]*Bundle, len(bundles))
 	for key, bundle := range bundles {
 		out[key] = bundle
 	}

--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -312,7 +312,10 @@ func (c *Cache) UpdateEntries(update *UpdateEntries, checkSVID func(*common.Regi
 			for _, id := range newEntry.FederatesWith {
 				td, err := spiffeid.TrustDomainFromString(id)
 				if err != nil {
-					c.log.WithField(telemetry.TrustDomainID, id).Warn("Federated Trust Domain invalid")
+					c.log.WithFields(logrus.Fields{
+						telemetry.TrustDomainID: id,
+						logrus.ErrorKey:         err,
+					}).Warn("Invalid federated trust domain")
 					continue
 				}
 				if bundleChanged[td] {
@@ -614,7 +617,10 @@ func (c *Cache) buildWorkloadUpdate(set selectorSet) *WorkloadUpdate {
 		for _, federatesWith := range identity.Entry.FederatesWith {
 			td, err := spiffeid.TrustDomainFromString(federatesWith)
 			if err != nil {
-				c.log.WithField(telemetry.TrustDomainID, federatesWith).Warn("Federated Trust Domain invalid")
+				c.log.WithFields(logrus.Fields{
+					telemetry.TrustDomainID: federatesWith,
+					logrus.ErrorKey:         err,
+				}).Warn("Invalid federated trust domain")
 				continue
 			}
 			if federatedBundle := c.bundles[td]; federatedBundle != nil {

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -677,10 +677,11 @@ func assertWorkloadUpdateEqual(t *testing.T, sub Subscriber, expected *WorkloadU
 	}
 }
 
-func makeBundles(bundles ...*Bundle) map[string]*Bundle {
-	out := make(map[string]*Bundle)
+func makeBundles(bundles ...*Bundle) map[spiffeid.TrustDomain]*Bundle {
+	out := make(map[spiffeid.TrustDomain]*Bundle)
 	for _, bundle := range bundles {
-		out[bundle.TrustDomainID()] = bundle
+		td := spiffeid.RequireTrustDomainFromString(bundle.TrustDomainID())
+		out[td] = bundle
 	}
 	return out
 }

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -16,11 +17,13 @@ import (
 )
 
 var (
-	bundleV1      = bundleutil.BundleFromRootCA("spiffe://domain.test", &x509.Certificate{Raw: []byte{1}})
-	bundleV2      = bundleutil.BundleFromRootCA("spiffe://domain.test", &x509.Certificate{Raw: []byte{2}})
-	bundleV3      = bundleutil.BundleFromRootCA("spiffe://domain.test", &x509.Certificate{Raw: []byte{3}})
-	otherBundleV1 = bundleutil.BundleFromRootCA("spiffe://otherdomain.test", &x509.Certificate{Raw: []byte{4}})
-	otherBundleV2 = bundleutil.BundleFromRootCA("spiffe://otherdomain.test", &x509.Certificate{Raw: []byte{5}})
+	trustDomain1  = spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+	trustDomain2  = spiffeid.RequireTrustDomainFromString("spiffe://otherdomain.test")
+	bundleV1      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{1}})
+	bundleV2      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{2}})
+	bundleV3      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{3}})
+	otherBundleV1 = bundleutil.BundleFromRootCA(trustDomain2, &x509.Certificate{Raw: []byte{4}})
+	otherBundleV2 = bundleutil.BundleFromRootCA(trustDomain2, &x509.Certificate{Raw: []byte{5}})
 	defaultTTL    = int32(600)
 )
 
@@ -379,7 +382,7 @@ func TestSubcriberNotificationsOnSelectorChanges(t *testing.T) {
 
 func newTestCache() *Cache {
 	log, _ := test.NewNullLogger()
-	return New(log, "spiffe://domain.test", bundleV1, telemetry.Blackhole{})
+	return New(log, spiffeid.RequireTrustDomainFromString("domain.test"), bundleV1, telemetry.Blackhole{})
 }
 
 func TestSubcriberNotifiedWhenEntryDropped(t *testing.T) {

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 var (
-	trustDomain1  = spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
-	trustDomain2  = spiffeid.RequireTrustDomainFromString("spiffe://otherdomain.test")
+	trustDomain1  = spiffeid.RequireTrustDomainFromString("domain.test")
+	trustDomain2  = spiffeid.RequireTrustDomainFromString("otherdomain.test")
 	bundleV1      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{1}})
 	bundleV2      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{2}})
 	bundleV3      = bundleutil.BundleFromRootCA(trustDomain1, &x509.Certificate{Raw: []byte{3}})

--- a/pkg/agent/manager/cache/jwt_cache.go
+++ b/pkg/agent/manager/cache/jwt_cache.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/client"
 )
 
@@ -21,7 +22,7 @@ func NewJWTSVIDCache() *JWTSVIDCache {
 	}
 }
 
-func (c *JWTSVIDCache) GetJWTSVID(spiffeID string, audience []string) (*client.JWTSVID, bool) {
+func (c *JWTSVIDCache) GetJWTSVID(spiffeID spiffeid.ID, audience []string) (*client.JWTSVID, bool) {
 	key := jwtSVIDKey(spiffeID, audience)
 
 	c.mu.Lock()
@@ -30,7 +31,7 @@ func (c *JWTSVIDCache) GetJWTSVID(spiffeID string, audience []string) (*client.J
 	return svid, ok
 }
 
-func (c *JWTSVIDCache) SetJWTSVID(spiffeID string, audience []string, svid *client.JWTSVID) {
+func (c *JWTSVIDCache) SetJWTSVID(spiffeID spiffeid.ID, audience []string, svid *client.JWTSVID) {
 	key := jwtSVIDKey(spiffeID, audience)
 
 	c.mu.Lock()
@@ -38,14 +39,14 @@ func (c *JWTSVIDCache) SetJWTSVID(spiffeID string, audience []string, svid *clie
 	c.svids[key] = svid
 }
 
-func jwtSVIDKey(spiffeID string, audience []string) string {
+func jwtSVIDKey(spiffeID spiffeid.ID, audience []string) string {
 	h := sha256.New()
 
 	// duplicate and sort the audience slice
 	audience = append([]string(nil), audience...)
 	sort.Strings(audience)
 
-	_, _ = io.WriteString(h, spiffeID)
+	_, _ = io.WriteString(h, spiffeID.String())
 	for _, a := range audience {
 		_, _ = io.WriteString(h, a)
 	}

--- a/pkg/agent/manager/cache/jwt_cache_test.go
+++ b/pkg/agent/manager/cache/jwt_cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,14 +15,16 @@ func TestJWTSVIDCache(t *testing.T) {
 
 	cache := NewJWTSVIDCache()
 
+	spiffeID := spiffeid.RequireFromString("spiffe://example.org/blog")
+
 	// JWT is not cached
-	actual, ok := cache.GetJWTSVID("spiffe://example.org/blog", []string{"bar"})
+	actual, ok := cache.GetJWTSVID(spiffeID, []string{"bar"})
 	assert.False(t, ok)
 	assert.Nil(t, actual)
 
 	// JWT is cached
-	cache.SetJWTSVID("spiffe://example.org/blog", []string{"bar"}, expected)
-	actual, ok = cache.GetJWTSVID("spiffe://example.org/blog", []string{"bar"})
+	cache.SetJWTSVID(spiffeID, []string{"bar"}, expected)
+	actual, ok = cache.GetJWTSVID(spiffeID, []string{"bar"})
 	assert.True(t, ok)
 	assert.Equal(t, expected, actual)
 }

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -3,12 +3,12 @@ package manager
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
-	"net/url"
 	"sync"
 	"time"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/agent/svid"
@@ -22,7 +22,7 @@ type Config struct {
 	SVIDKey          *ecdsa.PrivateKey
 	Bundle           *cache.Bundle
 	Catalog          catalog.Catalog
-	TrustDomain      url.URL
+	TrustDomain      spiffeid.TrustDomain
 	Log              logrus.FieldLogger
 	Metrics          telemetry.Metrics
 	ServerAddr       string
@@ -53,7 +53,7 @@ func newManager(c *Config) *manager {
 		c.Clk = clock.New()
 	}
 
-	cache := cache.New(c.Log.WithField(telemetry.SubsystemName, telemetry.CacheManager), c.TrustDomain.String(), c.Bundle, c.Metrics)
+	cache := cache.New(c.Log.WithField(telemetry.SubsystemName, telemetry.CacheManager), c.TrustDomain, c.Bundle, c.Metrics)
 
 	rotCfg := &svid.RotatorConfig{
 		Catalog:      c.Catalog,

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	observer "github.com/imkira/go-observer"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/common/backoff"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
@@ -68,7 +69,7 @@ type Manager interface {
 
 	// FetchJWTSVID returns a JWT SVID for the specified SPIFFEID and audience. If there
 	// is no JWT cached, the manager will get one signed upstream.
-	FetchJWTSVID(ctx context.Context, spiffeID string, audience []string) (*client.JWTSVID, error)
+	FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audience []string) (*client.JWTSVID, error)
 
 	// CountSVIDs returns the amount of X509 SVIDs on memory
 	CountSVIDs() int
@@ -183,7 +184,7 @@ func (m *manager) FetchWorkloadUpdate(selectors []*common.Selector) *cache.Workl
 	return m.cache.FetchWorkloadUpdate(selectors)
 }
 
-func (m *manager) FetchJWTSVID(ctx context.Context, spiffeID string, audience []string) (*client.JWTSVID, error) {
+func (m *manager) FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audience []string) (*client.JWTSVID, error) {
 	now := m.clk.Now()
 
 	cachedSVID, ok := m.cache.GetJWTSVID(spiffeID, audience)
@@ -191,7 +192,7 @@ func (m *manager) FetchJWTSVID(ctx context.Context, spiffeID string, audience []
 		return cachedSVID, nil
 	}
 
-	entryID := m.getEntryID(spiffeID)
+	entryID := m.getEntryID(spiffeID.String())
 	if entryID == "" {
 		return nil, errors.New("no entry found")
 	}
@@ -292,7 +293,7 @@ func (m *manager) runBundleObserver(ctx context.Context) error {
 			return nil
 		case <-bundleStream.Changes():
 			b := bundleStream.Next()
-			m.storeBundle(b[m.c.TrustDomain.String()])
+			m.storeBundle(b[m.c.TrustDomain.IDString()])
 		}
 	}
 }

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -293,7 +293,7 @@ func (m *manager) runBundleObserver(ctx context.Context) error {
 			return nil
 		case <-bundleStream.Changes():
 			b := bundleStream.Next()
-			m.storeBundle(b[m.c.TrustDomain.IDString()])
+			m.storeBundle(b[m.c.TrustDomain])
 		}
 	}
 }

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -49,10 +49,9 @@ import (
 )
 
 var (
-	trustDomain    = spiffeid.RequireTrustDomainFromString("example.org")
-	trustDomainURL = *trustDomain.ID().URL()
-	agentID        = trustDomain.NewID("agent")
-	joinTokenID    = trustDomain.NewID("spire/agent/join_token/abcd")
+	trustDomain = spiffeid.RequireTrustDomainFromString("example.org")
+	agentID     = trustDomain.NewID("agent")
+	joinTokenID = trustDomain.NewID("spire/agent/join_token/abcd")
 )
 
 var (
@@ -74,7 +73,7 @@ func TestInitializationFailure(t *testing.T) {
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
 		Metrics:         &telemetry.Blackhole{},
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Clk:             clk,
@@ -105,10 +104,10 @@ func TestStoreBundleOnStartup(t *testing.T) {
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
 		Metrics:         &telemetry.Blackhole{},
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
-		Bundle:          bundleutil.BundleFromRootCA(trustDomain.IDString(), ca),
+		Bundle:          bundleutil.BundleFromRootCA(trustDomain, ca),
 		Clk:             clk,
 		Catalog:         cat,
 	}
@@ -158,7 +157,7 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
 		Metrics:         &telemetry.Blackhole{},
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Clk:             clk,
@@ -206,7 +205,7 @@ func TestStoreKeyOnStartup(t *testing.T) {
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
 		Metrics:         &telemetry.Blackhole{},
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Clk:             clk,
@@ -273,7 +272,7 @@ func TestHappyPathWithoutSyncNorRotation(t *testing.T) {
 		SVID:            baseSVID,
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Bundle:          api.bundle,
@@ -364,7 +363,7 @@ func TestSVIDRotation(t *testing.T) {
 		SVID:             baseSVID,
 		SVIDKey:          baseSVIDKey,
 		Log:              testLogger,
-		TrustDomain:      trustDomainURL,
+		TrustDomain:      trustDomain,
 		SVIDCachePath:    path.Join(dir, "svid.der"),
 		BundleCachePath:  path.Join(dir, "bundle.der"),
 		Bundle:           api.bundle,
@@ -473,7 +472,7 @@ func TestSynchronization(t *testing.T) {
 		SVID:             baseSVID,
 		SVIDKey:          baseSVIDKey,
 		Log:              testLogger,
-		TrustDomain:      trustDomainURL,
+		TrustDomain:      trustDomain,
 		SVIDCachePath:    path.Join(dir, "svid.der"),
 		BundleCachePath:  path.Join(dir, "bundle.der"),
 		Bundle:           api.bundle,
@@ -630,7 +629,7 @@ func TestSynchronizationClearsStaleCacheEntries(t *testing.T) {
 		SVID:            baseSVID,
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Bundle:          api.bundle,
@@ -707,7 +706,7 @@ func TestSynchronizationUpdatesRegistrationEntries(t *testing.T) {
 		SVID:            baseSVID,
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Bundle:          api.bundle,
@@ -770,7 +769,7 @@ func TestSubscribersGetUpToDateBundle(t *testing.T) {
 		SVID:             baseSVID,
 		SVIDKey:          baseSVIDKey,
 		Log:              testLogger,
-		TrustDomain:      trustDomainURL,
+		TrustDomain:      trustDomain,
 		SVIDCachePath:    path.Join(dir, "svid.der"),
 		BundleCachePath:  path.Join(dir, "bundle.der"),
 		Bundle:           api.bundle,
@@ -837,7 +836,7 @@ func TestSurvivesCARotation(t *testing.T) {
 		SVID:             baseSVID,
 		SVIDKey:          baseSVIDKey,
 		Log:              testLogger,
-		TrustDomain:      trustDomainURL,
+		TrustDomain:      trustDomain,
 		SVIDCachePath:    path.Join(dir, "svid.der"),
 		BundleCachePath:  path.Join(dir, "bundle.der"),
 		Bundle:           api.bundle,
@@ -899,7 +898,7 @@ func TestFetchJWTSVID(t *testing.T) {
 		SVID:            baseSVID,
 		SVIDKey:         baseSVIDKey,
 		Log:             testLogger,
-		TrustDomain:     trustDomainURL,
+		TrustDomain:     trustDomain,
 		SVIDCachePath:   path.Join(dir, "svid.der"),
 		BundleCachePath: path.Join(dir, "bundle.der"),
 		Bundle:          api.bundle,
@@ -911,7 +910,7 @@ func TestFetchJWTSVID(t *testing.T) {
 	m := newManager(c)
 	require.NoError(t, m.Initialize(context.Background()))
 
-	spiffeID := "spiffe://example.org/blog"
+	spiffeID := spiffeid.RequireFromString("spiffe://example.org/blog")
 	audience := []string{"foo"}
 
 	// nothing in cache, fetch fails
@@ -1095,7 +1094,7 @@ func newMockAPI(t *testing.T, config *mockAPIConfig) *mockAPI {
 	h := &mockAPI{
 		t:      t,
 		c:      config,
-		bundle: bundleutil.BundleFromRootCA(trustDomain.IDString(), ca),
+		bundle: bundleutil.BundleFromRootCA(trustDomain, ca),
 		cakey:  cakey,
 		clk:    config.clk,
 	}

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -118,7 +118,7 @@ func TestStoreBundleOnStartup(t *testing.T) {
 		sub := m.SubscribeToBundleChanges()
 		bundles := sub.Value()
 		require.NotNil(t, bundles)
-		bundle := bundles[trustDomain.IDString()]
+		bundle := bundles[trustDomain]
 		require.Equal(t, bundle.RootCAs(), []*x509.Certificate{ca})
 	})
 

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/rotationutil"
@@ -126,7 +127,12 @@ func (m *manager) fetchSVIDs(ctx context.Context, csrs []csrRequest) (_ *cache.U
 		}
 
 		log.Info("Renewing X509-SVID")
-		privateKey, csrBytes, err := newCSR(csr.SpiffeID)
+
+		spiffeID, err := spiffeid.FromString(csr.SpiffeID)
+		if err != nil {
+			return nil, err
+		}
+		privateKey, csrBytes, err := newCSR(spiffeID)
 		if err != nil {
 			return nil, err
 		}
@@ -181,7 +187,7 @@ func (m *manager) fetchEntries(ctx context.Context) (_ *cache.UpdateEntries, err
 	}, nil
 }
 
-func newCSR(spiffeID string) (pk *ecdsa.PrivateKey, csr []byte, err error) {
+func newCSR(spiffeID spiffeid.ID) (pk *ecdsa.PrivateKey, csr []byte, err error) {
 	pk, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -199,14 +199,18 @@ func newCSR(spiffeID spiffeid.ID) (pk *ecdsa.PrivateKey, csr []byte, err error) 
 	return
 }
 
-func parseBundles(bundles map[string]*common.Bundle) (map[string]*cache.Bundle, error) {
-	out := make(map[string]*cache.Bundle, len(bundles))
+func parseBundles(bundles map[string]*common.Bundle) (map[spiffeid.TrustDomain]*cache.Bundle, error) {
+	out := make(map[spiffeid.TrustDomain]*cache.Bundle, len(bundles))
 	for _, bundle := range bundles {
 		bundle, err := bundleutil.BundleFromProto(bundle)
 		if err != nil {
 			return nil, err
 		}
-		out[bundle.TrustDomainID()] = bundle
+		td, err := spiffeid.TrustDomainFromString(bundle.TrustDomainID())
+		if err != nil {
+			return nil, err
+		}
+		out[td] = bundle
 	}
 	return out, nil
 }

--- a/pkg/agent/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/hcl"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
@@ -43,7 +44,7 @@ type IITAttestorPlugin struct {
 
 // IITAttestorConfig configures a IITAttestorPlugin.
 type IITAttestorConfig struct {
-	trustDomain       string
+	trustDomain       spiffeid.TrustDomain
 	IdentityTokenHost string `hcl:"identity_token_host"`
 	ServiceAccount    string `hcl:"service_account"`
 }
@@ -86,7 +87,12 @@ func (p *IITAttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReq
 	if req.GlobalConfig.TrustDomain == "" {
 		return nil, newError("trust_domain is required")
 	}
-	config.trustDomain = req.GlobalConfig.TrustDomain
+
+	td, err := spiffeid.TrustDomainFromString(req.GlobalConfig.TrustDomain)
+	if err != nil {
+		return nil, err
+	}
+	config.trustDomain = td
 
 	if config.ServiceAccount == "" {
 		config.ServiceAccount = defaultServiceAccount

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
@@ -54,7 +55,7 @@ type AttestorConfig struct {
 }
 
 type attestorConfig struct {
-	trustDomain string
+	trustDomain spiffeid.TrustDomain
 	cluster     string
 	tokenPath   string
 }
@@ -104,8 +105,13 @@ func (p *AttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReques
 		return nil, psatError.New("configuration missing cluster")
 	}
 
+	td, err := spiffeid.TrustDomainFromString(req.GlobalConfig.TrustDomain)
+	if err != nil {
+		return nil, err
+	}
+
 	config := &attestorConfig{
-		trustDomain: req.GlobalConfig.TrustDomain,
+		trustDomain: td,
 		cluster:     hclConfig.Cluster,
 		tokenPath:   hclConfig.TokenPath,
 	}

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
@@ -39,7 +40,7 @@ type AttestorConfig struct {
 }
 
 type attestorConfig struct {
-	trustDomain string
+	trustDomain spiffeid.TrustDomain
 	cluster     string
 	tokenPath   string
 }
@@ -98,8 +99,13 @@ func (p *AttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReques
 		return nil, satError.New("configuration missing cluster")
 	}
 
+	td, err := spiffeid.TrustDomainFromString(req.GlobalConfig.TrustDomain)
+	if err != nil {
+		return nil, err
+	}
+
 	config := &attestorConfig{
-		trustDomain: req.GlobalConfig.TrustDomain,
+		trustDomain: td,
 		cluster:     hclConfig.Cluster,
 		tokenPath:   hclConfig.TokenPath,
 	}

--- a/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
@@ -37,7 +38,7 @@ type configData struct {
 }
 
 type Config struct {
-	trustDomain       string
+	trustDomain       spiffeid.TrustDomain
 	PrivateKeyPath    string `hcl:"private_key_path"`
 	CertificatePath   string `hcl:"certificate_path"`
 	IntermediatesPath string `hcl:"intermediates_path"`
@@ -111,7 +112,12 @@ func (p *Plugin) Configure(ctx context.Context, req *plugin.ConfigureRequest) (*
 	if req.GlobalConfig.TrustDomain == "" {
 		return nil, errors.New("x509pop: trust_domain is required")
 	}
-	config.trustDomain = req.GlobalConfig.TrustDomain
+
+	td, err := spiffeid.TrustDomainFromString(req.GlobalConfig.TrustDomain)
+	if err != nil {
+		return nil, err
+	}
+	config.trustDomain = td
 
 	if config.PrivateKeyPath == "" {
 		return nil, errors.New("x509pop: private_key_path is required")

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -72,7 +72,7 @@ func newRotator(c *RotatorConfig) (*rotator, client.Client) {
 			bsm.RUnlock()
 
 			var rootCAs []*x509.Certificate
-			if bundle := bundles[c.TrustDomain.IDString()]; bundle != nil {
+			if bundle := bundles[c.TrustDomain]; bundle != nil {
 				rootCAs = bundle.RootCAs()
 			}
 			return s.SVID, s.Key, rootCAs

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -3,13 +3,13 @@ package svid
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
-	"net/url"
 	"sync"
 	"time"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/imkira/go-observer"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/common/backoff"
@@ -23,7 +23,7 @@ type RotatorConfig struct {
 	Catalog     catalog.Catalog
 	Log         logrus.FieldLogger
 	Metrics     telemetry.Metrics
-	TrustDomain url.URL
+	TrustDomain spiffeid.TrustDomain
 	ServerAddr  string
 	// Initial SVID and key
 	SVID    []*x509.Certificate
@@ -72,7 +72,7 @@ func newRotator(c *RotatorConfig) (*rotator, client.Client) {
 			bsm.RUnlock()
 
 			var rootCAs []*x509.Certificate
-			if bundle := bundles[c.TrustDomain.String()]; bundle != nil {
+			if bundle := bundles[c.TrustDomain.IDString()]; bundle != nil {
 				rootCAs = bundle.RootCAs()
 			}
 			return s.SVID, s.Key, rootCAs

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -3,13 +3,13 @@ package svid
 import (
 	"context"
 	"crypto/x509"
-	"net/url"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/imkira/go-observer"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
@@ -55,15 +55,11 @@ func (s *RotatorTestSuite) SetupTest() {
 	s.mockClock = clock.NewMock(s.T())
 	s.mockClock.Set(time.Now())
 	log, _ := test.NewNullLogger()
-	td := url.URL{
-		Scheme: "spiffe",
-		Host:   "example.org",
-	}
 	c := &RotatorConfig{
 		Catalog:      cat,
 		Log:          log,
 		Metrics:      telemetry.Blackhole{},
-		TrustDomain:  td,
+		TrustDomain:  spiffeid.RequireTrustDomainFromString("example.org"),
 		BundleStream: cache.NewBundleStream(s.bundle.Observe()),
 		Clk:          s.mockClock,
 	}

--- a/pkg/common/bundleutil/bundle.go
+++ b/pkg/common/bundleutil/bundle.go
@@ -22,10 +22,10 @@ type Bundle struct {
 	jwtSigningKeys map[string]crypto.PublicKey
 }
 
-func New(trustDomainID string) *Bundle {
+func New(trustDomain spiffeid.TrustDomain) *Bundle {
 	return &Bundle{
 		b: &common.Bundle{
-			TrustDomainId: trustDomainID,
+			TrustDomainId: trustDomain.IDString(),
 		},
 		jwtSigningKeys: make(map[string]crypto.PublicKey),
 	}
@@ -55,12 +55,12 @@ func BundleFromProto(b *common.Bundle) (*Bundle, error) {
 	}, nil
 }
 
-func BundleFromRootCA(trustDomainID string, rootCA *x509.Certificate) *Bundle {
-	return bundleFromRootCAs(trustDomainID, rootCA)
+func BundleFromRootCA(trustDomain spiffeid.TrustDomain, rootCA *x509.Certificate) *Bundle {
+	return bundleFromRootCAs(trustDomain, rootCA)
 }
 
-func BundleFromRootCAs(trustDomainID string, rootCAs []*x509.Certificate) *Bundle {
-	return bundleFromRootCAs(trustDomainID, rootCAs...)
+func BundleFromRootCAs(trustDomain spiffeid.TrustDomain, rootCAs []*x509.Certificate) *Bundle {
+	return bundleFromRootCAs(trustDomain, rootCAs...)
 }
 
 func CommonBundleFromProto(b *types.Bundle) (*common.Bundle, error) {
@@ -101,8 +101,8 @@ func CommonBundleFromProto(b *types.Bundle) (*common.Bundle, error) {
 	}, nil
 }
 
-func bundleFromRootCAs(trustDomainID string, rootCAs ...*x509.Certificate) *Bundle {
-	b := New(trustDomainID)
+func bundleFromRootCAs(trustDomain spiffeid.TrustDomain, rootCAs ...*x509.Certificate) *Bundle {
+	b := New(trustDomain)
 	for _, rootCA := range rootCAs {
 		b.AppendRootCA(rootCA)
 	}

--- a/pkg/common/bundleutil/marshal_test.go
+++ b/pkg/common/bundleutil/marshal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -125,10 +126,12 @@ func TestMarshal(t *testing.T) {
 		},
 	}
 
+	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			bundle := New("spiffe://domain.test")
+			bundle := New(trustDomain)
 			bundle.SetRefreshHint(time.Minute)
 			if !testCase.empty {
 				bundle.AppendRootCA(rootCA)

--- a/pkg/common/bundleutil/marshal_test.go
+++ b/pkg/common/bundleutil/marshal_test.go
@@ -126,7 +126,7 @@ func TestMarshal(t *testing.T) {
 		},
 	}
 
-	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
 
 	for _, testCase := range testCases {
 		testCase := testCase

--- a/pkg/common/bundleutil/refreshhint_test.go
+++ b/pkg/common/bundleutil/refreshhint_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCalculateRefreshHint(t *testing.T) {
-	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
 	emptyBundle := New(trustDomain)
 
 	emptyBundleWithRefreshHint, err := BundleFromProto(&common.Bundle{

--- a/pkg/common/bundleutil/refreshhint_test.go
+++ b/pkg/common/bundleutil/refreshhint_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateRefreshHint(t *testing.T) {
-	emptyBundle := New("domain.test")
+	trustDomain := spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+	emptyBundle := New(trustDomain)
 
 	emptyBundleWithRefreshHint, err := BundleFromProto(&common.Bundle{
 		TrustDomainId: "domain.test",
@@ -19,7 +21,7 @@ func TestCalculateRefreshHint(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	bundleWithCerts := New("domain.test")
+	bundleWithCerts := New(trustDomain)
 	bundleWithCerts.AppendRootCA(&x509.Certificate{
 		NotBefore: now,
 		NotAfter:  now.Add(time.Hour * 2),

--- a/pkg/common/bundleutil/unmarshal.go
+++ b/pkg/common/bundleutil/unmarshal.go
@@ -6,27 +6,28 @@ import (
 	"io"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 )
 
-func Decode(trustDomainID string, r io.Reader) (*Bundle, error) {
+func Decode(trustDomain spiffeid.TrustDomain, r io.Reader) (*Bundle, error) {
 	doc := new(bundleDoc)
 	if err := json.NewDecoder(r).Decode(doc); err != nil {
 		return nil, fmt.Errorf("failed to decode bundle: %v", err)
 	}
-	return unmarshal(trustDomainID, doc)
+	return unmarshal(trustDomain, doc)
 }
 
-func Unmarshal(trustDomainID string, data []byte) (*Bundle, error) {
+func Unmarshal(trustDomain spiffeid.TrustDomain, data []byte) (*Bundle, error) {
 	doc := new(bundleDoc)
 	if err := json.Unmarshal(data, doc); err != nil {
 		return nil, errs.Wrap(err)
 	}
-	return unmarshal(trustDomainID, doc)
+	return unmarshal(trustDomain, doc)
 }
 
-func unmarshal(trustDomainID string, doc *bundleDoc) (*Bundle, error) {
-	bundle := New(trustDomainID)
+func unmarshal(trustDomain spiffeid.TrustDomain, doc *bundleDoc) (*Bundle, error) {
+	bundle := New(trustDomain)
 	bundle.SetRefreshHint(time.Second * time.Duration(doc.RefreshHint))
 
 	for i, key := range doc.Keys {

--- a/pkg/common/bundleutil/unmarshal_test.go
+++ b/pkg/common/bundleutil/unmarshal_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshal(t *testing.T) {
 	rootCA := createCACertificate(t)
-
+	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
 	testCases := []struct {
 		name   string
 		doc    string
@@ -19,7 +20,7 @@ func TestUnmarshal(t *testing.T) {
 		{
 			name:   "empty bundle",
 			doc:    "{}",
-			bundle: New("spiffe://domain.test"),
+			bundle: New(trustDomain),
 		},
 		{
 			name: "entry missing use",
@@ -104,7 +105,7 @@ func TestUnmarshal(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
-			bundle, err := Unmarshal("spiffe://domain.test", []byte(testCase.doc))
+			bundle, err := Unmarshal(trustDomain, []byte(testCase.doc))
 			if testCase.err != "" {
 				require.EqualError(t, err, testCase.err)
 				return

--- a/pkg/common/util/csr.go
+++ b/pkg/common/util/csr.go
@@ -6,22 +6,18 @@ import (
 	"crypto/x509/pkix"
 	"net/url"
 
-	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 )
 
-func MakeCSR(privateKey interface{}, spiffeID string) ([]byte, error) {
-	uri, err := idutil.ParseSpiffeID(spiffeID, idutil.AllowAny())
-	if err != nil {
-		return nil, err
-	}
+func MakeCSR(privateKey interface{}, spiffeID spiffeid.ID) ([]byte, error) {
 	return makeCSR(privateKey, &x509.CertificateRequest{
 		Subject: pkix.Name{
 			Country:      []string{"US"},
 			Organization: []string{"SPIRE"},
 		},
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
-		URIs:               []*url.URL{uri},
+		URIs:               []*url.URL{spiffeID.URL()},
 	})
 }
 

--- a/pkg/server/bundle/client/client.go
+++ b/pkg/server/bundle/client/client.go
@@ -81,7 +81,7 @@ func (c *client) FetchBundle(ctx context.Context) (*bundleutil.Bundle, error) {
 		return nil, errs.New("unexpected status %d fetching bundle: %s", resp.StatusCode, tryRead(resp.Body))
 	}
 
-	b, err := bundleutil.Decode(c.c.TrustDomain.IDString(), resp.Body)
+	b, err := bundleutil.Decode(c.c.TrustDomain, resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/bundle/client/manager_test.go
+++ b/pkg/server/bundle/client/manager_test.go
@@ -21,9 +21,9 @@ import (
 func TestManager(t *testing.T) {
 	// create a pair of bundles with distinct refresh hints so we can assert
 	// that the manager selected the correct refresh hint.
-	localBundle := bundleutil.BundleFromRootCA("spiffe://domain.test", createCACertificate(t, "local"))
+	localBundle := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "local"))
 	localBundle.SetRefreshHint(time.Hour)
-	endpointBundle := bundleutil.BundleFromRootCA("spiffe://domain.test", createCACertificate(t, "endpoint"))
+	endpointBundle := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "endpoint"))
 	endpointBundle.SetRefreshHint(time.Hour * 2)
 
 	testCases := []struct {

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -20,8 +20,8 @@ import (
 func TestBundleUpdater(t *testing.T) {
 	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
 
-	bundle1 := bundleutil.BundleFromRootCA(trustDomain.IDString(), createCACertificate(t, "bundle1"))
-	bundle2 := bundleutil.BundleFromRootCA(trustDomain.IDString(), createCACertificate(t, "bundle2"))
+	bundle1 := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "bundle1"))
+	bundle2 := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "bundle2"))
 	bundle2.SetRefreshHint(time.Minute)
 
 	testCases := []struct {

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	testTrustDomain = spiffeid.RequireTrustDomainFromString("spiffe://domain.test")
+	testTrustDomain = spiffeid.RequireTrustDomainFromString("domain.test")
 )
 
 func TestManager(t *testing.T) {

--- a/pkg/server/endpoints/bundle/server_test.go
+++ b/pkg/server/endpoints/bundle/server_test.go
@@ -39,7 +39,8 @@ func TestServer(t *testing.T) {
 	// create a bundle for testing. we need a certificate in the bundle since
 	// the root lifetimes are used to heuristically determine the refresh hint.
 	// since the content doesn't really matter, we'll just add the server cert.
-	bundle := bundleutil.New("spiffe://domain.test")
+	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
+	bundle := bundleutil.New(trustDomain)
 	bundle.AppendRootCA(serverCert)
 
 	// even though this will be SPIFFE authentication in production, there is
@@ -155,7 +156,8 @@ func TestServer(t *testing.T) {
 func TestACMEAuth(t *testing.T) {
 	dir := spiretest.TempDir(t)
 
-	bundle := bundleutil.New("spiffe://domain.test")
+	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
+	bundle := bundleutil.New(trustDomain)
 	km := memory.New()
 
 	ca := acmetest.NewCAServer([]string{"tls-alpn-01"}, []string{"domain.test"})

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -142,7 +142,7 @@ func (h *handler) startServerAPITestServer(t *testing.T) {
 func (h *handler) loadInitialBundle(t *testing.T) {
 	jwksBytes, err := ioutil.ReadFile("_test_data/keys/jwks.json")
 	require.NoError(t, err)
-	b, err := bundleutil.Unmarshal(trustDomain.IDString(), jwksBytes)
+	b, err := bundleutil.Unmarshal(trustDomain, jwksBytes)
 	require.NoError(t, err)
 
 	// Append X509 authorities


### PR DESCRIPTION

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Description of change**
Migrate agent units to using `TrustDomain` and `SpiffeID` types, mainly as part of the public methods and structs. Also migrate common package method `MakeCSR` and related code in server.

**Which issue this PR fixes**
Address #1828 

Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>