### PR TITLE
Fix error tracking for entry cache telemetry

### DIFF
--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -98,7 +98,7 @@ func New(ctx context.Context, c Config) (*Endpoints, error) {
 		return nil, err
 	}
 
-	buildCacheFn := func(ctx context.Context) (entrycache.Cache, error) {
+	buildCacheFn := func(ctx context.Context) (_ entrycache.Cache, err error) {
 		call := telemetry.StartCall(c.Metrics, telemetry.Entry, telemetry.Cache, telemetry.Reload)
 		defer call.Done(&err)
 		return entrycache.BuildFromDataStore(ctx, c.Catalog.GetDataStore())


### PR DESCRIPTION
The lack of a named error variable (and an accidental capture) was preventing the deferred call counter done method from picking up the error returned from building the cache.

This change fixes the bug by naming the error variable in the closure.