### PR TITLE
JWT SVID exp validation

### DIFF
--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -290,6 +290,9 @@ func (ca *CA) SignJWTSVID(ctx context.Context, params JWTSVIDParams) (string, er
 		ttl = ca.c.JWTSVIDTTL
 	}
 	_, expiresAt := ca.capLifetime(ttl, jwtKey.NotAfter)
+	if !expiresAt.After(time.Now()) {
+		return "", errs.New("JWT SVID NotAfter cannot be in the past")
+	}
 
 	token, err := ca.jwtSigner.SignToken(params.SpiffeID.String(), params.Audience, expiresAt, jwtKey.Signer, jwtKey.Kid)
 	if err != nil {

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -288,6 +288,12 @@ func (s *CATestSuite) TestSignJWTSVIDCapsTTLToKeyExpiry() {
 	s.Require().Equal(s.clock.Now().Add(10*time.Minute), expiresAt)
 }
 
+func (s *CATestSuite) TestSignJWTSVIDWithNotAfterInPast() {
+	s.ca.jwtKey.NotAfter = time.Now().Add(-1 * time.Second)
+	_, err := s.ca.SignJWTSVID(ctx, s.createJWTSVIDParams(trustDomainExample, 0))
+	s.Require().EqualError(err, "JWT SVID NotAfter cannot be in the past")
+}
+
 func (s *CATestSuite) TestSignJWTSVIDValidatesJSR() {
 	// spiffe id for wrong trust domain
 	_, err := s.ca.SignJWTSVID(ctx, s.createJWTSVIDParams(trustDomainFoo, 0))


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
JWT SVID issuance

**Description of change**
SPIFFE mandates that the "exp" claim of JWT SVIDs MUST NOT be a time in the past when validating the JWT SVID. This is not explicitly validated in the JWT SVID CA component of SPIRE Server. If the JWT signing key was not rotated properly, it could result in a case where SPIRE Server issued JWT SVIDs with "exp" claims in the past.

Explicitly validate this case rather than rely on proper Server configuration validation and successful JWT key rotation.

**Which issue this PR fixes**
N/A

