### PR TITLE
Implement basic server gRPC health service

### DIFF
--- a/cmd/spire-server/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck_test.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/mitchellh/cli"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
-	"github.com/spiffe/spire/proto/spire/api/server/bundle/v1"
-	"github.com/spiffe/spire/proto/spire/types"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -75,22 +74,22 @@ func (s *HealthCheckSuite) TestFailsIfSocketDoesNotExist() {
 	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock"})
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
-	s.Equal("Server is unhealthy: cannot create registration client\n", s.stderr.String(), "stderr")
+	s.Equal("Server is unhealthy: cannot create health client\n", s.stderr.String(), "stderr")
 }
 
 func (s *HealthCheckSuite) TestFailsIfSocketDoesNotExistVerbose() {
 	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock", "--verbose"})
 	s.NotEqual(0, code, "exit code")
-	s.Equal(`Fetching bundle via Bundle API...
+	s.Equal(`Checking server health...
 `, s.stdout.String(), "stdout")
 	s.Equal(`Failed to create client: connection error: desc = "transport: error while dialing: dial unix doesnotexist.sock: connect: no such file or directory"
-Server is unhealthy: cannot create registration client
+Server is unhealthy: cannot create health client
 `, s.stderr.String(), "stderr")
 }
 
-func (s *HealthCheckSuite) TestSucceedsIfBundleFetched() {
+func (s *HealthCheckSuite) TestSucceedsIfServingStatusServing() {
 	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
-		bundle.RegisterBundleServer(srv, withBundle{})
+		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_SERVING))
 	})
 	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath})
 	s.Equal(0, code, "exit code")
@@ -98,23 +97,45 @@ func (s *HealthCheckSuite) TestSucceedsIfBundleFetched() {
 	s.Equal("", s.stderr.String(), "stderr")
 }
 
-func (s *HealthCheckSuite) TestSucceedsIfBundleFetchedVerbose() {
+func (s *HealthCheckSuite) TestSucceedsIfServingStatusServingVerbose() {
 	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
-		bundle.RegisterBundleServer(srv, withBundle{})
+		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_SERVING))
 	})
 	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath, "--verbose"})
 	s.Equal(0, code, "exit code")
-	s.Equal(`Fetching bundle via Bundle API...
-Successfully fetched bundle.
+	s.Equal(`Checking server health...
 Server is healthy.
 `, s.stdout.String(), "stdout")
 	s.Equal("", s.stderr.String(), "stderr")
 }
 
-type withBundle struct {
-	bundle.BundleServer
+func (s *HealthCheckSuite) TestFailsIfServiceStatusOther() {
+	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
+		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_NOT_SERVING))
+	})
+	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath, "--verbose"})
+	s.NotEqual(0, code, "exit code")
+	s.Equal(`Checking server health...
+`, s.stdout.String(), "stdout")
+	s.Equal(`Server is unhealthy: server returned status "NOT_SERVING"
+`, s.stderr.String(), "stderr")
 }
 
