### PR TITLE
Fix broken rotator tests

### DIFF
--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -72,18 +72,30 @@ func (s *RotatorTestSuite) TearDownTest() {
 	s.ctrl.Finish()
 }
 
-func (s *RotatorTestSuite) TestRun() {
-	cert, key, err := util.LoadSVIDFixture()
+func (s *RotatorTestSuite) TestRunWithGoodExistingSVID() {
+	// Cert that's valid for 1hr
+	temp, err := util.NewSVIDTemplate(s.mockClock, "spiffe://example.org/test")
 	s.Require().NoError(err)
-	s.expectSVIDRotation(cert)
+	goodCert, key, err := util.SelfSign(temp)
+	s.Require().NoError(err)
 
 	state := State{
-		SVID: []*x509.Certificate{cert},
+		SVID: []*x509.Certificate{goodCert},
 		Key:  key,
 	}
 	s.r.state = observer.NewProperty(state)
 
+	s.client.EXPECT().Release()
+
 	stream := s.r.Subscribe()
+
+	rotationDone := make(chan struct{}, 1)
+	s.r.SetRotationFinishedHook(func() {
+		select {
+		case rotationDone <- struct{}{}:
+		default:
+		}
+	})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t := new(tomb.Tomb)
@@ -91,23 +103,25 @@ func (s *RotatorTestSuite) TestRun() {
 		return s.r.Run(ctx)
 	})
 
+	// Wait for the first rotation check to finish
+	select {
+	case <-time.After(time.Minute):
+		s.FailNow("timed out waiting for rotation check to finish")
+	case <-rotationDone:
+	}
+
 	// We should have the latest state
 	s.Assert().False(stream.HasNext())
 
 	// Should be equal to the fixture
 	state = stream.Value().(State)
 	s.Require().Len(state.SVID, 1)
-	s.Assert().Equal(cert, state.SVID[0])
+	s.Assert().Equal(goodCert, state.SVID[0])
 	s.Assert().Equal(key, state.Key)
 
 	cancel()
 	err = t.Wait()
-
-	// The error returned by the tomb is non-deterministic so we verify it is either one of the
-	// expected cases. When the Run context is cancelled, either all the runnable tasks terminate returning
-	// a nil error _or_ the Run loop itself returns and returns the context Err(), which in this case is
-	// context.Canceled.
-	s.Require().True(errors.Is(err, context.Canceled) || err == nil)
+	s.Require().True(errors.Is(err, context.Canceled))
 }
 
 func (s *RotatorTestSuite) TestRunWithUpdates() {
@@ -132,6 +146,14 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 
 	stream := s.r.Subscribe()
 
+	rotationDone := make(chan struct{}, 1)
+	s.r.SetRotationFinishedHook(func() {
+		select {
+		case rotationDone <- struct{}{}:
+		default:
+		}
+	})
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t := new(tomb.Tomb)
 	t.Go(func() error {
@@ -139,6 +161,13 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 	})
 
 	s.mockClock.Add(s.r.c.Interval)
+
+	// Wait for the first rotation check to finish
+	select {
+	case <-time.After(time.Minute):
+		s.FailNow("timed out waiting for rotation check to finish")
+	case <-rotationDone:
+	}
 
 	select {
 	case <-time.After(time.Second):
@@ -151,12 +180,7 @@ func (s *RotatorTestSuite) TestRunWithUpdates() {
 
 	cancel()
 	err = t.Wait()
-
-	// The error returned by the tomb is non-deterministic so we verify it is either one of the
-	// expected cases. When the Run context is cancelled, either all the runnable tasks terminate returning
-	// a nil error _or_ the Run loop itself returns and returns the context Err(), which in this case is
-	// context.Canceled.
-	s.Require().True(errors.Is(err, context.Canceled) || err == nil)
+	s.Require().True(errors.Is(err, context.Canceled))
 }
 
 func (s *RotatorTestSuite) TestRotateSVID() {


### PR DESCRIPTION
The rotator tests try and assert rotator behavior when run with both a good and expired SVID. However, the tests are flaky since they do not reliably wait until the rotation check finishes.

Furthermore, the rotation test for an existing SVID is loading an expired certificate from the test fixtures. This is against the
preconditions required for the test case, which are that it does not rotate when a good SVID already exists.

These tests are super hacky. I'd clean them up now but I have hopes that they don't survive in the short to mid term. I have a local branch that I need to wrap up that cleans up the interactions between the attestor, rotator, client, and manager packages, and replaces these tests as part of the work to re-attest without shutting down the agent. One day I'll get the time to finish up that work.