### PR TITLE
Fix spiffe ID equality

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go
@@ -306,8 +306,15 @@ func spiffeIDFromString(rawID string) (*types.SPIFFEID, error) {
 func entryEqual(existing, current *types.Entry) bool {
 	return equalStringSlice(existing.DnsNames, current.DnsNames) &&
 		selectorSetsEqual(existing.Selectors, current.Selectors) &&
-		existing.SpiffeId == current.SpiffeId &&
-		existing.ParentId == current.ParentId
+		spiffeIDEqual(existing.SpiffeId, current.SpiffeId) &&
+		spiffeIDEqual(existing.ParentId, current.ParentId)
+}
+
+func spiffeIDEqual(existing, current *types.SPIFFEID) bool {
+	if existing == nil || current == nil {
+		return existing == current
+	}
+	return existing.String() == current.String()
 }
 
 func selectorSetsEqual(as, bs []*types.Selector) bool {

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller_test.go
@@ -117,6 +117,28 @@ func (s *SpiffeIDControllerTestSuite) TestCreateSpiffeID() {
 	s.Require().Equal(createdSpiffeID.Spec.Selector.PodName, "test")
 }
 
+func (s *SpiffeIDControllerTestSuite) TestSpiffeIDEqual() {
+	var existing, current *spireTypes.SPIFFEID
+	// Both nil
+	s.Require().True(spiffeIDEqual(existing, current))
+
+	// One nil
+	var err error
+	current, err = spiffeIDFromString(makeID(s.trustDomain, "%s", SpiffeIDName))
+	s.Require().Nil(err)
+	s.Require().False(spiffeIDEqual(existing, current))
+
+	// Equal
+	existing, err = spiffeIDFromString(makeID(s.trustDomain, "%s", SpiffeIDName))
+	s.Require().Nil(err)
+	s.Require().True(spiffeIDEqual(existing, current))
+
+	// Not equal
+	current, err = spiffeIDFromString(makeID(s.trustDomain, "%s", "spiffeid-not-equal"))
+	s.Require().Nil(err)
+	s.Require().False(spiffeIDEqual(existing, current))
+}
+
 func stringFromID(id *spireTypes.SPIFFEID) string {
 	return fmt.Sprintf("spiffe://%s%s", id.TrustDomain, id.Path)
 }


### PR DESCRIPTION
Signed-off-by: SirNexus <ai.carson@f5.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [] Documentation updated?

**Affected functionality**
k8s-workload-registrar crd mode update method

**Description of change**
I experienced an issue using crd mode of the k8s registrar where on each restart, new svids would be generated for all workloads in my cluster. I submitted a question in the spiffe slack [here](https://spiffe.slack.com/archives/CBNCC2V17/p1615581868106500) and eventually realized that the issue lied in the fact that in crd mode, the k8s-workload-registrar was updating entries for every workload due to a bug in the equality (pointer comparison rather than value).

**Which issue this PR fixes**
n/a

