### PR TITLE
Remove unused BuiltIn from plugin info

### DIFF
--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -649,13 +649,9 @@ func (s *CatalogSuite) TestPluginsFill() {
 				r.Len(c.JustPluginInfos, 2)
 				r.Equal("testext", c.JustPluginInfos[0].Name())
 				r.Equal("testbuiltin", c.JustPluginInfos[1].Name())
-				r.False(c.JustPluginInfos[0].BuiltIn())
-				r.True(c.JustPluginInfos[1].BuiltIn())
 				r.Len(c.PluginInfosInStruct, 2)
 				r.Equal("testext", c.PluginInfosInStruct[0].Name())
 				r.Equal("testbuiltin", c.PluginInfosInStruct[1].Name())
-				r.False(c.PluginInfosInStruct[0].BuiltIn())
-				r.True(c.PluginInfosInStruct[1].BuiltIn())
 			},
 		},
 	}

--- a/pkg/common/catalog/fill.go
+++ b/pkg/common/catalog/fill.go
@@ -15,7 +15,6 @@ var (
 
 type PluginInfo interface {
 	Name() string
-	BuiltIn() bool
 }
 
 type catalogFiller struct {

--- a/pkg/common/catalog/init.go
+++ b/pkg/common/catalog/init.go
@@ -68,7 +68,6 @@ func newCatalogPlugin(ctx context.Context, c *grpc.ClientConn, config catalogPlu
 
 	return &LoadedPlugin{
 		name:         config.Name,
-		builtIn:      config.BuiltIn,
 		plugin:       pluginImpl,
 		all:          append([]interface{}{pluginImpl}, serviceImpls...),
 		serviceNames: serviceNames,

--- a/pkg/common/catalog/plugin.go
+++ b/pkg/common/catalog/plugin.go
@@ -10,7 +10,6 @@ import (
 
 type LoadedPlugin struct {
 	name         string
-	builtIn      bool
 	plugin       interface{}
 	all          []interface{}
 	serviceNames []string
@@ -21,10 +20,6 @@ type LoadedPlugin struct {
 
 func (p *LoadedPlugin) Name() string {
 	return p.name
-}
-
-func (p *LoadedPlugin) BuiltIn() bool {
-	return p.builtIn
 }
 
 func (p *LoadedPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) error {


### PR DESCRIPTION
Code outside of the catalog does not need to know and in fact shouldn't know if a plugin comes from a built in. Having this method here makes it easy for code to do the wrong thing. For operators, whether or not a plugin is built in is logged when the plugin is loaded.