-func (withBundle) GetBundle(context.Context, *bundle.GetBundleRequest) (*types.Bundle, error) {
-	return &types.Bundle{}, nil
+func withStatus(status grpc_health_v1.HealthCheckResponse_ServingStatus) healthServer {
+	return healthServer{status: status}
+}
+
+type healthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	status grpc_health_v1.HealthCheckResponse_ServingStatus
+	err    error
+}
+
+func (s healthServer) Check(context.Context, *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: s.status,
+	}, nil
 }

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire/proto/spire/api/server/svid/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 const (
@@ -49,6 +50,7 @@ type ServerClient interface {
 	NewBundleClient() bundle.BundleClient
 	NewEntryClient() entry.EntryClient
 	NewSVIDClient() svid.SVIDClient
+	NewHealthClient() grpc_health_v1.HealthClient
 }
 
 func NewServerClient(socketPath string) (ServerClient, error) {
@@ -81,6 +83,10 @@ func (c *serverClient) NewEntryClient() entry.EntryClient {
 
 func (c *serverClient) NewSVIDClient() svid.SVIDClient {
 	return svid.NewSVIDClient(c.conn)
+}
+
+func (c *serverClient) NewHealthClient() grpc_health_v1.HealthClient {
+	return grpc_health_v1.NewHealthClient(c.conn)
 }
 
 // Pluralizer concatenates `singular` to `msg` when `val` is one, and

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -245,6 +245,9 @@ const (
 	// Pruned flagging something has been pruned
 	Pruned = "pruned"
 
+	// Reason is the reason for something
+	Reason = "reason"
+
 	// RegistrationID tags some registration entry ID
 	RegistrationID = "entry_id"
 

--- a/pkg/server/api/health/v1/service.go
+++ b/pkg/server/api/health/v1/service.go
@@ -1,0 +1,73 @@
+package health
+
+import (
+	"context"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// RegisterService registers the service on the gRPC server.
+func RegisterService(s *grpc.Server, service *Service) {
+	grpc_health_v1.RegisterHealthServer(s, service)
+}
+
+// Config is the service configuration
+type Config struct {
+	TrustDomain spiffeid.TrustDomain
+	DataStore   datastore.DataStore
+}
+
+// New creates a new Health service
+func New(config Config) *Service {
+	return &Service{
+		ds: config.DataStore,
+		td: config.TrustDomain,
+	}
+}
+
+// Service implements the v1 Health service
+type Service struct {
+	grpc_health_v1.UnimplementedHealthServer
+
+	ds datastore.DataStore
+	td spiffeid.TrustDomain
+}
+
+func (s *Service) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	log := rpccontext.Logger(ctx)
+
+	// Ensure per-service health is not being requested.
+	if req.Service != "" {
+		return nil, api.MakeErr(log, codes.InvalidArgument, "per-service health is not supported", nil)
+	}
+
+	resp, err := s.ds.FetchBundle(ctx, &datastore.FetchBundleRequest{
+		TrustDomainId: s.td.IDString(),
+	})
+
+	var unhealthyReason string
+	switch {
+	case err != nil:
+		log = log.WithError(err)
+		unhealthyReason = "unable to fetch bundle"
+	case resp.Bundle == nil:
+		unhealthyReason = "bundle is missing"
+	}
+
+	healthStatus := grpc_health_v1.HealthCheckResponse_SERVING
+	if unhealthyReason != "" {
+		healthStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
+		log.WithField(telemetry.Reason, unhealthyReason).Warn("Health check failed")
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: healthStatus,
+	}, nil
+}

--- a/pkg/server/api/health/v1/service_test.go
+++ b/pkg/server/api/health/v1/service_test.go
@@ -1,0 +1,133 @@
+package health_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/spiffe/spire/pkg/server/api/health/v1"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/fakes/fakedatastore"
+	"github.com/spiffe/spire/test/spiretest"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var (
+	td = spiffeid.RequireTrustDomainFromString("example.org")
+)
+
+func TestServiceCheck(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		bundle              *common.Bundle
+		dsErr               error
+		service             string
+		expectCode          codes.Code
+		expectMsg           string
+		expectServingStatus grpc_health_v1.HealthCheckResponse_ServingStatus
+		expectLogs          []spiretest.LogEntry
+	}{
+		{
+			name:                "success",
+			bundle:              &common.Bundle{TrustDomainId: td.IDString()},
+			expectCode:          codes.OK,
+			expectServingStatus: grpc_health_v1.HealthCheckResponse_SERVING,
+		},
+		{
+			name:       "service name not supported",
+			service:    "WHATEVER",
+			expectCode: codes.InvalidArgument,
+			expectMsg:  "per-service health is not supported",
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid argument: per-service health is not supported",
+				},
+			},
+		},
+		{
+			name:                "unable to retrieve bundle",
+			dsErr:               errors.New("ohno"),
+			expectCode:          codes.OK,
+			expectServingStatus: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.WarnLevel,
+					Message: "Health check failed",
+					Data: logrus.Fields{
+						"reason": "unable to fetch bundle",
+						"error":  "ohno",
+					},
+				},
+			},
+		},
+		{
+			name:                "bundle is missing",
+			expectCode:          codes.OK,
+			expectServingStatus: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.WarnLevel,
+					Message: "Health check failed",
+					Data: logrus.Fields{
+						"reason": "bundle is missing",
+					},
+				},
+			},
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			log, logHook := test.NewNullLogger()
+
+			ds := fakedatastore.New(t)
+			if tt.dsErr != nil {
+				ds.SetNextError(tt.dsErr)
+			}
+			if tt.bundle != nil {
+				_, err := ds.CreateBundle(context.Background(), &datastore.CreateBundleRequest{
+					Bundle: tt.bundle,
+				})
+				require.NoError(t, err)
+			}
+
+			service := health.New(health.Config{
+				TrustDomain: td,
+				DataStore:   ds,
+			})
+
+			conn, done := spiretest.NewAPIServer(t,
+				func(s *grpc.Server) {
+					health.RegisterService(s, service)
+				},
+				func(ctx context.Context) context.Context {
+					return rpccontext.WithLogger(ctx, log)
+				},
+			)
+			defer done()
+
+			client := grpc_health_v1.NewHealthClient(conn)
+			resp, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+				Service: tt.service,
+			})
+
+			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			spiretest.AssertLogs(t, logHook.AllEntries(), tt.expectLogs)
+
+			if err != nil {
+				return
+			}
+			require.Equal(t, tt.expectServingStatus, resp.Status)
+		})
+	}
+}

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -17,6 +17,7 @@ import (
 	bundlev1 "github.com/spiffe/spire/pkg/server/api/bundle/v1"
 	debugv1 "github.com/spiffe/spire/pkg/server/api/debug/v1"
 	entryv1 "github.com/spiffe/spire/pkg/server/api/entry/v1"
+	healthv1 "github.com/spiffe/spire/pkg/server/api/health/v1"
 	svidv1 "github.com/spiffe/spire/pkg/server/api/svid/v1"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/cache/dscache"
@@ -151,23 +152,27 @@ func (c *Config) makeAPIServers(entryFetcher api.AuthorizedEntryFetcher) APIServ
 			DataStore:         ds,
 			UpstreamPublisher: upstreamPublisher,
 		}),
