### PR TITLE
Fix upgrade integration test version check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,7 @@ jobs:
             # CircleCI is silly and doesn't provide this incredibly helpful
             # environment variable. Requests for it go back years. For shame.
             CIRCLE_PR_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref')
-            echo "CIRCLE_PR_BRANCH: ${CIRCLE_PR_BRANCH}"
-            circleci tests glob "suites/*" | circleci tests split | TEST_TARGET_BRANCH="${CIRCLE_PR_BRANCH}" xargs ./test.sh
+            circleci tests glob "suites/*" | circleci tests split | PR_BRANCH="${CIRCLE_PR_BRANCH}" xargs ./test.sh
 
   # Publish "unstable" docker images
   publish-unstable-images:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,11 @@ jobs:
           name: Execute integration test suites
           working_directory: test/integration/
           command: |
-            circleci tests glob "suites/*" | circleci tests split | xargs ./test.sh
+            # CircleCI is silly and doesn't provide this incredibly helpful
+            # environment variable. Requests for it go back years. For shame.
+            CIRCLE_PR_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref')
+            echo "CIRCLE_PR_BRANCH: ${CIRCLE_PR_BRANCH}"
+            circleci tests glob "suites/*" | circleci tests split | TEST_TARGET_BRANCH="${CIRCLE_PR_BRANCH}" xargs ./test.sh
 
   # Publish "unstable" docker images
   publish-unstable-images:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
       script:
         - make images
         - make scratch-images
-        - TEST_TARGET_BRANCH="$TRAVIS_BRANCH" make integration
+        - PR_BRANCH="$TRAVIS_BRANCH" make integration
         - .travis/publish-images.sh
 
     - stage: nightly integration tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,16 @@ language: go
 go:
   - 1.15.5
 
+git:
+  # The upgrade integration test inspects the version tags. The default depth
+  # (50) is sometimes not enough if there have been many commits in between
+  # releases. This causes the integration test to fail to locate the previous
+  # version tag. Bumping this to 100 for now. If we encounter the failure again
+  # we may consider just cloning the whole repo. Alternatively, we can run `git
+  # fetch --tags` in the integration test job below but that is effectively the
+  # same thing.
+  depth: 100
+
 cache:
   directories:
     # cache build tools
@@ -92,7 +102,7 @@ jobs:
       script:
         - make images
         - make scratch-images
-        - make integration
+        - TEST_TARGET_BRANCH="$TRAVIS_BRANCH" make integration
         - .travis/publish-images.sh
 
     - stage: nightly integration tests

--- a/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
+++ b/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
@@ -1,27 +1,40 @@
 #!/bin/bash
 
