### PR TITLE
AttestAgent: Include the attestor type in the error returned when could not find the node attestor type

### DIFF
--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -550,7 +550,7 @@ func (s *Service) attestChallengeResponse(ctx context.Context, agentStream agent
 
 	nodeAttestor, ok := s.cat.GetNodeAttestorNamed(attestorType)
 	if !ok {
-		return nil, api.MakeErr(log, codes.FailedPrecondition, "could not find node attestor type", nil)
+		return nil, api.MakeErr(log, codes.FailedPrecondition, "error getting node attestor", fmt.Errorf("could not find node attestor type %q", attestorType))
 	}
 
 	attestorStream, err := nodeAttestor.Attest(ctx)

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -1621,12 +1621,13 @@ func TestAttestAgent(t *testing.T) {
 			name:       "attest with bad attestor",
 			request:    getAttestAgentRequest("bad_type", []byte("payload_with_result"), testCsr),
 			expectCode: codes.FailedPrecondition,
-			expectMsg:  "could not find node attestor type",
+			expectMsg:  "error getting node attestor: could not find node attestor type \"bad_type\"",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
-					Message: "Could not find node attestor type",
+					Message: "Error getting node attestor",
 					Data: logrus.Fields{
+						logrus.ErrorKey:            "could not find node attestor type \"bad_type\"",
 						telemetry.NodeAttestorType: "bad_type",
 					},
 				},


### PR DESCRIPTION
Improve the error returned to include the attestor type in the error returned when could not find the node attestor type.