### PR TITLE
Fix upgrade integration test for merge commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,12 @@ jobs:
       - checkout
       - run:
           name: Execute integration test suites
-          working_directory: test/integration/
           command: |
             # CircleCI is silly and doesn't provide this incredibly helpful
             # environment variable. Requests for it go back years. For shame.
-            CIRCLE_PR_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref')
-            circleci tests glob "suites/*" | circleci tests split | PR_BRANCH="${CIRCLE_PR_BRANCH}" xargs ./test.sh
+            CIRCLE_TARGET_BRANCH=$(.circleci/determine-target-branch.sh)
+            cd test/integration
+            circleci tests glob "suites/*" | circleci tests split | CICD_TARGET_BRANCH="${CIRCLE_TARGET_BRANCH}" xargs ./test.sh
 
   # Publish "unstable" docker images
   publish-unstable-images:

--- a/.circleci/determine_target_branch.sh
+++ b/.circleci/determine_target_branch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# The intent of this script, when invoked by CircleCI is to mimic the behavior
+# the TRAVIS_BRANCH environment variable to determine the target branch of
+# the build.
+#
+# Namely, it is set to a value according to the following rules:
+# - for push builds, or builds not triggered by a pull request, this is the name of the branch.
+# - for builds triggered by a pull request this is the name of the branch targeted by the pull request.
+# - for builds triggered by a tag, this is the same as the name of the tag (CIRCLECI_TAG).
+
+if [ -n "${CIRCLE_PR_NUMBER}" ]; then
+    curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.base.ref'
+elif [ -n "${CIRCLE_TAG}" ]; then
+    echo "${CIRCLE_TAG}"
+else
+    echo "${CIRCLE_BRANCH}"
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
       script:
         - make images
         - make scratch-images
-        - PR_BRANCH="$TRAVIS_BRANCH" make integration
+        - CICD_TARGET_BRANCH="$TRAVIS_BRANCH" make integration
         - .travis/publish-images.sh
 
     - stage: nightly integration tests

--- a/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
+++ b/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
@@ -9,20 +9,20 @@ check-version-against-latest-release() {
 
     # Determine which branch to detect the "latest" version from:
     # - for PRs, this will be the branch the PR targets (as supplied via
-    #   PR_BRANCH by the CI/CD pipeline).
+    #   CICD_TARGET_BRANCH by the CI/CD pipeline).
     # - for non-PRs from a local branch with a tracking branch, we'll use
     #   the tracking branch (e.g. local development branch tracking master)
     # - for non-PRs from a local branch without a tracking branch, we'll fail
     #   the test, since it isn't clear which version we should be tracking.
     _version_from_branch=
-    if [ -n "${PR_BRANCH}" ]; then
-        _version_from_branch="origin/${PR_BRANCH}"
+    if [ -n "${CICD_TARGET_BRANCH}" ]; then
+        _version_from_branch="origin/${CICD_TARGET_BRANCH}"
         log-info "target branch (explicit): ${_version_from_branch}"
     elif [ -n "${_tracking_branch}" ]; then
         _version_from_branch="${_tracking_branch}"
         log-info "target branch (tracking): ${_version_from_branch}"
     else
-        fail-now "unable to determine latest version; either the PR_BRANCH envvar or an upstream tracking branch needs to be set"
+        fail-now "unable to determine latest version; either the CICD_TARGET_BRANCH envvar or an upstream tracking branch needs to be set"
     fi
 
     if [ "${_version_from_branch}" = "${_default_branch}" ]; then


### PR DESCRIPTION
On CircleCI, the newly introduced version check logic fails on merge commits because there is no PR number from which to determine the target branch.

This change fixes it by providing a small script that returns the target branch, following the same semantics as the TRAVIS_BRANCH environment variable used in the Travis CI/CD pipeline.

It also renames the PR_BRANCH variable to CICD_TARGET_BRANCH to more accurately represent the value.