### PR TITLE
Introduce Agent NodeAttestor Facade Interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ plugingen_plugins = \
 	proto/spire/server/upstreamauthority/upstreamauthority.proto,pkg/server/plugin/upstreamauthority,UpstreamAuthority \
 	proto/spire/server/noderesolver/noderesolver.proto,pkg/server/plugin/noderesolver,NodeResolver \
 	proto/spire/server/keymanager/keymanager.proto,pkg/server/plugin/keymanager,KeyManager \
-	proto/spire/agent/nodeattestor/nodeattestor.proto,pkg/agent/plugin/nodeattestor,NodeAttestor \
+	proto/spire/agent/nodeattestor/nodeattestor.proto,proto/spire/agent/nodeattestor/v0,NodeAttestor \
 	proto/spire/agent/workloadattestor/workloadattestor.proto,pkg/agent/plugin/workloadattestor,WorkloadAttestor \
 	proto/spire/agent/keymanager/keymanager.proto,pkg/agent/plugin/keymanager,KeyManager \
 	proto/spire/agent/svidstore/svidstore.proto,pkg/agent/plugin/svidstore,SVIDStore \

--- a/examples/plugins/agent-node-attestor/plugin.go
+++ b/examples/plugins/agent-node-attestor/plugin.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
@@ -32,7 +32,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 type Config struct {
@@ -46,7 +46,7 @@ type Config struct {
 type Plugin struct {
 	// gRPC requires embedding either the "Unimplemented" or "Unsafe" stub as
 	// a way of opting in or out of forward build compatibility.
-	nodeattestor.UnimplementedNodeAttestorServer
+	nodeattestorv0.UnimplementedNodeAttestorServer
 
 	// mu is a mutex that protects the configuration. Plugins may at some point
 	// need to support hot-reloading of configuration (by receiving another
@@ -94,7 +94,7 @@ func (p *Plugin) BrokerHostServices(broker catalog.HostServiceBroker) error {
 //   3) Receive a challenge from the server
 //   4) Send a challenge response back to the server
 //   5) Repeat 3 and 4 as much as necessary to complete the challenge/response.
-func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) (err error) {
+func (p *Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) (err error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAtte
 
 	// Send the attestation data back to the agent. The "type" of the
 	// attestation data should be set to the plugin name.
-	if err := stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: pluginName,
 			Data: data,

--- a/pkg/agent/attestor/node/experimental.go
+++ b/pkg/agent/attestor/node/experimental.go
@@ -5,94 +5,29 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io"
 
+	"github.com/sirupsen/logrus"
 	agentv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/x509util"
-	"github.com/spiffe/spire/proto/spire/common"
 	"google.golang.org/grpc"
 )
 
-func (a *attestor) getSVID(ctx context.Context, conn *grpc.ClientConn, csr []byte, fetchStream nodeattestor.NodeAttestor_FetchAttestationDataClient) ([]*x509.Certificate, error) {
-	data, err := a.fetchAttestationData(fetchStream, nil)
-	if err != nil {
+func (a *attestor) getSVID(ctx context.Context, conn *grpc.ClientConn, csr []byte, attestor nodeattestor.NodeAttestor) ([]*x509.Certificate, error) {
+	// make sure all of the streams are cancelled if something goes awry
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream := &serverStream{client: agentv1.NewAgentClient(conn), csr: csr}
+
+	if err := attestor.Attest(ctx, stream); err != nil {
 		return nil, err
 	}
 
-	attestReq := &agentv1.AttestAgentRequest{
-		Step: &agentv1.AttestAgentRequest_Params_{
-			Params: &agentv1.AttestAgentRequest_Params{
-				Data: protoFromAttestationData(data.AttestationData),
-				Params: &agentv1.AgentX509SVIDParams{
-					Csr: csr,
-				},
-			},
-		},
-	}
-
-	attestStream, err := agentv1.NewAgentClient(conn).AttestAgent(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("could not create new agent client for attestation: %v", err)
-	}
-
-	if err := attestStream.Send(attestReq); err != nil {
-		return nil, fmt.Errorf("error sending attestation request to SPIRE server: %v", err)
-	}
-
-	var attestResp *agentv1.AttestAgentResponse
-	for {
-		// if the response has no additional data then break out and parse
-		// the response.
-		attestResp, err = attestStream.Recv()
-		if err != nil {
-			return nil, fmt.Errorf("error getting attestation response from SPIRE server: %v", err)
-		}
-		if attestResp.GetChallenge() == nil {
-			break
-		}
-
-		data, err := a.fetchAttestationData(fetchStream, attestResp.GetChallenge())
-		if err != nil {
-			return nil, err
-		}
-
-		attestReq = &agentv1.AttestAgentRequest{
-			Step: &agentv1.AttestAgentRequest_ChallengeResponse{
-				ChallengeResponse: data.Response,
-			},
-		}
-
-		if err := attestStream.Send(attestReq); err != nil {
-			return nil, fmt.Errorf("sending attestation request to SPIRE server: %v", err)
-		}
-	}
-
-	if fetchStream != nil {
-		if err := fetchStream.CloseSend(); err != nil {
-			return nil, fmt.Errorf("failed to close send on fetch stream: %v", err)
-		}
-		if _, err := fetchStream.Recv(); err != io.EOF {
-			a.c.Log.WithError(err).Warn("Received unexpected result on trailing recv")
-		}
-	}
-	if err := attestStream.CloseSend(); err != nil {
-		return nil, fmt.Errorf("failed to close send on attest stream: %v", err)
-	}
-
-	if _, err := attestStream.Recv(); err != io.EOF {
-		a.c.Log.WithError(err).Warn("Received unexpected result on trailing recv")
-	}
-
-	svid, err := getSVIDFromAttestAgentResponse(attestResp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse attestation response: %v", err)
-	}
-
-	return svid, nil
+	return stream.svid, nil
 }
 
 func (a *attestor) getBundle(ctx context.Context, conn *grpc.ClientConn) (*bundleutil.Bundle, error) {
@@ -131,13 +66,69 @@ func getSVIDFromAttestAgentResponse(r *agentv1.AttestAgentResponse) ([]*x509.Cer
 	return svid, nil
 }
 
-func protoFromAttestationData(attData *common.AttestationData) *types.AttestationData {
-	if attData == nil {
-		return nil
+type serverStream struct {
+	log    logrus.FieldLogger
+	client agentv1.AgentClient
+	csr    []byte
+	stream agentv1.Agent_AttestAgentClient
+	svid   []*x509.Certificate
+}
+
+func (b *serverStream) SendAttestationData(ctx context.Context, attestationData nodeattestor.AttestationData) ([]byte, error) {
+	return b.sendRequest(ctx, &agentv1.AttestAgentRequest{
+		Step: &agentv1.AttestAgentRequest_Params_{
+			Params: &agentv1.AttestAgentRequest_Params{
+				Data: &types.AttestationData{
+					Type:    attestationData.Type,
+					Payload: attestationData.Payload,
+				},
+				Params: &agentv1.AgentX509SVIDParams{
+					Csr: b.csr,
+				},
+			},
+		},
+	})
+}
+
+func (b *serverStream) SendChallengeResponse(ctx context.Context, response []byte) ([]byte, error) {
+	return b.sendRequest(ctx, &agentv1.AttestAgentRequest{
+		Step: &agentv1.AttestAgentRequest_ChallengeResponse{
+			ChallengeResponse: response,
+		},
+	})
+}
+
+func (b *serverStream) sendRequest(ctx context.Context, req *agentv1.AttestAgentRequest) ([]byte, error) {
+	if b.stream == nil {
+		stream, err := b.client.AttestAgent(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not open attestation stream to SPIRE server: %v", err)
+		}
+		b.stream = stream
 	}
 
-	return &types.AttestationData{
-		Type:    attData.Type,
-		Payload: attData.Data,
+	if err := b.stream.Send(req); err != nil {
+		return nil, fmt.Errorf("failed to send attestion request to SPIRE server: %v", err)
 	}
+
+	resp, err := b.stream.Recv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive attestion response: %v", err)
+	}
+
+	if challenge := resp.GetChallenge(); challenge != nil {
+		return challenge, nil
+	}
+
+	svid, err := getSVIDFromAttestAgentResponse(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse attestation response: %v", err)
+	}
+
+	if err := b.stream.CloseSend(); err != nil {
+		b.log.WithError(err).Warn("failed to close stream send side")
+	}
+
+	b.svid = svid
+	return nil, nil
 }

--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -23,11 +23,12 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	keymanager_telemetry "github.com/spiffe/spire/pkg/common/telemetry/agent/keymanager"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 )
 
 type Catalog interface {
 	GetKeyManager() KeyManager
-	GetNodeAttestor() NodeAttestor
+	GetNodeAttestor() nodeattestor.NodeAttestor
 	GetWorkloadAttestors() []WorkloadAttestor
 }
 
@@ -38,7 +39,7 @@ type HCLPluginConfigMap = catalog.HCLPluginConfigMap
 func KnownPlugins() []catalog.PluginClient {
 	return []catalog.PluginClient{
 		keymanager.PluginClient,
-		nodeattestor.PluginClient,
+		nodeattestorv0.PluginClient,
 		workloadattestor.PluginClient,
 	}
 }
@@ -69,11 +70,6 @@ type KeyManager struct {
 	keymanager.KeyManager
 }
 
-type NodeAttestor struct {
-	catalog.PluginInfo
-	nodeattestor.NodeAttestor
-}
-
 type WorkloadAttestor struct {
 	catalog.PluginInfo
 	workloadattestor.WorkloadAttestor
@@ -81,8 +77,8 @@ type WorkloadAttestor struct {
 
 type Plugins struct {
 	KeyManager        KeyManager
-	NodeAttestor      NodeAttestor
-	WorkloadAttestors []WorkloadAttestor `catalog:"min=1"`
+	NodeAttestor      nodeattestor.NodeAttestor
+	WorkloadAttestors []WorkloadAttestor
 }
 
 var _ Catalog = (*Plugins)(nil)
@@ -91,7 +87,7 @@ func (p *Plugins) GetKeyManager() KeyManager {
 	return p.KeyManager
 }
 
-func (p *Plugins) GetNodeAttestor() NodeAttestor {
+func (p *Plugins) GetNodeAttestor() nodeattestor.NodeAttestor {
 	return p.NodeAttestor
 }
 
@@ -118,7 +114,7 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 		return nil, err
 	}
 
-	p := new(Plugins)
+	p := new(versionedPlugins)
 	closer, err := catalog.Fill(ctx, catalog.Config{
 		Log:           config.Log,
 		GlobalConfig:  config.GlobalConfig,
@@ -135,7 +131,22 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 	p.KeyManager.KeyManager = keymanager_telemetry.WithMetrics(p.KeyManager.KeyManager, config.Metrics)
 
 	return &Repository{
-		Catalog: p,
-		Closer:  closer,
+		Catalog: &Plugins{
+			KeyManager:        p.KeyManager,
+			NodeAttestor:      p.NodeAttestor,
+			WorkloadAttestors: p.WorkloadAttestors,
+		},
+		Closer: closer,
 	}, nil
+}
+
+// versionedPlugins is a temporary struct with the v0 version shims as they are
+// introduced. The catalog will fill this struct, which is them converted to
+// the Plugins struct which contains the facade interfaces. It will be removed
+// when the catalog is refactored to the leverage the new common catalog with
+// native versioning support (see issue #2153).
+type versionedPlugins struct {
+	KeyManager        KeyManager
+	NodeAttestor      nodeattestor.V0
+	WorkloadAttestors []WorkloadAttestor `catalog:"min=1"`
 }

--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -141,9 +141,9 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 }
 
 // versionedPlugins is a temporary struct with the v0 version shims as they are
-// introduced. The catalog will fill this struct, which is them converted to
+// introduced. The catalog will fill this struct, which is then converted to
 // the Plugins struct which contains the facade interfaces. It will be removed
-// when the catalog is refactored to the leverage the new common catalog with
+// when the catalog is refactored to leverage the new common catalog with
 // native versioning support (see issue #2153).
 type versionedPlugins struct {
 	KeyManager        KeyManager

--- a/pkg/agent/plugin/nodeattestor/aws/iid.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid.go
@@ -10,9 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc/codes"
@@ -33,7 +33,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *IIDAttestorPlugin) catalog.Plugin {
-	return catalog.MakePlugin(caws.PluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(caws.PluginName, nodeattestorv0.PluginServer(p))
 }
 
 // IIDAttestorConfig configures a IIDAttestorPlugin.
@@ -43,7 +43,7 @@ type IIDAttestorConfig struct {
 
 // IIDAttestorPlugin implements aws nodeattestation in the agent.
 type IIDAttestorPlugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	log    hclog.Logger
 	config *IIDAttestorConfig
@@ -61,7 +61,7 @@ func (p *IIDAttestorPlugin) SetLogger(log hclog.Logger) {
 
 // FetchAttestationData fetches attestation data from the aws metadata server and sends an attestation response
 // on given stream.
-func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	c, err := p.getConfig()
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (p *IIDAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttesto
 		return caws.AttestationStepError("marshaling the attested data", err)
 	}
 
-	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: caws.PluginName,
 			Data: respData,

--- a/pkg/agent/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/agent/plugin/nodeattestor/aws/iid_test.go
@@ -13,9 +13,9 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 )
@@ -49,7 +49,7 @@ func TestIIDAttestorPlugin(t *testing.T) {
 type Suite struct {
 	spiretest.Suite
 
-	p       nodeattestor.Plugin
+	p       nodeattestorv0.Plugin
 	server  *httptest.Server
 	status  int
 	docBody string
@@ -161,13 +161,13 @@ func (s *Suite) TestGetPluginInfo() {
 	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
 }
 
-func (s *Suite) newPlugin() nodeattestor.Plugin {
-	var p nodeattestor.Plugin
+func (s *Suite) newPlugin() nodeattestorv0.Plugin {
+	var p nodeattestorv0.Plugin
 	s.LoadPlugin(BuiltIn(), &p)
 	return p
 }
 
-func (s *Suite) fetchAttestationData() (*nodeattestor.FetchAttestationDataResponse, error) {
+func (s *Suite) fetchAttestationData() (*nodeattestorv0.FetchAttestationDataResponse, error) {
 	stream, err := s.p.FetchAttestationData(context.Background())
 	s.NoError(err)
 	s.NoError(stream.CloseSend())

--- a/pkg/agent/plugin/nodeattestor/azure/msi.go
+++ b/pkg/agent/plugin/nodeattestor/azure/msi.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
@@ -29,7 +29,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *MSIAttestorPlugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 type MSIAttestorConfig struct {
@@ -45,7 +45,7 @@ type MSIAttestorConfig struct {
 }
 
 type MSIAttestorPlugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	mu     sync.RWMutex
 	config *MSIAttestorConfig
@@ -61,7 +61,7 @@ func New() *MSIAttestorPlugin {
 	return p
 }
 
-func (p *MSIAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *MSIAttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	config, err := p.getConfig()
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (p *MSIAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttesto
 		return msiError.Wrap(err)
 	}
 
-	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: pluginName,
 			Data: data,

--- a/pkg/agent/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/agent/plugin/nodeattestor/azure/msi_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -24,7 +24,7 @@ func TestMSIAttestorPlugin(t *testing.T) {
 type MSIAttestorSuite struct {
 	spiretest.Suite
 
-	attestor nodeattestor.Plugin
+	attestor nodeattestorv0.Plugin
 
 	expectedResource string
 	token            string

--- a/pkg/agent/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/hcl"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
@@ -31,12 +31,12 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *IITAttestorPlugin) catalog.Plugin {
-	return catalog.MakePlugin(gcp.PluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(gcp.PluginName, nodeattestorv0.PluginServer(p))
 }
 
 // IITAttestorPlugin implements GCP nodeattestation in the agent.
 type IITAttestorPlugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	mtx    sync.RWMutex
 	config *IITAttestorConfig
@@ -56,7 +56,7 @@ func New() *IITAttestorPlugin {
 
 // FetchAttestationData fetches attestation data from the GCP metadata server and sends an attestation response
 // on given stream.
-func (p *IITAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *IITAttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	c, err := p.getConfig()
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (p *IITAttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttesto
 		return newErrorf("unable to retrieve valid identity token: %v", err)
 	}
 
-	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: gcp.PluginName,
 			Data: identityToken,

--- a/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/agent/plugin/nodeattestor/gcp/iit_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -25,7 +25,7 @@ func TestIITAttestorPlugin(t *testing.T) {
 type Suite struct {
 	spiretest.Suite
 
-	p      nodeattestor.Plugin
+	p      nodeattestorv0.Plugin
 	server *httptest.Server
 	status int
 	body   string
@@ -166,10 +166,10 @@ func (s *Suite) TestGetPluginInfo() {
 	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
 }
 
-func (s *Suite) newPlugin() nodeattestor.Plugin {
+func (s *Suite) newPlugin() nodeattestorv0.Plugin {
 	p := New()
 
-	var plugin nodeattestor.Plugin
+	var plugin nodeattestorv0.Plugin
 	s.LoadPlugin(builtin(p), &plugin)
 	return plugin
 }
@@ -188,7 +188,7 @@ identity_token_host = "%s"
 	s.status = http.StatusOK
 }
 
-func (s *Suite) fetchAttestationData() (*nodeattestor.FetchAttestationDataResponse, error) {
+func (s *Suite) fetchAttestationData() (*nodeattestorv0.FetchAttestationDataResponse, error) {
 	stream, err := s.p.FetchAttestationData(context.Background())
 	s.NoError(err)
 	s.NoError(stream.CloseSend())
@@ -252,9 +252,9 @@ func TestRetrieveIdentity(t *testing.T) {
 }
 
 type failSendStream struct {
-	nodeattestor.NodeAttestor_FetchAttestationDataServer
+	nodeattestorv0.NodeAttestor_FetchAttestationDataServer
 }
 
-func (s *failSendStream) Send(*nodeattestor.FetchAttestationDataResponse) error {
+func (s *failSendStream) Send(*nodeattestorv0.FetchAttestationDataResponse) error {
 	return errors.New("failed to send to stream")
 }

--- a/pkg/agent/plugin/nodeattestor/jointoken.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken.go
@@ -1,0 +1,35 @@
+package nodeattestor
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"google.golang.org/grpc/codes"
+)
+
+func JoinToken(token string) NodeAttestor {
+	return joinToken{
+		Facade: plugin.FixedFacade("join_token", "NodeAttestor"),
+		token:  token,
+	}
+}
+
+type joinToken struct {
+	plugin.Facade
+	token string
+}
+
+func (plugin joinToken) Attest(ctx context.Context, serverStream ServerStream) error {
+	challenge, err := serverStream.SendAttestationData(ctx, AttestationData{
+		Type:    plugin.Name(),
+		Payload: []byte(plugin.token),
+	})
+	switch {
+	case err != nil:
+		return err
+	case challenge != nil:
+		return plugin.Error(codes.Internal, "server issued unexpected challenge")
+	default:
+		return nil
+	}
+}

--- a/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
@@ -18,18 +18,18 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 type Plugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 }
 
 func New() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	return errors.New("join token attestation is currently implemented within the agent")
 }
 

--- a/pkg/agent/plugin/nodeattestor/jointoken_test.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken_test.go
@@ -1,0 +1,43 @@
+package nodeattestor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestJoinToken(t *testing.T) {
+	attestor := nodeattestor.JoinToken("foo")
+
+	t.Run("success", func(t *testing.T) {
+		err := attestor.Attest(context.Background(), &fakeStream{
+			expectData: nodeattestor.AttestationData{Type: "join_token", Payload: []byte("foo")},
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("attestation fails", func(t *testing.T) {
+		err := attestor.Attest(context.Background(), &fakeStream{
+			attestationErr: errors.New("ohno"),
+			expectData:     nodeattestor.AttestationData{Type: "join_token", Payload: []byte("bar")},
+			challenges:     challenges("hello"),
+		})
+		// ServerStream errors are not the responsibility of the plugin, so
+		// we shouldn't wrap them. ServerStream implementations are responsible
+		// for the shape of those errors.
+		spiretest.RequireGRPCStatus(t, err, codes.Unknown, "ohno")
+	})
+
+	t.Run("server issues unexpected challenge", func(t *testing.T) {
+		err := attestor.Attest(context.Background(), &fakeStream{
+			expectData: nodeattestor.AttestationData{Type: "join_token", Payload: []byte("foo")},
+			challenges: challenges("hello"),
+		})
+		spiretest.RequireGRPCStatus(t, err, codes.Internal, "nodeattestor(join_token): server issued unexpected challenge")
+	})
+}

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
@@ -30,7 +30,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *AttestorPlugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 // New creates a new PSAT attestor plugin
@@ -40,7 +40,7 @@ func New() *AttestorPlugin {
 
 // AttestorPlugin is a PSAT (projected SAT) attestor plugin
 type AttestorPlugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	mu     sync.RWMutex
 	config *attestorConfig
@@ -61,7 +61,7 @@ type attestorConfig struct {
 }
 
 // FetchAttestationData loads PSAT from the configured path and send it to server node attestor
-func (p *AttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *AttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	config, err := p.getConfig()
 	if err != nil {
 		return err
@@ -80,7 +80,7 @@ func (p *AttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_F
 		return psatError.Wrap(err)
 	}
 
-	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: pluginName,
 			Data: data,

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
@@ -9,9 +9,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	sat_common "github.com/spiffe/spire/pkg/common/plugin/k8s"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -40,7 +40,7 @@ type AttestorSuite struct {
 	spiretest.Suite
 
 	dir      string
-	attestor nodeattestor.Plugin
+	attestor nodeattestorv0.Plugin
 }
 
 func (s *AttestorSuite) SetupTest() {

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
@@ -31,7 +31,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *AttestorPlugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 type AttestorConfig struct {
@@ -46,7 +46,7 @@ type attestorConfig struct {
 }
 
 type AttestorPlugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	mu     sync.RWMutex
 	config *attestorConfig
@@ -56,7 +56,7 @@ func New() *AttestorPlugin {
 	return &AttestorPlugin{}
 }
 
-func (p *AttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) error {
+func (p *AttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
 	config, err := p.getConfig()
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func (p *AttestorPlugin) FetchAttestationData(stream nodeattestor.NodeAttestor_F
 		return satError.Wrap(err)
 	}
 
-	return stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: pluginName,
 			Data: data,

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -23,7 +23,7 @@ type AttestorSuite struct {
 	spiretest.Suite
 
 	dir      string
-	attestor nodeattestor.Plugin
+	attestor nodeattestorv0.Plugin
 }
 
 func (s *AttestorSuite) SetupTest() {

--- a/pkg/agent/plugin/nodeattestor/nodeattestor.go
+++ b/pkg/agent/plugin/nodeattestor/nodeattestor.go
@@ -1,95 +1,31 @@
-// Provides interfaces and adapters for the NodeAttestor service
-//
-// Generated code. Do not modify by hand.
 package nodeattestor
 
 import (
 	"context"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/proto/spire/agent/nodeattestor"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"google.golang.org/grpc"
 )
 
-type FetchAttestationDataRequest = nodeattestor.FetchAttestationDataRequest                         //nolint: golint
-type FetchAttestationDataResponse = nodeattestor.FetchAttestationDataResponse                       //nolint: golint
-type NodeAttestorClient = nodeattestor.NodeAttestorClient                                           //nolint: golint
-type NodeAttestorServer = nodeattestor.NodeAttestorServer                                           //nolint: golint
-type NodeAttestor_FetchAttestationDataClient = nodeattestor.NodeAttestor_FetchAttestationDataClient //nolint: golint
-type NodeAttestor_FetchAttestationDataServer = nodeattestor.NodeAttestor_FetchAttestationDataServer //nolint: golint
-type UnimplementedNodeAttestorServer = nodeattestor.UnimplementedNodeAttestorServer                 //nolint: golint
-type UnsafeNodeAttestorServer = nodeattestor.UnsafeNodeAttestorServer                               //nolint: golint
-
-const (
-	Type = "NodeAttestor"
-)
-
-// NodeAttestor is the client interface for the service type NodeAttestor interface.
+// NodeAttestor attests the agent with the server
 type NodeAttestor interface {
-	FetchAttestationData(context.Context) (NodeAttestor_FetchAttestationDataClient, error)
+	catalog.PluginInfo
+
+	// Attest attests the agent with the server using the provided server
+	// stream. Errors produced by the ServerStream are returned from this
+	// function unchanged.
+	Attest(ctx context.Context, serverStream ServerStream) error
 }
 
-// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
-type Plugin interface {
-	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
-	FetchAttestationData(context.Context) (NodeAttestor_FetchAttestationDataClient, error)
-	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+// ServerStream is used by the NodeAttestor to send the attestation data and
+// challenge responses to the server.
+type ServerStream interface {
+	SendAttestationData(ctx context.Context, attestationData AttestationData) ([]byte, error)
+	SendChallengeResponse(ctx context.Context, response []byte) ([]byte, error)
 }
 
-// PluginServer returns a catalog PluginServer implementation for the NodeAttestor plugin.
-func PluginServer(server NodeAttestorServer) catalog.PluginServer {
-	return &pluginServer{
-		server: server,
-	}
-}
-
-type pluginServer struct {
-	server NodeAttestorServer
-}
-
-func (s pluginServer) PluginType() string {
-	return Type
-}
-
-func (s pluginServer) PluginClient() catalog.PluginClient {
-	return PluginClient
-}
-
-func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
-	nodeattestor.RegisterNodeAttestorServer(server, s.server)
-	return s.server
-}
-
-// PluginClient is a catalog PluginClient implementation for the NodeAttestor plugin.
-var PluginClient catalog.PluginClient = pluginClient{}
-
-type pluginClient struct{}
-
-func (pluginClient) PluginType() string {
-	return Type
-}
-
-func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
-	return AdaptPluginClient(nodeattestor.NewNodeAttestorClient(conn))
-}
-
-func AdaptPluginClient(client NodeAttestorClient) NodeAttestor {
-	return pluginClientAdapter{client: client}
-}
-
-type pluginClientAdapter struct {
-	client NodeAttestorClient
-}
-
-func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return a.client.Configure(ctx, in)
-}
-
-func (a pluginClientAdapter) FetchAttestationData(ctx context.Context) (NodeAttestor_FetchAttestationDataClient, error) {
-	return a.client.FetchAttestationData(ctx)
-}
-
-func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return a.client.GetPluginInfo(ctx, in)
+// AttestationData represents the attestation type and payload that is sent
+// to the server.
+type AttestationData struct {
+	Type    string
+	Payload []byte
 }

--- a/pkg/agent/plugin/nodeattestor/sshpop/sshpop.go
+++ b/pkg/agent/plugin/nodeattestor/sshpop/sshpop.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"sync"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/sshpop"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
 type Plugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	mu        sync.RWMutex
 	sshclient *sshpop.Client
@@ -23,14 +23,14 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(sshpop.PluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(sshpop.PluginName, nodeattestorv0.PluginServer(p))
 }
 
 func New() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) (err error) {
+func (p *Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) (err error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
@@ -43,7 +43,7 @@ func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAtte
 	if err != nil {
 		return err
 	}
-	if err := stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: &common.AttestationData{
 			Type: sshpop.PluginName,
 			Data: attestationData,
@@ -61,7 +61,7 @@ func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAtte
 		return err
 	}
 
-	if err := stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		Response: challengeRes,
 	}); err != nil {
 		return err

--- a/pkg/agent/plugin/nodeattestor/sshpop/sshpop_test.go
+++ b/pkg/agent/plugin/nodeattestor/sshpop/sshpop_test.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/plugin/sshpop"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/fixture"
 	"github.com/spiffe/spire/test/spiretest"
@@ -21,7 +21,7 @@ func TestSSHPoP(t *testing.T) {
 type Suite struct {
 	spiretest.Suite
 
-	p         nodeattestor.Plugin
+	p         nodeattestorv0.Plugin
 	sshclient *sshpop.Client
 	sshserver *sshpop.Server
 }
@@ -31,8 +31,8 @@ func (s *Suite) SetupTest() {
 	s.configure()
 }
 
-func (s *Suite) newPlugin() nodeattestor.Plugin {
-	var p nodeattestor.Plugin
+func (s *Suite) newPlugin() nodeattestorv0.Plugin {
+	var p nodeattestorv0.Plugin
 	s.LoadPlugin(BuiltIn(), &p)
 	return p
 }
@@ -91,7 +91,7 @@ func (s *Suite) TestFetchAttestationDataSuccess() {
 	require.NoError(err)
 	challenge, err := server.IssueChallenge()
 	require.NoError(err)
-	err = stream.Send(&nodeattestor.FetchAttestationDataRequest{
+	err = stream.Send(&nodeattestorv0.FetchAttestationDataRequest{
 		Challenge: challenge,
 	})
 	require.NoError(err)
@@ -118,7 +118,7 @@ func (s *Suite) TestFetchAttestationDataFailure() {
 		require.NoError(err)
 		require.NotNil(resp)
 
-		require.NoError(stream.Send(&nodeattestor.FetchAttestationDataRequest{
+		require.NoError(stream.Send(&nodeattestorv0.FetchAttestationDataRequest{
 			Challenge: challenge,
 		}))
 
@@ -150,7 +150,7 @@ func (s *Suite) TestGetPluginInfo() {
 	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
 }
 
-func (s *Suite) fetchAttestationData() (nodeattestor.NodeAttestor_FetchAttestationDataClient, func()) {
+func (s *Suite) fetchAttestationData() (nodeattestorv0.NodeAttestor_FetchAttestationDataClient, func()) {
 	stream, err := s.p.FetchAttestationData(context.Background())
 	s.Require().NoError(err)
 	return stream, func() {

--- a/pkg/agent/plugin/nodeattestor/v0.go
+++ b/pkg/agent/plugin/nodeattestor/v0.go
@@ -1,0 +1,80 @@
+package nodeattestor
+
+import (
+	"context"
+	"io"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
+	"google.golang.org/grpc/codes"
+)
+
+type V0 struct {
+	plugin.Facade
+
+	Plugin nodeattestorv0.NodeAttestor
+}
+
+func (v0 V0) Attest(ctx context.Context, serverStream ServerStream) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pluginStream, err := v0.Plugin.FetchAttestationData(ctx)
+	if err != nil {
+		return v0.WrapErr(err)
+	}
+
+	resp, err := pluginStream.Recv()
+	switch {
+	case err == io.EOF:
+		return v0.Error(codes.Internal, "plugin closed stream before returning attestation data")
+	case err != nil:
+		return v0.WrapErr(err)
+	}
+
+	switch {
+	case resp.AttestationData == nil:
+		return v0.Error(codes.Internal, "plugin response missing attestation data")
+	case resp.AttestationData.Type == "":
+		return v0.Error(codes.Internal, "plugin response missing attestation data type")
+	case resp.AttestationData.Data == nil:
+		return v0.Error(codes.Internal, "plugin response missing attestation data payload")
+	}
+
+	challenge, err := serverStream.SendAttestationData(ctx, AttestationData{
+		Type:    resp.AttestationData.Type,
+		Payload: resp.AttestationData.Data,
+	})
+	if err != nil {
+		return err
+	}
+
+	for {
+		if challenge == nil {
+			return nil
+		}
+
+		err = pluginStream.Send(&nodeattestorv0.FetchAttestationDataRequest{
+			Challenge: challenge,
+		})
+		switch {
+		case err == io.EOF:
+			return v0.Error(codes.Internal, "plugin closed stream after being issued a challenge")
+		case err != nil:
+			return v0.WrapErr(err)
+		}
+
+		resp, err := pluginStream.Recv()
+		switch {
+		case err != nil:
+			return v0.WrapErr(err)
+		case resp.Response == nil:
+			return v0.Error(codes.Internal, "plugin response missing challenge response")
+		}
+
+		challenge, err = serverStream.SendChallengeResponse(ctx, resp.Response)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/agent/plugin/nodeattestor/v0_test.go
+++ b/pkg/agent/plugin/nodeattestor/v0_test.go
@@ -248,7 +248,7 @@ func challenges(ss ...string) []string {
 func challengeResponses(ss ...string) map[string]string {
 	set := make(map[string]string)
 	for i := 0; i < len(ss); i += 2 {
-		set[ss[i+0]] = ss[i+1]
+		set[ss[i]] = ss[i+1]
 	}
 	return set
 }

--- a/pkg/agent/plugin/nodeattestor/v0_test.go
+++ b/pkg/agent/plugin/nodeattestor/v0_test.go
@@ -1,0 +1,254 @@
+package nodeattestor_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
+	"github.com/spiffe/spire/proto/spire/common"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestV0(t *testing.T) {
+	attestationData := nodeattestor.AttestationData{Type: "test", Payload: []byte("test")}
+	attestationDataMissingType := nodeattestor.AttestationData{Payload: []byte("test")}
+	attestationDataMissingPayload := nodeattestor.AttestationData{Type: "test"}
+
+	for _, tt := range []struct {
+		test          string
+		pluginImpl    *fakeV0Plugin
+		streamImpl    *fakeStream
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "plugin closes stream without returning attestation data",
+			pluginImpl:    &fakeV0Plugin{closeStream: true},
+			streamImpl:    &fakeStream{},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin closed stream before returning attestation data",
+		},
+		{
+			test:          "plugin fails fetching attestation data",
+			pluginImpl:    &fakeV0Plugin{attestationDataErr: errors.New("ohno")},
+			streamImpl:    &fakeStream{},
+			expectCode:    codes.Unknown,
+			expectMessage: "nodeattestor(test): ohno",
+		},
+		{
+			test:          "plugin does not return attestation data",
+			pluginImpl:    &fakeV0Plugin{},
+			streamImpl:    &fakeStream{},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing attestation data",
+		},
+		{
+			test:          "plugin does not return attestation data type",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationDataMissingType},
+			streamImpl:    &fakeStream{},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing attestation data type",
+		},
+		{
+			test:          "plugin does not return attestation data payload",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationDataMissingPayload},
+			streamImpl:    &fakeStream{},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing attestation data payload",
+		},
+		{
+			test:          "server stream fails sending attestation data",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData},
+			streamImpl:    &fakeStream{attestationErr: errors.New("ohno")},
+			expectCode:    codes.Unknown,
+			expectMessage: "ohno",
+		},
+		{
+			test:          "server stream issues no challenge",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData},
+			streamImpl:    &fakeStream{expectData: attestationData},
+			expectCode:    codes.OK,
+			expectMessage: "",
+		},
+		{
+			test:          "plugin ignores server stream issued challenge",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData},
+			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin closed stream after being issued a challenge",
+		},
+		{
+			test:          "plugin fails responding to challenge",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData, challengeResponses: challengeResponses("echo", "echo"), challengeResponseErr: errors.New("ohno")},
+			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
+			expectCode:    codes.Unknown,
+			expectMessage: "nodeattestor(test): ohno",
+		},
+		{
+			test:          "plugin answers server stream issued challenge correctly",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData, challengeResponses: challengeResponses("echo", "echo")},
+			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
+			expectCode:    codes.OK,
+			expectMessage: "",
+		},
+		{
+			test:          "plugin answers server stream issued challenge incorrectly",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData, challengeResponses: challengeResponses("echo", "foo")},
+			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
+			expectCode:    codes.InvalidArgument,
+			expectMessage: "stream received invalid challenge response",
+		},
+		{
+			test:          "plugin response with empty challenge response",
+			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData, challengeResponses: challengeResponses("echo", "")},
+			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing challenge response",
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			nodeattestor := loadV0Plugin(t, tt.pluginImpl)
+			err := nodeattestor.Attest(context.Background(), tt.streamImpl)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func loadV0Plugin(t *testing.T, fake *fakeV0Plugin) nodeattestor.NodeAttestor {
+	server := nodeattestorv0.PluginServer(fake)
+
+	var plugin nodeattestor.V0
+	spiretest.LoadPlugin(t, catalog.MakePlugin("test", server), &plugin)
+	return plugin
+}
+
+type fakeV0Plugin struct {
+	nodeattestorv0.UnimplementedNodeAttestorServer
+
+	closeStream        bool
+	attestationData    *nodeattestor.AttestationData
+	attestationDataErr error
+
+	challengeResponses   map[string]string
+	challengeResponseErr error
+}
+
+func (plugin *fakeV0Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
+	if plugin.closeStream {
+		return nil
+	}
+	if plugin.attestationDataErr != nil {
+		return plugin.attestationDataErr
+	}
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
+		AttestationData: v0AttestationData(plugin.attestationData),
+	}); err != nil {
+		return err
+	}
+
+	for len(plugin.challengeResponses) > 0 {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		challenge := string(req.Challenge)
+		if plugin.challengeResponseErr != nil {
+			return plugin.challengeResponseErr
+		}
+		response, ok := plugin.challengeResponses[challenge]
+		if !ok {
+			return fmt.Errorf("test not configured to handle challenge %q", challenge)
+		}
+		delete(plugin.challengeResponses, challenge)
+		if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
+			Response: []byte(response),
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (plugin *fakeV0Plugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return &spi.ConfigureResponse{}, nil
+}
+
+func (plugin *fakeV0Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return &spi.GetPluginInfoResponse{}, nil
+}
+
+type fakeStream struct {
+	attestationErr error
+	expectData     nodeattestor.AttestationData
+	challenges     []string
+}
+
+func (ss *fakeStream) SendAttestationData(ctx context.Context, attestationData nodeattestor.AttestationData) ([]byte, error) {
+	switch {
+	case ss.attestationErr != nil:
+		return nil, ss.attestationErr
+	case ss.expectData.Type != attestationData.Type:
+		return nil, fmt.Errorf("expected attestation type %q; got %q", ss.expectData.Type, attestationData.Type)
+	case string(ss.expectData.Payload) != string(attestationData.Payload):
+		return nil, fmt.Errorf("expected attestation payload %q; got %q", string(ss.expectData.Payload), string(attestationData.Payload))
+	default:
+		return ss.nextChallenge(), nil
+	}
+}
+
+func (ss *fakeStream) SendChallengeResponse(ctx context.Context, response []byte) ([]byte, error) {
+	switch {
+	case len(ss.challenges) == 0:
+		// This shouldn't happen unless there is a problem in the shim since
+		// it shouldn't be issuing challenge responses for challenges that
+		// were never issued.
+		return nil, errors.New("stream received unexpected challenge response")
+	case ss.challenges[0] != string(response):
+		return nil, status.Error(codes.InvalidArgument, "stream received invalid challenge response")
+	}
+	ss.challenges = ss.challenges[1:]
+	return ss.nextChallenge(), nil
+}
+
+func (ss *fakeStream) nextChallenge() []byte {
+	if len(ss.challenges) > 0 {
+		return []byte(ss.challenges[0])
+	}
+	return nil
+}
+
+func v0AttestationData(attestationData *nodeattestor.AttestationData) *common.AttestationData {
+	if attestationData == nil {
+		return nil
+	}
+	return &common.AttestationData{
+		Type: attestationData.Type,
+		Data: attestationData.Payload,
+	}
+}
+
+func challenges(ss ...string) []string {
+	return ss
+}
+
+func challengeResponses(ss ...string) map[string]string {
+	set := make(map[string]string)
+	for i := 0; i < len(ss); i += 2 {
+		set[ss[i+0]] = ss[i+1]
+	}
+	return set
+}

--- a/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/agent/plugin/nodeattestor/x509pop/x509pop.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
 	"github.com/spiffe/spire/pkg/common/util"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 )
@@ -29,7 +29,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, nodeattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, nodeattestorv0.PluginServer(p))
 }
 
 type configData struct {
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 type Plugin struct {
-	nodeattestor.UnsafeNodeAttestorServer
+	nodeattestorv0.UnsafeNodeAttestorServer
 
 	m sync.Mutex
 	c *Config
@@ -55,14 +55,14 @@ func New() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAttestationDataServer) (err error) {
+func (p *Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) (err error) {
 	data, err := p.loadConfigData()
 	if err != nil {
 		return err
 	}
 
 	// send the attestation data back to the agent
-	if err := stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		AttestationData: data.attestationData,
 	}); err != nil {
 		return err
@@ -90,7 +90,7 @@ func (p *Plugin) FetchAttestationData(stream nodeattestor.NodeAttestor_FetchAtte
 		return fmt.Errorf("x509pop: unable to marshal challenge response: %v", err)
 	}
 
-	if err := stream.Send(&nodeattestor.FetchAttestationDataResponse{
+	if err := stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
 		Response: responseBytes,
 	}); err != nil {
 		return err

--- a/pkg/agent/plugin/nodeattestor/x509pop/x509pop_test.go
+++ b/pkg/agent/plugin/nodeattestor/x509pop/x509pop_test.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
 	"github.com/spiffe/spire/pkg/common/util"
+	nodeattestorv0 "github.com/spiffe/spire/proto/spire/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/fixture"
 	"github.com/spiffe/spire/test/spiretest"
@@ -24,7 +24,7 @@ func TestX509PoP(t *testing.T) {
 type Suite struct {
 	spiretest.Suite
 
-	p          nodeattestor.Plugin
+	p          nodeattestorv0.Plugin
 	leafBundle [][]byte
 	leafCert   *x509.Certificate
 }
@@ -36,8 +36,8 @@ func (s *Suite) SetupTest() {
 	s.configure(leafKeyPath, leafCertPath, "")
 }
 
-func (s *Suite) newPlugin() nodeattestor.Plugin {
-	var p nodeattestor.Plugin
+func (s *Suite) newPlugin() nodeattestorv0.Plugin {
+	var p nodeattestorv0.Plugin
 	s.LoadPlugin(BuiltIn(), &p)
 	return p
 }
@@ -98,7 +98,7 @@ func (s *Suite) TestFetchAttestationDataSuccess() {
 	require.NoError(err)
 	challengeBytes, err := json.Marshal(challenge)
 	require.NoError(err)
-	err = stream.Send(&nodeattestor.FetchAttestationDataRequest{
+	err = stream.Send(&nodeattestorv0.FetchAttestationDataRequest{
 		Challenge: challengeBytes,
 	})
 	require.NoError(err)
@@ -135,7 +135,7 @@ func (s *Suite) TestFetchAttestationDataFailure() {
 		require.NoError(err)
 		require.NotNil(resp)
 
-		require.NoError(stream.Send(&nodeattestor.FetchAttestationDataRequest{
+		require.NoError(stream.Send(&nodeattestorv0.FetchAttestationDataRequest{
 			Challenge: challenge,
 		}))
 
@@ -245,7 +245,7 @@ func (s *Suite) TestGetPluginInfo() {
 	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
 }
 
-func (s *Suite) fetchAttestationData() (nodeattestor.NodeAttestor_FetchAttestationDataClient, func()) {
+func (s *Suite) fetchAttestationData() (nodeattestorv0.NodeAttestor_FetchAttestationDataClient, func()) {
 	stream, err := s.p.FetchAttestationData(context.Background())
 	s.Require().NoError(err)
 	return stream, func() {

--- a/pkg/common/catalog/init.go
+++ b/pkg/common/catalog/init.go
@@ -68,6 +68,7 @@ func newCatalogPlugin(ctx context.Context, c *grpc.ClientConn, config catalogPlu
 
 	return &LoadedPlugin{
 		name:         config.Name,
+		pluginType:   config.Plugin.PluginType(),
 		plugin:       pluginImpl,
 		all:          append([]interface{}{pluginImpl}, serviceImpls...),
 		serviceNames: serviceNames,

--- a/pkg/common/catalog/plugin.go
+++ b/pkg/common/catalog/plugin.go
@@ -10,6 +10,7 @@ import (
 
 type LoadedPlugin struct {
 	name         string
+	pluginType   string
 	plugin       interface{}
 	all          []interface{}
 	serviceNames []string
@@ -20,6 +21,10 @@ type LoadedPlugin struct {
 
 func (p *LoadedPlugin) Name() string {
 	return p.name
+}
+
+func (p *LoadedPlugin) Type() string {
+	return p.pluginType
 }
 
 func (p *LoadedPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) error {

--- a/pkg/common/plugin/facade.go
+++ b/pkg/common/plugin/facade.go
@@ -1,0 +1,118 @@
+package plugin
+
+import (
+	"strings"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PrefixMessage prefixes the given message with plugin information. The prefix
+// is only applied if it is not already applied.
+func PrefixMessage(pluginInfo catalog.PluginInfo, message string) string {
+	message, _ = prefixMessage(pluginInfo, message)
+	return message
+}
+
+// Facade is embedded by plugin interface facade implementations as a
+// convenient way to embed PluginInfo but also provide a set of convenient
+// functions for embellishing and generating errors that have the plugin
+// name prefixed.
+type Facade struct {
+	catalog.PluginInfo
+}
+
+// FixedFacade is a helper that creates a facade from fixed information, i.e.
+// not the product of a loaded plugin.
+func FixedFacade(pluginName, pluginType string) Facade {
+	return Facade{
+		PluginInfo: pluginInfo{
+			pluginName: pluginName,
+			pluginType: pluginType,
+		},
+	}
+}
+
+// WrapError wraps a given error such that it will be prefixed with the plugin
+// name. This method should be used by facade implementations to wrap errors
+// that come out of plugin implementations.
+func (f Facade) WrapErr(err error) error {
+	if err == nil {
+		return err
+	}
+
+	// Embellish the a gRPC status with the prefix, if necessary.
+	if st, ok := status.FromError(err); ok {
+		// Care must be taken to preserve any status details. Therefore, the
+		// proto is embellished directly and a new status created from that
+		// proto.
+		pb := st.Proto()
+		if message, ok := prefixMessage(f, pb.Message); ok {
+			pb.Message = message
+			return status.FromProto(pb).Err()
+		}
+		return err
+	}
+
+	// Embellish the normal error with the prefix, if necessary. This is a
+	// defensive measure since plugins go over gRPC.
+	if message, ok := prefixMessage(f, err.Error()); ok {
+		return &facadeError{wrapped: err, message: message}
+	}
+
+	return err
+}
+
+// Error creates a gRPC status with the given code and message. The message
+// will be prefixed with the plugin name.
+func (f Facade) Error(code codes.Code, message string) error {
+	return status.Error(code, messagePrefix(f)+message)
+}
+
+// Errorf creates a gRPC status with the given code and
+// formatted message. The message will be prefixed with the plugin name.
+func (f Facade) Errorf(code codes.Code, format string, args ...interface{}) error {
+	return status.Errorf(code, messagePrefix(f)+format, args...)
+}
+
+func prefixMessage(pluginInfo catalog.PluginInfo, message string) (string, bool) {
+	prefix := messagePrefix(pluginInfo)
+	oldPrefix := pluginInfo.Name() + ": "
+
+	if strings.HasPrefix(message, prefix) {
+		return message, false
+	}
+
+	return prefix + strings.TrimPrefix(message, oldPrefix), true
+}
+
+func messagePrefix(pluginInfo catalog.PluginInfo) string {
+	return strings.ToLower(pluginInfo.Type()) + "(" + pluginInfo.Name() + "): "
+}
+
+type facadeError struct {
+	wrapped error
+	message string
+}
+
+func (e *facadeError) Error() string {
+	return e.message
+}
+
+func (e *facadeError) Unwrap() error {
+	return e.wrapped
+}
+
+type pluginInfo struct {
+	pluginName string
+	pluginType string
+}
+
+func (info pluginInfo) Name() string {
+	return info.pluginName
+}
+
+func (info pluginInfo) Type() string {
+	return info.pluginType
+}

--- a/pkg/common/plugin/facade.go
+++ b/pkg/common/plugin/facade.go
@@ -42,7 +42,7 @@ func (f Facade) WrapErr(err error) error {
 		return err
 	}
 
-	// Embellish the a gRPC status with the prefix, if necessary.
+	// Embellish the gRPC status with the prefix, if necessary.
 	if st, ok := status.FromError(err); ok {
 		// Care must be taken to preserve any status details. Therefore, the
 		// proto is embellished directly and a new status created from that
@@ -78,12 +78,12 @@ func (f Facade) Errorf(code codes.Code, format string, args ...interface{}) erro
 
 func prefixMessage(pluginInfo catalog.PluginInfo, message string) (string, bool) {
 	prefix := messagePrefix(pluginInfo)
-	oldPrefix := pluginInfo.Name() + ": "
 
 	if strings.HasPrefix(message, prefix) {
 		return message, false
 	}
 
+	oldPrefix := pluginInfo.Name() + ": "
 	return prefix + strings.TrimPrefix(message, oldPrefix), true
 }
 

--- a/pkg/common/plugin/facade_test.go
+++ b/pkg/common/plugin/facade_test.go
@@ -17,6 +17,20 @@ var (
 	facade = plugin.FixedFacade("name", "type")
 )
 
+func TestPrefixMessage(t *testing.T) {
+	t.Run("without prefix", func(t *testing.T) {
+		assert.Equal(t, "type(name): ohno", plugin.PrefixMessage(facade, "ohno"))
+	})
+
+	t.Run("with old prefix", func(t *testing.T) {
+		assert.Equal(t, "type(name): ohno", plugin.PrefixMessage(facade, "name: ohno"))
+	})
+
+	t.Run("already prefixed", func(t *testing.T) {
+		assert.Equal(t, "type(name): ohno", plugin.PrefixMessage(facade, "type(name): ohno"))
+	})
+}
+
 func TestFacadeWrapErr(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {
 		assert.Nil(t, facade.WrapErr(nil))

--- a/pkg/common/plugin/facade_test.go
+++ b/pkg/common/plugin/facade_test.go
@@ -1,0 +1,103 @@
+package plugin_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes/any"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	facade = plugin.FixedFacade("name", "type")
+)
+
+func TestFacadeWrapErr(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.Nil(t, facade.WrapErr(nil))
+	})
+
+	t.Run("standard error without prefix", func(t *testing.T) {
+		err := facade.WrapErr(ohnoError(""))
+		assert.EqualError(t, err, "type(name): ohno")
+		assert.True(t, errors.Is(err, ohnoError("")))
+	})
+
+	t.Run("standard error with old prefix prefixed", func(t *testing.T) {
+		err := facade.WrapErr(ohnoError("name: "))
+		assert.EqualError(t, err, "type(name): ohno")
+		assert.True(t, errors.Is(err, ohnoError("name: ")))
+	})
+
+	t.Run("standard error already prefixed", func(t *testing.T) {
+		err := facade.WrapErr(ohnoError("type(name): "))
+		assert.EqualError(t, err, "type(name): ohno")
+		assert.True(t, errors.Is(err, ohnoError("type(name): ")))
+	})
+
+	t.Run("grpc status without prefix", func(t *testing.T) {
+		stIn := status.FromProto(&spb.Status{
+			Code:    int32(codes.InvalidArgument),
+			Message: "ohno",
+			Details: []*any.Any{{TypeUrl: "fake"}},
+		})
+
+		stOut := status.Convert(facade.WrapErr(stIn.Err()))
+
+		assert.Equal(t, stIn.Code(), stOut.Code())
+		assert.Equal(t, stIn.Details(), stOut.Details())
+		assert.Equal(t, "type(name): ohno", stOut.Message())
+	})
+
+	t.Run("grpc status with old prefix", func(t *testing.T) {
+		stIn := status.FromProto(&spb.Status{
+			Code:    int32(codes.InvalidArgument),
+			Message: "name: ohno",
+			Details: []*any.Any{{TypeUrl: "fake"}},
+		})
+
+		stOut := status.Convert(facade.WrapErr(stIn.Err()))
+		assert.Equal(t, stIn.Code(), stOut.Code())
+		assert.Equal(t, stIn.Details(), stOut.Details())
+		assert.Equal(t, "type(name): ohno", stOut.Message())
+	})
+
+	t.Run("grpc status with prefix", func(t *testing.T) {
+		stIn := status.FromProto(&spb.Status{
+			Code:    int32(codes.InvalidArgument),
+			Message: "type(name): ohno",
+			Details: []*any.Any{{TypeUrl: "fake"}},
+		})
+
+		stOut := status.Convert(facade.WrapErr(stIn.Err()))
+
+		assert.Equal(t, stIn.Code(), stOut.Code())
+		assert.Equal(t, stIn.Details(), stOut.Details())
+		assert.Equal(t, "type(name): ohno", stOut.Message())
+	})
+}
+
+func TestFacadeError(t *testing.T) {
+	st, ok := status.FromError(facade.Error(codes.Internal, "ohno"))
+	require.True(t, ok, "error is not a gRPC status")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Equal(t, "type(name): ohno", st.Message())
+}
+
+func TestFacadeErrorf(t *testing.T) {
+	st, ok := status.FromError(facade.Errorf(codes.Internal, "%s", "ohno"))
+	require.True(t, ok, "error is not a gRPC status")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Equal(t, "type(name): ohno", st.Message())
+}
+
+type ohnoError string
+
+func (prefix ohnoError) Error() string {
+	return string(prefix) + "ohno"
+}

--- a/proto/spire/agent/nodeattestor/v0/nodeattestor.go
+++ b/proto/spire/agent/nodeattestor/v0/nodeattestor.go
@@ -1,0 +1,95 @@
+// Provides interfaces and adapters for the NodeAttestor service
+//
+// Generated code. Do not modify by hand.
+package v0
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/proto/spire/agent/nodeattestor"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"google.golang.org/grpc"
+)
+
+type FetchAttestationDataRequest = nodeattestor.FetchAttestationDataRequest                         //nolint: golint
+type FetchAttestationDataResponse = nodeattestor.FetchAttestationDataResponse                       //nolint: golint
+type NodeAttestorClient = nodeattestor.NodeAttestorClient                                           //nolint: golint
+type NodeAttestorServer = nodeattestor.NodeAttestorServer                                           //nolint: golint
+type NodeAttestor_FetchAttestationDataClient = nodeattestor.NodeAttestor_FetchAttestationDataClient //nolint: golint
+type NodeAttestor_FetchAttestationDataServer = nodeattestor.NodeAttestor_FetchAttestationDataServer //nolint: golint
+type UnimplementedNodeAttestorServer = nodeattestor.UnimplementedNodeAttestorServer                 //nolint: golint
+type UnsafeNodeAttestorServer = nodeattestor.UnsafeNodeAttestorServer                               //nolint: golint
+
+const (
+	Type = "NodeAttestor"
+)
+
+// NodeAttestor is the client interface for the service type NodeAttestor interface.
+type NodeAttestor interface {
+	FetchAttestationData(context.Context) (NodeAttestor_FetchAttestationDataClient, error)
+}
+
+// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
+type Plugin interface {
+	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
+	FetchAttestationData(context.Context) (NodeAttestor_FetchAttestationDataClient, error)
+	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+}
+
+// PluginServer returns a catalog PluginServer implementation for the NodeAttestor plugin.
+func PluginServer(server NodeAttestorServer) catalog.PluginServer {
+	return &pluginServer{
+		server: server,
+	}
+}
+
+type pluginServer struct {
+	server NodeAttestorServer
+}
+
+func (s pluginServer) PluginType() string {
+	return Type
+}
+
+func (s pluginServer) PluginClient() catalog.PluginClient {
+	return PluginClient
+}
+
+func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
+	nodeattestor.RegisterNodeAttestorServer(server, s.server)
+	return s.server
+}
+
+// PluginClient is a catalog PluginClient implementation for the NodeAttestor plugin.
+var PluginClient catalog.PluginClient = pluginClient{}
+
+type pluginClient struct{}
+
+func (pluginClient) PluginType() string {
+	return Type
+}
+
+func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
+	return AdaptPluginClient(nodeattestor.NewNodeAttestorClient(conn))
+}
+
+func AdaptPluginClient(client NodeAttestorClient) NodeAttestor {
+	return pluginClientAdapter{client: client}
+}
+
+type pluginClientAdapter struct {
+	client NodeAttestorClient
+}
+
+func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return a.client.Configure(ctx, in)
+}
+
+func (a pluginClientAdapter) FetchAttestationData(ctx context.Context) (NodeAttestor_FetchAttestationDataClient, error) {
+	return a.client.FetchAttestationData(ctx)
+}
+
+func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return a.client.GetPluginInfo(ctx, in)
+}

--- a/test/fakes/fakeagentcatalog/catalog.go
+++ b/test/fakes/fakeagentcatalog/catalog.go
@@ -19,7 +19,7 @@ func (c *Catalog) SetKeyManager(keyManager catalog.KeyManager) {
 	c.KeyManager = keyManager
 }
 
-func (c *Catalog) SetNodeAttestor(nodeAttestor catalog.NodeAttestor) {
+func (c *Catalog) SetNodeAttestor(nodeAttestor nodeattestor.NodeAttestor) {
 	c.NodeAttestor = nodeAttestor
 }
 
@@ -30,13 +30,6 @@ func (c *Catalog) SetWorkloadAttestors(workloadAttestors ...catalog.WorkloadAtte
 func KeyManager(keyManager keymanager.KeyManager) catalog.KeyManager {
 	return catalog.KeyManager{
 		KeyManager: keyManager,
-	}
-}
-
-func NodeAttestor(name string, nodeAttestor nodeattestor.NodeAttestor) catalog.NodeAttestor {
-	return catalog.NodeAttestor{
-		PluginInfo:   pluginInfo{name: name, typ: nodeattestor.Type},
-		NodeAttestor: nodeAttestor,
 	}
 }
 

--- a/test/spiretest/assertions.go
+++ b/test/spiretest/assertions.go
@@ -46,7 +46,7 @@ func AssertGRPCStatus(tb testing.TB, err error, code codes.Code, message string)
 	st := status.Convert(err)
 
 	ok := true
-	if !assert.Equal(tb, code, st.Code(), "GRPC status code does not match") {
+	if !assert.Equal(tb, code.String(), st.Code().String(), "GRPC status code does not match") {
 		ok = false
 	}
 	if !assert.Equal(tb, message, st.Message(), "GRPC status message does not match") {


### PR DESCRIPTION
This PR is the first in a large series of PRs geared towards providing a catalog system that supports multiple plugin versions for each plugin type (#2153).

It provides a Agent NodeAttestor Facade interface and provides a shim for the v0 (i.e. current) version of the plugin type. Some of the code introduced in this PR is temporary and will be refactored/removed later after the new catalog system is in place.