+git="git --git-dir ${REPODIR}/.git"
+
 check-version-against-latest-release() {
-    # This should be set by the CI/CD system based on the target branch of
-    # the PR.
-    if [ -n "${TEST_TARGET_BRANCH}" ]; then
-        log-info "target branch (explicit): ${TEST_TARGET_BRANCH}"
+    _commit_version="$1"
+    _default_branch="origin/$($git remote show origin | grep 'HEAD branch' | cut -d":" -f2 | xargs)"
+    _tracking_branch=$($git for-each-ref --format='%(upstream:short)' "$($git symbolic-ref -q HEAD)")
+
+    # Determine which branch to detect the "latest" version from:
+    # - for PRs, this will be the branch the PR targets (as supplied via
+    #   PR_BRANCH by the CI/CD pipeline).
+    # - for non-PRs from a local branch with a tracking branch, we'll use
+    #   the tracking branch (e.g. local development branch tracking master)
+    # - for non-PRs from a local branch without a tracking branch, we'll use
+    #   the local branch (e.g. checkout of the v0.11 release branch)
+    _version_from_branch=
+    if [ -n "${PR_BRANCH}" ]; then
+        _version_from_branch="origin/${PR_BRANCH}"
+        log-info "target branch (explicit): ${_version_from_branch}"
+    elif [ -n "${_tracking_branch}" ]; then
+        _version_from_branch="${_tracking_branch}"
+        log-info "target branch (tracking): ${_version_from_branch}"
     else
-        TEST_TARGET_BRANCH="$(git --git-dir "${REPODIR}"/.git branch --show-current)"
-        log-info "target branch (detected): ${TEST_TARGET_BRANCH}"
+        _version_from_branch="$($git branch --show-current)"
+        log-info "target branch (local): ${_version_from_branch}"
     fi
 
-    _commit_version="$1"
-
-    if [ "${TEST_TARGET_BRANCH}" = "master" ]; then
-        # master should use the latest release tag from the repo
-        _latest_version=$(git --git-dir "${REPODIR}"/.git tag -l 'v*' --sort -v:refname | head -n1 | cut -c 2-)
+    if [ "${_version_from_branch}" = "${_default_branch}" ]; then
+        # The default branch should use the latest release tag from the repo
+        _latest_version=$($git tag --list 'v*' --sort -version:refname | head -n1 | cut -c 2-)
         log-info "latest release: ${_latest_version}"
     else
-        # non-master should use the latest release tag from the branch, which
-        # is assumed to be a parent of the current commit... if not, we'll need
-        # to explicitly pass the remote branch to the "describe" command.
-        _latest_version=$(git --git-dir "${REPODIR}"/.git describe --match "v*" --abbrev=0 | cut -c 2-)
-        log-info "latest release from ${TEST_TARGET_BRANCH}: ${_latest_version}"
+        # Non-default branches should have aligned version with the latest
+        # release from that branch. So we'll scan for the latest tag.
+        _latest_version=$($git describe --match "v*" --abbrev=0 "${_version_from_branch}"| cut -c 2-)
+        log-info "latest release from ${_version_from_branch}: ${_latest_version}"
     fi
 
     log-info "commit version: ${_commit_version}"
@@ -40,7 +53,7 @@ _commit_version=$(docker-compose exec -T spire-server-latest-local \
 docker-down
 
 # Get tag of the current commit
-_current_tag=$(git --git-dir "${REPODIR}"/.git describe --exact-match HEAD --match "v*"  2> /dev/null | cut -c 2- || true)
+_current_tag=$($git describe --exact-match HEAD --match "v*"  2> /dev/null | cut -c 2- || true)
 
 case "${_current_tag}" in
 
@@ -49,7 +62,7 @@ case "${_current_tag}" in
     ;;
 
   "")
-    log-info "current commit is not tagged; checking against the latest release in the branch"
+    log-info "current commit is not tagged; checking against the latest release in the target branch"
     check-version-against-latest-release "${_commit_version}"
     ;;
 

--- a/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
+++ b/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
@@ -12,8 +12,8 @@ check-version-against-latest-release() {
     #   PR_BRANCH by the CI/CD pipeline).
     # - for non-PRs from a local branch with a tracking branch, we'll use
     #   the tracking branch (e.g. local development branch tracking master)
-    # - for non-PRs from a local branch without a tracking branch, we'll use
-    #   the local branch (e.g. checkout of the v0.11 release branch)
+    # - for non-PRs from a local branch without a tracking branch, we'll fail
+    #   the test, since it isn't clear which version we should be tracking.
     _version_from_branch=
     if [ -n "${PR_BRANCH}" ]; then
         _version_from_branch="origin/${PR_BRANCH}"
@@ -22,8 +22,7 @@ check-version-against-latest-release() {
         _version_from_branch="${_tracking_branch}"
         log-info "target branch (tracking): ${_version_from_branch}"
     else
-        _version_from_branch="$($git branch --show-current)"
-        log-info "target branch (local): ${_version_from_branch}"
+        fail-now "unable to determine latest version; either the PR_BRANCH envvar or an upstream tracking branch needs to be set"
     fi
 
     if [ "${_version_from_branch}" = "${_default_branch}" ]; then

--- a/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
+++ b/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
@@ -1,40 +1,60 @@
 #!/bin/bash
 
-check-version-against-prior-tag() {
-    # Get nearest prior tag in this branch
-    _nearest_prior_tag=$(git --git-dir $REPODIR/.git describe --match "v*" --abbrev=0 | cut -c 2-)
-
-    if [ "$_nearest_prior_tag" == "$1" ]; then
-        fail-now "codebase version is the same than the last tag ($1), was the codebase version number bumped after the last release?"
+check-version-against-latest-release() {
+    # This should be set by the CI/CD system based on the target branch of
+    # the PR.
+    if [ -n "${TEST_TARGET_BRANCH}" ]; then
+        log-info "target branch (explicit): ${TEST_TARGET_BRANCH}"
+    else
+        TEST_TARGET_BRANCH="$(git --git-dir "${REPODIR}"/.git branch --show-current)"
+        log-info "target branch (detected): ${TEST_TARGET_BRANCH}"
     fi
 
-    if [ "$(printf '%s\n' "$_nearest_prior_tag" "$1" | sort -V | head -n1)" = $_nearest_prior_tag ]; then
-        fail-now "codebase version ($1) is lower than the last tag in this branch ($_nearest_prior_tag)"
+    _commit_version="$1"
+
+    if [ "${TEST_TARGET_BRANCH}" = "master" ]; then
+        # master should use the latest release tag from the repo
+        _latest_version=$(git --git-dir "${REPODIR}"/.git tag -l 'v*' --sort -v:refname | head -n1 | cut -c 2-)
+        log-info "latest release: ${_latest_version}"
+    else
+        # non-master should use the latest release tag from the branch, which
+        # is assumed to be a parent of the current commit... if not, we'll need
+        # to explicitly pass the remote branch to the "describe" command.
+        _latest_version=$(git --git-dir "${REPODIR}"/.git describe --match "v*" --abbrev=0 | cut -c 2-)
+        log-info "latest release from ${TEST_TARGET_BRANCH}: ${_latest_version}"
+    fi
+
+    log-info "commit version: ${_commit_version}"
+
+    if [ "${_commit_version}" == "${_latest_version}" ]; then
+        fail-now "commit version (${_commit_version}) must be greater than the latest release in this branch (${_latest_version}); has the version been bumped?"
+    elif [ "$(printf '%s\n%s' "${_latest_version}" "${_commit_version}" | sort -V -r | head -n1)" != "${_commit_version}" ]; then
+        fail-now "commit version (${_commit_version}) must be greater than the latest release in this branch (${_latest_version}); has the version been bumped?"
     fi
 }
 
 # Get current version from latest local image
 docker-up spire-server-latest-local
-_codebase_version=$(docker-compose exec -T spire-server-latest-local \
+_commit_version=$(docker-compose exec -T spire-server-latest-local \
             /opt/spire/bin/spire-server --version 2>&1 | cut -d'-' -f 1)
 docker-down
 
 # Get tag of the current commit
-_current_tag=$(git --git-dir $REPODIR/.git describe --exact-match HEAD --match "v*"  2> /dev/null | cut -c 2- || true)
+_current_tag=$(git --git-dir "${REPODIR}"/.git describe --exact-match HEAD --match "v*"  2> /dev/null | cut -c 2- || true)
 
-case "$_current_tag" in
+case "${_current_tag}" in
 
-  "$_codebase_version")
-    log-info "current commit is a tagged commit and has the right codebase version ("$_codebase_version")"
+  "${_commit_version}")
+    log-info "current commit is a tagged commit and has the correct version (${_commit_version})"
     ;;
 
   "")
-    log-info "current commit is not tagged, checking against the nearest prior tag"
-    check-version-against-prior-tag "$codebase_version"
+    log-info "current commit is not tagged; checking against the latest release in the branch"
+    check-version-against-latest-release "${_commit_version}"
     ;;
 
   *)
-    fail-now "codebase version ("$_codebase_version") does not match the commit tag ("$_current_tag")"
+    fail-now "current commit version (${_commit_version}) does not match the commit tag (${_current_tag})"
     ;;
 
 esac


### PR DESCRIPTION
The upgrade integration test does some sanity checking to ensure that the code under test reflects the proper version. This helps us remember to bump the in-code version after making a release.

Unfortunately, the version check is broken and does not successfully detect the prior release version for the PR target branch due both to the use of git describe and various scripting bugs. This change fixes the test to properly detect the most recent version of the branch (or of the project in the case of master). It relies on the CI/CD pipeline setting the proper target branch for the PR in the environment.

Additionally, Travis only clones to depth 50. If there are more than 50 commits since the last release, then the test fails to detect the prior version. This change bumps the clone depth to 100. It is a bit of a band-aid but still serves to reduce the amount of data needing to be cloned. If we surpass this limit, it might make sense to just clone the whole repository. At the time of this change, this is the difference between 2MB and 12MB downloaded, but that delta would increase with time.