### PR TITLE
Update supported versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Versions of the project that are currently being supported with security updates
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.12.x   | :white_check_mark: |
 | 0.11.x   | :white_check_mark: |
-| 0.10.x   | :white_check_mark: |
-| <=0.9.x   | :x: |
+| <=0.10.x   | :x: |
 
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
SPIRE only supports the most recent major version and the previous major version for security patches. The security policy currently specifies exact version ranges of major releases that are supported.

<=0.10.x is no longer supported after the release of 0.12.0. Updating the supported versions in SECURITY.md to reflect the current state.