### PR TITLE
Fix k8s scratch test

### DIFF
--- a/test/integration/suites/k8s-scratch/conf/workload.yaml
+++ b/test/integration/suites/k8s-scratch/conf/workload.yaml
@@ -21,7 +21,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: example-workload
-          image: spire-agent:latest-local
+          image: spire-agent-scratch:latest-local
           command: ["/usr/bin/dumb-init", "/opt/spire/bin/spire-agent", "api", "watch"]
           args: ["-socketPath", "/tmp/spire-agent/public/api.sock"]
           volumeMounts:


### PR DESCRIPTION
The k8s scratch integration test was using the non-scratch agent image for the "workload" (copy-paste from the k8s integration test). On Travis, this "just worked" because Kind had already been loaded with the non-scratch images by the time the scratch integration test ran. On CircleCI however, these tests are executed by different workers. Since the non-scratch image has not been pushed into the Kind cluster on the worker, the test fails.

This change fixes the k8s-scratch test to rely on the scratch agent image.