### PR TITLE
Fix workload image on k8s-scratch test

### DIFF
--- a/test/integration/suites/k8s-scratch/conf/workload.yaml
+++ b/test/integration/suites/k8s-scratch/conf/workload.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: example-workload
           image: spire-agent-scratch:latest-local
-          command: ["/usr/bin/dumb-init", "/opt/spire/bin/spire-agent", "api", "watch"]
+          command: ["/opt/spire/bin/spire-agent", "api", "watch"]
           args: ["-socketPath", "/tmp/spire-agent/public/api.sock"]
           volumeMounts:
             - name: spire-agent-socket


### PR DESCRIPTION
PR #2096 changed the workload image on the k8s-scratch test to the correct one but neglected to change the entrypoint, which relied on dumb-init (which we use across the board for PID 1 child reaping responsibilites).

This change updates the entrypoint for the workload image to not use dumb-init.