### PR TITLE
Change default socket paths and server CLI flag

### DIFF
--- a/api/workload/v2/workload.go
+++ b/api/workload/v2/workload.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	// DefaultAgentAddress is the default GRPC address to contact the spire agent at.
-	DefaultAgentAddress = "unix:///tmp/agent.sock"
+	DefaultAgentAddress = "unix:///tmp/spire-agent/public/api.sock"
 
 	// EnvVarAgentAddress is the environment variable name where the Workload API address may be configured.
 	EnvVarAgentAddress = "SPIFFE_ENDPOINT_SOCKET"

--- a/api/workload/v2/workload_test.go
+++ b/api/workload/v2/workload_test.go
@@ -127,7 +127,7 @@ func TestStartStop(t *testing.T) {
 func TestGetAgentAddress(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		os.Unsetenv(EnvVarAgentAddress)
-		require.Equal(t, "unix:///tmp/agent.sock", GetAgentAddress())
+		require.Equal(t, "unix:///tmp/spire-agent/public/api.sock", GetAgentAddress())
 	})
 	t.Run("env", func(t *testing.T) {
 		os.Setenv(EnvVarAgentAddress, "/foo")

--- a/cmd/spire-agent/cli/api/common.go
+++ b/cmd/spire-agent/cli/api/common.go
@@ -74,7 +74,7 @@ func adaptCommand(env *cli.Env, clientsMaker workloadClientMaker, cmd command) *
 
 	fs := flag.NewFlagSet(cmd.name(), flag.ContinueOnError)
 	fs.SetOutput(env.Stderr)
-	fs.StringVar(&a.socketPath, "socketPath", common.DefaultSocketPath, "Path to the Agent API socket")
+	fs.StringVar(&a.socketPath, "socketPath", common.DefaultSocketPath, "Path to the SPIRE Agent API socket")
 	fs.Var(&a.timeout, "timeout", "Time to wait for a response")
 	a.cmd.appendFlags(fs)
 	a.flags = fs

--- a/cmd/spire-agent/cli/api/common.go
+++ b/cmd/spire-agent/cli/api/common.go
@@ -74,7 +74,7 @@ func adaptCommand(env *cli.Env, clientsMaker workloadClientMaker, cmd command) *
 
 	fs := flag.NewFlagSet(cmd.name(), flag.ContinueOnError)
 	fs.SetOutput(env.Stderr)
-	fs.StringVar(&a.socketPath, "socketPath", common.DefaultSocketPath, "Path to Workload API socket")
+	fs.StringVar(&a.socketPath, "socketPath", common.DefaultSocketPath, "Path to the Agent API socket")
 	fs.Var(&a.timeout, "timeout", "Time to wait for a response")
 	a.cmd.appendFlags(fs)
 	a.flags = fs

--- a/cmd/spire-agent/cli/api/watch.go
+++ b/cmd/spire-agent/cli/api/watch.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/spiffe/spire/api/workload"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
 )
 
 type WatchConfig struct {
@@ -67,7 +68,7 @@ func (w *WatchCLI) Run(args []string) int {
 func (w *WatchCLI) parseConfig(args []string) error {
 	fs := flag.NewFlagSet("watch", flag.ContinueOnError)
 	c := &WatchConfig{}
-	fs.StringVar(&c.socketPath, "socketPath", "/tmp/agent.sock", "Path to the Workload API socket")
+	fs.StringVar(&c.socketPath, "socketPath", common.DefaultSocketPath, "Path to the Workload API socket")
 
 	w.config = c
 	return fs.Parse(args)

--- a/cmd/spire-agent/cli/common/defaults.go
+++ b/cmd/spire-agent/cli/common/defaults.go
@@ -2,5 +2,5 @@ package common
 
 const (
 	// DefaultSocketPath is the SPIRE agent's default socket path
-	DefaultSocketPath = "/tmp/agent.sock"
+	DefaultSocketPath = "/tmp/spire-agent/public/api.sock"
 )

--- a/cmd/spire-agent/cli/healthcheck/healthcheck.go
+++ b/cmd/spire-agent/cli/healthcheck/healthcheck.go
@@ -61,7 +61,7 @@ func (c *healthCheckCommand) Run(args []string) int {
 func (c *healthCheckCommand) parseFlags(args []string) error {
 	fs := flag.NewFlagSet("health", flag.ContinueOnError)
 	fs.SetOutput(c.env.Stderr)
-	fs.StringVar(&c.socketPath, "socketPath", common.DefaultSocketPath, "Path to Workload API socket")
+	fs.StringVar(&c.socketPath, "socketPath", common.DefaultSocketPath, "Path to the Agent API socket")
 	fs.BoolVar(&c.shallow, "shallow", false, "Perform a less stringent health check")
 	fs.BoolVar(&c.verbose, "verbose", false, "Print verbose information")
 	return fs.Parse(args)

--- a/cmd/spire-agent/cli/healthcheck/healthcheck.go
+++ b/cmd/spire-agent/cli/healthcheck/healthcheck.go
@@ -61,7 +61,7 @@ func (c *healthCheckCommand) Run(args []string) int {
 func (c *healthCheckCommand) parseFlags(args []string) error {
 	fs := flag.NewFlagSet("health", flag.ContinueOnError)
 	fs.SetOutput(c.env.Stderr)
-	fs.StringVar(&c.socketPath, "socketPath", common.DefaultSocketPath, "Path to the Agent API socket")
+	fs.StringVar(&c.socketPath, "socketPath", common.DefaultSocketPath, "Path to the SPIRE Agent API socket")
 	fs.BoolVar(&c.shallow, "shallow", false, "Perform a less stringent health check")
 	fs.BoolVar(&c.verbose, "verbose", false, "Print verbose information")
 	return fs.Parse(args)

--- a/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
@@ -49,7 +49,7 @@ func (s *HealthCheckSuite) TestHelp() {
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to Workload API socket (default "/tmp/agent.sock")
+    	Path to the Agent API socket (default "/tmp/spire-agent/public/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")
@@ -64,7 +64,7 @@ Usage of health:
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to Workload API socket (default "/tmp/agent.sock")
+    	Path to the Agent API socket (default "/tmp/spire-agent/public/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")

--- a/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-agent/cli/healthcheck/healthcheck_test.go
@@ -49,7 +49,7 @@ func (s *HealthCheckSuite) TestHelp() {
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to the Agent API socket (default "/tmp/spire-agent/public/api.sock")
+    	Path to the SPIRE Agent API socket (default "/tmp/spire-agent/public/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")
@@ -64,7 +64,7 @@ Usage of health:
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to the Agent API socket (default "/tmp/spire-agent/public/api.sock")
+    	Path to the SPIRE Agent API socket (default "/tmp/spire-agent/public/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -249,7 +249,7 @@ func parseFlags(name string, args []string, output io.Writer) (*agentConfig, err
 	flags.StringVar(&c.LogLevel, "logLevel", "", "'debug', 'info', 'warn', or 'error'")
 	flags.StringVar(&c.ServerAddress, "serverAddress", "", "IP address or DNS name of the SPIRE server")
 	flags.IntVar(&c.ServerPort, "serverPort", 0, "Port number of the SPIRE server")
-	flags.StringVar(&c.SocketPath, "socketPath", "", "Path to bind the Agent API socket to")
+	flags.StringVar(&c.SocketPath, "socketPath", "", "Path to bind the SPIRE Agent API socket to")
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this agent belongs to")
 	flags.StringVar(&c.TrustBundlePath, "trustBundle", "", "Path to the SPIRE server CA bundle")
 	flags.StringVar(&c.TrustBundleURL, "trustBundleUrl", "", "URL to download the SPIRE server CA bundle")

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -249,7 +249,7 @@ func parseFlags(name string, args []string, output io.Writer) (*agentConfig, err
 	flags.StringVar(&c.LogLevel, "logLevel", "", "'debug', 'info', 'warn', or 'error'")
 	flags.StringVar(&c.ServerAddress, "serverAddress", "", "IP address or DNS name of the SPIRE server")
 	flags.IntVar(&c.ServerPort, "serverPort", 0, "Port number of the SPIRE server")
-	flags.StringVar(&c.SocketPath, "socketPath", "", "Location to bind the workload API socket")
+	flags.StringVar(&c.SocketPath, "socketPath", "", "Path to bind the Agent API socket to")
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this agent belongs to")
 	flags.StringVar(&c.TrustBundlePath, "trustBundle", "", "Path to the SPIRE server CA bundle")
 	flags.StringVar(&c.TrustBundleURL, "trustBundleUrl", "", "URL to download the SPIRE server CA bundle")

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -93,7 +93,7 @@ func TestParseConfigGood(t *testing.T) {
 	assert.Equal(t, c.Agent.LogLevel, "INFO")
 	assert.Equal(t, c.Agent.ServerAddress, "127.0.0.1")
 	assert.Equal(t, c.Agent.ServerPort, 8081)
-	assert.Equal(t, c.Agent.SocketPath, "/tmp/agent.sock")
+	assert.Equal(t, c.Agent.SocketPath, "/tmp/spire-agent/public/api.sock")
 	assert.Equal(t, c.Agent.TrustBundlePath, "conf/agent/dummy_root_ca.crt")
 	assert.Equal(t, c.Agent.TrustDomain, "example.org")
 
@@ -137,7 +137,7 @@ func TestParseFlagsGood(t *testing.T) {
 		"-logLevel=INFO",
 		"-serverAddress=127.0.0.1",
 		"-serverPort=8081",
-		"-socketPath=/tmp/agent.sock",
+		"-socketPath=/tmp/spire-agent/public/api.sock",
 		"-trustBundle=conf/agent/dummy_root_ca.crt",
 		"-trustBundleUrl=https://test.url",
 		"-trustDomain=example.org",
@@ -147,7 +147,7 @@ func TestParseFlagsGood(t *testing.T) {
 	assert.Equal(t, c.LogLevel, "INFO")
 	assert.Equal(t, c.ServerAddress, "127.0.0.1")
 	assert.Equal(t, c.ServerPort, 8081)
-	assert.Equal(t, c.SocketPath, "/tmp/agent.sock")
+	assert.Equal(t, c.SocketPath, "/tmp/spire-agent/public/api.sock")
 	assert.Equal(t, c.TrustBundlePath, "conf/agent/dummy_root_ca.crt")
 	assert.Equal(t, c.TrustBundleURL, "https://test.url")
 	assert.Equal(t, c.TrustDomain, "example.org")
@@ -459,11 +459,11 @@ func TestMergeInput(t *testing.T) {
 			},
 		},
 		{
-			msg:       "socket_path should default to /tmp/agent.sock if not set",
+			msg:       "socket_path should default to /tmp/spire-agent/public/api.sock if not set",
 			fileInput: func(c *Config) {},
 			cliInput:  func(c *agentConfig) {},
 			test: func(t *testing.T, c *Config) {
-				require.Equal(t, "/tmp/agent.sock", c.Agent.SocketPath)
+				require.Equal(t, "/tmp/spire-agent/public/api.sock", c.Agent.SocketPath)
 			},
 		},
 		{

--- a/cmd/spire-server/cli/agent/agent_test.go
+++ b/cmd/spire-server/cli/agent/agent_test.go
@@ -47,9 +47,9 @@ func TestEvictHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent evict:
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the agent to evict (agent identity)
 `, test.stderr.String())
@@ -109,9 +109,9 @@ func TestListHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent list:
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -167,9 +167,9 @@ func TestShowHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent show:
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the agent to show (agent identity)
 `, test.stderr.String())

--- a/cmd/spire-server/cli/agent/agent_test.go
+++ b/cmd/spire-server/cli/agent/agent_test.go
@@ -47,7 +47,9 @@ func TestEvictHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent evict:
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the agent to evict (agent identity)
 `, test.stderr.String())
@@ -76,7 +78,7 @@ func TestEvict(t *testing.T) {
 		},
 		{
 			name:               "wrong UDS path",
-			args:               []string{"-registrationUDSPath", "does-not-exist.sock"},
+			args:               []string{"-socketPath", "does-not-exist.sock"},
 			expectedReturnCode: 1,
 			expectedStderr:     "Error: connection error: desc = \"transport: error while dialing: dial unix does-not-exist.sock: connect: no such file or directory\"\n",
 		},
@@ -107,7 +109,9 @@ func TestListHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent list:
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -139,7 +143,7 @@ func TestList(t *testing.T) {
 		},
 		{
 			name:               "wrong UDS path",
-			args:               []string{"-registrationUDSPath", "does-not-exist.sock"},
+			args:               []string{"-socketPath", "does-not-exist.sock"},
 			expectedReturnCode: 1,
 			expectedStderr:     "Error: connection error: desc = \"transport: error while dialing: dial unix does-not-exist.sock: connect: no such file or directory\"\n",
 		},
@@ -163,7 +167,9 @@ func TestShowHelp(t *testing.T) {
 	test.client.Help()
 	require.Equal(t, `Usage of agent show:
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the agent to show (agent identity)
 `, test.stderr.String())
@@ -201,7 +207,7 @@ func TestShow(t *testing.T) {
 		},
 		{
 			name:               "wrong UDS path",
-			args:               []string{"-registrationUDSPath", "does-not-exist.sock"},
+			args:               []string{"-socketPath", "does-not-exist.sock"},
 			expectedReturnCode: 1,
 			expectedStderr:     "Error: connection error: desc = \"transport: error while dialing: dial unix does-not-exist.sock: connect: no such file or directory\"\n",
 		},
@@ -241,7 +247,7 @@ func setupTest(t *testing.T, newClient func(*common_cli.Env) cli.Command) *agent
 		stdin:  stdin,
 		stdout: stdout,
 		stderr: stderr,
-		args:   []string{"-registrationUDSPath", socketPath},
+		args:   []string{"-socketPath", socketPath},
 		server: server,
 		client: client,
 	}

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -24,9 +24,9 @@ func TestShowHelp(t *testing.T) {
   -format string
     	The format to show the bundle. Either "pem" or "spiffe". (default "pem")
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -101,9 +101,9 @@ func TestSetHelp(t *testing.T) {
   -path string
     	Path to the bundle data
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -392,9 +392,9 @@ func TestListHelp(t *testing.T) {
   -id string
     	SPIFFE ID of the trust domain
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -513,9 +513,9 @@ func TestDeleteHelp(t *testing.T) {
   -mode string
     	Deletion mode: one of restrict, delete, or dissociate (default "restrict")
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -24,7 +24,9 @@ func TestShowHelp(t *testing.T) {
   -format string
     	The format to show the bundle. Either "pem" or "spiffe". (default "pem")
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -99,7 +101,9 @@ func TestSetHelp(t *testing.T) {
   -path string
     	Path to the bundle data
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -388,7 +392,9 @@ func TestListHelp(t *testing.T) {
   -id string
     	SPIFFE ID of the trust domain
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 
@@ -507,7 +513,9 @@ func TestDeleteHelp(t *testing.T) {
   -mode string
     	Deletion mode: one of restrict, delete, or dissociate (default "restrict")
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 

--- a/cmd/spire-server/cli/bundle/common_test.go
+++ b/cmd/spire-server/cli/bundle/common_test.go
@@ -204,7 +204,7 @@ func setupTest(t *testing.T, newClient func(*common_cli.Env) cli.Command) *bundl
 		stdin:    stdin,
 		stdout:   stdout,
 		stderr:   stderr,
-		args:     []string{"-registrationUDSPath", socketPath},
+		args:     []string{"-socketPath", socketPath},
 		server:   server,
 		client:   client,
 	}

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -77,7 +77,7 @@ func (c *createCommand) AppendFlags(f *flag.FlagSet) {
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
 	f.BoolVar(&c.node, "node", false, "If set, this entry will be applied to matching nodes rather than workloads")
-	f.BoolVar(&c.admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the Registration API")
+	f.BoolVar(&c.admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the Server APIs")
 	f.BoolVar(&c.downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 	f.Int64Var(&c.entryExpiry, "entryExpiry", 0, "An expiry, from epoch in seconds, for the resulting registration entry to be pruned")
 	f.Var(&c.dnsNames, "dns", "A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once")

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -77,7 +77,7 @@ func (c *createCommand) AppendFlags(f *flag.FlagSet) {
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
 	f.BoolVar(&c.node, "node", false, "If set, this entry will be applied to matching nodes rather than workloads")
-	f.BoolVar(&c.admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the Server APIs")
+	f.BoolVar(&c.admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the SPIRE Server's management APIs")
 	f.BoolVar(&c.downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 	f.Int64Var(&c.entryExpiry, "entryExpiry", 0, "An expiry, from epoch in seconds, for the resulting registration entry to be pruned")
 	f.Var(&c.dnsNames, "dns", "A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once")

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -18,7 +18,7 @@ func TestCreateHelp(t *testing.T) {
 
 	require.Equal(t, `Usage of entry create:
   -admin
-    	If set, the SPIFFE ID in this entry will be granted access to the Server APIs
+    	If set, the SPIFFE ID in this entry will be granted access to the SPIRE Server's management APIs
   -data string
     	Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.
   -dns value
@@ -34,11 +34,11 @@ func TestCreateHelp(t *testing.T) {
   -parentID string
     	The SPIFFE ID of this record's parent
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID that this record represents
   -ttl int

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -18,7 +18,7 @@ func TestCreateHelp(t *testing.T) {
 
 	require.Equal(t, `Usage of entry create:
   -admin
-    	If set, the SPIFFE ID in this entry will be granted access to the Registration API
+    	If set, the SPIFFE ID in this entry will be granted access to the Server APIs
   -data string
     	Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.
   -dns value
@@ -34,9 +34,11 @@ func TestCreateHelp(t *testing.T) {
   -parentID string
     	The SPIFFE ID of this record's parent
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID that this record represents
   -ttl int

--- a/cmd/spire-server/cli/entry/delete_test.go
+++ b/cmd/spire-server/cli/entry/delete_test.go
@@ -18,9 +18,9 @@ func TestDeleteHelp(t *testing.T) {
   -entryID string
     	The Registration Entry ID of the record to delete
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 

--- a/cmd/spire-server/cli/entry/delete_test.go
+++ b/cmd/spire-server/cli/entry/delete_test.go
@@ -18,7 +18,9 @@ func TestDeleteHelp(t *testing.T) {
   -entryID string
     	The Registration Entry ID of the record to delete
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
 `, test.stderr.String())
 }
 

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -26,9 +26,11 @@ func TestShowHelp(t *testing.T) {
   -parentID string
     	The Parent ID of the records to show
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the records to show
 `, test.stderr.String())

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -26,11 +26,11 @@ func TestShowHelp(t *testing.T) {
   -parentID string
     	The Parent ID of the records to show
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID of the records to show
 `, test.stderr.String())

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -77,7 +77,7 @@ func (c *updateCommand) AppendFlags(f *flag.FlagSet) {
 	f.StringVar(&c.path, "data", "", "Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.")
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
-	f.BoolVar(&c.admin, "admin", false, "If true, the SPIFFE ID in this entry will be granted access to the Server APIs")
+	f.BoolVar(&c.admin, "admin", false, "If set, the SPIFFE ID in this entry will be granted access to the SPIRE Server's management APIs")
 	f.BoolVar(&c.downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 	f.Int64Var(&c.entryExpiry, "entryExpiry", 0, "An expiry, from epoch in seconds, for the resulting registration entry to be pruned")
 	f.Var(&c.dnsNames, "dns", "A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once")

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -77,7 +77,7 @@ func (c *updateCommand) AppendFlags(f *flag.FlagSet) {
 	f.StringVar(&c.path, "data", "", "Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.")
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
-	f.BoolVar(&c.admin, "admin", false, "If true, the SPIFFE ID in this entry will be granted access to the Registration API")
+	f.BoolVar(&c.admin, "admin", false, "If true, the SPIFFE ID in this entry will be granted access to the Server APIs")
 	f.BoolVar(&c.downstream, "downstream", false, "A boolean value that, when set, indicates that the entry describes a downstream SPIRE server")
 	f.Int64Var(&c.entryExpiry, "entryExpiry", 0, "An expiry, from epoch in seconds, for the resulting registration entry to be pruned")
 	f.Var(&c.dnsNames, "dns", "A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once")

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -18,7 +18,7 @@ func TestUpdateHelp(t *testing.T) {
 
 	require.Equal(t, `Usage of entry update:
   -admin
-    	If true, the SPIFFE ID in this entry will be granted access to the Server APIs
+    	If set, the SPIFFE ID in this entry will be granted access to the SPIRE Server's management APIs
   -data string
     	Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.
   -dns value
@@ -34,11 +34,11 @@ func TestUpdateHelp(t *testing.T) {
   -parentID string
     	The SPIFFE ID of this record's parent
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID that this record represents
   -ttl int

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -18,7 +18,7 @@ func TestUpdateHelp(t *testing.T) {
 
 	require.Equal(t, `Usage of entry update:
   -admin
-    	If true, the SPIFFE ID in this entry will be granted access to the Registration API
+    	If true, the SPIFFE ID in this entry will be granted access to the Server APIs
   -data string
     	Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.
   -dns value
@@ -34,9 +34,11 @@ func TestUpdateHelp(t *testing.T) {
   -parentID string
     	The SPIFFE ID of this record's parent
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
   -selector value
     	A colon-delimited type:value selector. Can be used more than once
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	The SPIFFE ID that this record represents
   -ttl int

--- a/cmd/spire-server/cli/entry/util_test.go
+++ b/cmd/spire-server/cli/entry/util_test.go
@@ -209,7 +209,7 @@ func setupTest(t *testing.T, newClient func(*common_cli.Env) cli.Command) *entry
 		stdin:  stdin,
 		stdout: stdout,
 		stderr: stderr,
-		args:   []string{"-registrationUDSPath", socketPath},
+		args:   []string{"-socketPath", socketPath},
 		server: server,
 		client: client,
 	}

--- a/cmd/spire-server/cli/healthcheck/healthcheck.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-server/util"
@@ -17,82 +16,52 @@ func NewHealthCheckCommand() cli.Command {
 	return newHealthCheckCommand(common_cli.DefaultEnv)
 }
 
-func newHealthCheckCommand(env *common_cli.Env) *healthCheckCommand {
-	return &healthCheckCommand{
-		env:     env,
-		timeout: common_cli.DurationFlag(time.Second * 5),
-	}
+func newHealthCheckCommand(env *common_cli.Env) cli.Command {
+	return util.AdaptCommand(env, new(healthCheckCommand))
 }
 
 type healthCheckCommand struct {
-	env *common_cli.Env
-
-	socketPath string
-	timeout    common_cli.DurationFlag
-	shallow    bool
-	verbose    bool
+	shallow bool
+	verbose bool
 }
 
-func (c *healthCheckCommand) Help() string {
-	// ignoring parsing errors since "-h" is always supported by the flags package
-	_ = c.parseFlags([]string{"-h"})
-	return ""
+func (c *healthCheckCommand) Name() string {
+	return "healthcheck"
 }
 
 func (c *healthCheckCommand) Synopsis() string {
 	return "Determines server health status"
 }
 
-func (c *healthCheckCommand) Run(args []string) int {
-	if err := c.parseFlags(args); err != nil {
-		return 1
-	}
-	if err := c.run(); err != nil {
-		// Ignore error since a failure to write to stderr cannot very well be
-		// reported
-		_ = c.env.ErrPrintf("Server is unhealthy: %v\n", err)
-		return 1
-	}
-	if err := c.env.Println("Server is healthy."); err != nil {
-		return 1
-	}
-	return 0
-}
-
-func (c *healthCheckCommand) parseFlags(args []string) error {
-	fs := flag.NewFlagSet("health", flag.ContinueOnError)
-	fs.SetOutput(c.env.Stderr)
-	fs.StringVar(&c.socketPath, "registrationUDSPath", util.DefaultSocketPath, "Registration API UDS path")
+func (c *healthCheckCommand) AppendFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.shallow, "shallow", false, "Perform a less stringent health check")
 	fs.BoolVar(&c.verbose, "verbose", false, "Print verbose information")
-	return fs.Parse(args)
 }
 
-func (c *healthCheckCommand) run() error {
+func (c *healthCheckCommand) Run(ctx context.Context, env *common_cli.Env, client util.ServerClient) error {
+	if err := c.run(ctx, env, client); err != nil {
+		return fmt.Errorf("server is unhealthy: %w", err)
+	}
+	if err := env.Println("Server is healthy."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *healthCheckCommand) run(ctx context.Context, env *common_cli.Env, client util.ServerClient) error {
 	if c.verbose {
-		if err := c.env.Println("Checking server health..."); err != nil {
+		if err := env.Println("Checking server health..."); err != nil {
 			return err
 		}
 	}
 
-	client, err := util.NewServerClient(c.socketPath)
-	if err != nil {
-		if c.verbose {
-			// Ignore error since a failure to write to stderr cannot very well
-			// be reported
-			_ = c.env.ErrPrintf("Failed to create client: %v\n", err)
-		}
-		return errors.New("cannot create health client")
-	}
-	defer client.Release()
-
 	healthClient := client.NewHealthClient()
-	resp, err := healthClient.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	resp, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 	if err != nil {
 		if c.verbose {
 			// Ignore error since a failure to write to stderr cannot very well
 			// be reported
-			_ = c.env.ErrPrintf("Failed to check health: %v\n", err)
+			_ = env.ErrPrintf("Failed to check health: %v\n", err)
 		}
 		return errors.New("unable to determine health")
 	}

--- a/cmd/spire-server/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck_test.go
@@ -44,12 +44,14 @@ func (s *HealthCheckSuite) TestSynopsis() {
 }
 
 func (s *HealthCheckSuite) TestHelp() {
-	s.Equal("", s.cmd.Help())
-	s.Equal(`Usage of health:
+	s.Equal("flag: help requested", s.cmd.Help())
+	s.Equal(`Usage of healthcheck:
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
   -shallow
     	Perform a less stringent health check
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")
@@ -60,30 +62,31 @@ func (s *HealthCheckSuite) TestBadFlags() {
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
 	s.Equal(`flag provided but not defined: -badflag
-Usage of health:
+Usage of healthcheck:
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
   -shallow
     	Perform a less stringent health check
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")
 }
 
 func (s *HealthCheckSuite) TestFailsIfSocketDoesNotExist() {
-	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock"})
+	code := s.cmd.Run([]string{"--socketPath", "doesnotexist.sock"})
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
-	s.Equal("Server is unhealthy: cannot create health client\n", s.stderr.String(), "stderr")
+	s.Equal(`Error: connection error: desc = "transport: error while dialing: dial unix doesnotexist.sock: connect: no such file or directory"
+`, s.stderr.String(), "stderr")
 }
 
 func (s *HealthCheckSuite) TestFailsIfSocketDoesNotExistVerbose() {
-	code := s.cmd.Run([]string{"--registrationUDSPath", "doesnotexist.sock", "--verbose"})
+	code := s.cmd.Run([]string{"--socketPath", "doesnotexist.sock", "--verbose"})
 	s.NotEqual(0, code, "exit code")
-	s.Equal(`Checking server health...
-`, s.stdout.String(), "stdout")
-	s.Equal(`Failed to create client: connection error: desc = "transport: error while dialing: dial unix doesnotexist.sock: connect: no such file or directory"
-Server is unhealthy: cannot create health client
+	s.Equal("", s.stdout.String(), "stdout")
+	s.Equal(`Error: connection error: desc = "transport: error while dialing: dial unix doesnotexist.sock: connect: no such file or directory"
 `, s.stderr.String(), "stderr")
 }
 
@@ -91,7 +94,7 @@ func (s *HealthCheckSuite) TestSucceedsIfServingStatusServing() {
 	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
 		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_SERVING))
 	})
-	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath})
+	code := s.cmd.Run([]string{"--socketPath", socketPath})
 	s.Equal(0, code, "exit code")
 	s.Equal("Server is healthy.\n", s.stdout.String(), "stdout")
 	s.Equal("", s.stderr.String(), "stderr")
@@ -101,7 +104,7 @@ func (s *HealthCheckSuite) TestSucceedsIfServingStatusServingVerbose() {
 	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
 		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_SERVING))
 	})
-	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath, "--verbose"})
+	code := s.cmd.Run([]string{"--socketPath", socketPath, "--verbose"})
 	s.Equal(0, code, "exit code")
 	s.Equal(`Checking server health...
 Server is healthy.
@@ -113,11 +116,11 @@ func (s *HealthCheckSuite) TestFailsIfServiceStatusOther() {
 	socketPath := spiretest.StartGRPCSocketServerOnTempSocket(s.T(), func(srv *grpc.Server) {
 		grpc_health_v1.RegisterHealthServer(srv, withStatus(grpc_health_v1.HealthCheckResponse_NOT_SERVING))
 	})
-	code := s.cmd.Run([]string{"--registrationUDSPath", socketPath, "--verbose"})
+	code := s.cmd.Run([]string{"--socketPath", socketPath, "--verbose"})
 	s.NotEqual(0, code, "exit code")
 	s.Equal(`Checking server health...
 `, s.stdout.String(), "stdout")
-	s.Equal(`Server is unhealthy: server returned status "NOT_SERVING"
+	s.Equal(`Error: server is unhealthy: server returned status "NOT_SERVING"
 `, s.stderr.String(), "stderr")
 }
 

--- a/cmd/spire-server/cli/healthcheck/healthcheck_test.go
+++ b/cmd/spire-server/cli/healthcheck/healthcheck_test.go
@@ -47,11 +47,11 @@ func (s *HealthCheckSuite) TestHelp() {
 	s.Equal("flag: help requested", s.cmd.Help())
 	s.Equal(`Usage of healthcheck:
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")
@@ -64,11 +64,11 @@ func (s *HealthCheckSuite) TestBadFlags() {
 	s.Equal(`flag provided but not defined: -badflag
 Usage of healthcheck:
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -shallow
     	Perform a less stringent health check
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -verbose
     	Print verbose information
 `, s.stderr.String(), "stderr")

--- a/cmd/spire-server/cli/jwt/mint_test.go
+++ b/cmd/spire-server/cli/jwt/mint_test.go
@@ -38,9 +38,9 @@ const (
   -audience value
     	Audience claim that will be included in the SVID. Can be used more than once.
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	SPIFFE ID of the JWT-SVID
   -ttl duration

--- a/cmd/spire-server/cli/jwt/mint_test.go
+++ b/cmd/spire-server/cli/jwt/mint_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	svidpb "github.com/spiffe/spire/proto/spire/api/server/svid/v1"
@@ -39,7 +38,9 @@ const (
   -audience value
     	Audience claim that will be included in the SVID. Can be used more than once.
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	SPIFFE ID of the JWT-SVID
   -ttl duration
@@ -74,11 +75,9 @@ func TestMintRun(t *testing.T) {
 
 	server := new(fakeSVIDServer)
 
-	spiretest.StartGRPCSocketServer(t, util.DefaultSocketPath, func(s *grpc.Server) {
-		svidpb.RegisterSVIDServer(s, server)
-	})
+	socketPath := filepath.Join(dir, "socket")
 
-	alternativeSocket := spiretest.StartGRPCSocketServerOnTempSocket(t, func(s *grpc.Server) {
+	spiretest.StartGRPCSocketServer(t, socketPath, func(s *grpc.Server) {
 		svidpb.RegisterSVIDServer(s, server)
 	})
 
@@ -107,13 +106,12 @@ func TestMintRun(t *testing.T) {
 		name string
 
 		// flags
-		spiffeID   string
-		expectID   *types.SPIFFEID
-		ttl        time.Duration
-		audience   []string
-		socketPath string
-		write      string
-		extraArgs  []string
+		spiffeID  string
+		expectID  *types.SPIFFEID
+		ttl       time.Duration
+		audience  []string
+		write     string
+		extraArgs []string
 
 		// results
 		code   int
@@ -132,7 +130,7 @@ func TestMintRun(t *testing.T) {
 		{
 			name:              "invalid flag",
 			code:              1,
-			stderr:            fmt.Sprintf("flag provided but not defined: -bad\n%s\n", expectedUsage),
+			stderr:            fmt.Sprintf("flag provided but not defined: -bad\n%s", expectedUsage),
 			extraArgs:         []string{"-bad", "flag"},
 			noRequestExpected: true,
 		},
@@ -248,17 +246,16 @@ func TestMintRun(t *testing.T) {
 			stderr: fmt.Sprintf("JWT-SVID lifetime was capped shorter than specified ttl; expires %q\n", expiredAt.UTC().Format(time.RFC3339)),
 		},
 		{
-			name:     "success with ttl and extra audience, output to file, using alternate socket",
+			name:     "success with ttl and extra audience, output to file",
 			spiffeID: "spiffe://domain.test/workload",
 			expectID: &types.SPIFFEID{
 				TrustDomain: "domain.test",
 				Path:        "/workload",
 			},
-			ttl:        time.Minute,
-			audience:   []string{"AUDIENCE1", "AUDIENCE2"},
-			socketPath: alternativeSocket,
-			code:       0,
-			write:      "token",
+			ttl:      time.Minute,
+			audience: []string{"AUDIENCE1", "AUDIENCE2"},
+			code:     0,
+			write:    "token",
 			resp: &svidpb.MintJWTSVIDResponse{
 				Svid: &types.JWTSVID{
 					Token: token,
@@ -283,10 +280,7 @@ func TestMintRun(t *testing.T) {
 				BaseDir: dir,
 			})
 
-			args := []string{}
-			if tt.socketPath != "" {
-				args = append(args, "-registrationUDSPath", tt.socketPath)
-			}
+			args := []string{"-socketPath", socketPath}
 			if tt.spiffeID != "" {
 				args = append(args, "-spiffeID", tt.spiffeID)
 			}

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -280,12 +280,12 @@ func parseFlags(name string, args []string, output io.Writer) (*serverConfig, er
 	flags.StringVar(&c.LogFile, "logFile", "", "File to write logs to")
 	flags.StringVar(&c.LogFormat, "logFormat", "", "'text' or 'json'")
 	flags.StringVar(&c.LogLevel, "logLevel", "", "'debug', 'info', 'warn', or 'error'")
-	flags.StringVar(&c.DeprecatedRegistrationUDSPath, "registrationUDSPath", "", "Path to bind the Server API socket to (deprecated; use -socketPath)")
+	flags.StringVar(&c.DeprecatedRegistrationUDSPath, "registrationUDSPath", "", "Path to bind the SPIRE Server API socket to (deprecated; use -socketPath)")
 	// TODO: in 1.1.0. After registrationUDSPath is deprecated, we can put back the
 	// default flag value on socketPath like it was previously, since we'll no
 	// longer need to detect an unset flag from the default for deprecation
 	// logging/error handling purposes.
-	flags.StringVar(&c.SocketPath, "socketPath", "", `Path to bind the Server API socket to (default "`+defaultSocketPath+`")`)
+	flags.StringVar(&c.SocketPath, "socketPath", "", `Path to bind the SPIRE Server API socket to (default "`+defaultSocketPath+`")`)
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this server belongs to")
 	flags.BoolVar(&c.ExpandEnv, "expandEnv", false, "Expand environment variables in SPIRE config file")
 

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -37,7 +37,7 @@ const (
 	commandName = "run"
 
 	defaultConfigPath         = "conf/server/server.conf"
-	defaultSocketPath         = "/tmp/spire-registration.sock"
+	defaultSocketPath         = "/tmp/spire-server/private/api.sock"
 	defaultLogLevel           = "INFO"
 	defaultBundleEndpointPort = 443
 )
@@ -61,22 +61,22 @@ type Config struct {
 }
 
 type serverConfig struct {
-	BindAddress         string             `hcl:"bind_address"`
-	BindPort            int                `hcl:"bind_port"`
-	CAKeyType           string             `hcl:"ca_key_type"`
-	CASubject           *caSubjectConfig   `hcl:"ca_subject"`
-	CATTL               string             `hcl:"ca_ttl"`
-	DataDir             string             `hcl:"data_dir"`
-	Experimental        experimentalConfig `hcl:"experimental"`
-	Federation          *federationConfig  `hcl:"federation"`
-	JWTIssuer           string             `hcl:"jwt_issuer"`
-	LogFile             string             `hcl:"log_file"`
-	LogLevel            string             `hcl:"log_level"`
-	LogFormat           string             `hcl:"log_format"`
-	RateLimit           rateLimitConfig    `hcl:"ratelimit"`
-	RegistrationUDSPath string             `hcl:"registration_uds_path"`
-	DefaultSVIDTTL      string             `hcl:"default_svid_ttl"`
-	TrustDomain         string             `hcl:"trust_domain"`
+	BindAddress    string             `hcl:"bind_address"`
+	BindPort       int                `hcl:"bind_port"`
+	CAKeyType      string             `hcl:"ca_key_type"`
+	CASubject      *caSubjectConfig   `hcl:"ca_subject"`
+	CATTL          string             `hcl:"ca_ttl"`
+	DataDir        string             `hcl:"data_dir"`
+	DefaultSVIDTTL string             `hcl:"default_svid_ttl"`
+	Experimental   experimentalConfig `hcl:"experimental"`
+	Federation     *federationConfig  `hcl:"federation"`
+	JWTIssuer      string             `hcl:"jwt_issuer"`
+	LogFile        string             `hcl:"log_file"`
+	LogLevel       string             `hcl:"log_level"`
+	LogFormat      string             `hcl:"log_format"`
+	RateLimit      rateLimitConfig    `hcl:"ratelimit"`
+	SocketPath     string             `hcl:"socket_path"`
+	TrustDomain    string             `hcl:"trust_domain"`
 
 	ConfigPath string
 	ExpandEnv  bool
@@ -86,6 +86,9 @@ type serverConfig struct {
 	ProfilingPort    int      `hcl:"profiling_port"`
 	ProfilingFreq    int      `hcl:"profiling_freq"`
 	ProfilingNames   []string `hcl:"profiling_names"`
+
+	// TODO: Remove support for deprecated registration_uds_path in 1.1.0
+	DeprecatedRegistrationUDSPath string `hcl:"registration_uds_path"`
 
 	UnusedKeys []string `hcl:",unusedKeys"`
 }
@@ -277,7 +280,12 @@ func parseFlags(name string, args []string, output io.Writer) (*serverConfig, er
 	flags.StringVar(&c.LogFile, "logFile", "", "File to write logs to")
 	flags.StringVar(&c.LogFormat, "logFormat", "", "'text' or 'json'")
 	flags.StringVar(&c.LogLevel, "logLevel", "", "'debug', 'info', 'warn', or 'error'")
-	flags.StringVar(&c.RegistrationUDSPath, "registrationUDSPath", "", "UDS Path to bind registration API")
+	flags.StringVar(&c.DeprecatedRegistrationUDSPath, "registrationUDSPath", "", "Path to bind the Server API socket to (deprecated; use -socketPath)")
+	// TODO: in 1.1.0. After registrationUDSPath is deprecated, we can put back the
+	// default flag value on socketPath like it was previously, since we'll no
+	// longer need to detect an unset flag from the default for deprecation
+	// logging/error handling purposes.
+	flags.StringVar(&c.SocketPath, "socketPath", "", `Path to bind the Server API socket to (default "`+defaultSocketPath+`")`)
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this server belongs to")
 	flags.BoolVar(&c.ExpandEnv, "expandEnv", false, "Expand environment variables in SPIRE config file")
 
@@ -318,28 +326,6 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		return nil, err
 	}
 
-	ip := net.ParseIP(c.Server.BindAddress)
-	if ip == nil {
-		return nil, fmt.Errorf("could not parse bind_address %q", c.Server.BindAddress)
-	}
-	sc.BindAddress = &net.TCPAddr{
-		IP:   ip,
-		Port: c.Server.BindPort,
-	}
-
-	sc.BindUDSAddress = &net.UnixAddr{
-		Name: c.Server.RegistrationUDSPath,
-		Net:  "unix",
-	}
-
-	sc.DataDir = c.Server.DataDir
-
-	trustDomain, err := spiffeid.TrustDomainFromString(c.Server.TrustDomain)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse trust_domain %q: %v", c.Server.TrustDomain, err)
-	}
-	sc.TrustDomain = trustDomain
-
 	logOptions = append(logOptions,
 		log.WithLevel(c.Server.LogLevel),
 		log.WithFormat(c.Server.LogFormat),
@@ -350,6 +336,39 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		return nil, fmt.Errorf("could not start logger: %s", err)
 	}
 	sc.Log = logger
+
+	ip := net.ParseIP(c.Server.BindAddress)
+	if ip == nil {
+		return nil, fmt.Errorf("could not parse bind_address %q", c.Server.BindAddress)
+	}
+	sc.BindAddress = &net.TCPAddr{
+		IP:   ip,
+		Port: c.Server.BindPort,
+	}
+
+	var socketPath string
+	switch {
+	case c.Server.SocketPath != "":
+		socketPath = c.Server.SocketPath
+	case c.Server.DeprecatedRegistrationUDSPath != "":
+		logger.Warn("The registration_uds_path configurable is deprecated; use socket_path instead.")
+		socketPath = c.Server.DeprecatedRegistrationUDSPath
+	default:
+		socketPath = defaultSocketPath
+	}
+
+	sc.BindUDSAddress = &net.UnixAddr{
+		Name: socketPath,
+		Net:  "unix",
+	}
+
+	sc.DataDir = c.Server.DataDir
+
+	trustDomain, err := spiffeid.TrustDomainFromString(c.Server.TrustDomain)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse trust_domain %q: %v", c.Server.TrustDomain, err)
+	}
+	sc.TrustDomain = trustDomain
 
 	if c.Server.RateLimit.Attestation == nil {
 		c.Server.RateLimit.Attestation = &defaultRateLimitAttestation
@@ -480,8 +499,8 @@ func validateConfig(c *Config) error {
 		return errors.New("bind_address and bind_port must be configured")
 	}
 
-	if c.Server.RegistrationUDSPath == "" {
-		return errors.New("registration_uds_path must be configured")
+	if c.Server.SocketPath != "" && c.Server.DeprecatedRegistrationUDSPath != "" {
+		return errors.New("socket_path and the deprecated registration_uds_path are mutually exclusive")
 	}
 
 	if c.Server.TrustDomain == "" {
@@ -622,12 +641,11 @@ func checkForUnknownConfig(c *Config, l logrus.FieldLogger) (err error) {
 func defaultConfig() *Config {
 	return &Config{
 		Server: &serverConfig{
-			BindAddress:         "0.0.0.0",
-			BindPort:            8081,
-			LogLevel:            defaultLogLevel,
-			LogFormat:           log.DefaultFormat,
-			RegistrationUDSPath: defaultSocketPath,
-			Experimental:        experimentalConfig{},
+			BindAddress:  "0.0.0.0",
+			BindPort:     8081,
+			LogLevel:     defaultLogLevel,
+			LogFormat:    log.DefaultFormat,
+			Experimental: experimentalConfig{},
 		},
 	}
 }

--- a/cmd/spire-server/cli/token/generate_test.go
+++ b/cmd/spire-server/cli/token/generate_test.go
@@ -127,7 +127,7 @@ func setupTest(t *testing.T) *tokenTest {
 		stderr: stderr,
 		stdin:  stdin,
 		stdout: stdout,
-		args:   []string{"-registrationUDSPath", socketPath},
+		args:   []string{"-socketPath", socketPath},
 		server: server,
 		client: client,
 	}

--- a/cmd/spire-server/cli/x509/mint_test.go
+++ b/cmd/spire-server/cli/x509/mint_test.go
@@ -34,9 +34,9 @@ const (
   -dns value
     	DNS name that will be included in SVID. Can be used more than once.
   -registrationUDSPath string
-    	Path to the Server API socket (deprecated; use -socketPath)
+    	Path to the SPIRE Server API socket (deprecated; use -socketPath)
   -socketPath string
-    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
+    	Path to the SPIRE Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	SPIFFE ID of the X509-SVID
   -ttl duration

--- a/cmd/spire-server/cli/x509/mint_test.go
+++ b/cmd/spire-server/cli/x509/mint_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	bundlepb "github.com/spiffe/spire/proto/spire/api/server/bundle/v1"
@@ -35,7 +34,9 @@ const (
   -dns value
     	DNS name that will be included in SVID. Can be used more than once.
   -registrationUDSPath string
-    	Registration API UDS path (default "/tmp/spire-registration.sock")
+    	Path to the Server API socket (deprecated; use -socketPath)
+  -socketPath string
+    	Path to the Server API socket (default "/tmp/spire-server/private/api.sock")
   -spiffeID string
     	SPIFFE ID of the X509-SVID
   -ttl duration
@@ -93,6 +94,7 @@ func TestMintRun(t *testing.T) {
 	svidPath := filepath.Join(dir, "svid.pem")
 	keyPath := filepath.Join(dir, "key.pem")
 	bundlePath := filepath.Join(dir, "bundle.pem")
+	socketPath := filepath.Join(dir, "socket")
 
 	notAfter := time.Now().Add(30 * time.Second)
 	tmpl := &x509.Certificate{
@@ -108,12 +110,7 @@ func TestMintRun(t *testing.T) {
 	}))
 
 	server := new(fakeSVIDServer)
-	spiretest.StartGRPCSocketServer(t, util.DefaultSocketPath, func(s *grpc.Server) {
-		svidpb.RegisterSVIDServer(s, server)
-		bundlepb.RegisterBundleServer(s, server)
-	})
-
-	alternativeSocket := spiretest.StartGRPCSocketServerOnTempSocket(t, func(s *grpc.Server) {
+	spiretest.StartGRPCSocketServer(t, socketPath, func(s *grpc.Server) {
 		svidpb.RegisterSVIDServer(s, server)
 		bundlepb.RegisterBundleServer(s, server)
 	})
@@ -133,12 +130,11 @@ func TestMintRun(t *testing.T) {
 		name string
 
 		// flags
-		spiffeID   string
-		ttl        time.Duration
-		dnsNames   []string
-		socketPath string
-		write      string
-		extraArgs  []string
+		spiffeID  string
+		ttl       time.Duration
+		dnsNames  []string
+		write     string
+		extraArgs []string
 
 		// results
 		code   int
@@ -170,7 +166,7 @@ func TestMintRun(t *testing.T) {
 		{
 			name:              "invalid flag",
 			code:              1,
-			stderr:            fmt.Sprintf("flag provided but not defined: -bad\n%s\n", expectedUsage),
+			stderr:            fmt.Sprintf("flag provided but not defined: -bad\n%s", expectedUsage),
 			extraArgs:         []string{"-bad", "flag"},
 			noRequestExpected: true,
 		},
@@ -234,12 +230,11 @@ func TestMintRun(t *testing.T) {
 			bundle: bundle,
 		},
 		{
-			name:       "success with ttl and dnsnames, written to directory, using alternate socket",
-			spiffeID:   "spiffe://domain.test/workload",
-			ttl:        time.Minute,
-			socketPath: alternativeSocket,
-			code:       0,
-			write:      ".",
+			name:     "success with ttl and dnsnames, written to directory",
+			spiffeID: "spiffe://domain.test/workload",
+			ttl:      time.Minute,
+			code:     0,
+			write:    ".",
 			resp: &svidpb.MintX509SVIDResponse{
 				Svid: &types.X509SVID{
 					CertChain: [][]byte{certDER},
@@ -274,10 +269,7 @@ func TestMintRun(t *testing.T) {
 				return testKey, nil
 			})
 
-			args := []string{}
-			if testCase.socketPath != "" {
-				args = append(args, "-registrationUDSPath", testCase.socketPath)
-			}
+			args := []string{"-socketPath", socketPath}
 			if testCase.spiffeID != "" {
 				args = append(args, "-spiffeID", testCase.spiffeID)
 			}

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -130,12 +130,12 @@ func AdaptCommand(env *common_cli.Env, cmd Command) *Adapter {
 
 	f := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
 	f.SetOutput(env.Stderr)
-	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", "", "Path to the Server API socket (deprecated; use -socketPath)")
+	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", "", "Path to the SPIRE Server API socket (deprecated; use -socketPath)")
 	// TODO: in 1.1.0. After registrationUDSPath is deprecated, we can put back the
 	// default flag value on socketPath like it was previously, since we'll no
 	// longer need to detect an unset flag from the default for deprecation
 	// logging/error handling purposes.
-	f.StringVar(&a.socketPath, "socketPath", "", `Path to the Server API socket (default "`+DefaultSocketPath+`")`)
+	f.StringVar(&a.socketPath, "socketPath", "", `Path to the SPIRE Server API socket (default "`+DefaultSocketPath+`")`)
 	a.cmd.AppendFlags(f)
 	a.flags = f
 

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	DefaultSocketPath = "/tmp/spire-registration.sock"
+	DefaultSocketPath = "/tmp/spire-server/private/api.sock"
 )
 
 func NewRegistrationClient(socketPath string) (registration.RegistrationClient, error) {
@@ -118,6 +118,7 @@ type Adapter struct {
 
 	flags               *flag.FlagSet
 	registrationUDSPath string
+	socketPath          string
 }
 
 // AdaptCommand converts a command into one conforming to the Command interface from github.com/mitchellh/cli
@@ -129,7 +130,12 @@ func AdaptCommand(env *common_cli.Env, cmd Command) *Adapter {
 
 	f := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
 	f.SetOutput(env.Stderr)
-	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", DefaultSocketPath, "Registration API UDS path")
+	f.StringVar(&a.registrationUDSPath, "registrationUDSPath", "", "Path to the Server API socket (deprecated; use -socketPath)")
+	// TODO: in 1.1.0. After registrationUDSPath is deprecated, we can put back the
+	// default flag value on socketPath like it was previously, since we'll no
+	// longer need to detect an unset flag from the default for deprecation
+	// logging/error handling purposes.
+	f.StringVar(&a.socketPath, "socketPath", "", `Path to the Server API socket (default "`+DefaultSocketPath+`")`)
 	a.cmd.AppendFlags(f)
 	a.flags = f
 
@@ -140,11 +146,24 @@ func (a *Adapter) Run(args []string) int {
 	ctx := context.Background()
 
 	if err := a.flags.Parse(args); err != nil {
-		fmt.Fprintln(a.env.Stderr)
 		return 1
 	}
 
-	client, err := NewServerClient(a.registrationUDSPath)
+	var socketPath string
+	switch {
+	case a.socketPath == "" && a.registrationUDSPath == "":
+		socketPath = DefaultSocketPath
+	case a.socketPath != "" && a.registrationUDSPath == "":
+		socketPath = a.socketPath
+	case a.socketPath == "" && a.registrationUDSPath != "":
+		fmt.Fprintln(a.env.Stderr, "warning: -registrationUDSPath is deprecated; use -socketPath")
+		socketPath = a.registrationUDSPath
+	case a.socketPath != "" && a.registrationUDSPath != "":
+		fmt.Fprintln(a.env.Stderr, "The -socketPath and deprecated -registrationUDSPath flags are mutually exclusive")
+		return 1
+	}
+
+	client, err := NewServerClient(socketPath)
 	if err != nil {
 		fmt.Fprintln(a.env.Stderr, "Error: "+err.Error())
 		return 1

--- a/conf/agent/agent.conf
+++ b/conf/agent/agent.conf
@@ -3,7 +3,7 @@ agent {
     log_level = "DEBUG"
     server_address = "127.0.0.1"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
+    socket_path ="/tmp/spire-agent/public/api.sock"
     trust_bundle_path = "./conf/agent/dummy_root_ca.crt"
     trust_domain = "example.org"
 }

--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -28,8 +28,8 @@ agent {
     # server_port: Port number of the SPIRE server.
     server_port = "8081"
 
-    # socket_path: Location to bind the workload API socket. Default: /tmp/agent.sock.
-    socket_path = "/tmp/agent.sock"
+    # socket_path: Location to bind the workload API socket. Default: /tmp/spire-agent/public/api.sock.
+    socket_path = "/tmp/spire-agent/public/api.sock"
 
     # trust_bundle_path: Path to the SPIRE server CA bundle.
     trust_bundle_path = "./conf/agent/dummy_root_ca.crt"

--- a/conf/server/server.conf
+++ b/conf/server/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-server/private/api.sock"
     trust_domain = "example.org"
     data_dir = "./.data"
     log_level = "DEBUG"

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -107,7 +107,7 @@ server {
     #     attestation = true
     # }
 
-    # socket_path: Path to bind the Server API socket to.
+    # socket_path: Path to bind the SPIRE Server API socket to.
     # Default: /tmp/spire-server/private/api.sock.
     # socket_path = "/tmp/spire-server/private/api.sock"
 
@@ -640,7 +640,7 @@ plugins {
     #         # trust domain.
     #         # server_port = ""
 
-    #         # workload_api_socket: Path to the Agent API socket.
+    #         # workload_api_socket: Path to the SPIRE Agent API socket.
     #         # workload_api_socket = ""
     #     }
     # }

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -107,9 +107,9 @@ server {
     #     attestation = true
     # }
 
-    # registration_uds_path: Location to bind the registration API socket.
-    # Default: /tmp/spire-registration.sock.
-    # registration_uds_path = "/tmp/spire-registration.sock"
+    # socket_path: Path to bind the Server API socket to.
+    # Default: /tmp/spire-server/private/api.sock.
+    # socket_path = "/tmp/spire-server/private/api.sock"
 
     # default_svid_ttl: The default SVID TTL. Default: 1h.
     # default_svid_ttl = "1h"
@@ -640,7 +640,7 @@ plugins {
     #         # trust domain.
     #         # server_port = ""
 
-    #         # workload_api_socket: Path to the workload API socket.
+    #         # workload_api_socket: Path to the Agent API socket.
     #         # workload_api_socket = ""
     #     }
     # }

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -63,7 +63,6 @@ If you don't already have Docker installed, please follow these [installation in
     server {
         bind_address = "127.0.0.1"
         bind_port = "8081"
-        registration_uds_path = "/tmp/spire-registration.sock"
         trust_domain = "example.org"
         data_dir = "./.data"
         log_level = "DEBUG"
@@ -128,7 +127,7 @@ If you don't already have Docker installed, please follow these [installation in
         log_level = "DEBUG"
         server_address = "127.0.0.1"
         server_port = "8081"
-        socket_path ="/tmp/agent.sock"
+        socket_path ="/tmp/spire-agent/public/api.sock"
         trust_bundle_path = "./conf/agent/dummy_root_ca.crt"
         trust_domain = "example.org"
     }

--- a/doc/plugin_server_upstreamauthority_spire.md
+++ b/doc/plugin_server_upstreamauthority_spire.md
@@ -12,7 +12,7 @@ The plugin accepts the following configuration options:
 | ----------------------- | ---------------------------------------------------------------------------- |
 | server_address          | IP address or DNS name of the upstream SPIRE server in the same trust domain |
 | server_port             | Port number of the upstream SPIRE server in the same trust domain            |
-| workload_api_socket     | Path to the workload API socket                                              |
+| workload_api_socket     | Path to the Workload API socket (e.g. the Agent API socket)                  |
 
 A sample configuration:
 
@@ -21,7 +21,7 @@ A sample configuration:
         plugin_data {
             server_address = "upstream-spire-server",
             server_port = "8081",
-            workload_api_socket = "/tmp/agent.sock"
+            workload_api_socket = "/tmp/spire-agent/public/api.sock"
         }
     }
 ```

--- a/doc/plugin_server_upstreamauthority_spire.md
+++ b/doc/plugin_server_upstreamauthority_spire.md
@@ -12,7 +12,7 @@ The plugin accepts the following configuration options:
 | ----------------------- | ---------------------------------------------------------------------------- |
 | server_address          | IP address or DNS name of the upstream SPIRE server in the same trust domain |
 | server_port             | Port number of the upstream SPIRE server in the same trust domain            |
-| workload_api_socket     | Path to the Workload API socket (e.g. the Agent API socket)                  |
+| workload_api_socket     | Path to the Workload API socket (e.g. the SPIRE Agent API socket)                  |
 
 A sample configuration:
 

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -48,7 +48,7 @@ This may be useful for templating configuration files, for example across differ
 | `log_format`              | Format of logs, \<text\|json\>                                        | Text                 |
 | `server_address`          | DNS name or IP address of the SPIRE server                            |                      |
 | `server_port`             | Port number of the SPIRE server                                       |                      |
-| `socket_path`             | Location to bind the Workload API socket                              | /tmp/agent.sock      |
+| `socket_path`             | Location to bind the Agent API socket                              | /tmp/spire-agent/public/api.sock      |
 | `sds`                     | Optional SDS configuration section                                    |                      |
 | `trust_bundle_path`       | Path to the SPIRE server CA bundle                                    |                      |
 | `trust_bundle_url`        | URL to download the initial SPIRE server trust bundle                 |                      |
@@ -145,7 +145,7 @@ Calls the workload API to fetch an X509-SVID. This command is aliased to `spire-
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-silent` | Suppress stdout | |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-timeout` | Time to wait for a response | 1s |
 | `-write` | Write SVID data to the specified path | |
 
@@ -156,7 +156,7 @@ Calls the workload API to fetch a JWT-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-audience` | A comma separated list of audience values | |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-spiffeID` | The SPIFFE ID of the JWT being requested (optional) | |
 | `-timeout` | Time to wait for a response | 1s |
 
@@ -167,7 +167,7 @@ Calls the workload API to fetch a x.509-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-silent` | Suppress stdout | |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-timeout` | Time to wait for a response | 1s |
 | `-write` | Write SVID data to the specified path | |
 
@@ -178,7 +178,7 @@ Calls the workload API to validate the supplied JWT-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-audience` | A comma separated list of audience values | |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-svid` | The JWT-SVID to be validated | |
 | `-timeout` | Time to wait for a response | 1s |
 
@@ -188,7 +188,7 @@ Attaches to the workload API and watches for X509-SVID updates, printing details
 
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 
 ### `spire-agent healthcheck`
 
@@ -197,7 +197,7 @@ Checks SPIRE agent's health.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-shallow` | Perform a less stringent health check | |
-| `-socketPath` | Path to the workload API socket | /tmp/agent.sock |
+| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-verbose` | Print verbose information | |
 
 ### `spire-agent validate`
@@ -222,7 +222,7 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
+    socket_path ="/tmp/spire-agent/public/api.sock"
 }
 
 telemetry {

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -48,7 +48,7 @@ This may be useful for templating configuration files, for example across differ
 | `log_format`              | Format of logs, \<text\|json\>                                        | Text                 |
 | `server_address`          | DNS name or IP address of the SPIRE server                            |                      |
 | `server_port`             | Port number of the SPIRE server                                       |                      |
-| `socket_path`             | Location to bind the Agent API socket                              | /tmp/spire-agent/public/api.sock      |
+| `socket_path`             | Location to bind the SPIRE Agent API socket                              | /tmp/spire-agent/public/api.sock      |
 | `sds`                     | Optional SDS configuration section                                    |                      |
 | `trust_bundle_path`       | Path to the SPIRE server CA bundle                                    |                      |
 | `trust_bundle_url`        | URL to download the initial SPIRE server trust bundle                 |                      |
@@ -145,7 +145,7 @@ Calls the workload API to fetch an X509-SVID. This command is aliased to `spire-
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-silent` | Suppress stdout | |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-timeout` | Time to wait for a response | 1s |
 | `-write` | Write SVID data to the specified path | |
 
@@ -156,7 +156,7 @@ Calls the workload API to fetch a JWT-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-audience` | A comma separated list of audience values | |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-spiffeID` | The SPIFFE ID of the JWT being requested (optional) | |
 | `-timeout` | Time to wait for a response | 1s |
 
@@ -167,7 +167,7 @@ Calls the workload API to fetch a x.509-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-silent` | Suppress stdout | |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-timeout` | Time to wait for a response | 1s |
 | `-write` | Write SVID data to the specified path | |
 
@@ -178,7 +178,7 @@ Calls the workload API to validate the supplied JWT-SVID.
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
 | `-audience` | A comma separated list of audience values | |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-svid` | The JWT-SVID to be validated | |
 | `-timeout` | Time to wait for a response | 1s |
 
@@ -188,7 +188,7 @@ Attaches to the workload API and watches for X509-SVID updates, printing details
 
 | Command          | Action                      | Default                 |
 | ---------------- | --------------------------- | ----------------------- |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 
 ### `spire-agent healthcheck`
 
@@ -197,7 +197,7 @@ Checks SPIRE agent's health.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-shallow` | Perform a less stringent health check | |
-| `-socketPath` | Path to the Agent API socket | /tmp/spire-agent/public/api.sock |
+| `-socketPath` | Path to the SPIRE Agent API socket | /tmp/spire-agent/public/api.sock |
 | `-verbose` | Print verbose information | |
 
 ### `spire-agent validate`

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -63,7 +63,7 @@ This may be useful for templating configuration files, for example across differ
 | `log_level`                 | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>                                              | INFO                          |
 | `log_format`                | Format of logs, \<text\|json\>                                                                   | text                          |
 | `ratelimit`                 | Rate limiting configurations, usually used when the server is behind a load balancer (see below) |                               |
-| `socketPath`                | Path to bind the Server API socket to                                                            | /tmp/spire-server/private/api.sock  |
+| `socketPath`                | Path to bind the SPIRE Server API socket to                                                            | /tmp/spire-server/private/api.sock  |
 | `trust_domain`              | The trust domain that this server belongs to                                                     |                               |
 
 | ca_subject                  | Description                    | Default        |
@@ -207,7 +207,7 @@ Most of the configuration file above options have identical command-line counter
 | `-logFormat` | Format of logs, \<text\|json\> | |
 | `-logLevel` | DEBUG, INFO, WARN or ERROR | |
 | `-serverPort` | Port number of the SPIRE server | |
-| `-socketPath` | Path to bind the Server API socket to | |
+| `-socketPath` | Path to bind the SPIRE Server API socket to | |
 | `-trustDomain` | The trust domain that this server belongs to | |
 
 ### `spire-server token generate`
@@ -218,7 +218,7 @@ human-readable registration entry name in addition to the token-based ID.
 
 | Command       | Action                                                    | Default        |
 |:--------------|:----------------------------------------------------------|:---------------|
-| `-socketPath` | Path to the Server API socket                             | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket                             | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | Additional SPIFFE ID to assign the token owner (optional) |                |
 | `-ttl`        | Token TTL in seconds                                      | 600            |
 
@@ -237,7 +237,7 @@ Creates registration entries.
 | `-node`          | If set, this entry will be applied to matching nodes rather than workloads | |
 | `-parentID`      | The SPIFFE ID of this record's parent.                                 |                |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
-| `-socketPath`    | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath`    | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
 | `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
@@ -256,7 +256,7 @@ Updates registration entries.
 | `-federatesWith` | A list of trust domain SPIFFE IDs representing the trust domains this registration entry federates with. A bundle for that trust domain must already exist | |
 | `-parentID`      | The SPIFFE ID of this record's parent.                                 |                |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
-| `-socketPath`    | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath`    | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
 | `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
@@ -267,7 +267,7 @@ Deletes a specified registration entry.
 | Command       | Action                                             | Default        |
 |:--------------|:---------------------------------------------------|:---------------|
 | `-entryID`    | The Registration Entry ID of the record to delete  |                |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server entry show`
 
@@ -280,7 +280,7 @@ Displays configured registration entries.
 | `-federatesWith` | SPIFFE ID of a trust domain an entry is federate with. Can be used more than once | |
 | `-parentID`   | The Parent ID of the records to show.                              |                |
 | `-selector`   | A colon-delimeted type:value selector. Can be used more than once to specify multiple selectors. | |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the records to show.                              |                |
 
 ### `spire-server bundle show`
@@ -290,7 +290,7 @@ Displays the bundle for the trust domain of the server.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-format` | The format to show the bundle. Either `pem` or `spiffe` | pem |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server bundle list`
 
@@ -300,7 +300,7 @@ Displays federated bundles.
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to show. If unset, all trust bundles are shown | |
 | `-format`     | The format to show the federated bundles. Either `pem` or `spiffe` | pem |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server bundle set`
 
@@ -310,7 +310,7 @@ Creates or updates bundle data for a trust domain. This command cannot be used t
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to set. | |
 | `-path`       | Path on disk to the file containing the bundle data. If unset, data is read from stdin. | |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-format`     | The format of the bundle to set. Either `pem` or `spiffe` | pem |
 
 ### `spire-server bundle delete`
@@ -321,7 +321,7 @@ Deletes bundle data for a trust domain. This command cannot be used to delete th
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to delete. | |
 | `-mode`       | One of: `restrict`, `dissociate`, `delete`. `restrict` prevents the bundle from being deleted if it is associated to registration entries (i.e. federated with). `dissociate` allows the bundle to be deleted and removes the association from registration entries. `delete` deletes the bundle as well as associated registration entries. | `restrict` |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server agent evict`
 
@@ -329,7 +329,7 @@ De-attesting an already attested node given its spiffeID.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the agent to evict (agent identity) | |
 
 ### `spire-server agent list`
@@ -338,7 +338,7 @@ Displays attested nodes.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server agent show`
 
@@ -346,7 +346,7 @@ Displays the details (including node selectors) of an attested node given its sp
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID` | The SPIFFE ID of the agent to show (agent identity) | |
 
 ### `spire-server healthcheck`
@@ -356,7 +356,7 @@ Checks SPIRE server's health.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-shallow`    | Perform a less stringent health check | |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-verbose`    | Print verbose information | |
 
 ### `spire-server validate`
@@ -376,7 +376,7 @@ Mints an X509-SVID.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-dns`        | A DNS name that will be included in SVID. Can be used more than once | |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the X509-SVID                                     | |
 | `-ttl`        | The TTL of the X509-SVID                                           | The TTL configured with `default_svid_ttl` |
 | `-write`      | Directory to write output to instead of stdout                     | |
@@ -388,7 +388,7 @@ Mints a JWT-SVID.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-audience`   | Audience claim that will be included in the SVID. Can be used more than once | |
-| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the JWT-SVID                                      | |
 | `-ttl`        | The TTL of the JWT-SVID                                            | |
 | `-write`      | File to write token to instead of stdout                           | |

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -63,7 +63,7 @@ This may be useful for templating configuration files, for example across differ
 | `log_level`                 | Sets the logging level \<DEBUG\|INFO\|WARN\|ERROR\>                                              | INFO                          |
 | `log_format`                | Format of logs, \<text\|json\>                                                                   | text                          |
 | `ratelimit`                 | Rate limiting configurations, usually used when the server is behind a load balancer (see below) |                               |
-| `registration_uds_path`     | Location to bind the registration API socket                                                     | /tmp/spire-registration.sock  |
+| `socketPath`                | Path to bind the Server API socket to                                                            | /tmp/spire-server/private/api.sock  |
 | `trust_domain`              | The trust domain that this server belongs to                                                     |                               |
 
 | ca_subject                  | Description                    | Default        |
@@ -206,8 +206,8 @@ Most of the configuration file above options have identical command-line counter
 | `-logFile` | File to write logs to | |
 | `-logFormat` | Format of logs, \<text\|json\> | |
 | `-logLevel` | DEBUG, INFO, WARN or ERROR | |
-| `-registrationUDSPath` | UDS Path to bind registration API | |
 | `-serverPort` | Port number of the SPIRE server | |
+| `-socketPath` | Path to bind the Server API socket to | |
 | `-trustDomain` | The trust domain that this server belongs to | |
 
 ### `spire-server token generate`
@@ -218,7 +218,7 @@ human-readable registration entry name in addition to the token-based ID.
 
 | Command       | Action                                                    | Default        |
 |:--------------|:----------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket                             | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | Additional SPIFFE ID to assign the token owner (optional) |                |
 | `-ttl`        | Token TTL in seconds                                      | 600            |
 
@@ -228,7 +228,7 @@ Creates registration entries.
 
 | Command          | Action                                                                 | Default        |
 |:-----------------|:-----------------------------------------------------------------------|:---------------|
-| `-admin`         | If set, the SPIFFE ID in this entry will be granted access to the Registration API | |
+| `-admin`         | If set, the SPIFFE ID in this entry will be granted access to the Server APIs | |
 | `-data`          | Path to a file containing registration data in JSON format (optional). If set to '-', read the JSON from stdin. |                |
 | `-dns`           | A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once | |
 | `-downstream`    | A boolean value that, when set, indicates that the entry describes a downstream SPIRE server | |
@@ -236,8 +236,8 @@ Creates registration entries.
 | `-federatesWith` | A list of trust domain SPIFFE IDs representing the trust domains this registration entry federates with. A bundle for that trust domain must already exist | |
 | `-node`          | If set, this entry will be applied to matching nodes rather than workloads | |
 | `-parentID`      | The SPIFFE ID of this record's parent.                                 |                |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
+| `-socketPath`    | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
 | `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
@@ -247,7 +247,7 @@ Updates registration entries.
 
 | Command          | Action                                                                 | Default        |
 |:-----------------|:-----------------------------------------------------------------------|:---------------|
-| `-admin`         | If true, the SPIFFE ID in this entry will be granted access to the Registration API | |
+| `-admin`         | If true, the SPIFFE ID in this entry will be granted access to the Server APIs | |
 | `-data`          | Path to a file containing registration data in JSON format (optional). If set to '-', read the JSON from stdin. |                |
 | `-dns`           | A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once | |
 | `-downstream`    | A boolean value that, when set, indicates that the entry describes a downstream SPIRE server | |
@@ -255,8 +255,8 @@ Updates registration entries.
 | `-entryID`       | The Registration Entry ID of the record to update                      |                |
 | `-federatesWith` | A list of trust domain SPIFFE IDs representing the trust domains this registration entry federates with. A bundle for that trust domain must already exist | |
 | `-parentID`      | The SPIFFE ID of this record's parent.                                 |                |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied. | |
+| `-socketPath`    | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued. | |
 | `-ttl`           | A TTL, in seconds, for any SVID issued as a result of this record.     | The TTL configured with `default_svid_ttl` |
 
@@ -267,7 +267,7 @@ Deletes a specified registration entry.
 | Command       | Action                                             | Default        |
 |:--------------|:---------------------------------------------------|:---------------|
 | `-entryID`    | The Registration Entry ID of the record to delete  |                |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server entry show`
 
@@ -279,8 +279,8 @@ Displays configured registration entries.
 | `-entryID`    | The Entry ID of the record to show.                                |                |
 | `-federatesWith` | SPIFFE ID of a trust domain an entry is federate with. Can be used more than once | |
 | `-parentID`   | The Parent ID of the records to show.                              |                |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-selector`   | A colon-delimeted type:value selector. Can be used more than once to specify multiple selectors. | |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the records to show.                              |                |
 
 ### `spire-server bundle show`
@@ -289,8 +289,8 @@ Displays the bundle for the trust domain of the server.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
 | `-format` | The format to show the bundle. Either `pem` or `spiffe` | pem |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server bundle list`
 
@@ -299,8 +299,8 @@ Displays federated bundles.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to show. If unset, all trust bundles are shown | |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
-| `-format` | The format to show the federated bundles. Either `pem` or `spiffe` | pem |
+| `-format`     | The format to show the federated bundles. Either `pem` or `spiffe` | pem |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server bundle set`
 
@@ -310,8 +310,8 @@ Creates or updates bundle data for a trust domain. This command cannot be used t
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to set. | |
 | `-path`       | Path on disk to the file containing the bundle data. If unset, data is read from stdin. | |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
-| `-format` | The format of the bundle to set. Either `pem` or `spiffe` | pem |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-format`     | The format of the bundle to set. Either `pem` or `spiffe` | pem |
 
 ### `spire-server bundle delete`
 
@@ -321,7 +321,7 @@ Deletes bundle data for a trust domain. This command cannot be used to delete th
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-id`         | The trust domain SPIFFE ID of the bundle to delete. | |
 | `-mode`       | One of: `restrict`, `dissociate`, `delete`. `restrict` prevents the bundle from being deleted if it is associated to registration entries (i.e. federated with). `dissociate` allows the bundle to be deleted and removes the association from registration entries. `delete` deletes the bundle as well as associated registration entries. | `restrict` |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server agent evict`
 
@@ -329,8 +329,8 @@ De-attesting an already attested node given its spiffeID.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
-| `-spiffeID` | The SPIFFE ID of the agent to evict (agent identity) | |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-spiffeID`   | The SPIFFE ID of the agent to evict (agent identity) | |
 
 ### `spire-server agent list`
 
@@ -338,7 +338,7 @@ Displays attested nodes.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 
 ### `spire-server agent show`
 
@@ -346,7 +346,7 @@ Displays the details (including node selectors) of an attested node given its sp
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID` | The SPIFFE ID of the agent to show (agent identity) | |
 
 ### `spire-server healthcheck`
@@ -355,9 +355,9 @@ Checks SPIRE server's health.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
-| `-shallow` | Perform a less stringent health check | |
-| `-verbose` | Print verbose information | |
+| `-shallow`    | Perform a less stringent health check | |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
+| `-verbose`    | Print verbose information | |
 
 ### `spire-server validate`
 
@@ -376,7 +376,7 @@ Mints an X509-SVID.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-dns`        | A DNS name that will be included in SVID. Can be used more than once | |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the X509-SVID                                     | |
 | `-ttl`        | The TTL of the X509-SVID                                           | The TTL configured with `default_svid_ttl` |
 | `-write`      | Directory to write output to instead of stdout                     | |
@@ -388,7 +388,7 @@ Mints a JWT-SVID.
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-audience`   | Audience claim that will be included in the SVID. Can be used more than once | |
-| `-registrationUDSPath` | Path to the SPIRE server registration api socket | /tmp/spire-registration.sock |
+| `-socketPath` | Path to the Server API socket | /tmp/spire-server/private/api.sock |
 | `-spiffeID`   | The SPIFFE ID of the JWT-SVID                                      | |
 | `-ttl`        | The TTL of the JWT-SVID                                            | |
 | `-write`      | File to write token to instead of stdout                           | |
@@ -420,7 +420,6 @@ server {
     bind_port = "8081"
     log_level = "INFO"
     data_dir = "/opt/spire/.data/"
-    registration_uds_path = "/opt/spire/registration.sock"
     default_svid_ttl = "6h"
     ca_ttl = "72h"
     ca_subject {

--- a/pkg/agent/plugin/workloadattestor/k8s/testdata/kind_pod_list.json
+++ b/pkg/agent/plugin/workloadattestor/k8s/testdata/kind_pod_list.json
@@ -32,9 +32,7 @@
                   {
                       "args": [
                           "api",
-                          "watch",
-                          "-socketPath",
-                          "/run/spire/sockets/agent.sock"
+                          "watch"
                       ],
                       "command": [
                           "/opt/spire/bin/spire-agent"
@@ -47,7 +45,7 @@
                       "terminationMessagePolicy": "File",
                       "volumeMounts": [
                           {
-                              "mountPath": "/run/spire/sockets",
+                              "mountPath": "/tmp/spire-agent/public",
                               "name": "spire-agent-socket",
                               "readOnly": true
                           },
@@ -86,7 +84,7 @@
               "volumes": [
                   {
                       "hostPath": {
-                          "path": "/run/spire/sockets",
+                          "path": "/run/spire-agent/public",
                           "type": "Directory"
                       },
                       "name": "spire-agent-socket"

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -89,6 +89,10 @@ type RateLimitConfig struct {
 
 // New creates new endpoints struct
 func New(ctx context.Context, c Config) (*Endpoints, error) {
+	if err := os.MkdirAll(c.UDSAddr.String(), 0750); err != nil {
+		return nil, fmt.Errorf("unable to create socket directory: %w", err)
+	}
+
 	oldAPIServers, err := c.makeOldAPIServers()
 	if err != nil {
 		return nil, err

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -56,9 +56,11 @@ var (
 )
 
 func TestNew(t *testing.T) {
+	tempdir := spiretest.TempDir(t)
+
 	ctx := context.Background()
-	tcpAddr := &net.TCPAddr{}
-	udsAddr := &net.UnixAddr{}
+	tcpAddr := &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+	udsAddr := &net.UnixAddr{Net: "unix", Name: filepath.Join(tempdir, "sockets")}
 
 	svidObserver := newSVIDObserver(nil)
 

--- a/proto/spire/common/common.pb.go
+++ b/proto/spire/common/common.pb.go
@@ -357,7 +357,7 @@ type RegistrationEntry struct {
 	//* Entry ID
 	EntryId string `protobuf:"bytes,6,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
 	//* Whether or not the workload is an admin workload. Admin workloads
-	//can use their SVID's to authenticate with the Registration API, for
+	//can use their SVID's to authenticate with the Server APIs, for
 	//example.
 	Admin bool `protobuf:"varint,7,opt,name=admin,proto3" json:"admin,omitempty"`
 	//* To enable signing CA CSR in upstream spire server

--- a/proto/spire/common/common.proto
+++ b/proto/spire/common/common.proto
@@ -72,7 +72,7 @@ message RegistrationEntry {
     /** Entry ID */
     string entry_id = 6;
     /** Whether or not the workload is an admin workload. Admin workloads
-    can use their SVID's to authenticate with the Registration API, for
+    can use their SVID's to authenticate with the Server APIs, for
     example. */
     bool admin = 7;
     /** To enable signing CA CSR in upstream spire server  */

--- a/release/spire-extras/conf/k8s-workload-registrar/k8s-workload-registrar.conf
+++ b/release/spire-extras/conf/k8s-workload-registrar/k8s-workload-registrar.conf
@@ -1,4 +1,4 @@
 log_level = "debug"
 trust_domain = "example.org"
-server_socket_path = "/tmp/spire-registration.sock"
+server_socket_path = "/tmp/spire-server/private/api.sock"
 cluster = "MyCluster"

--- a/release/spire-extras/conf/oidc-discovery-provider/oidc-discovery-provider.conf
+++ b/release/spire-extras/conf/oidc-discovery-provider/oidc-discovery-provider.conf
@@ -6,6 +6,6 @@ acme {
     # required to use ACME to provide certificates for the OIDC discovery provider.
     # tos_accepted = true
 }
-registration_api {
-    socket_path = "/tmp/spire-registration.sock"
+server_api {
+    socket_path = "/tmp/spire-server/private/api.sock"
 }

--- a/release/spire/conf/agent/agent.conf
+++ b/release/spire/conf/agent/agent.conf
@@ -4,7 +4,6 @@ agent {
     trust_domain = "example.org"
     server_address = "localhost"
     server_port = 8081
-    socket_path ="/tmp/agent.sock"
 
     # Insecure bootstrap is NOT appropriate for production use but is ok for 
     # simple testing/evaluation purposes.

--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -71,7 +71,7 @@ The following configuration directives are specific to `"reconcile"` mode:
 ```
 log_level = "debug"
 trust_domain = "domain.test"
-server_socket_path = "/run/spire/sockets/registration.sock"
+server_socket_path = "/tmp/spire-server/private/api.sock"
 cluster = "production"
 ```
 

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -90,7 +90,7 @@ acme {
     tos_accepted = true
 }
 server_api {
-    address = "unix:///run/spire/sockets/registration.sock"
+    address = "unix:///tmp/spire-server/private/api.sock"
 }
 ```
 
@@ -104,7 +104,7 @@ acme {
     tos_accepted = true
 }
 workload_api {
-    socket_path = "/run/spire/sockets/agent.sock"
+    socket_path = "/tmp/spire-agent/public/api.sock"
     trust_domain = "domain.test"
 }
 ```
@@ -122,7 +122,7 @@ domain = "mypublicdomain.test"
 listen_socket_path = "/run/oidc-discovery-provider/server.sock"
 
 workload_api {
-    socket_path = "/run/spire/sockets/agent.sock"
+    socket_path = "/tmp/spire-agent/private/api.sock"
     trust_domain = "domain.test"
 }
 ```

--- a/test/fixture/config/agent_good.conf
+++ b/test/fixture/config/agent_good.conf
@@ -5,7 +5,7 @@ agent {
     log_level = "INFO"
     server_address = "127.0.0.1"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
+    socket_path = "/tmp/spire-agent/public/api.sock"
     trust_bundle_path = "conf/agent/dummy_root_ca.crt"
     trust_domain = "example.org"
 }

--- a/test/fixture/config/server_good.conf
+++ b/test/fixture/config/server_good.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "127.0.0.1"
     bind_port = "8081"
-    registration_uds_path ="/tmp/server.sock"
+    socket_path ="/tmp/spire-server/private/api.sock"
     trust_domain = "example.org"
     log_level = "INFO"
     experimental {

--- a/test/integration/setup/debugserver/main.go
+++ b/test/integration/setup/debugserver/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	socketPathFlag = flag.String("socket", "unix:///tmp/spire-registration.sock", "server socket path")
+	socketPathFlag = flag.String("socket", "unix:///tmp/spire-server/private/api.sock", "server socket path")
 )
 
 func main() {

--- a/test/integration/setup/itclient/client.go
+++ b/test/integration/setup/itclient/client.go
@@ -22,9 +22,9 @@ import (
 
 var (
 	tdFlag               = flag.String("trustDomain", "domain.test", "server trust domain")
-	socketPathFlag       = flag.String("socketPath", "unix:///tmp/agent.sock", "agent socket path")
+	socketPathFlag       = flag.String("socketPath", "unix:///tmp/spire-agent/public/api.sock", "agent socket path")
 	serverAddrFlag       = flag.String("serverAddr", "spire-server:8081", "server addr")
-	serverSocketPathFlag = flag.String("serverSocketPath", "unix:///tmp/spire-registration.sock", "server socket path")
+	serverSocketPathFlag = flag.String("serverSocketPath", "unix:///tmp/spire-server/private/api.sock", "server socket path")
 	expectErrorsFlag     = flag.Bool("expectErrors", false, "client is used to validate permission errors")
 )
 

--- a/test/integration/suites/admin-endpoints/conf/agent/agent.conf
+++ b/test/integration/suites/admin-endpoints/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
 }

--- a/test/integration/suites/admin-endpoints/conf/server/server.conf
+++ b/test/integration/suites/admin-endpoints/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/debug-endpoints/conf/agent/agent.conf
+++ b/test/integration/suites/debug-endpoints/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
 

--- a/test/integration/suites/debug-endpoints/conf/server/server.conf
+++ b/test/integration/suites/debug-endpoints/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/downstream-endpoints/conf/agent/agent.conf
+++ b/test/integration/suites/downstream-endpoints/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
 }

--- a/test/integration/suites/downstream-endpoints/conf/server/server.conf
+++ b/test/integration/suites/downstream-endpoints/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/envoy-sds-v2/conf/server/server.conf
+++ b/test/integration/suites/envoy-sds-v2/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "domain.test"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"

--- a/test/integration/suites/envoy-sds-v3/conf/server/server.conf
+++ b/test/integration/suites/envoy-sds-v3/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "domain.test"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"

--- a/test/integration/suites/ghostunnel-federation/conf/downstream/server/server.conf
+++ b/test/integration/suites/ghostunnel-federation/conf/downstream/server/server.conf
@@ -1,7 +1,6 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "downstream-domain.test"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"

--- a/test/integration/suites/ghostunnel-federation/conf/upstream/server/server.conf
+++ b/test/integration/suites/ghostunnel-federation/conf/upstream/server/server.conf
@@ -1,7 +1,6 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
     trust_domain = "upstream-domain.test"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"

--- a/test/integration/suites/join-token/conf/agent/agent.conf
+++ b/test/integration/suites/join-token/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
     

--- a/test/integration/suites/join-token/conf/server/server.conf
+++ b/test/integration/suites/join-token/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/k8s-reconcile/02-check-for-workload-svid
+++ b/test/integration/suites/k8s-reconcile/02-check-for-workload-svid
@@ -9,7 +9,6 @@ for ((i=1; i<=${MAXFETCHCHECKS}; i++)); do
     log-info "checking for workload SPIFFE ID ($i of $MAXFETCHCHECKS max)..."
     if ./bin/kubectl -nspire exec -t "${EXAMPLEPOD}" -- \
         /opt/spire/bin/spire-agent api fetch \
-            -socketPath /run/spire/sockets/agent.sock \
             | grep "SPIFFE ID:"; then
         DONE=1
         break

--- a/test/integration/suites/k8s-reconcile/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/agent/spire-agent.yaml
@@ -51,7 +51,6 @@ data:
       log_level = "DEBUG"
       server_address = "spire-server"
       server_port = "8081"
-      socket_path = "/run/spire/sockets/agent.sock"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "example.org"
     }
@@ -132,7 +131,7 @@ spec:
               mountPath: /run/spire/bundle
               readOnly: true
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens

--- a/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
@@ -114,7 +114,6 @@ data:
       bind_port = "8081"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
-      registration_uds_path = "/run/spire/sockets/registration.sock"
       log_level = "DEBUG"
       default_svid_ttl = "1h"
       ca_ttl = "12h"
@@ -177,7 +176,7 @@ data:
     mode = "reconcile"
     trust_domain = "example.org"
     cluster = "example-cluster"
-    server_socket_path = "/run/spire/sockets/registration.sock"
+    server_socket_path = "/tmp/spire-server/private/api.sock"
     leader_election = true
     metrics_addr = "0.0.0.0:18080"
 
@@ -218,7 +217,7 @@ spec:
               mountPath: /run/spire/config
               readOnly: true
             - name: spire-server-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-server/private
               readOnly: false
           livenessProbe:
             httpGet:
@@ -241,7 +240,7 @@ spec:
             name: registrar-port
           volumeMounts:
           - name: spire-server-socket
-            mountPath: /run/spire/sockets
+            mountPath: /tmp/spire-server/private
             readOnly: true
           - name: k8s-workload-registrar
             mountPath: /run/spire/k8s-workload-registrar/conf

--- a/test/integration/suites/k8s-reconcile/conf/workload.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/workload.yaml
@@ -23,10 +23,10 @@ spec:
         - name: example-workload
           image: spire-agent:latest-local
           command: ["/usr/bin/dumb-init", "/opt/spire/bin/spire-agent", "api", "watch"]
-          args: ["-socketPath", "/run/spire/sockets/agent.sock"]
+          args: ["-socketPath", "/tmp/spire-agent/public/api.sock"]
           volumeMounts:
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: true
       volumes:
         - name: spire-agent-socket

--- a/test/integration/suites/k8s-scratch/02-check-for-workload-svid
+++ b/test/integration/suites/k8s-scratch/02-check-for-workload-svid
@@ -9,7 +9,6 @@ for ((i=1; i<=${MAXFETCHCHECKS}; i++)); do
     log-info "checking for workload SPIFFE ID ($i of $MAXFETCHCHECKS max)..."
     if ./bin/kubectl -nspire exec -t "${EXAMPLEPOD}" -- \
         /opt/spire/bin/spire-agent api fetch \
-            -socketPath /run/spire/sockets/agent.sock \
             | grep "SPIFFE ID:"; then
         DONE=1
         break

--- a/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
@@ -51,7 +51,6 @@ data:
       log_level = "DEBUG"
       server_address = "spire-server"
       server_port = "8081"
-      socket_path = "/run/spire/sockets/agent.sock"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "example.org"
     }
@@ -125,18 +124,18 @@ spec:
               mountPath: /run/spire/bundle
               readOnly: true
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens
           livenessProbe:
             exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+              command: ["/opt/spire/bin/spire-agent", "healthcheck"]
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             exec:
-              command: ["/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock", "--shallow"]
+              command: ["/opt/spire/bin/spire-agent", "healthcheck", "--shallow"]
             initialDelaySeconds: 10
             periodSeconds: 10
       volumes:

--- a/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
@@ -104,7 +104,6 @@ data:
       bind_port = "8081"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
-      registration_uds_path = "/run/spire/sockets/registration.sock"
       log_level = "DEBUG"
       default_svid_ttl = "1h"
       ca_ttl = "12h"
@@ -161,7 +160,7 @@ data:
     cacert_path = "/run/spire/k8s-workload-registrar/certs/cacert.pem" 
     trust_domain = "example.org"
     cluster = "example-cluster"
-    server_socket_path = "/run/spire/sockets/registration.sock"
+    server_socket_path = "/tmp/spire-server/private/api.sock"
 
 ---
 
@@ -239,16 +238,16 @@ spec:
               mountPath: /run/spire/config
               readOnly: true
             - name: spire-server-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-server/private
               readOnly: false
           livenessProbe:
             exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock"]
+              command: ["/opt/spire/bin/spire-server", "healthcheck"]
             initialDelaySeconds: 5
             periodSeconds: 5
           readinessProbe:
             exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock", "--shallow"]
+              command: ["/opt/spire/bin/spire-server", "healthcheck", "--shallow"]
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: k8s-workload-registrar
@@ -260,7 +259,7 @@ spec:
             name: registrar-port
           volumeMounts:
           - name: spire-server-socket
-            mountPath: /run/spire/sockets
+            mountPath: /tmp/spire-server/private
             readOnly: true
           - name: k8s-workload-registrar
             mountPath: /run/spire/k8s-workload-registrar/conf

--- a/test/integration/suites/k8s-scratch/conf/workload.yaml
+++ b/test/integration/suites/k8s-scratch/conf/workload.yaml
@@ -23,10 +23,10 @@ spec:
         - name: example-workload
           image: spire-agent:latest-local
           command: ["/usr/bin/dumb-init", "/opt/spire/bin/spire-agent", "api", "watch"]
-          args: ["-socketPath", "/run/spire/sockets/agent.sock"]
+          args: ["-socketPath", "/tmp/spire-agent/public/api.sock"]
           volumeMounts:
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: true
       volumes:
         - name: spire-agent-socket

--- a/test/integration/suites/k8s/02-check-for-workload-svid
+++ b/test/integration/suites/k8s/02-check-for-workload-svid
@@ -9,7 +9,6 @@ for ((i=1; i<=${MAXFETCHCHECKS}; i++)); do
     log-info "checking for workload SPIFFE ID ($i of $MAXFETCHCHECKS max)..."
     if ./bin/kubectl -nspire exec -t "${EXAMPLEPOD}" -- \
         /opt/spire/bin/spire-agent api fetch \
-            -socketPath /run/spire/sockets/agent.sock \
             | grep "SPIFFE ID:"; then
         DONE=1
         break

--- a/test/integration/suites/k8s/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s/conf/agent/spire-agent.yaml
@@ -51,7 +51,6 @@ data:
       log_level = "DEBUG"
       server_address = "spire-server"
       server_port = "8081"
-      socket_path = "/run/spire/sockets/agent.sock"
       trust_bundle_path = "/run/spire/bundle/bundle.crt"
       trust_domain = "example.org"
     }
@@ -132,7 +131,7 @@ spec:
               mountPath: /run/spire/bundle
               readOnly: true
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: false
             - name: spire-token
               mountPath: /var/run/secrets/tokens

--- a/test/integration/suites/k8s/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s/conf/server/spire-server.yaml
@@ -104,7 +104,6 @@ data:
       bind_port = "8081"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
-      registration_uds_path = "/run/spire/sockets/registration.sock"
       log_level = "DEBUG"
       default_svid_ttl = "1h"
       ca_ttl = "12h"
@@ -169,7 +168,7 @@ data:
     cacert_path = "/run/spire/k8s-workload-registrar/certs/cacert.pem"
     trust_domain = "example.org"
     cluster = "example-cluster"
-    server_socket_path = "/run/spire/sockets/registration.sock"
+    server_socket_path = "/tmp/spire-server/private/api.sock"
 
 ---
 
@@ -247,7 +246,7 @@ spec:
               mountPath: /run/spire/config
               readOnly: true
             - name: spire-server-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-server/private
               readOnly: false
           livenessProbe:
             httpGet:
@@ -270,7 +269,7 @@ spec:
             name: registrar-port
           volumeMounts:
           - name: spire-server-socket
-            mountPath: /run/spire/sockets
+            mountPath: /tmp/spire-server/private
             readOnly: true
           - name: k8s-workload-registrar
             mountPath: /run/spire/k8s-workload-registrar/conf

--- a/test/integration/suites/k8s/conf/workload.yaml
+++ b/test/integration/suites/k8s/conf/workload.yaml
@@ -23,10 +23,10 @@ spec:
         - name: example-workload
           image: spire-agent:latest-local
           command: ["/usr/bin/dumb-init", "/opt/spire/bin/spire-agent", "api", "watch"]
-          args: ["-socketPath", "/run/spire/sockets/agent.sock"]
+          args: ["-socketPath", "/tmp/spire-agent/public/api.sock"]
           volumeMounts:
             - name: spire-agent-socket
-              mountPath: /run/spire/sockets
+              mountPath: /tmp/spire-agent/public
               readOnly: true
       volumes:
         - name: spire-agent-socket

--- a/test/integration/suites/nested-rotation/intermediateA/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/nested-rotation/intermediateB/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/nested-rotation/leafA/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafA/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/nested-rotation/leafB/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafB/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/nested-rotation/root/server/server.conf
+++ b/test/integration/suites/nested-rotation/root/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/node-attestation/conf/agent/agent.conf
+++ b/test/integration/suites/node-attestation/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
 }

--- a/test/integration/suites/node-attestation/conf/server/server.conf
+++ b/test/integration/suites/node-attestation/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/rotation/conf/agent/agent.conf
+++ b/test/integration/suites/rotation/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
 }

--- a/test/integration/suites/rotation/conf/server/server.conf
+++ b/test/integration/suites/rotation/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/spire-server-cli/conf/agent/agent.conf
+++ b/test/integration/suites/spire-server-cli/conf/agent/agent.conf
@@ -3,7 +3,6 @@ agent {
     log_level = "DEBUG"
     server_address = "spire-server"
     server_port = "8081"
-    socket_path ="/tmp/agent.sock"
     trust_bundle_path = "/opt/spire/conf/agent/bootstrap.crt"
     trust_domain = "domain.test"
     

--- a/test/integration/suites/spire-server-cli/conf/server/server.conf
+++ b/test/integration/suites/spire-server-cli/conf/server/server.conf
@@ -1,7 +1,6 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/test/integration/suites/upgrade/01-run-upgrade-tests
+++ b/test/integration/suites/upgrade/01-run-upgrade-tests
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# TODO: in 1.1.0. Once we're no longer testing 0.12.0, we can and should fix
+# this test and these commands to rely on the default socket path. We can't do
+# it until then because 0.12.0 does not understand the new CLI flag on the
+# server, and also doesn't make the socket directory like the agent (which
+# gives a little needless friction using the new default, since we'd need
+# something else to create the directory first).
+
 start-old-server() {
     log-info "bringing up $1 agent..."
     docker-up "spire-server-$1"
@@ -8,7 +15,9 @@ start-old-server() {
 bootstrap-agent() {
     log-debug "bootstrapping $1 agent..."
     docker-compose exec -T "spire-server-$1" \
-        /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
+        /opt/spire/bin/spire-server bundle show \
+        -registrationUDSPath /tmp/spire-registration.sock \
+        > conf/agent/bootstrap.crt
 }
 
 start-old-agent() {
@@ -20,6 +29,7 @@ create-registration-entry() {
     log-debug "creating registration entry..."
     docker-compose exec -T "spire-server-$1" \
         /opt/spire/bin/spire-server entry create \
+        -registrationUDSPath /tmp/spire-registration.sock \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/workload" \
         -selector "unix:uid:${UID}" \
@@ -44,6 +54,7 @@ check-old-agent-svid() {
     log-info "checking X509-SVID on $1 agent..."
         docker-compose exec -T "spire-agent-$1" \
             /opt/spire/bin/spire-agent api fetch x509 \
+            -socketPath /tmp/agent.sock \
             -write /opt/test/before-server-upgrade || fail-now "SVID check failed"
 }
 
@@ -77,6 +88,7 @@ check-old-agent-svid-after-upgrade() {
         log-info "checking X509-SVID after server upgrade ($i of $_maxchecks max)..."
         docker-compose exec -T "spire-agent-$1" \
             /opt/spire/bin/spire-agent api fetch x509 \
+            -socketPath /tmp/agent.sock \
             -write /opt/test/after-server-upgrade || fail-now "SVID check failed"
         if ! cmp --silent svids/before-server-upgrade/svid.0.pem svids/after-server-upgrade/svid.0.pem; then
             # SVID has rotated
@@ -100,6 +112,7 @@ stop-and-evict-agent() {
     log-info "evicting agent..."
     docker-compose exec -T "spire-server-$1" \
         /opt/spire/bin/spire-server agent evict \
+        -registrationUDSPath /tmp/spire-registration.sock \
         -spiffeID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"
 
     rm -rf shared/agent-data/*
@@ -109,6 +122,7 @@ check-new-agent-svid-after-upgrade() {
     log-info "checking X509-SVID after agent upgrade..."
     docker-compose exec -T spire-agent-latest-local \
         /opt/spire/bin/spire-agent api fetch x509 \
+        -socketPath /tmp/agent.sock \
         -write /opt/test/after-agent-upgrade || fail-now "SVID check failed"
 
     # SVIDs are cached in agent memory only. As the agent was restarted, there


### PR DESCRIPTION
This change updates the default socket paths.

The agent socket path changed from `/tmp/agent.sock` to`/tmp/spire-agent/public/api.sock`.

The server socket path changed from `/tmp/spire-registration.sock` to `/tmp/spire-server/private/api.sock`.

In addition, the server CLI flag and configurable to set the socket path has been changed from 
 registrationUDSPath`/`registration_uds_path` to `socketPath`/`socket_path` to mimic the agent and more accurately
reflect the use of the socket. The previous configurables are deprecated and warn on use.

A bulk of the change is updating tests that show the CLI help and configuration files used in integration tests. The integration tests have been changed to use the default socket path where possible (the upgrade test needs the old configuration until registrationUDSPath has been fully removed.

The mint tests were also changed to no longer rely on the default socket path, since that caused failures if the server was running.

As part of fixing up the server with the changes, the server healthcheck command was changed to utilize the common command structure the other commands rely on.

Fixes: #2064.
