### PR TITLE
Fix timezone mismatch in test

### DIFF
--- a/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/google_public_key_retriever_test.go
@@ -107,7 +107,7 @@ func (s *GooglePublicKeyRetrieverSuite) TestMalformedCertificatePEM() {
 
 func (s *GooglePublicKeyRetrieverSuite) TestSuccess() {
 	s.body = publicKeyPayload
-	s.expires = "Thu, 21 Jun 2018 01:53:33 GMT"
+	s.expires = "Thu, 21 Jun 2018 01:53:33 UTC"
 
 	key, err := s.retriever.retrieveKey(s.token)
 	s.Require().NotNil(key)


### PR DESCRIPTION
For me the tests currently fail with:
```
--- FAIL: TestGooglePublicKeyRetriever (0.00s)
    --- FAIL: TestGooglePublicKeyRetriever/TestSuccess (0.00s)
        google_public_key_retriever_test.go:115:
                Error Trace:    google_public_key_retriever_test.go:115
                Error:          Not equal:
                                expected: "2018-06-21T01:53:33Z"
                                actual  : "2018-06-21T02:53:33+01:00"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -2018-06-21T01:53:33Z
                                +2018-06-21T02:53:33+01:00
                Test:           TestGooglePublicKeyRetriever/TestSuccess
FAIL
```
It seems like `time.Parse` output can depend on the local time zone.
In fact https://play.golang.org/p/WYpu5XAtWLO prints what the test expects,
but gives a different result when run locally.

Fix this by  using UTC which shouldn't depend on the local timezone.

Signed-off-by: Sorin Dumitru <sdumitru@bloomberg.net>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
`TestGooglePublicKeyRetriever/TestSuccess` fails when I run it locally.

**Description of change**
Use UTC for the expiry time, this should provide consistent results regardless
of local time zone.

