### PR TITLE
sort identities by SPIFFE ID path

### DIFF
--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -726,7 +726,7 @@ func makeIdentity(record *cacheRecord) Identity {
 // are sorted by path complexity, and alphabetically within path segments.
 //
 // Default order is fewest path segments first in the spirit of more generic
-// identities as default and more complex identies left to workload decision.
+// identities as default and more complex identities left to workload decision.
 func sortIdentities(identities []Identity) {
 	sort.Sort(byIdentity(identities))
 }

--- a/pkg/agent/manager/cache/cache_test.go
+++ b/pkg/agent/manager/cache/cache_test.go
@@ -63,25 +63,29 @@ func TestMatchingIdentities(t *testing.T) {
 
 	// populate the cache with FOO and BAR without SVIDS
 	foo := makeRegistrationEntry("FOO", "A")
-	bar := makeRegistrationEntry("BAR", "B")
+	foobaz := makeRegistrationEntry("FOO/BAZ", "B")
+	foobar := makeRegistrationEntry("FOO/BAR", "C")
+	bar := makeRegistrationEntry("BAR", "D")
 	updateEntries := &UpdateEntries{
 		Bundles:             makeBundles(bundleV1),
-		RegistrationEntries: makeRegistrationEntries(foo, bar),
+		RegistrationEntries: makeRegistrationEntries(foo, bar, foobar, foobaz),
 	}
 	cache.UpdateEntries(updateEntries, nil)
 
-	identities := cache.MatchingIdentities(makeSelectors("A", "B"))
+	identities := cache.MatchingIdentities(makeSelectors("A", "B", "C", "D"))
 	assert.Len(t, identities, 0, "identities should not be returned that don't have SVIDs")
 
 	updateSVIDs := &UpdateSVIDs{
-		X509SVIDs: makeX509SVIDs(foo, bar),
+		X509SVIDs: makeX509SVIDs(foo, bar, foobar, foobaz),
 	}
 	cache.UpdateSVIDs(updateSVIDs)
 
-	identities = cache.MatchingIdentities(makeSelectors("A", "B"))
+	identities = cache.MatchingIdentities(makeSelectors("A", "B", "C", "D"))
 	assert.Equal(t, []Identity{
 		{Entry: bar},
 		{Entry: foo},
+		{Entry: foobar},
+		{Entry: foobaz},
 	}, identities)
 }
 


### PR DESCRIPTION
Signed-off-by: Brian Martin <bri365@gmail.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
MatchingIdentities returns SVIDs sorted by SPIFFE ID complexity rather than alphabetically sorted Entry ID (UUID). 

**Description of change**
SVID sort order is by path length then alphabetically by path segment for equal path lengths. Default order is fewest path segments first in the spirit of more generic identities as default and more complex identities left to workload decision. This will hopefully serve as an acceptable interim solution for administratively selected default SVIDs.

**Which issue this PR fixes**
fixes #745

