### PR TITLE
Fix Vault token auth bug

### DIFF
--- a/pkg/server/plugin/upstreamauthority/vault/vault_client.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client.go
@@ -162,7 +162,6 @@ func (c *ClientConfig) NewAuthenticatedClient(method AuthMethod) (client *Client
 		if sec == nil {
 			return nil, false, errors.New("lookup self response is nil")
 		}
-		client.SetToken(c.clientParams.Token)
 	case CERT:
 		path := fmt.Sprintf("auth/%v/login", c.clientParams.CertAuthMountPoint)
 		sec, err = client.Auth(path, map[string]interface{}{
@@ -306,6 +305,11 @@ func (c *Client) Auth(path string, body map[string]interface{}) (*vapi.Secret, e
 }
 
 func (c *Client) LookupSelf(token string) (*vapi.Secret, error) {
+	if token == "" {
+		return nil, errors.New("token is empty")
+	}
+	c.SetToken(token)
+
 	secret, err := c.vaultClient.Logical().Read("auth/token/lookup-self")
 	if err != nil {
 		return nil, fmt.Errorf("token lookup failed: %v", err)


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

UpstreamAuthority 'vault' plugin

**Description of change**
<!-- Please provide a description of the change -->

The Vault token will  be set correctly in the Token Auth Method.

In v0.12.0, we get an error as below even if the token is given via plugin config or environment variable.

```
level=error msg="Fatal run error" error="rpc error: code = Unknown desc = failed to prepare authenticated client: token lookup failed: Error making API request.\n\nURL: GET http://<vault_addr>/v1/auth/token/lookup-self\nCode: 400. Errors:\n\n* missing client token"
```

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

No Issues or PRs.
https://spiffe.slack.com/archives/CBNCC2V17/p1613059475073700