### PR TITLE
Document supported Kubernetes versions

### DIFF
--- a/doc/supported_integrations.md
+++ b/doc/supported_integrations.md
@@ -15,3 +15,8 @@ versions of Envoy, starting with v1.13 (the earliest build with the v3 API).
 
 Envoy v2 API support is deprecated and as such we only actively test against
 the last minor version that supports it (v1.16).
+
+## Kubernetes
+
+The SPIRE project currently supports Kubernetes 1.18 through 1.20. Later
+versions may also work but are not explicitly exercised by integration tests.

--- a/test/integration/suites/k8s-reconcile/00-setup
+++ b/test/integration/suites/k8s-reconcile/00-setup
@@ -5,7 +5,7 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.9.0
+KINDVERSION=v0.10.0
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
 KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
@@ -20,11 +20,13 @@ else
     chmod +x ./bin/kubectl
 fi
 
-# Ensure kind is available
+# Ensure kind is available and at the expected version
 mkdir -p ./bin
-if [ -n "${KINDPATH}" ]; then
+if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
     ln -s "${KINDPATH}" ./bin/kind
-else
+fi
+
+if [ ! -f ./bin/kind ]; then
     log-info "downloading kind from ${KINDURL}..."
     curl -# -f -Lo ./bin/kind "${KINDURL}"
     chmod +x ./bin/kind

--- a/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
@@ -17,6 +17,3 @@ nodes:
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-- role: worker
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb

--- a/test/integration/suites/k8s-scratch/00-setup
+++ b/test/integration/suites/k8s-scratch/00-setup
@@ -42,6 +42,6 @@ log-info "starting cluster..."
 ./bin/kind create cluster --name k8stest --config ./conf/kind-config.yaml || fail-now "unable to create cluster"
 
 log-info "loading container images..."
-./bin/kind load docker-image --name k8stest spire-server:latest-local
-./bin/kind load docker-image --name k8stest spire-agent:latest-local
-./bin/kind load docker-image --name k8stest k8s-workload-registrar:latest-local
+./bin/kind load docker-image --name k8stest spire-server-scratch:latest-local
+./bin/kind load docker-image --name k8stest spire-agent-scratch:latest-local
+./bin/kind load docker-image --name k8stest k8s-workload-registrar-scratch:latest-local

--- a/test/integration/suites/k8s-scratch/00-setup
+++ b/test/integration/suites/k8s-scratch/00-setup
@@ -5,7 +5,7 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.9.0
+KINDVERSION=v0.10.0
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
 KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
@@ -20,11 +20,13 @@ else
     chmod +x ./bin/kubectl
 fi
 
-# Ensure kind is available
+# Ensure kind is available and at the expected version
 mkdir -p ./bin
-if [ -n "${KINDPATH}" ]; then
+if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
     ln -s "${KINDPATH}" ./bin/kind
-else
+fi
+
+if [ ! -f ./bin/kind ]; then
     log-info "downloading kind from ${KINDURL}..."
     curl -# -f -Lo ./bin/kind "${KINDURL}"
     chmod +x ./bin/kind
@@ -40,7 +42,6 @@ log-info "starting cluster..."
 ./bin/kind create cluster --name k8stest --config ./conf/kind-config.yaml || fail-now "unable to create cluster"
 
 log-info "loading container images..."
-./bin/kind load docker-image --name k8stest spire-server-scratch:latest-local
+./bin/kind load docker-image --name k8stest spire-server:latest-local
 ./bin/kind load docker-image --name k8stest spire-agent:latest-local
-./bin/kind load docker-image --name k8stest spire-agent-scratch:latest-local
-./bin/kind load docker-image --name k8stest k8s-workload-registrar-scratch:latest-local
+./bin/kind load docker-image --name k8stest k8s-workload-registrar:latest-local

--- a/test/integration/suites/k8s-scratch/conf/kind-config.yaml
+++ b/test/integration/suites/k8s-scratch/conf/kind-config.yaml
@@ -17,6 +17,3 @@ nodes:
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-- role: worker
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb

--- a/test/integration/suites/k8s/00-setup
+++ b/test/integration/suites/k8s/00-setup
@@ -5,7 +5,7 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.9.0
+KINDVERSION=v0.10.0
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
 KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
@@ -20,11 +20,13 @@ else
     chmod +x ./bin/kubectl
 fi
 
-# Ensure kind is available
+# Ensure kind is available and at the expected version
 mkdir -p ./bin
-if [ -n "${KINDPATH}" ]; then
+if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
     ln -s "${KINDPATH}" ./bin/kind
-else
+fi
+
+if [ ! -f ./bin/kind ]; then
     log-info "downloading kind from ${KINDURL}..."
     curl -# -f -Lo ./bin/kind "${KINDURL}"
     chmod +x ./bin/kind

--- a/test/integration/suites/k8s/conf/kind-config.yaml
+++ b/test/integration/suites/k8s/conf/kind-config.yaml
@@ -17,6 +17,3 @@ nodes:
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb
-- role: worker
-  image: kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb


### PR DESCRIPTION
Also upgrade to kind 0.10.0 and ensure integration tests use the default image versions (k8s 1.20.2).

Fixes: #1500