-		EntryServer: entryv1.New(entryv1.Config{
-			TrustDomain:  c.TrustDomain,
-			DataStore:    ds,
-			EntryFetcher: entryFetcher,
-		}),
-		SVIDServer: svidv1.New(svidv1.Config{
-			TrustDomain:  c.TrustDomain,
-			EntryFetcher: entryFetcher,
-			ServerCA:     c.ServerCA,
-			DataStore:    ds,
-		}),
 		DebugServer: debugv1.New(debugv1.Config{
 			TrustDomain:  c.TrustDomain,
 			Clock:        c.Clock,
 			DataStore:    ds,
 			SVIDObserver: c.SVIDObserver,
 			Uptime:       c.Uptime,
+		}),
+		EntryServer: entryv1.New(entryv1.Config{
+			TrustDomain:  c.TrustDomain,
+			DataStore:    ds,
+			EntryFetcher: entryFetcher,
+		}),
+		HealthServer: healthv1.New(healthv1.Config{
+			TrustDomain: c.TrustDomain,
+			DataStore:   ds,
+		}),
+		SVIDServer: svidv1.New(svidv1.Config{
+			TrustDomain:  c.TrustDomain,
+			EntryFetcher: entryFetcher,
+			ServerCA:     c.ServerCA,
+			DataStore:    ds,
 		}),
 	}
 }

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/andres-erbsen/clock"
@@ -76,6 +77,7 @@ type APIServers struct {
 	BundleServer bundlev1_pb.BundleServer
 	DebugServer  debugv1_pb.DebugServer
 	EntryServer  entryv1_pb.EntryServer
+	HealthServer grpc_health_v1.HealthServer
 	SVIDServer   svidv1_pb.SVIDServer
 }
 
@@ -145,7 +147,9 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 	entryv1_pb.RegisterEntryServer(udsServer, e.APIServers.EntryServer)
 	svidv1_pb.RegisterSVIDServer(tcpServer, e.APIServers.SVIDServer)
 	svidv1_pb.RegisterSVIDServer(udsServer, e.APIServers.SVIDServer)
-	// Register Debug API only on UDS server
+
+	// Register Health and Debug only on UDS server
+	grpc_health_v1.RegisterHealthServer(udsServer, e.APIServers.HealthServer)
 	debugv1_pb.RegisterDebugServer(udsServer, e.APIServers.DebugServer)
 
 	tasks := []func(context.Context) error{

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -81,6 +81,8 @@ func Authorization(log logrus.FieldLogger, ds datastore.DataStore, clk clock.Clo
 		"/spire.api.server.agent.v1.Agent/AttestAgent":                  any,
 		"/spire.api.server.agent.v1.Agent/RenewAgent":                   agent,
 		"/spire.api.server.agent.v1.Agent/CreateJoinToken":              localOrAdmin,
+		"/grpc.health.v1.Health/Check":                                  local,
+		"/grpc.health.v1.Health/Watch":                                  local,
 	}
 }
 
@@ -228,6 +230,8 @@ func RateLimits(config RateLimitConfig) map[string]api.RateLimiter {
 		"/spire.api.server.agent.v1.Agent/AttestAgent":                  attestLimit,
 		"/spire.api.server.agent.v1.Agent/RenewAgent":                   csrLimit,
 		"/spire.api.server.agent.v1.Agent/CreateJoinToken":              noLimit,
+		"/grpc.health.v1.Health/Check":                                  noLimit,
+		"/grpc.health.v1.Health/Watch":                                  noLimit,
 	}
 }
 


### PR DESCRIPTION
This PR introduces a standard gRPC v1 health service on SPIRE server. It does not attempt to redefine the health checks currently exercised by the spire-server CLI, but rather keeps those semantics pending a larger discussion on SPIRE health.

The Watch RPC is left unimplemented for now.

The CLI is also updated to use the health service Check endpoint.