### PR TITLE
Fix race conditions in pkg/agent/svid

### DIFF
--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -3,6 +3,7 @@ package svid
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"net/url"
 	"testing"
 	"time"
@@ -136,8 +137,6 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 	})
 
 	s.mockClock.Add(s.r.c.Interval)
-	err = s.r.rotateSVID(context.Background())
-	s.Require().NoError(err)
 
 	select {
 	case <-time.After(time.Second):
@@ -149,7 +148,13 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 	}
 
 	cancel()
-	s.Require().Equal(context.Canceled, t.Wait())
+	err = t.Wait()
+
+	// The error returned by the tomb is non-deterministic so we verify it is either one of the
+	// expected cases. When the Run context is cancelled, either all the runnable tasks terminate returning
+	// a nil error _or_ the Run loop itself returns and returns the context Err(), which in this case is
+	// context.Canceled.
+	s.Require().True(errors.Is(err, context.Canceled) || err == nil)
 }
 
 func (s *RotatorTestSuite) TestRotateSVID() {


### PR DESCRIPTION
The TestRunWithUpdates test case has two race conditions which
cause intermittent test failures. First, the return value of the
Run method of the rotator is non-deterministic in the face of
context cancellations. Second, it is possible for the RenewSVID
function of the test mock to be called multiple times depending on
test timing conditions.

The first race is fixed by adjusting the test assertion to accept
either possible return value. The second race is fixed by removing
an extranous explicit call to rotateSVID

Signed-off-by: Brad Blackard <bradb@uber.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
Tests only

**Description of change**
Fixes race conditions in a test

**Which issue this PR fixes**
No issue.

