### PR TITLE
Update CHANGELOG for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,31 +3,32 @@
 ## [1.0.0] - 2021-02-02
 
 ### Added
-- Filtering by federated trust domains in `ListEntries` (#1967)
+- Filtering by federated trust domains in `ListEntries` RPC in SPIRE Server (#1967)
 - Logging when lookup of user by uid or group by gid fails in the `unix` WorkloadAttestor plugin (#2048)
 - Timeouts to calls to KeyManager plugins (#2044)
-- gRPC Health v1 services in Server and Agent exposed at `/grpc.health.v1.Health/Check` path (#2057, #2058, #2087)
-- Uptime metrics in Server and Agent (#2032)
+- Basic [gRPC Health v1 services](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) in server and agent exposed at `/grpc.health.v1.Health/Check` path (#2057, #2058, #2087)
+- Uptime metrics in server and agent (#2032)
 
 ### Changed
-- `/ready` HTTP endpoint on Agent now checks the health of the Workload API (#2015)
+- HTTP readiness endpoint on agent now checks the health of the Workload API (#2015)
 - Bundle and k8s-workload-registrar endpoints now only accept clients using TLS v1.2+ (#2025)
-- SDS API in Agent will return an error if an SDS client requests resource names that don't exist (#2020)
+- SDS API in agent now returns an error if an SDS client requests resource names that don't exist (#2020)
 - Server can now be built without `cgo` enabled when `sqlite3` is not used as a datastore (#2051)
-- Default Server Unix domain socket path is now `/tmp/spire-server/private/api.sock` (#2075)
-- Default Agent Unix domain socket path is now `/tmp/spire-agent/public/api.sock` (#2075)
+- Default server Unix domain socket path is now `/tmp/spire-server/private/api.sock` (#2075)
+- Default agent Unix domain socket path is now `/tmp/spire-agent/public/api.sock` (#2075)
 
 ### Removed
-- Deprecated `enable_sds` configuration field in Agent (#2021)
-- `experimental bundle` Server CLI commands (#2062)
-- Deprecated `bundle_endpoint_enabled`, `bundle_endpoint_address`, `bundle_endpoint_port`, `bundle_endpoint_acme`, and `federates_with` federation configuration fields in Server (#2062)
-- Deprecated Server Node APIs: `Attest`, `FetchX509SVID`, `FetchJWTSVID`, `FetchX509CASVID`, `PushJWTKeyUpstream`, and `FetchBundle` (#2093)
-- Experimental `allow_agentless_node_attestors` configuration field in Server (#2098)
+- Deprecated `enable_sds` configuration field in agent (#2021)
+- `experimental bundle` server CLI commands (#2062)
+- Deprecated `bundle_endpoint_enabled`, `bundle_endpoint_address`, `bundle_endpoint_port`, `bundle_endpoint_acme`, and `federates_with` federation configuration fields in server (#2062)
+- Deprecated server Node APIs: `Attest`, `FetchX509SVID`, `FetchJWTSVID`, `FetchX509CASVID`, `PushJWTKeyUpstream`, and `FetchBundle` (#2093)
+- Experimental `allow_agentless_node_attestors` configuration field in server (#2098)
 
 ### Fixed
 - File descriptor leak on new connections to the Workload API on Linux (#2043)
 - Agent logs an error and automatically shuts down when its SVID has expired and it requires re-attestation (#2065)
-- Reporting of errors in Server entry cache telemetry (#2091)
+- Reporting of errors in server entry cache telemetry (#2091)
+- "No identity issued" error logs are no longer produced when the `spire-agent healthcheck` CLI command is run (#2058)
 
 ## [0.12.0] - 2020-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Filtering by federated trust domains in `ListEntries` RPC in SPIRE Server (#1967)
 - Logging when lookup of user by uid or group by gid fails in the `unix` WorkloadAttestor plugin (#2048)
 - Timeouts to calls to KeyManager plugins (#2044)
-- Basic [gRPC Health v1 services](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) in server and agent exposed at `/grpc.health.v1.Health/Check` path (#2057, #2058, #2087)
+- Initial implementation of [gRPC Health v1 services](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) in server and agent exposed at `/grpc.health.v1.Health/Check` path (#2057, #2058, #2087)
 - Uptime metrics in server and agent (#2032)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [1.0.0] - 2021-02-02
+
+### Added
+- Filtering by federated trust domains in `ListEntries` (#1967)
+- Logging when lookup of user by uid or group by gid fails in the `unix` WorkloadAttestor plugin (#2048)
+- Timeouts to calls to KeyManager plugins (#2044)
+- gRPC Health v1 services in Server and Agent exposed at `/grpc.health.v1.Health/Check` path (#2057, #2058, #2087)
+- Uptime metrics in Server and Agent (#2032)
+
+### Changed
+- `/ready` HTTP endpoint on Agent now checks the health of the Workload API (#2015)
+- Bundle and k8s-workload-registrar endpoints now only accept clients using TLS v1.2+ (#2025)
+- SDS API in Agent will return an error if an SDS client requests resource names that don't exist (#2020)
+- Server can now be built without `cgo` enabled when `sqlite3` is not used as a datastore (#2051)
+- Default Server Unix domain socket path is now `/tmp/spire-server/private/api.sock` (#2075)
+- Default Agent Unix domain socket path is now `/tmp/spire-agent/public/api.sock` (#2075)
+
+### Removed
+- Deprecated `enable_sds` configuration field in Agent (#2021)
+- `experimental bundle` Server CLI commands (#2062)
+- Deprecated `bundle_endpoint_enabled`, `bundle_endpoint_address`, `bundle_endpoint_port`, `bundle_endpoint_acme`, and `federates_with` federation configuration fields in Server (#2062)
+- Deprecated Server Node APIs: `Attest`, `FetchX509SVID`, `FetchJWTSVID`, `FetchX509CASVID`, `PushJWTKeyUpstream`, and `FetchBundle` (#2093)
+- Experimental `allow_agentless_node_attestors` configuration field in Server (#2098)
+
+### Fixed
+- File descriptor leak on new connections to the Workload API on Linux (#2043)
+- Agent logs an error and automatically shuts down when its SVID has expired and it requires re-attestation (#2065)
+- Reporting of errors in Server entry cache telemetry (#2091)
+
 ## [0.12.0] - 2020-12-17
 
 ### Added


### PR DESCRIPTION
For #2059 

Queried with `git log 1549503 ^v0.12`

Release date: TBD
