### PR TITLE
Removes allow_agentless_node_attestors flag

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -94,8 +94,6 @@ type serverConfig struct {
 }
 
 type experimentalConfig struct {
-	DeprecatedAllowAgentlessNodeAttestors *bool `hcl:"allow_agentless_node_attestors"`
-
 	UnusedKeys []string `hcl:",unusedKeys"`
 }
 
@@ -374,11 +372,6 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		c.Server.RateLimit.Attestation = &defaultRateLimitAttestation
 	}
 	sc.RateLimit.Attestation = *c.Server.RateLimit.Attestation
-
-	if c.Server.Experimental.DeprecatedAllowAgentlessNodeAttestors != nil {
-		// TODO: remove in 1.1.0
-		logger.Warn("The experimental allow_agentless_node_attestors configurable is deprecated and unused; it will be removed in a future release")
-	}
 
 	if c.Server.Federation != nil {
 		if c.Server.Federation.BundleEndpoint != nil {

--- a/test/fixture/config/server_good.conf
+++ b/test/fixture/config/server_good.conf
@@ -4,9 +4,6 @@ server {
     socket_path ="/tmp/spire-server/private/api.sock"
     trust_domain = "example.org"
     log_level = "INFO"
-    experimental {
-        allow_agentless_node_attestors = true
-    }
     federation {
         bundle_endpoint {
             address = "0.0.0.0"


### PR DESCRIPTION
The flag is experimental and was introduced as part of a POC that never took flight. Furthermore, it was only functional on the old (now removed) Node API and not ported to the new Agent API.

It is highly unlikely this is set anywhere.

Fixes: #2094