### PR TITLE
Migrate units and utility functions to using go-spiffe-v2 strong types

### DIFF
--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -135,11 +135,6 @@ func TestSet(t *testing.T) {
 		},
 		{
 			name:           "invalid trust domain ID",
-			expectedStderr: "Error: \"spiffe://otherdomain.test/spire/server\" is not a valid trust domain SPIFFE ID: path is not empty\n",
-			args:           []string{"-id", "spiffe://otherdomain.test/spire/server"},
-		},
-		{
-			name:           "invalid trust domain ID",
 			expectedStderr: "Error: unable to parse bundle data: no PEM blocks\n",
 			args:           []string{"-id", "spiffe://otherdomain.test"},
 		},
@@ -153,7 +148,7 @@ func TestSet(t *testing.T) {
 			name:           "invalid trustdomain",
 			stdin:          cert1PEM,
 			args:           []string{"-id", "otherdomain test"},
-			expectedStderr: "Error: \"otherdomain%20test\" is not a valid trust domain SPIFFE ID: invalid scheme\n",
+			expectedStderr: "Error: spiffeid: unable to parse: parse \"spiffe://otherdomain test\": invalid character \" \" in host name\n",
 		},
 		{
 			name:           "invalid bundle (pem)",

--- a/cmd/spire-server/cli/bundle/common.go
+++ b/cmd/spire-server/cli/bundle/common.go
@@ -148,9 +148,9 @@ func jwtKeysFromProto(proto []*types.JWTKey) (map[string]crypto.PublicKey, error
 	return keys, nil
 }
 
-func bundleProtoFromX509Authorities(trustDomain string, rootCAs []*x509.Certificate) *types.Bundle {
+func bundleProtoFromX509Authorities(trustDomain spiffeid.TrustDomain, rootCAs []*x509.Certificate) *types.Bundle {
 	b := &types.Bundle{
-		TrustDomain: trustDomain,
+		TrustDomain: trustDomain.IDString(),
 	}
 	for _, rootCA := range rootCAs {
 		b.X509Authorities = append(b.X509Authorities, &types.X509Certificate{

--- a/cmd/spire-server/cli/bundle/list.go
+++ b/cmd/spire-server/cli/bundle/list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mitchellh/cli"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -42,12 +43,17 @@ func (c *listCommand) AppendFlags(fs *flag.FlagSet) {
 func (c *listCommand) Run(ctx context.Context, env *common_cli.Env, serverClient util.ServerClient) error {
 	bundleClient := serverClient.NewBundleClient()
 	if c.id != "" {
-		id, err := idutil.NormalizeSpiffeID(c.id, idutil.AllowAnyTrustDomain())
+		id, err := spiffeid.FromString(c.id)
 		if err != nil {
 			return err
 		}
+		err = idutil.ValidateSpiffeID(id, idutil.AllowAnyTrustDomain())
+		if err != nil {
+			return err
+		}
+
 		resp, err := bundleClient.GetFederatedBundle(ctx, &bundle.GetFederatedBundleRequest{
-			TrustDomain: id,
+			TrustDomain: id.String(),
 		})
 		if err != nil {
 			return err

--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -3,8 +3,10 @@ package entry
 import (
 	"errors"
 	"flag"
+	"fmt"
 
 	"github.com/mitchellh/cli"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -153,23 +155,26 @@ func (c *createCommand) validate() (err error) {
 	}
 
 	// make sure all SPIFFE ID's are well formed
-	c.spiffeID, err = idutil.NormalizeSpiffeID(c.spiffeID, idutil.AllowAny())
+	spiffeID, err := spiffeid.FromString(c.spiffeID)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.spiffeID, err)
 	}
+	c.spiffeID = spiffeID.String()
 
 	if c.parentID != "" {
-		c.parentID, err = idutil.NormalizeSpiffeID(c.parentID, idutil.AllowAny())
+		parentID, err := spiffeid.FromString(c.parentID)
 		if err != nil {
-			return err
+			return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.parentID, err)
 		}
+		c.parentID = parentID.String()
 	}
 
 	for i := range c.federatesWith {
-		c.federatesWith[i], err = idutil.NormalizeSpiffeID(c.federatesWith[i], idutil.AllowAny())
+		id, err := spiffeid.FromString(c.federatesWith[i])
 		if err != nil {
-			return err
+			return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.federatesWith[i], err)
 		}
+		c.federatesWith[i] = id.String()
 	}
 
 	return nil

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -149,12 +149,12 @@ func TestCreate(t *testing.T) {
 		{
 			name:   "Wrong SPIFFE ID",
 			args:   []string{"-selector", "unix:uid:1", "-parentID", "spiffe://example.org/parent", "-spiffeID", "invalid-id"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name:   "Wrong parent SPIFFE ID",
 			args:   []string{"-selector", "unix:uid:1", "-parentID", "invalid-id", "-spiffeID", "spiffe://example.org/workload"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name:   "Wrong selectors",
@@ -174,7 +174,7 @@ func TestCreate(t *testing.T) {
 		{
 			name:   "Wrong federated trust domain",
 			args:   []string{"-selector", "unix", "-spiffeID", "spiffe://example.org/workload", "-parentID", "spiffe://example.org/parent", "-federatesWith", "invalid-id"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name: "Server error",

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -3,11 +3,12 @@ package entry
 import (
 	"errors"
 	"flag"
+	"fmt"
 
 	"github.com/mitchellh/cli"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
-	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire/proto/spire/types"
 	"google.golang.org/grpc/codes"
@@ -153,19 +154,24 @@ func (c *updateCommand) validate() (err error) {
 	}
 
 	// make sure all SPIFFE ID's are well formed
-	c.spiffeID, err = idutil.NormalizeSpiffeID(c.spiffeID, idutil.AllowAny())
+	spiffeID, err := spiffeid.FromString(c.spiffeID)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.spiffeID, err)
 	}
-	c.parentID, err = idutil.NormalizeSpiffeID(c.parentID, idutil.AllowAny())
+	c.spiffeID = spiffeID.String()
+
+	parentID, err := spiffeid.FromString(c.parentID)
 	if err != nil {
-		return err
+		return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.parentID, err)
 	}
+	c.parentID = parentID.String()
+
 	for i := range c.federatesWith {
-		c.federatesWith[i], err = idutil.NormalizeSpiffeID(c.federatesWith[i], idutil.AllowAny())
+		id, err := spiffeid.FromString(c.federatesWith[i])
 		if err != nil {
-			return err
+			return fmt.Errorf("%q is not a valid SPIFFE ID: %s", c.federatesWith[i], err)
 		}
+		c.federatesWith[i] = id.String()
 	}
 
 	return nil

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -154,12 +154,12 @@ func TestUpdate(t *testing.T) {
 		{
 			name:   "Wrong SPIFFE ID",
 			args:   []string{"-entryID", "entry-id", "-selector", "unix:uid:1", "-parentID", "spiffe://example.org/parent", "-spiffeID", "invalid-id"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name:   "Wrong parent SPIFFE ID",
 			args:   []string{"-entryID", "entry-id", "-selector", "unix:uid:1", "-parentID", "invalid-id", "-spiffeID", "spiffe://example.org/workload"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name:   "Wrong selectors",
@@ -174,7 +174,7 @@ func TestUpdate(t *testing.T) {
 		{
 			name:   "Wrong federated trust domain",
 			args:   []string{"-entryID", "entry-id", "-selector", "unix", "-spiffeID", "spiffe://example.org/workload", "-parentID", "spiffe://example.org/parent", "-federatesWith", "invalid-id"},
-			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: invalid scheme\n",
+			expErr: "Error: \"invalid-id\" is not a valid SPIFFE ID: spiffeid: invalid scheme\n",
 		},
 		{
 			name: "Server error",

--- a/pkg/agent/attestor/node/node_test.go
+++ b/pkg/agent/attestor/node/node_test.go
@@ -470,7 +470,7 @@ func createCACertificate(t *testing.T) *x509.Certificate {
 	tmpl := &x509.Certificate{
 		BasicConstraintsValid: true,
 		IsCA:                  true,
-		URIs:                  []*url.URL{idutil.TrustDomainURI(trustDomain.String())},
+		URIs:                  []*url.URL{trustDomain.ID().URL()},
 	}
 	return createCertificate(t, tmpl, tmpl)
 }
@@ -485,7 +485,7 @@ func createServerCertificate(t *testing.T, caCert *x509.Certificate) *x509.Certi
 
 func createAgentCertificate(t *testing.T, caCert *x509.Certificate, path string) *x509.Certificate {
 	tmpl := &x509.Certificate{
-		URIs: []*url.URL{idutil.AgentURI(trustDomain.String(), path)},
+		URIs: []*url.URL{idutil.AgentID(trustDomain, path).URL()},
 	}
 	return createCertificate(t, tmpl, caCert)
 }
@@ -493,7 +493,7 @@ func createAgentCertificate(t *testing.T, caCert *x509.Certificate, path string)
 func createExpiredCertificate(t *testing.T, caCert *x509.Certificate) *x509.Certificate {
 	tmpl := &x509.Certificate{
 		NotAfter: time.Now().Add(-1 * time.Hour),
-		URIs:     []*url.URL{idutil.AgentURI(trustDomain.String(), "/test/expired")},
+		URIs:     []*url.URL{idutil.AgentID(trustDomain, "/test/expired").URL()},
 	}
 	return createCertificate(t, tmpl, caCert)
 }

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -178,7 +178,7 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 	}
 
 	return &workload.ValidateJWTSVIDResponse{
-		SpiffeId: spiffeID,
+		SpiffeId: spiffeID.String(),
 		Claims:   s,
 	}, nil
 }

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -735,7 +735,7 @@ func TestValidateJWTSVID(t *testing.T) {
 			svid:       federatedSVID.Marshal(),
 			updates:    updatesWithBundleOnly,
 			expectCode: codes.InvalidArgument,
-			expectMsg:  `no keys found for trust domain "spiffe://domain2.test"`,
+			expectMsg:  `no keys found for trust domain "domain2.test"`,
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.WarnLevel,
@@ -744,7 +744,7 @@ func TestValidateJWTSVID(t *testing.T) {
 						"audience":      "AUDIENCE",
 						"service":       "WorkloadAPI",
 						"method":        "ValidateJWTSVID",
-						logrus.ErrorKey: `no keys found for trust domain "spiffe://domain2.test"`,
+						logrus.ErrorKey: `no keys found for trust domain "domain2.test"`,
 					},
 				},
 			},

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -192,7 +192,7 @@ func (m *manager) FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audien
 		return cachedSVID, nil
 	}
 
-	entryID := m.getEntryID(spiffeID.String())
+	entryID := m.getEntryID(spiffeID)
 	if entryID == "" {
 		return nil, errors.New("no entry found")
 	}
@@ -213,9 +213,9 @@ func (m *manager) FetchJWTSVID(ctx context.Context, spiffeID spiffeid.ID, audien
 	return newSVID, nil
 }
 
-func (m *manager) getEntryID(spiffeID string) string {
+func (m *manager) getEntryID(spiffeID spiffeid.ID) string {
 	for _, identity := range m.cache.Identities() {
-		if identity.Entry.SpiffeId == spiffeID {
+		if identity.Entry.SpiffeId == spiffeID.String() {
 			return identity.Entry.EntryId
 		}
 	}

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -1257,11 +1257,7 @@ func (h *mockAPI) getCertFromCtx(ctx context.Context) (certificate *x509.Certifi
 }
 
 func createCA(t *testing.T, clk clock.Clock) (*x509.Certificate, *ecdsa.PrivateKey) {
-	tmpl, err := util.NewCATemplate(clk, trustDomain)
-	if err != nil {
-		t.Fatalf("cannot create ca template: %v", err)
-	}
-
+	tmpl := util.NewCATemplate(clk, trustDomain)
 	ca, cakey, err := util.SelfSign(tmpl)
 	if err != nil {
 		t.Fatalf("cannot self sign ca template: %v", err)
@@ -1270,10 +1266,7 @@ func createCA(t *testing.T, clk clock.Clock) (*x509.Certificate, *ecdsa.PrivateK
 }
 
 func createSVID(t *testing.T, clk clock.Clock, ca *x509.Certificate, cakey *ecdsa.PrivateKey, spiffeID spiffeid.ID, ttl time.Duration) ([]*x509.Certificate, *ecdsa.PrivateKey) {
-	tmpl, err := util.NewSVIDTemplate(clk, spiffeID.String())
-	if err != nil {
-		t.Fatalf("cannot create svid template for %s: %v", spiffeID, err)
-	}
+	tmpl := util.NewSVIDTemplate(clk, spiffeID)
 
 	tmpl.NotAfter = tmpl.NotBefore.Add(ttl)
 
@@ -1288,7 +1281,7 @@ func createSVIDFromCSR(t *testing.T, clk clock.Clock, ca *x509.Certificate, cake
 	req, err := x509.ParseCertificateRequest(csr)
 	require.NoError(t, err)
 
-	tmpl, err := util.NewSVIDTemplate(clk, spiffeID.String())
+	tmpl := util.NewSVIDTemplate(clk, spiffeID)
 	require.NoError(t, err)
 	tmpl.PublicKey = req.PublicKey
 	tmpl.NotAfter = tmpl.NotBefore.Add(time.Duration(ttl) * time.Second)

--- a/pkg/agent/plugin/nodeattestor/sshpop/sshpop.go
+++ b/pkg/agent/plugin/nodeattestor/sshpop/sshpop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/sshpop"
@@ -71,7 +72,11 @@ func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAtte
 
 // Configure configures the Plugin.
 func (p *Plugin) Configure(ctx context.Context, req *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error) {
-	sshclient, err := sshpop.NewClient(req.GlobalConfig.GetTrustDomain(), req.Configuration)
+	trustDomain, err := spiffeid.TrustDomainFromString(req.GlobalConfig.GetTrustDomain())
+	if err != nil {
+		return nil, err
+	}
+	sshclient, err := sshpop.NewClient(trustDomain, req.Configuration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -112,8 +112,7 @@ func (s *RotatorTestSuite) TestRun() {
 
 func (s *RotatorTestSuite) TestRunWithUpdates() {
 	// Cert that's valid for 1hr
-	temp, err := util.NewSVIDTemplate(s.mockClock, "spiffe://example.org/test")
-	s.Require().NoError(err)
+	temp := util.NewSVIDTemplate(s.mockClock, spiffeid.RequireFromString("spiffe://example.org/test"))
 	goodCert, _, err := util.SelfSign(temp)
 	s.Require().NoError(err)
 
@@ -161,8 +160,7 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 
 func (s *RotatorTestSuite) TestRotateSVID() {
 	// Cert that's valid for 1hr
-	temp, err := util.NewSVIDTemplate(s.mockClock, "spiffe://example.org/test")
-	s.Require().NoError(err)
+	temp := util.NewSVIDTemplate(s.mockClock, spiffeid.RequireFromString("spiffe://example.org/test"))
 	goodCert, _, err := util.SelfSign(temp)
 	s.Require().NoError(err)
 

--- a/pkg/common/idutil/spiffeid.go
+++ b/pkg/common/idutil/spiffeid.go
@@ -3,7 +3,6 @@ package idutil
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -22,31 +21,13 @@ const (
 
 const (
 	ServerIDPath = "/spire/server"
+	AgentIDPath  = "/spire/agent"
 )
 
-// ValidateSpiffeID validates the SPIFFE ID according to the SPIFFE
-// specification. The validation mode controls the type of validation.
-func ValidateSpiffeID(spiffeID string, mode ValidationMode) error {
-	_, err := ParseSpiffeID(spiffeID, mode)
-	return err
-}
-
-// ValidateSpiffeIDURL validates the SPIFFE ID according to the SPIFFE
-// specification, namely:
-// - spiffe id is not empty
-// - spiffe id is a valid url
-// - scheme is 'spiffe'
-// - user info is not allowed
-// - host is not empty
-// - port is not allowed
-// - query values are not allowed
-// - fragment is not allowed
-// - path does not start with '/spire' since it is reserved for agent, server, etc.
-// In addition, the validation mode is used to control what kind of SPIFFE ID
-// is expected.
-// For more information:
-// [https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md]
-func ValidateSpiffeIDURL(id *url.URL, mode ValidationMode) error {
+// ValidateSpiffeId  performs additional validations on the SPIFFE ID object:
+// - validates that the path does not start with '/spire' since it is reserved for agent, server, etc.
+// - uses a validation to control what kind of SPIFFE ID that is expected.
+func ValidateSpiffeID(id spiffeid.ID, mode ValidationMode) error {
 	options := mode.validationOptions()
 
 	validationError := func(format string, args ...interface{}) error {
@@ -67,24 +48,8 @@ func ValidateSpiffeIDURL(id *url.URL, mode ValidationMode) error {
 			append([]interface{}{id.String(), kind}, args...)...)
 	}
 
-	if id == nil || *id == (url.URL{}) {
+	if id.IsZero() {
 		return validationError("SPIFFE ID is empty")
-	}
-
-	// General validation
-	switch {
-	case strings.ToLower(id.Scheme) != "spiffe":
-		return validationError("invalid scheme")
-	case id.User != nil:
-		return validationError("user info is not allowed")
-	case id.Host == "":
-		return validationError("trust domain is empty")
-	case id.Port() != "":
-		return validationError("port is not allowed")
-	case id.Fragment != "":
-		return validationError("fragment is not allowed")
-	case id.RawQuery != "":
-		return validationError("query is not allowed")
 	}
 
 	// trust domain validation
@@ -92,7 +57,7 @@ func ValidateSpiffeIDURL(id *url.URL, mode ValidationMode) error {
 		if options.trustDomain.IsZero() {
 			return errors.New("trust domain to validate against cannot be empty")
 		}
-		if id.Host != options.trustDomain.String() {
+		if id.TrustDomain().String() != options.trustDomain.String() {
 			return fmt.Errorf("%q does not belong to trust domain %q", id, options.trustDomain)
 		}
 	}
@@ -101,32 +66,32 @@ func ValidateSpiffeIDURL(id *url.URL, mode ValidationMode) error {
 	switch options.idType {
 	case anyID:
 	case trustDomainID:
-		if id.Path != "" {
+		if id.Path() != "" {
 			return validationError("path is not empty")
 		}
 	case memberID:
-		if id.Path == "" {
+		if id.Path() == "" {
 			return validationError("path is empty")
 		}
 	case workloadID:
-		if id.Path == "" {
+		if id.Path() == "" {
 			return validationError("path is empty")
 		}
-		if IsReservedPath(id.Path) {
+		if IsReservedPath(id.Path()) {
 			return validationError(`invalid path: "/spire/*" namespace is reserved`)
 		}
 	case serverID:
-		if id.Path == "" {
+		if id.Path() == "" {
 			return validationError("path is empty")
 		}
-		if !isServerPath(id.Path) {
+		if !isServerPath(id.Path()) {
 			return validationError(`invalid path: expecting "/spire/server"`)
 		}
 	case agentID:
-		if id.Path == "" {
+		if id.Path() == "" {
 			return validationError("path is empty")
 		}
-		if !IsAgentPath(id.Path) {
+		if !IsAgentPath(id.Path()) {
 			return validationError(`invalid path: expecting "/spire/agent/*"`)
 		}
 	default:
@@ -153,17 +118,17 @@ func isServerPath(path string) bool {
 
 // ParseSpiffeID parses the SPIFFE ID and makes sure it is valid according to
 // the specified validation mode.
-func ParseSpiffeID(spiffeID string, mode ValidationMode) (*url.URL, error) {
-	u, err := url.Parse(spiffeID)
+func ParseSpiffeID(spiffeID string, mode ValidationMode) (spiffeid.ID, error) {
+	id, err := spiffeid.FromString(spiffeID)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse SPIFFE ID: %v", err)
+		return spiffeid.ID{}, fmt.Errorf("could not parse SPIFFE ID: %v", err)
 	}
 
-	if err := ValidateSpiffeIDURL(u, mode); err != nil {
-		return nil, err
+	if err := ValidateSpiffeID(id, mode); err != nil {
+		return spiffeid.ID{}, err
 	}
 
-	return normalizeSpiffeIDURL(u), nil
+	return id, nil
 }
 
 type ValidationMode interface {
@@ -277,62 +242,10 @@ func AllowAnyTrustDomainAgent() ValidationMode {
 	}
 }
 
-// NormalizeSpiffeID normalizes the SPIFFE ID so it can be directly compared
-// for equality.
-func NormalizeSpiffeID(id string, mode ValidationMode) (string, error) {
-	u, err := ParseSpiffeID(id, mode)
-	if err != nil {
-		return "", err
-	}
-	return u.String(), nil
-}
-
-// NormalizeSpiffeIDURL normalizes the SPIFFE ID URL so it can be directly
-// compared for equality.
-func NormalizeSpiffeIDURL(u *url.URL, mode ValidationMode) (*url.URL, error) {
-	if err := ValidateSpiffeIDURL(u, mode); err != nil {
-		return nil, err
-	}
-	return normalizeSpiffeIDURL(u), nil
-}
-
-func normalizeSpiffeIDURL(u *url.URL) *url.URL {
-	c := *u
-	c.Scheme = strings.ToLower(c.Scheme)
-	// SPIFFE ID's can't contain ports so don't bother handling that here.
-	c.Host = strings.ToLower(u.Hostname())
-	return &c
-}
-
-// TrustDomainID creates a trust domain SPIFFE ID given a trust domain name. If the passed
-// trust domain already is a trust domain ID, it is returned unchanged.
-func TrustDomainID(trustDomain string) string {
-	return TrustDomainURI(trustDomain).String()
-}
-
-// TrustDomainURI creates a trust domain SPIFFE URI given a trust domain name or trust domain ID.
-func TrustDomainURI(trustDomain string) *url.URL {
-	trustDomain = strings.TrimPrefix(trustDomain, "spiffe://")
-	return &url.URL{
-		Scheme: "spiffe",
-		Host:   trustDomain,
-	}
-}
-
 // AgentID creates an agent SPIFFE ID given a trust domain and a path.
 // The /spire/agent prefix in the path is implied.
-func AgentID(trustDomain, p string) string {
-	return AgentURI(trustDomain, p).String()
-}
-
-// AgentURI creates an agent SPIFFE URI given a trust domain and a path.
-// The /spire/agent prefix in the path is implied.
-func AgentURI(trustDomain, p string) *url.URL {
-	return &url.URL{
-		Scheme: "spiffe",
-		Host:   trustDomain,
-		Path:   "/spire/agent" + ensureLeadingSlash(p),
-	}
+func AgentID(trustDomain spiffeid.TrustDomain, p string) spiffeid.ID {
+	return trustDomain.NewID(AgentIDPath + ensureLeadingSlash(p))
 }
 
 // ServerID creates a server SPIFFE ID string given a trustDomain.

--- a/pkg/common/idutil/spiffeid_test.go
+++ b/pkg/common/idutil/spiffeid_test.go
@@ -11,103 +11,55 @@ import (
 var trustDomain = spiffeid.RequireTrustDomainFromString("test.com")
 
 func TestValidateSpiffeID(t *testing.T) {
+	testSpiffeID := spiffeid.RequireFromString("spiffe://test.com")
+	testSpiffeIDPath := spiffeid.RequireFromString("spiffe://test.com/path")
+	otherSpiffeID := spiffeid.RequireFromString("spiffe://othertest.com")
+	otherSpiffeIDPath := spiffeid.RequireFromString("spiffe://othertest.com/path")
+	reservedSpiffeID := spiffeid.RequireFromString("spiffe://test.com/spire/foo")
+
 	tests := []struct {
 		name          string
-		spiffeID      string
+		spiffeID      spiffeid.ID
 		mode          ValidationMode
 		expectedError string
 	}{
-		// General validation
-		{
-			name:          "test_validate_spiffe_id_empty_spiffe_id",
-			spiffeID:      "",
-			mode:          AllowAny(),
-			expectedError: `"" is not a valid SPIFFE ID: SPIFFE ID is empty`,
-		},
-		{
-			name:          "test_validate_spiffe_id_invalid_uri",
-			spiffeID:      "192.168.2.2:6688",
-			mode:          AllowAny(),
-			expectedError: "could not parse SPIFFE ID:",
-		},
-		{
-			name:          "test_validate_spiffe_id_invalid_scheme",
-			spiffeID:      "http://test.com/path/validate",
-			mode:          AllowAny(),
-			expectedError: "\"http://test.com/path/validate\" is not a valid SPIFFE ID: invalid scheme",
-		},
-		{
-			name:     "test_validate_spiffe_id_scheme_mixed_case",
-			spiffeID: "SPIFFE://test.com/path/validate",
-			mode:     AllowAny(),
-		},
-		{
-			name:          "test_validate_spiffe_id_empty_host",
-			spiffeID:      "spiffe:///path/validate",
-			mode:          AllowAny(),
-			expectedError: "\"spiffe:///path/validate\" is not a valid SPIFFE ID: trust domain is empty",
-		},
-		{
-			name:          "test_validate_spiffe_id_query_not_allowed",
-			spiffeID:      "spiffe://test.com/path/validate?query=1",
-			mode:          AllowAny(),
-			expectedError: "\"spiffe://test.com/path/validate?query=1\" is not a valid SPIFFE ID: query is not allowed",
-		},
-		{
-			name:          "test_validate_spiffe_id_fragmentnot_allowed",
-			spiffeID:      "spiffe://test.com/path/validate?#fragment-1",
-			mode:          AllowAny(),
-			expectedError: "\"spiffe://test.com/path/validate?#fragment-1\" is not a valid SPIFFE ID: fragment is not allowed",
-		},
-		{
-			name:          "test_validate_spiffe_id_port_not_allowed",
-			spiffeID:      "spiffe://test.com:8080/path/validate",
-			mode:          AllowAny(),
-			expectedError: "\"spiffe://test.com:8080/path/validate\" is not a valid SPIFFE ID: port is not allowed",
-		},
-		{
-			name:          "test_validate_spiffe_id_user_info_not_allowed",
-			spiffeID:      "spiffe://user:password@test.org/path/validate",
-			mode:          AllowAny(),
-			expectedError: "\"spiffe://user:password@test.org/path/validate\" is not a valid SPIFFE ID: user info is not allowed",
-		},
 		// AllowAny() mode
 		{
 			name:     "test_allow_any_with_trust_domain_id",
-			spiffeID: "spiffe://test.com",
+			spiffeID: testSpiffeID,
 			mode:     AllowAny(),
 		},
 		{
 			name:     "test_allow_any_with_trust_domain_workload_id",
-			spiffeID: "spiffe://test.com/path",
+			spiffeID: testSpiffeIDPath,
 			mode:     AllowAny(),
 		},
 		// AllowAnyInTrustDomain() mode
 		{
 			name:          "test_allow_any_in_trust_domain_invalid_with_trust_domain_id",
-			spiffeID:      "spiffe://test.com",
+			spiffeID:      testSpiffeID,
 			mode:          AllowAnyInTrustDomain(trustDomain),
 			expectedError: `"spiffe://test.com" is not a valid trust domain member SPIFFE ID: path is empty`,
 		},
 		{
 			name:     "test_allow_any_in_trust_domain_good_with_workload_id",
-			spiffeID: "spiffe://test.com/path",
+			spiffeID: testSpiffeIDPath,
 			mode:     AllowAnyInTrustDomain(trustDomain),
 		},
 		{
 			name:     "test_allow_any_in_trust_domain_good_with_reserved_path",
-			spiffeID: "spiffe://test.com/spire/foo",
+			spiffeID: reservedSpiffeID,
 			mode:     AllowAnyInTrustDomain(trustDomain),
 		},
 		{
 			name:          "test_allow_any_in_trust_domain_invalid_domain_with_trust_domain_id",
-			spiffeID:      "spiffe://othertest.com",
+			spiffeID:      otherSpiffeID,
 			mode:          AllowAnyInTrustDomain(trustDomain),
 			expectedError: `"spiffe://othertest.com" does not belong to trust domain "test.com"`,
 		},
 		{
 			name:          "test_allow_any_in_trust_domain_invalid_domain_with_workload_id",
-			spiffeID:      "spiffe://othertest.com/path",
+			spiffeID:      otherSpiffeIDPath,
 			mode:          AllowAnyInTrustDomain(trustDomain),
 			expectedError: `"spiffe://othertest.com/path" does not belong to trust domain "test.com"`,
 		},
@@ -115,138 +67,138 @@ func TestValidateSpiffeID(t *testing.T) {
 		// AllowTrustDomain() mode
 		{
 			name:     "test_allow_trust_domain_good",
-			spiffeID: "spiffe://test.com",
+			spiffeID: testSpiffeID,
 			mode:     AllowTrustDomain(trustDomain),
 		},
 		{
 			name:          "test_allow_trust_domain_empty_domain_to_validate",
-			spiffeID:      "spiffe://test.com",
+			spiffeID:      testSpiffeID,
 			mode:          AllowTrustDomain(spiffeid.TrustDomain{}),
 			expectedError: "trust domain to validate against cannot be empty",
 		},
 		{
 			name:          "test_allow_trust_domain_invalid",
-			spiffeID:      "spiffe://othertest.com",
+			spiffeID:      otherSpiffeID,
 			mode:          AllowTrustDomain(trustDomain),
 			expectedError: `"spiffe://othertest.com" does not belong to trust domain "test.com"`,
 		},
 		{
 			name:          "test_allow_trust_domain_with_a_workload",
-			spiffeID:      "spiffe://test.com/path",
+			spiffeID:      testSpiffeIDPath,
 			mode:          AllowTrustDomain(trustDomain),
 			expectedError: `"spiffe://test.com/path" is not a valid trust domain SPIFFE ID: path is not empty`,
 		},
 		// AllowTrustDomainWorkload() mode
 		{
 			name:     "test_allow_trust_domain_workload_good",
-			spiffeID: "spiffe://test.com/path",
+			spiffeID: testSpiffeIDPath,
 			mode:     AllowTrustDomainWorkload(trustDomain),
 		},
 		{
 			name:          "test_allow_trust_domain_workload_invalid_trust_domain",
-			spiffeID:      "spiffe://othertest.com/path",
+			spiffeID:      otherSpiffeIDPath,
 			mode:          AllowTrustDomainWorkload(trustDomain),
 			expectedError: `"spiffe://othertest.com/path" does not belong to trust domain "test.com"`,
 		},
 		{
 			name:          "test_allow_trust_domain_workload_missing_path",
-			spiffeID:      "spiffe://test.com",
+			spiffeID:      testSpiffeID,
 			mode:          AllowTrustDomainWorkload(trustDomain),
 			expectedError: `"spiffe://test.com" is not a valid workload SPIFFE ID: path is empty`,
 		},
 		{
 			name:          "test_allow_trust_domain_workload_invalid_path",
-			spiffeID:      "spiffe://test.com/spire/foo",
+			spiffeID:      reservedSpiffeID,
 			mode:          AllowTrustDomainWorkload(trustDomain),
 			expectedError: "\"spiffe://test.com/spire/foo\" is not a valid workload SPIFFE ID: invalid path: \"/spire/*\" namespace is reserved",
 		},
 		// AllowAnyTrustDomain() mode
 		{
 			name:     "test_allow_any_trust_domain_good",
-			spiffeID: "spiffe://othertest.com",
+			spiffeID: otherSpiffeID,
 			mode:     AllowAnyTrustDomain(),
 		},
 		{
 			name:          "test_allow_any_trust_domain_with_a_workload",
-			spiffeID:      "spiffe://othertest.com/path",
+			spiffeID:      otherSpiffeIDPath,
 			mode:          AllowAnyTrustDomain(),
 			expectedError: `"spiffe://othertest.com/path" is not a valid trust domain SPIFFE ID: path is not empty`,
 		},
 		// AllowAnyTrustDomainWorkload() mode
 		{
 			name:     "test_allow_any_trust_domain_workload_good",
-			spiffeID: "spiffe://othertest.com/path",
+			spiffeID: otherSpiffeIDPath,
 			mode:     AllowAnyTrustDomainWorkload(),
 		},
 		{
 			name:          "test_allow_any_trust_domain_workload_missing path",
-			spiffeID:      "spiffe://othertest.com",
+			spiffeID:      otherSpiffeID,
 			mode:          AllowAnyTrustDomainWorkload(),
 			expectedError: `"spiffe://othertest.com" is not a valid workload SPIFFE ID: path is empty`,
 		},
 		{
 			name:          "test_allow_any_trust_domain_workload_invalid_path",
-			spiffeID:      "spiffe://othertest.com/spire/foo",
+			spiffeID:      spiffeid.RequireFromString("spiffe://othertest.com/spire/foo"),
 			mode:          AllowAnyTrustDomainWorkload(),
 			expectedError: `"spiffe://othertest.com/spire/foo" is not a valid workload SPIFFE ID: invalid path: "/spire/*" namespace is reserved`,
 		},
 		// AllowTrustDomainAgent() mode
 		{
 			name:     "test_allow_trust_domain_agent_good",
-			spiffeID: "spiffe://test.com/spire/agent/foo",
+			spiffeID: spiffeid.RequireFromString("spiffe://test.com/spire/agent/foo"),
 			mode:     AllowTrustDomainAgent(trustDomain),
 		},
 		{
 			name:          "test_allow_trust_domain_agent_invalid_trust_domain",
-			spiffeID:      "spiffe://othertest.com/spire/agent/foo",
+			spiffeID:      spiffeid.RequireFromString("spiffe://othertest.com/spire/agent/foo"),
 			mode:          AllowTrustDomainAgent(trustDomain),
 			expectedError: `"spiffe://othertest.com/spire/agent/foo" does not belong to trust domain "test.com"`,
 		},
 		{
 			name:          "test_allow_trust_domain_agent_with_server",
-			spiffeID:      "spiffe://test.com/spire/server",
+			spiffeID:      spiffeid.RequireFromString("spiffe://test.com/spire/server"),
 			mode:          AllowTrustDomainAgent(trustDomain),
 			expectedError: `"spiffe://test.com/spire/server" is not a valid agent SPIFFE ID: invalid path: expecting "/spire/agent/*"`,
 		},
 		// AllowAnyTrustDomainAgent() mode
 		{
 			name:     "test_allow_any_trust_domain_agent_good",
-			spiffeID: "spiffe://othertest.com/spire/agent/foo",
+			spiffeID: spiffeid.RequireFromString("spiffe://othertest.com/spire/agent/foo"),
 			mode:     AllowAnyTrustDomainAgent(),
 		},
 		{
 			name:          "test_allow_any_trust_domain_agent_with_server",
-			spiffeID:      "spiffe://othertest.com/spire/server",
+			spiffeID:      spiffeid.RequireFromString("spiffe://othertest.com/spire/server"),
 			mode:          AllowAnyTrustDomainAgent(),
 			expectedError: `"spiffe://othertest.com/spire/server" is not a valid agent SPIFFE ID: invalid path: expecting "/spire/agent/*"`,
 		},
 		// AllowTrustDomainServer() mode
 		{
 			name:     "test_allow_trust_domain_server_good",
-			spiffeID: "spiffe://test.com/spire/server",
+			spiffeID: spiffeid.RequireFromString("spiffe://test.com/spire/server"),
 			mode:     AllowTrustDomainServer(trustDomain),
 		},
 		{
 			name:          "test_allow_trust_domain_server_invalid_trust_domain",
-			spiffeID:      "spiffe://othertest.com/spire/server",
+			spiffeID:      spiffeid.RequireFromString("spiffe://othertest.com/spire/server"),
 			mode:          AllowTrustDomainServer(trustDomain),
 			expectedError: `"spiffe://othertest.com/spire/server" does not belong to trust domain "test.com"`,
 		},
 		{
 			name:          "test_allow_trust_domain_server_with_agent",
-			spiffeID:      "spiffe://test.com/spire/agent/foo",
+			spiffeID:      spiffeid.RequireFromString("spiffe://test.com/spire/agent/foo"),
 			mode:          AllowTrustDomainServer(trustDomain),
 			expectedError: `"spiffe://test.com/spire/agent/foo" is not a valid server SPIFFE ID: invalid path: expecting "/spire/server"`,
 		},
 		// AllowAnyTrustDomainServer() mode
 		{
 			name:     "test_allow_any_trust_domain_server_good",
-			spiffeID: "spiffe://othertest.com/spire/server",
+			spiffeID: spiffeid.RequireFromString("spiffe://othertest.com/spire/server"),
 			mode:     AllowAnyTrustDomainServer(),
 		},
 		{
 			name:          "test_any_allow_trust_domain_server_with_agent",
-			spiffeID:      "spiffe://othertest.com/spire/agent/foo",
+			spiffeID:      spiffeid.RequireFromString("spiffe://othertest.com/spire/agent/foo"),
 			mode:          AllowAnyTrustDomainServer(),
 			expectedError: `"spiffe://othertest.com/spire/agent/foo" is not a valid server SPIFFE ID: invalid path: expecting "/spire/server"`,
 		},
@@ -262,26 +214,6 @@ func TestValidateSpiffeID(t *testing.T) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), test.expectedError)
 			}
-		})
-	}
-}
-
-func TestNormalizeSpiffeID(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		out  string
-	}{
-		{name: "scheme and host are lowercased", in: "SpIfFe://HoSt", out: "spiffe://host"},
-		{name: "path casing is preserved", in: "SpIfFe://HoSt/PaTh", out: "spiffe://host/PaTh"},
-	}
-
-	for _, test := range tests {
-		test := test // alias loop variable as it is used in the closure
-		t.Run(test.name, func(t *testing.T) {
-			out, err := NormalizeSpiffeID(test.in, AllowAny())
-			assert.NoError(t, err)
-			assert.Equal(t, test.out, out)
 		})
 	}
 }

--- a/pkg/common/jwtsvid/sign.go
+++ b/pkg/common/jwtsvid/sign.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/andres-erbsen/clock"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/zeebo/errs"
 	"gopkg.in/square/go-jose.v2"
@@ -35,7 +36,7 @@ func NewSigner(config SignerConfig) *Signer {
 	}
 }
 
-func (s *Signer) SignToken(spiffeID string, audience []string, expires time.Time, signer crypto.Signer, kid string) (string, error) {
+func (s *Signer) SignToken(spiffeID spiffeid.ID, audience []string, expires time.Time, signer crypto.Signer, kid string) (string, error) {
 	if err := idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomainWorkload()); err != nil {
 		return "", err
 	}
@@ -53,7 +54,7 @@ func (s *Signer) SignToken(spiffeID string, audience []string, expires time.Time
 	}
 
 	claims := jwt.Claims{
-		Subject:  spiffeID,
+		Subject:  spiffeID.String(),
 		Issuer:   s.c.Issuer,
 		Expiry:   jwt.NewNumericDate(expires),
 		Audience: audience,

--- a/pkg/common/plugin/azure/msi.go
+++ b/pkg/common/plugin/azure/msi.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"path"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/zeebo/errs"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -38,13 +39,8 @@ type MSITokenClaims struct {
 	TenantID string `json:"tid,omitempty"`
 }
 
-func (c *MSITokenClaims) AgentID(trustDomain string) string {
-	u := url.URL{
-		Scheme: "spiffe",
-		Host:   trustDomain,
-		Path:   path.Join("spire", "agent", "azure_msi", c.TenantID, c.Subject),
-	}
-	return u.String()
+func (c *MSITokenClaims) AgentID(trustDomain spiffeid.TrustDomain) spiffeid.ID {
+	return idutil.AgentID(trustDomain, path.Join("azure_msi", c.TenantID, c.Subject))
 }
 
 type HTTPClient interface {

--- a/pkg/common/plugin/azure/msi_test.go
+++ b/pkg/common/plugin/azure/msi_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -19,7 +20,7 @@ func TestMSITokenClaims(t *testing.T) {
 		},
 		TenantID: "TENANTID",
 	}
-	require.Equal(t, "spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID", claims.AgentID("example.org"))
+	require.Equal(t, spiffeid.RequireFromString("spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID"), claims.AgentID(spiffeid.RequireTrustDomainFromString("example.org")))
 }
 
 func TestFetchMSIToken(t *testing.T) {

--- a/pkg/common/plugin/gcp/iit.go
+++ b/pkg/common/plugin/gcp/iit.go
@@ -2,10 +2,10 @@ package gcp
 
 import (
 	"bytes"
-	"net/url"
 	"text/template"
 
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
@@ -44,14 +44,14 @@ type agentPathTemplateData struct {
 // MakeSpiffeID makes an agent spiffe ID. The ID always has a host value equal to the given trust domain,
 // the path is created using the given agentPathTemplate which is given access to a fully populated
 // ComputeEngine object.
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, computeEngine ComputeEngine) (*url.URL, error) {
+func MakeSpiffeID(trustDomain spiffeid.TrustDomain, agentPathTemplate *template.Template, computeEngine ComputeEngine) (spiffeid.ID, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
 		ComputeEngine: computeEngine,
 		PluginName:    PluginName,
 	}); err != nil {
-		return nil, err
+		return spiffeid.ID{}, err
 	}
 
-	return idutil.AgentURI(trustDomain, agentPath.String()), nil
+	return idutil.AgentID(trustDomain, agentPath.String()), nil
 }

--- a/pkg/common/plugin/k8s/utils.go
+++ b/pkg/common/plugin/k8s/utils.go
@@ -3,10 +3,11 @@ package k8s
 import (
 	"errors"
 	"fmt"
-	"net/url"
 	"path"
 	"strings"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/proto/spire/common"
 	"gopkg.in/square/go-jose.v2/jwt"
 	authv1 "k8s.io/api/authentication/v1"
@@ -81,13 +82,8 @@ type PSATAttestationData struct {
 	Token   string `json:"token"`
 }
 
-func AgentID(pluginName, trustDomain, cluster, uuid string) string {
-	u := url.URL{
-		Scheme: "spiffe",
-		Host:   trustDomain,
-		Path:   path.Join("spire", "agent", pluginName, cluster, uuid),
-	}
-	return u.String()
+func AgentID(pluginName string, trustDomain spiffeid.TrustDomain, cluster, uuid string) spiffeid.ID {
+	return idutil.AgentID(trustDomain, path.Join(pluginName, cluster, uuid))
 }
 
 func MakeSelector(pluginName, kind string, values ...string) *common.Selector {

--- a/pkg/common/plugin/k8s/utils_test.go
+++ b/pkg/common/plugin/k8s/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	authv1 "k8s.io/api/authentication/v1"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -42,7 +43,8 @@ func TestPSATClaims(t *testing.T) {
 	require.Equal(t, "spire-agent-jcdgp", claims.K8s.Pod.Name)
 }
 func TestAgentID(t *testing.T) {
-	require.Equal(t, "spiffe://example.org/spire/agent/k8s_sat/production/1234", AgentID("k8s_sat", "example.org", "production", "1234"))
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	require.Equal(t, spiffeid.RequireFromString("spiffe://example.org/spire/agent/k8s_sat/production/1234"), AgentID("k8s_sat", trustDomain, "production", "1234"))
 }
 
 func TestMakeSelector(t *testing.T) {

--- a/pkg/common/plugin/sshpop/handshake.go
+++ b/pkg/common/plugin/sshpop/handshake.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"golang.org/x/crypto/ssh"
 )
@@ -194,7 +195,7 @@ func (s *ServerHandshake) VerifyChallengeResponse(res []byte) error {
 	return nil
 }
 
-func (s *ServerHandshake) AgentID() (string, error) {
+func (s *ServerHandshake) AgentID() (spiffeid.ID, error) {
 	return makeAgentID(s.s.trustDomain, s.s.agentPathTemplate, s.cert, s.hostname)
 }
 
@@ -221,7 +222,7 @@ func combineNonces(challenge, response []byte) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-func makeAgentID(trustDomain string, agentPathTemplate *template.Template, cert *ssh.Certificate, hostname string) (string, error) {
+func makeAgentID(trustDomain spiffeid.TrustDomain, agentPathTemplate *template.Template, cert *ssh.Certificate, hostname string) (spiffeid.ID, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
 		Certificate: cert,
@@ -229,9 +230,9 @@ func makeAgentID(trustDomain string, agentPathTemplate *template.Template, cert 
 		Fingerprint: urlSafeSSHFingerprintSHA256(cert),
 		Hostname:    hostname,
 	}); err != nil {
-		return "", err
+		return spiffeid.ID{}, err
 	}
-	return idutil.AgentURI(trustDomain, agentPath.String()).String(), nil
+	return idutil.AgentID(trustDomain, agentPath.String()), nil
 }
 
 // urlSafeSSHFingerprintSHA256 is a modified version of ssh.FingerprintSHA256

--- a/pkg/common/plugin/sshpop/sshpop.go
+++ b/pkg/common/plugin/sshpop/sshpop.go
@@ -9,6 +9,7 @@ import (
 	"text/template"
 
 	"github.com/hashicorp/hcl"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/zeebo/errs"
 	"golang.org/x/crypto/ssh"
 )
@@ -42,14 +43,14 @@ type agentPathTemplateData struct {
 type Client struct {
 	cert        *ssh.Certificate
 	signer      ssh.Signer
-	trustDomain string
+	trustDomain spiffeid.TrustDomain
 }
 
 // Server is a factory for generating server handshake objects.
 type Server struct {
 	certChecker       *ssh.CertChecker
 	agentPathTemplate *template.Template
-	trustDomain       string
+	trustDomain       spiffeid.TrustDomain
 	canonicalDomain   string
 }
 
@@ -69,8 +70,8 @@ type ServerConfig struct {
 	AgentPathTemplate string `hcl:"agent_path_template"`
 }
 
-func NewClient(trustDomain, configString string) (*Client, error) {
-	if trustDomain == "" {
+func NewClient(trustDomain spiffeid.TrustDomain, configString string) (*Client, error) {
+	if trustDomain.IsZero() {
 		return nil, Errorf("trust_domain global configuration is required")
 	}
 	config := new(ClientConfig)
@@ -121,8 +122,8 @@ func getCertAndSignerFromBytes(certBytes, keyBytes []byte) (*ssh.Certificate, ss
 	return cert, signer, nil
 }
 
-func NewServer(trustDomain, configString string) (*Server, error) {
-	if trustDomain == "" {
+func NewServer(trustDomain spiffeid.TrustDomain, configString string) (*Server, error) {
+	if trustDomain.IsZero() {
 		return nil, Errorf("trust_domain global configuration is required")
 	}
 	config := new(ServerConfig)

--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -15,6 +15,7 @@ import (
 	"math/big"
 	"text/template"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
@@ -32,7 +33,7 @@ type agentPathTemplateData struct {
 	*x509.Certificate
 	Fingerprint string
 	PluginName  string
-	TrustDomain string
+	TrustDomain spiffeid.TrustDomain
 }
 
 type AttestationData struct {
@@ -265,17 +266,17 @@ func Fingerprint(cert *x509.Certificate) string {
 }
 
 // MakeSpiffeID creates a SPIFFE ID from X.509 Certificate data.
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, cert *x509.Certificate) (string, error) {
+func MakeSpiffeID(trustDomain spiffeid.TrustDomain, agentPathTemplate *template.Template, cert *x509.Certificate) (spiffeid.ID, error) {
 	var agentPath bytes.Buffer
 	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
 		Certificate: cert,
 		PluginName:  PluginName,
 		Fingerprint: Fingerprint(cert),
 	}); err != nil {
-		return "", err
+		return spiffeid.ID{}, err
 	}
 
-	return idutil.AgentURI(trustDomain, agentPath.String()).String(), nil
+	return idutil.AgentID(trustDomain, agentPath.String()), nil
 }
 
 func generateNonce() ([]byte, error) {

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -132,18 +133,18 @@ func TestMakeSPIFFEID(t *testing.T) {
 	tests := []struct {
 		desc         string
 		template     *template.Template
-		expectSPIFFE string
+		expectSPIFFE spiffeid.ID
 		expectErr    string
 	}{
 		{
 			desc:         "default template with sha1",
 			template:     DefaultAgentPathTemplate,
-			expectSPIFFE: "spiffe://example.org/spire/agent/x509pop/da39a3ee5e6b4b0d3255bfef95601890afd80709",
+			expectSPIFFE: spiffeid.RequireFromString("spiffe://example.org/spire/agent/x509pop/da39a3ee5e6b4b0d3255bfef95601890afd80709"),
 		},
 		{
 			desc:         "custom template with subject identifiers",
 			template:     template.Must(template.New("test").Parse("foo/{{ .Subject.CommonName }}")),
-			expectSPIFFE: "spiffe://example.org/spire/agent/foo/test-cert",
+			expectSPIFFE: spiffeid.RequireFromString("spiffe://example.org/spire/agent/foo/test-cert"),
 		},
 		{
 			desc:      "custom template with nonexistant fields",
@@ -160,7 +161,7 @@ func TestMakeSPIFFEID(t *testing.T) {
 					CommonName: "test-cert",
 				},
 			}
-			spiffeid, err := MakeSpiffeID("example.org", tt.template, cert)
+			spiffeid, err := MakeSpiffeID(spiffeid.RequireTrustDomainFromString("example.org"), tt.template, cert)
 			if tt.expectErr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectErr)

--- a/pkg/common/rotationutil/rotationutil_test.go
+++ b/pkg/common/rotationutil/rotationutil_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/util"
@@ -11,11 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var spiffeID = spiffeid.RequireFromString("spiffe://example.org/test")
+
 func TestShouldRotateX509(t *testing.T) {
 	// Cert that's valid for 1hr
 	mockClk := clock.NewMock(t)
-	temp, err := util.NewSVIDTemplate(mockClk, "spiffe://example.org/test")
-	require.NoError(t, err)
+	temp := util.NewSVIDTemplate(mockClk, spiffeID)
 	goodCert, _, err := util.SelfSign(temp)
 	require.NoError(t, err)
 
@@ -34,8 +36,7 @@ func TestShouldRotateX509(t *testing.T) {
 func TestX509Expired(t *testing.T) {
 	// Cert that's valid for 1hr
 	mockClk := clock.NewMock(t)
-	temp, err := util.NewSVIDTemplate(mockClk, "spiffe://example.org/test")
-	require.NoError(t, err)
+	temp := util.NewSVIDTemplate(mockClk, spiffeID)
 	goodCert, _, err := util.SelfSign(temp)
 	require.NoError(t, err)
 

--- a/pkg/common/telemetry/server/bundle_manager.go
+++ b/pkg/common/telemetry/server/bundle_manager.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 )
 
@@ -8,13 +9,13 @@ import (
 
 // IncrBundleManagerUpdateFederatedBundleCounter indicate
 // the number of updating federated bundle by bundle manager
-func IncrBundleManagerUpdateFederatedBundleCounter(m telemetry.Metrics, trustDomain string) {
+func IncrBundleManagerUpdateFederatedBundleCounter(m telemetry.Metrics, trustDomain spiffeid.TrustDomain) {
 	m.IncrCounterWithLabels([]string{
 		telemetry.BundleManager,
 		telemetry.Update,
 		telemetry.FederatedBundle,
 	}, 1, []telemetry.Label{
-		{Name: telemetry.TrustDomainID, Value: trustDomain},
+		{Name: telemetry.TrustDomainID, Value: trustDomain.IDString()},
 	})
 }
 

--- a/pkg/common/telemetry/server/ca_manager.go
+++ b/pkg/common/telemetry/server/ca_manager.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 )
 
@@ -31,12 +32,12 @@ func StartServerCAManagerPrepareX509CACall(m telemetry.Metrics) *telemetry.CallC
 
 // SetX509CARotateGauge set gauge for X509 CA rotation,
 // TTL of CA for a specific TrustDomain
-func SetX509CARotateGauge(m telemetry.Metrics, trustDomain string, val float32) {
+func SetX509CARotateGauge(m telemetry.Metrics, trustDomain spiffeid.TrustDomain, val float32) {
 	m.SetGaugeWithLabels(
 		[]string{telemetry.Manager, telemetry.X509CA, telemetry.Rotate, telemetry.TTL},
 		val,
 		[]telemetry.Label{
-			{Name: telemetry.TrustDomainID, Value: trustDomain},
+			{Name: telemetry.TrustDomainID, Value: trustDomain.IDString()},
 		})
 }
 

--- a/pkg/common/x509svid/csr.go
+++ b/pkg/common/x509svid/csr.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
@@ -30,7 +31,11 @@ func ValidateCSR(csr *x509.CertificateRequest, validationMode idutil.ValidationM
 		return errors.New("CSR must have exactly one URI SAN")
 	}
 
-	if err := idutil.ValidateSpiffeIDURL(csr.URIs[0], validationMode); err != nil {
+	spiffeID, err := spiffeid.FromURI(csr.URIs[0])
+	if err != nil {
+		return err
+	}
+	if err := idutil.ValidateSpiffeID(spiffeID, validationMode); err != nil {
 		return err
 	}
 

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -104,7 +104,7 @@ func (m *Manager) runUpdater(ctx context.Context, trustDomain spiffeid.TrustDoma
 
 		switch {
 		case endpointBundle != nil:
-			telemetry_server.IncrBundleManagerUpdateFederatedBundleCounter(m.metrics, trustDomain.String())
+			telemetry_server.IncrBundleManagerUpdateFederatedBundleCounter(m.metrics, trustDomain)
 			log.Info("Bundle refreshed")
 			nextRefresh = calculateNextUpdate(endpointBundle)
 		case localBundle != nil:

--- a/pkg/server/ca/ca.go
+++ b/pkg/server/ca/ca.go
@@ -291,7 +291,7 @@ func (ca *CA) SignJWTSVID(ctx context.Context, params JWTSVIDParams) (string, er
 	}
 	_, expiresAt := ca.capLifetime(ttl, jwtKey.NotAfter)
 
-	token, err := ca.jwtSigner.SignToken(params.SpiffeID.String(), params.Audience, expiresAt, jwtKey.Signer, jwtKey.Kid)
+	token, err := ca.jwtSigner.SignToken(params.SpiffeID, params.Audience, expiresAt, jwtKey.Signer, jwtKey.Kid)
 	if err != nil {
 		return "", errs.New("unable to sign JWT SVID: %v", err)
 	}

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -279,7 +279,7 @@ func (m *Manager) activateX509CA() {
 	telemetry_server.IncrActivateX509CAManagerCounter(m.c.Metrics)
 
 	ttl := m.currentX509CA.x509CA.Certificate.NotAfter.Sub(m.c.Clock.Now())
-	telemetry_server.SetX509CARotateGauge(m.c.Metrics, m.c.TrustDomain.String(), float32(ttl.Seconds()))
+	telemetry_server.SetX509CARotateGauge(m.c.Metrics, m.c.TrustDomain, float32(ttl.Seconds()))
 	m.c.Log.WithFields(logrus.Fields{
 		telemetry.TrustDomainID: m.c.TrustDomain.IDString(),
 		telemetry.TTL:           ttl.Seconds(),

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -318,7 +318,7 @@ func (s *ManagerSuite) TestX509CARotationMetric() {
 	expected := fakemetrics.New()
 	ttl := s.currentX509CA().Certificate.NotAfter.Sub(s.clock.Now())
 	telemetry_server.IncrActivateX509CAManagerCounter(expected)
-	telemetry_server.SetX509CARotateGauge(expected, s.m.c.TrustDomain.String(), float32(ttl.Seconds()))
+	telemetry_server.SetX509CARotateGauge(expected, s.m.c.TrustDomain, float32(ttl.Seconds()))
 
 	s.Require().Equal(expected.AllMetrics(), metrics.AllMetrics())
 }

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -127,7 +127,8 @@ func TestCache(t *testing.T) {
 	cache, err := BuildFromDataStore(context.Background(), ds)
 	assert.NoError(t, err)
 
-	actual := cache.GetAuthorizedEntries(spiffeid.RequireFromString(rootID))
+	actual, err := cache.GetAuthorizedEntries(spiffeid.RequireFromString(rootID))
+	require.NoError(t, err)
 
 	assert.Equal(t, expected, actual)
 }
@@ -212,7 +213,9 @@ func TestFullCacheNodeAliasing(t *testing.T) {
 	assertAuthorizedEntries := func(agentID spiffeid.ID, entries ...*common.RegistrationEntry) {
 		expected, err := api.RegistrationEntriesToProto(entries)
 		require.NoError(t, err)
-		assert.ElementsMatch(t, expected, cache.GetAuthorizedEntries(agentID))
+		authorizedEntries, err := cache.GetAuthorizedEntries(agentID)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, expected, authorizedEntries)
 	}
 
 	assertAuthorizedEntries(agentIDs[0], append(nodeAliasEntries, workloadEntries[:2]...)...)
@@ -412,7 +415,8 @@ func TestFullCacheExcludesNodeSelectorMappedEntriesForExpiredAgents(t *testing.T
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
-	entries := c.GetAuthorizedEntries(expiredAgentID)
+	entries, err := c.GetAuthorizedEntries(expiredAgentID)
+	require.NoError(t, err)
 	require.Len(t, entries, 1)
 
 	expectedEntry, err := api.RegistrationEntryToProto(workloadEntries[numWorkloadEntries-1])
@@ -467,7 +471,7 @@ func BenchmarkGetAuthorizedEntriesInMemory(b *testing.B) {
 	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.GetAuthorizedEntries(agents[i%len(agents)].ID)
+		_, _ = cache.GetAuthorizedEntries(agents[i%len(agents)].ID)
 	}
 }
 

--- a/pkg/server/endpoints/entryfetcher.go
+++ b/pkg/server/endpoints/entryfetcher.go
@@ -48,7 +48,7 @@ func NewAuthorizedEntryFetcherWithFullCache(ctx context.Context, buildCache entr
 func (a *AuthorizedEntryFetcherWithFullCache) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	return a.cache.GetAuthorizedEntries(agentID), nil
+	return a.cache.GetAuthorizedEntries(agentID)
 }
 
 // RunRebuildCacheTask starts a ticker which rebuilds the in-memory entry cache.

--- a/pkg/server/endpoints/entryfetcher_test.go
+++ b/pkg/server/endpoints/entryfetcher_test.go
@@ -28,8 +28,8 @@ type staticEntryCache struct {
 	entries map[spiffeid.ID][]*types.Entry
 }
 
-func (sef *staticEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
-	return sef.entries[agentID]
+func (sef *staticEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) ([]*types.Entry, error) {
+	return sef.entries[agentID], nil
 }
 
 func newStaticEntryCache(entries map[spiffeid.ID][]*types.Entry) *staticEntryCache {

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -36,8 +36,8 @@ var isDNSLabel = regexp.MustCompile(`^[a-zA-Z0-9]([-]*[a-zA-Z0-9])+$`).MatchStri
 
 const defaultListEntriesPageSize = 50
 
-//Handler service is used to register SPIFFE IDs, and the attestation logic that should
-//be performed on a workload before those IDs can be issued.
+// Handler service is used to register SPIFFE IDs, and the attestation logic that should
+// be performed on a workload before those IDs can be issued.
 type Handler struct {
 	registration.UnsafeRegistrationServer
 
@@ -48,8 +48,8 @@ type Handler struct {
 	ServerCA    ca.ServerCA
 }
 
-//CreateEntry creates an entry in the Registration table,
-//used to assign SPIFFE IDs to nodes and workloads.
+// CreateEntry creates an entry in the Registration table,
+// used to assign SPIFFE IDs to nodes and workloads.
 func (h *Handler) CreateEntry(ctx context.Context, request *common.RegistrationEntry) (_ *registration.RegistrationEntryID, err error) {
 	counter := telemetry_registrationapi.StartCreateEntryCall(h.Metrics)
 	defer counter.Done(&err)
@@ -102,7 +102,7 @@ func (h *Handler) CreateEntryIfNotExists(ctx context.Context, request *common.Re
 	return resp, nil
 }
 
-//DeleteEntry deletes an entry in the Registration table
+// DeleteEntry deletes an entry in the Registration table
 func (h *Handler) DeleteEntry(ctx context.Context, request *registration.RegistrationEntryID) (_ *common.RegistrationEntry, err error) {
 	counter := telemetry_registrationapi.StartDeleteEntryCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -122,7 +122,7 @@ func (h *Handler) DeleteEntry(ctx context.Context, request *registration.Registr
 	return resp.Entry, nil
 }
 
-//FetchEntry Retrieves a specific registered entry
+// FetchEntry Retrieves a specific registered entry
 func (h *Handler) FetchEntry(ctx context.Context, request *registration.RegistrationEntryID) (_ *common.RegistrationEntry, err error) {
 	counter := telemetry_registrationapi.StartFetchEntryCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -144,7 +144,7 @@ func (h *Handler) FetchEntry(ctx context.Context, request *registration.Registra
 	return fetchResponse.Entry, nil
 }
 
-//FetchEntries retrieves all registered entries
+// FetchEntries retrieves all registered entries
 func (h *Handler) FetchEntries(ctx context.Context, request *common.Empty) (_ *common.RegistrationEntries, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -162,7 +162,7 @@ func (h *Handler) FetchEntries(ctx context.Context, request *common.Empty) (_ *c
 	}, nil
 }
 
-//UpdateEntry updates a specific registered entry
+// UpdateEntry updates a specific registered entry
 func (h *Handler) UpdateEntry(ctx context.Context, request *registration.UpdateEntryRequest) (_ *common.RegistrationEntry, err error) {
 	counter := telemetry_registrationapi.StartUpdateEntryCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -198,18 +198,19 @@ func (h *Handler) UpdateEntry(ctx context.Context, request *registration.UpdateE
 	return resp.Entry, nil
 }
 
-//ListByParentID Returns all the Entries associated with the ParentID value
+// ListByParentID Returns all the Entries associated with the ParentID value
 func (h *Handler) ListByParentID(ctx context.Context, request *registration.ParentID) (_ *common.RegistrationEntries, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
 	defer counter.Done(&err)
 	log := h.Log.WithField(telemetry.Method, telemetry.ListRegistrationsByParentID)
 
-	request.Id, err = idutil.NormalizeSpiffeID(request.Id, idutil.AllowAny())
+	spiffeID, err := spiffeid.FromString(request.Id)
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", request.Id, err))
 	}
+	request.Id = spiffeID.String()
 
 	ds := h.getDataStore()
 	listResponse, err := ds.ListRegistrationEntries(ctx,
@@ -228,7 +229,7 @@ func (h *Handler) ListByParentID(ctx context.Context, request *registration.Pare
 	}, nil
 }
 
-//ListBySelector returns all the Entries associated with the Selector
+// ListBySelector returns all the Entries associated with the Selector
 func (h *Handler) ListBySelector(ctx context.Context, request *common.Selector) (_ *common.RegistrationEntries, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -252,7 +253,7 @@ func (h *Handler) ListBySelector(ctx context.Context, request *common.Selector) 
 	}, nil
 }
 
-//ListBySelectors returns all the Entries associated with the Selectors
+// ListBySelectors returns all the Entries associated with the Selectors
 func (h *Handler) ListBySelectors(ctx context.Context, request *common.Selectors) (_ *common.RegistrationEntries, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -276,18 +277,19 @@ func (h *Handler) ListBySelectors(ctx context.Context, request *common.Selectors
 	}, nil
 }
 
-//ListBySpiffeID returns all the Entries associated with the SPIFFE ID
+// ListBySpiffeID returns all the Entries associated with the SPIFFE ID
 func (h *Handler) ListBySpiffeID(ctx context.Context, request *registration.SpiffeID) (_ *common.RegistrationEntries, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
 	defer counter.Done(&err)
 	log := h.Log.WithField(telemetry.Method, telemetry.ListRegistrationsBySPIFFEID)
 
-	request.Id, err = idutil.NormalizeSpiffeID(request.Id, idutil.AllowAny())
+	spiffeID, err := spiffeid.FromString(request.Id)
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", request.Id, err))
 	}
+	request.Id = spiffeID.String()
 
 	ds := h.getDataStore()
 	req := &datastore.ListRegistrationEntriesRequest{
@@ -306,7 +308,7 @@ func (h *Handler) ListBySpiffeID(ctx context.Context, request *registration.Spif
 	}, nil
 }
 
-//ListAllEntriesWithPages retrieves all registered entries with pagination.
+// ListAllEntriesWithPages retrieves all registered entries with pagination.
 func (h *Handler) ListAllEntriesWithPages(ctx context.Context, request *registration.ListAllEntriesRequest) (_ *registration.ListAllEntriesResponse, err error) {
 	counter := telemetry_registrationapi.StartListEntriesCall(h.Metrics)
 	telemetry_common.AddCallerID(counter, getCallerID(ctx))
@@ -353,11 +355,18 @@ func (h *Handler) CreateFederatedBundle(ctx context.Context, request *registrati
 		log.Error("Bundle field is required")
 		return nil, status.Error(codes.InvalidArgument, "bundle field is required")
 	}
-	bundle.TrustDomainId, err = idutil.NormalizeSpiffeID(bundle.TrustDomainId, idutil.AllowAnyTrustDomain())
+	spiffeID, err := spiffeid.FromString(bundle.TrustDomainId)
+	if err != nil {
+		log.WithError(err).Error("Failed to normalize SPIFFE ID")
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", bundle.TrustDomainId, err))
+	}
+
+	err = idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomain())
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	bundle.TrustDomainId = spiffeID.String()
 
 	if bundle.TrustDomainId == h.TrustDomain.IDString() {
 		log.Error("Federated bundle id cannot match server trust domain")
@@ -381,11 +390,18 @@ func (h *Handler) FetchFederatedBundle(ctx context.Context, request *registratio
 	defer counter.Done(&err)
 	log := h.Log.WithField(telemetry.Method, telemetry.FetchFederatedBundle)
 
-	request.Id, err = idutil.NormalizeSpiffeID(request.Id, idutil.AllowAnyTrustDomain())
+	spiffeID, err := spiffeid.FromString(request.Id)
+	if err != nil {
+		log.WithError(err).Error("Failed to normalize SPIFFE ID")
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", request.Id, err))
+	}
+
+	err = idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomain())
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	request.Id = spiffeID.String()
 
 	if request.Id == h.TrustDomain.IDString() {
 		log.Error("Federated bundle id cannot match server trust domain")
@@ -449,11 +465,19 @@ func (h *Handler) UpdateFederatedBundle(ctx context.Context, request *registrati
 		log.Error("Bundle field is required")
 		return nil, status.Error(codes.InvalidArgument, "bundle field is required")
 	}
-	bundle.TrustDomainId, err = idutil.NormalizeSpiffeID(bundle.TrustDomainId, idutil.AllowAnyTrustDomain())
+
+	spiffeID, err := spiffeid.FromString(bundle.TrustDomainId)
+	if err != nil {
+		log.WithError(err).Error("Failed to normalize SPIFFE ID")
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", bundle.TrustDomainId, err))
+	}
+
+	err = idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomain())
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	bundle.TrustDomainId = spiffeID.String()
 
 	if bundle.TrustDomainId == h.TrustDomain.IDString() {
 		log.Error("Federated bundle ID cannot match server trust domain")
@@ -477,11 +501,17 @@ func (h *Handler) DeleteFederatedBundle(ctx context.Context, request *registrati
 	defer counter.Done(&err)
 	log := h.Log.WithField(telemetry.Method, telemetry.DeleteFederatedBundle)
 
-	request.Id, err = idutil.NormalizeSpiffeID(request.Id, idutil.AllowAnyTrustDomain())
+	spiffeID, err := spiffeid.FromString(request.Id)
+	if err != nil {
+		log.WithError(err).Error("Failed to normalize SPIFFE ID")
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("%q is not a valid SPIFFE ID: %v", request.Id, err))
+	}
+	err = idutil.ValidateSpiffeID(spiffeID, idutil.AllowAnyTrustDomain())
 	if err != nil {
 		log.WithError(err).Error("Failed to normalize SPIFFE ID")
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
+	request.Id = spiffeID.String()
 
 	if request.Id == h.TrustDomain.IDString() {
 		log.Error("Federated bundle ID cannot match server trust domain")
@@ -839,16 +869,25 @@ func (h *Handler) prepareRegistrationEntry(entry *common.RegistrationEntry, forU
 		}
 	}
 
-	entry.ParentId, err = idutil.NormalizeSpiffeID(entry.ParentId, idutil.AllowAnyInTrustDomain(h.TrustDomain))
+	parentID, err := spiffeid.FromString(entry.ParentId)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not a valid SPIFFE ID: %v", entry.ParentId, err)
+	}
+	err = idutil.ValidateSpiffeID(parentID, idutil.AllowAnyInTrustDomain(h.TrustDomain))
 	if err != nil {
 		return nil, err
 	}
+	entry.ParentId = parentID.String()
 
-	// Validate Spiffe ID
-	entry.SpiffeId, err = idutil.NormalizeSpiffeID(entry.SpiffeId, idutil.AllowTrustDomainWorkload(h.TrustDomain))
+	spiffeID, err := spiffeid.FromString(entry.SpiffeId)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not a valid SPIFFE ID: %v", entry.SpiffeId, err)
+	}
+	err = idutil.ValidateSpiffeID(parentID, idutil.AllowTrustDomainWorkload(h.TrustDomain))
 	if err != nil {
 		return nil, err
 	}
+	entry.SpiffeId = spiffeID.String()
 
 	if err := idutil.CheckIDStringNormalization(original.ParentId); err != nil {
 		return nil, fmt.Errorf("parent ID is malformed: %v", err)
@@ -908,9 +947,9 @@ func getSpiffeIDFromCert(cert *x509.Certificate) (string, error) {
 	if err := idutil.CheckIDURLNormalization(cert.URIs[0]); err != nil {
 		return "", fmt.Errorf("SPIFFE ID is malformed: %v", err)
 	}
-	spiffeID, err := idutil.NormalizeSpiffeIDURL(cert.URIs[0], idutil.AllowAny())
+	spiffeID, err := spiffeid.FromURI(cert.URIs[0])
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%q is not a valid SPIFFE ID: %v", cert.URIs[0], err)
 	}
 	return spiffeID.String(), nil
 }

--- a/pkg/server/endpoints/registration/handler_test.go
+++ b/pkg/server/endpoints/registration/handler_test.go
@@ -325,7 +325,7 @@ func (s *HandlerSuite) TestCreateEntryAndCreateEntryIfNotExists() {
 				SpiffeId:  "spiffe://example.org/child",
 				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
 			},
-			Err: `"FOO" is not a valid trust domain member SPIFFE ID`,
+			Err: `"FOO" is not a valid SPIFFE ID`,
 		},
 		{
 			Name: "SPIFFE ID is malformed",
@@ -334,7 +334,7 @@ func (s *HandlerSuite) TestCreateEntryAndCreateEntryIfNotExists() {
 				SpiffeId:  "FOO",
 				Selectors: []*common.Selector{{Type: "B", Value: "b"}},
 			},
-			Err: `"FOO" is not a valid workload SPIFFE ID`,
+			Err: `"FOO" is not a valid SPIFFE ID`,
 		},
 		{
 			Name: "Bad DNS",
@@ -501,14 +501,14 @@ func (s *HandlerSuite) TestUpdateEntry() {
 			PrepareEntry: func(e *common.RegistrationEntry) {
 				e.ParentId = "FOO"
 			},
-			Err: `"FOO" is not a valid trust domain member SPIFFE ID`,
+			Err: `"FOO" is not a valid SPIFFE ID`,
 		},
 		{
 			Name: "SPIFFE ID is malformed",
 			PrepareEntry: func(e *common.RegistrationEntry) {
 				e.SpiffeId = "FOO"
 			},
-			Err: `"FOO" is not a valid workload SPIFFE ID`,
+			Err: `"FOO" is not a valid SPIFFE ID`,
 		},
 		{
 			Name: "Registration entry does not exist",

--- a/pkg/server/hostservices/agentstore/attestation.go
+++ b/pkg/server/hostservices/agentstore/attestation.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func EnsureNotAttested(ctx context.Context, store hostservices.AgentStore, agentID string) error {
+func EnsureNotAttested(ctx context.Context, store hostservices.AgentStore, agentID spiffeid.ID) error {
 	attested, err := IsAttested(ctx, store, agentID)
 	switch {
 	case err != nil:
@@ -22,9 +23,9 @@ func EnsureNotAttested(ctx context.Context, store hostservices.AgentStore, agent
 	}
 }
 
-func IsAttested(ctx context.Context, store hostservices.AgentStore, agentID string) (bool, error) {
+func IsAttested(ctx context.Context, store hostservices.AgentStore, agentID spiffeid.ID) (bool, error) {
 	_, err := store.GetAgentInfo(ctx, &hostservices.GetAgentInfoRequest{
-		AgentId: agentID,
+		AgentId: agentID.String(),
 	})
 	switch status.Code(err) {
 	case codes.OK:

--- a/pkg/server/hostservices/agentstore/attestation_test.go
+++ b/pkg/server/hostservices/agentstore/attestation_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
@@ -15,13 +16,13 @@ func TestEnsureNotAttested(t *testing.T) {
 	assert := assert.New(t)
 	store := fakeAgentStore{}
 
-	err := EnsureNotAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/attested")
+	err := EnsureNotAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/attested"))
 	assert.EqualError(err, "agent has already attested")
 
-	err = EnsureNotAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/notattested")
+	err = EnsureNotAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/notattested"))
 	assert.NoError(err)
 
-	err = EnsureNotAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/bad")
+	err = EnsureNotAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/bad"))
 	assert.EqualError(err, "unable to get agent info: ohno")
 }
 
@@ -29,15 +30,15 @@ func TestIsAttested(t *testing.T) {
 	assert := assert.New(t)
 	store := fakeAgentStore{}
 
-	attested, err := IsAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/attested")
+	attested, err := IsAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/attested"))
 	assert.NoError(err)
 	assert.True(attested)
 
-	attested, err = IsAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/notattested")
+	attested, err = IsAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/notattested"))
 	assert.NoError(err)
 	assert.False(attested)
 
-	attested, err = IsAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/bad")
+	attested, err = IsAttested(context.Background(), store, spiffeid.RequireFromString("spiffe://domain.test/spire/agent/test/bad"))
 	assert.EqualError(err, "unable to get agent info: ohno")
 	assert.False(attested)
 }

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -89,8 +89,7 @@ func (s *PluginSuite) SetupSuite() {
 	validNotAfterTime, err := time.Parse(time.RFC3339, _validNotAfterString)
 	s.Require().NoError(err)
 
-	caTemplate, err := testutil.NewCATemplate(clk, spiffeid.RequireTrustDomainFromString("foo"))
-	s.Require().NoError(err)
+	caTemplate := testutil.NewCATemplate(clk, spiffeid.RequireTrustDomainFromString("foo"))
 
 	caTemplate.NotAfter = expiredNotAfterTime
 	caTemplate.NotBefore = expiredNotAfterTime.Add(-_ttl)
@@ -98,7 +97,7 @@ func (s *PluginSuite) SetupSuite() {
 	cacert, cakey, err := testutil.SelfSign(caTemplate)
 	s.Require().NoError(err)
 
-	svidTemplate, err := testutil.NewSVIDTemplate(clk, "spiffe://foo/id1")
+	svidTemplate := testutil.NewSVIDTemplate(clk, spiffeid.RequireFromString("spiffe://foo/id1"))
 	s.Require().NoError(err)
 
 	svidTemplate.NotAfter = validNotAfterTime

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -516,7 +516,7 @@ func (s *IIDAttestorSuite) TestConfigure() {
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: ``,
 		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{}})
-	s.RequireErrorContains(err, "trust_domain is required")
+	s.RequireErrorContains(err, "aws-iid: failed to parse trust domain: spiffeid: trust domain is empty")
 	require.Nil(resp)
 
 	// fails with access id but no secret

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
@@ -5,15 +5,19 @@ import (
 	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 )
 
-var templateWithTags = template.Must(template.New("agent-svid").Parse("{{ .Tags.a }}/{{ .Tags.b }}"))
+var (
+	templateWithTags = template.Must(template.New("agent-svid").Parse("{{ .Tags.a }}/{{ .Tags.b }}"))
+	trustDomain      = spiffeid.RequireTrustDomainFromString("example.org")
+)
 
 func TestMakeSpiffeID(t *testing.T) {
 	tests := []struct {
 		name              string
-		trustDomain       string
+		trustDomain       spiffeid.TrustDomain
 		agentPathTemplate *template.Template
 		doc               ec2metadata.EC2InstanceIdentityDocument
 		tags              instanceTags
@@ -21,7 +25,7 @@ func TestMakeSpiffeID(t *testing.T) {
 	}{
 		{
 			name:              "default",
-			trustDomain:       "example.org",
+			trustDomain:       trustDomain,
 			agentPathTemplate: defaultAgentPathTemplate,
 			doc: ec2metadata.EC2InstanceIdentityDocument{
 				Region:     "region",
@@ -32,7 +36,7 @@ func TestMakeSpiffeID(t *testing.T) {
 		},
 		{
 			name:              "instance tags",
-			trustDomain:       "example.org",
+			trustDomain:       trustDomain,
 			agentPathTemplate: templateWithTags,
 			tags: instanceTags{
 				"a": "c",

--- a/pkg/server/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/server/plugin/nodeattestor/azure/msi_test.go
@@ -245,7 +245,7 @@ func (s *MSIAttestorSuite) TestConfigure() {
 
 	// missing trust domain
 	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{}})
-	s.requireErrorContains(err, "azure-msi: global configuration missing trust domain")
+	s.requireErrorContains(err, "azure-msi: unable to parse trust domain: spiffeid: trust domain is empty")
 	s.Require().Nil(resp)
 
 	// missing tenants

--- a/pkg/server/plugin/nodeattestor/base/base.go
+++ b/pkg/server/plugin/nodeattestor/base/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/server/hostservices/agentstore"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
@@ -27,6 +28,6 @@ func (p *Base) BrokerHostServices(broker catalog.HostServiceBroker) error {
 	return nil
 }
 
-func (p *Base) IsAttested(ctx context.Context, agentID string) (bool, error) {
+func (p *Base) IsAttested(ctx context.Context, agentID spiffeid.ID) (bool, error) {
 	return agentstore.IsAttested(ctx, p.store, agentID)
 }

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -386,7 +386,7 @@ projectid_whitelist = ["bar"]
 projectid_whitelist = ["bar"]
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{}})
-	s.RequireErrorContains(err, "gcp-iit: trust_domain is required")
+	s.RequireErrorContains(err, "gcp-iit: unable to parse trust domain: spiffeid: trust domain is empty")
 	require.Nil(resp)
 
 	// missing projectID whitelist

--- a/pkg/server/plugin/noderesolver/azure/msi.go
+++ b/pkg/server/plugin/noderesolver/azure/msi.go
@@ -188,7 +188,7 @@ func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string
 		return nil, msiError.Wrap(err)
 	}
 
-	tenantID, principalID, err := parseAgentIDPath(u.Path)
+	tenantID, principalID, err := parseAgentIDPath(u.Path())
 	if err != nil {
 		p.log.Warn("Unrecognized agent ID", telemetry.SPIFFEID, spiffeID)
 		return nil, nil

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/acmpca"
 	"github.com/hashicorp/go-hclog"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/server/plugin/upstreamauthority"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
@@ -482,7 +483,7 @@ func (as *PCAPluginSuite) SVIDFixture() (*x509.Certificate, *bytes.Buffer) {
 }
 
 func (as *PCAPluginSuite) generateCSR() ([]byte, *bytes.Buffer) {
-	csr, _, err := util.NewCSRTemplate("spiffe://example.com/foo")
+	csr, _, err := util.NewCSRTemplate(spiffeid.RequireFromString("spiffe://example.com/foo"))
 	as.Require().NoError(err)
 	encodedCsr := new(bytes.Buffer)
 	err = pem.Encode(encodedCsr, &pem.Block{

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -330,7 +330,7 @@ func TestSpirePlugin_MintX509CA(t *testing.T) {
 	// Create sever's CA
 	serverCert, serverKey := ca.CreateX509Certificate(testca.WithURIs(trustDomain.NewID("/spire/server").URL()))
 
-	csr, pubKey, err := util.NewCSRTemplate(trustDomain.IDString())
+	csr, pubKey, err := util.NewCSRTemplate(trustDomain.ID())
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -365,18 +365,9 @@ func TestSpirePlugin_MintX509CA(t *testing.T) {
 			expectedErr:      `rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp :0`,
 		},
 		{
-			name: "invalid scheme",
-			getCSR: func() ([]byte, crypto.PublicKey) {
-				csr, pubKey, err := util.NewCSRTemplate("invalid://localhost")
-				require.NoError(t, err)
-				return csr, pubKey
-			},
-			expectedErr: `rpc error: code = Unknown desc = unable to sign CSR: "invalid://localhost" is not a valid trust domain SPIFFE ID: invalid scheme`,
-		},
-		{
 			name: "wrong trust domain",
 			getCSR: func() ([]byte, crypto.PublicKey) {
-				csr, pubKey, err := util.NewCSRTemplate("spiffe://not-trusted")
+				csr, pubKey, err := util.NewCSRTemplate(spiffeid.RequireFromString("spiffe://not-trusted"))
 				require.NoError(t, err)
 				return csr, pubKey
 			},

--- a/test/fakes/fakenoderesolver/noderesolver.go
+++ b/test/fakes/fakenoderesolver/noderesolver.go
@@ -3,19 +3,20 @@ package fakenoderesolver
 import (
 	"context"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
-const (
-	defaultTrustDomain = "example.org"
+var (
+	defaultTrustDomain = spiffeid.RequireTrustDomainFromString("example.org")
 )
 
 type Config struct {
 	// TrustDomain is the trust domain for SPIFFE IDs created by the attestor.
 	// Defaults to "example.org" if empty.
-	TrustDomain string
+	TrustDomain spiffeid.TrustDomain
 
 	// Selectors is a map from ID to a list of selector values to return with that id.
 	Selectors map[string][]string
@@ -31,7 +32,7 @@ type NodeResolver struct {
 var _ noderesolver.Plugin = (*NodeResolver)(nil)
 
 func New(name string, config Config) *NodeResolver {
-	if config.TrustDomain == "" {
+	if config.TrustDomain.IsZero() {
 		config.TrustDomain = defaultTrustDomain
 	}
 	return &NodeResolver{

--- a/test/fakes/fakeservernodeattestor/nodeattestor.go
+++ b/test/fakes/fakeservernodeattestor/nodeattestor.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
 )
 
-const (
-	defaultTrustDomain = "example.org"
+var (
+	defaultTrustDomain = spiffeid.RequireTrustDomainFromString("example.org")
 )
 
 type Config struct {
@@ -20,7 +21,7 @@ type Config struct {
 
 	// TrustDomain is the trust domain for SPIFFE IDs created by the attestor.
 	// Defaults to "example.org" if empty.
-	TrustDomain string
+	TrustDomain spiffeid.TrustDomain
 
 	// Data is a map from attestation data (as a string) to the associated id
 	// produced by the attestor. For example, a mapping from "DATA" ==> "FOO
@@ -52,7 +53,7 @@ type NodeAttestor struct {
 }
 
 func New(name string, config Config) *NodeAttestor {
-	if config.TrustDomain == "" {
+	if config.TrustDomain.IsZero() {
 		config.TrustDomain = defaultTrustDomain
 	}
 	return &NodeAttestor{


### PR DESCRIPTION

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?


**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**

This PR migrates several units across the codebase replacing `string` parameters and return types by `SpiffeId` and `TrustDomain` go-spiffe-v2 types. It also refactors the utitlity methods for parsing, normalizing and validating SPIFFE IDs, removing logic that is already implemented in go-spiffe.
 
**Which issue this PR fixes**
Addresses #1828 


Signed-off-by: Max Lambrecht <maxlambrecht@gmail.com>
