### PR TITLE
Introduce Agent KeyManager Facade interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ plugingen_plugins = \
 	proto/spire/server/keymanager/keymanager.proto,pkg/server/plugin/keymanager,KeyManager \
 	proto/spire/agent/nodeattestor/nodeattestor.proto,proto/spire/agent/nodeattestor/v0,NodeAttestor \
 	proto/spire/agent/workloadattestor/workloadattestor.proto,pkg/agent/plugin/workloadattestor,WorkloadAttestor \
-	proto/spire/agent/keymanager/keymanager.proto,pkg/agent/plugin/keymanager,KeyManager \
+	proto/spire/agent/keymanager/keymanager.proto,proto/spire/agent/keymanager/v0,KeyManager \
 	proto/spire/agent/svidstore/svidstore.proto,pkg/agent/plugin/svidstore,SVIDStore \
 	proto/private/test/catalogtest/test.proto,proto/private/test/catalogtest,Plugin,shared \
 

--- a/pkg/agent/attestor/node/node.go
+++ b/pkg/agent/attestor/node/node.go
@@ -2,7 +2,7 @@ package attestor
 
 import (
 	"context"
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -14,7 +14,6 @@ import (
 	"github.com/spiffe/spire/pkg/agent/catalog"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/manager"
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -25,12 +24,14 @@ import (
 	"github.com/zeebo/errs"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/status"
 )
 
 type AttestationResult struct {
 	SVID   []*x509.Certificate
-	Key    *ecdsa.PrivateKey
+	Key    crypto.Signer
 	Bundle *bundleutil.Bundle
 }
 
@@ -99,24 +100,24 @@ func (a *attestor) Attest(ctx context.Context) (res *AttestationResult, err erro
 }
 
 // Load the current SVID and key. The returned SVID is nil to indicate a new SVID should be created.
-func (a *attestor) loadSVID(ctx context.Context) ([]*x509.Certificate, *ecdsa.PrivateKey, error) {
+func (a *attestor) loadSVID(ctx context.Context) ([]*x509.Certificate, crypto.Signer, error) {
 	km := a.c.Catalog.GetKeyManager()
-	fetchRes, err := km.FetchPrivateKey(ctx, &keymanager.FetchPrivateKeyRequest{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("load private key: %v", err)
+	key, err := km.GetKey(ctx)
+	switch status.Code(err) {
+	case codes.OK:
+	case codes.NotFound:
+	default:
+		return nil, nil, fmt.Errorf("unable to load private key: %v", err)
 	}
+
 	svid := a.readSVIDFromDisk()
 
-	privateKeyExists := len(fetchRes.PrivateKey) > 0
+	privateKeyExists := key != nil
 	svidExists := svid != nil
 	svidIsExpired := IsSVIDExpired(svid, time.Now)
 
 	switch {
 	case privateKeyExists && svidExists && !svidIsExpired:
-		key, err := x509.ParseECPrivateKey(fetchRes.PrivateKey)
-		if err != nil {
-			return nil, nil, fmt.Errorf("parse key from keymanager: %v", key)
-		}
 		return svid, key, nil
 	case privateKeyExists && svidExists && svidIsExpired:
 		a.c.Log.WithField("expiry", svid[0].NotAfter).Warn("Private key recovered, but SVID is expired. Generating new keypair")
@@ -128,13 +129,9 @@ func (a *attestor) loadSVID(ctx context.Context) ([]*x509.Certificate, *ecdsa.Pr
 		// Neither private key nor SVID were found.
 	}
 
-	generateRes, err := km.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	key, err = km.GenerateKey(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("generate key pair: %s", err)
-	}
-	key, err := x509.ParseECPrivateKey(generateRes.PrivateKey)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parse key from keymanager: %v", key)
+		return nil, nil, fmt.Errorf("unable to generate private key: %v", err)
 	}
 	return nil, key, nil
 }
@@ -191,7 +188,7 @@ func (a *attestor) readSVIDFromDisk() []*x509.Certificate {
 
 // newSVID obtains an agent svid for the given private key by performing node attesatation. The bundle is
 // necessary in order to validate the SPIRE server we are attesting to. Returns the SVID and an updated bundle.
-func (a *attestor) newSVID(ctx context.Context, key *ecdsa.PrivateKey, bundle *bundleutil.Bundle) (_ []*x509.Certificate, _ *bundleutil.Bundle, err error) {
+func (a *attestor) newSVID(ctx context.Context, key crypto.Signer, bundle *bundleutil.Bundle) (_ []*x509.Certificate, _ *bundleutil.Bundle, err error) {
 	counter := telemetry_agent.StartNodeAttestorNewSVIDCall(a.c.Metrics)
 	defer counter.Done(&err)
 

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"context"
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -59,7 +59,7 @@ type Config struct {
 	TrustDomain spiffeid.TrustDomain
 	// KeysAndBundle is a callback that must return the keys and bundle used by the client
 	// to connect via mTLS to Addr.
-	KeysAndBundle func() ([]*x509.Certificate, *ecdsa.PrivateKey, []*x509.Certificate)
+	KeysAndBundle func() ([]*x509.Certificate, crypto.Signer, []*x509.Certificate)
 
 	// RotMtx is used to prevent the creation of new connections during SVID rotations
 	RotMtx *sync.RWMutex

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"context"
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/x509"
 	"errors"
 	"sync"
@@ -742,7 +742,7 @@ func createClient() (*client, *testClient) {
 	return client, tc
 }
 
-func keysAndBundle() ([]*x509.Certificate, *ecdsa.PrivateKey, []*x509.Certificate) {
+func keysAndBundle() ([]*x509.Certificate, crypto.Signer, []*x509.Certificate) {
 	return nil, nil, nil
 }
 

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -1,7 +1,7 @@
 package manager
 
 import (
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/x509"
 	"sync"
 	"time"
@@ -19,7 +19,7 @@ import (
 type Config struct {
 	// Agent SVID and key resulting from successful attestation.
 	SVID             []*x509.Certificate
-	SVIDKey          *ecdsa.PrivateKey
+	SVIDKey          crypto.Signer
 	Bundle           *cache.Bundle
 	Catalog          catalog.Catalog
 	TrustDomain      spiffeid.TrustDomain

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -2,7 +2,7 @@ package manager
 
 import (
 	"context"
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -15,7 +15,6 @@ import (
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/common/backoff"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/agent/svid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/nodeutil"
@@ -316,18 +315,9 @@ func (m *manager) storeBundle(bundle *bundleutil.Bundle) {
 	}
 }
 
-func (m *manager) storePrivateKey(ctx context.Context, key *ecdsa.PrivateKey) error {
+func (m *manager) storePrivateKey(ctx context.Context, key crypto.Signer) error {
 	km := m.c.Catalog.GetKeyManager()
-	keyBytes, err := x509.MarshalECPrivateKey(key)
-	if err != nil {
-		return err
-	}
-
-	if _, err = km.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: keyBytes}); err != nil {
-		return err
-	}
-
-	return nil
+	return km.SetKey(ctx, key)
 }
 
 func (m *manager) deleteSVID() {

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -194,7 +194,7 @@ func TestStoreKeyOnStartup(t *testing.T) {
 	}
 
 	_, err := km.GetKey(context.Background())
-	spiretest.RequireGRPCStatus(t, err, codes.NotFound, "keymanager(disk): key not found")
+	spiretest.RequireGRPCStatus(t, err, codes.NotFound, "keymanager(disk): private key not found")
 
 	m := newManager(c)
 	require.Error(t, m.Initialize(context.Background()))

--- a/pkg/agent/plugin/keymanager/disk/disk.go
+++ b/pkg/agent/plugin/keymanager/disk/disk.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl"
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
 
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
@@ -31,7 +31,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, keymanager.PluginServer(p))
+	return catalog.MakePlugin(pluginName, keymanagerv0.PluginServer(p))
 }
 
 type Config struct {
@@ -39,7 +39,7 @@ type Config struct {
 }
 
 type Plugin struct {
-	keymanager.UnsafeKeyManagerServer
+	keymanagerv0.UnsafeKeyManagerServer
 
 	mtx *sync.RWMutex
 	dir string
@@ -51,7 +51,7 @@ func New() *Plugin {
 	}
 }
 
-func (d *Plugin) GenerateKeyPair(context.Context, *keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
+func (d *Plugin) GenerateKeyPair(context.Context, *keymanagerv0.GenerateKeyPairRequest) (*keymanagerv0.GenerateKeyPairResponse, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
@@ -67,11 +67,11 @@ func (d *Plugin) GenerateKeyPair(context.Context, *keymanager.GenerateKeyPairReq
 		return nil, err
 	}
 
-	resp := &keymanager.GenerateKeyPairResponse{PublicKey: pubData, PrivateKey: privData}
+	resp := &keymanagerv0.GenerateKeyPairResponse{PublicKey: pubData, PrivateKey: privData}
 	return resp, nil
 }
 
-func (d *Plugin) StorePrivateKey(ctx context.Context, req *keymanager.StorePrivateKeyRequest) (*keymanager.StorePrivateKeyResponse, error) {
+func (d *Plugin) StorePrivateKey(ctx context.Context, req *keymanagerv0.StorePrivateKeyRequest) (*keymanagerv0.StorePrivateKeyResponse, error) {
 	d.mtx.Lock()
 	defer d.mtx.Unlock()
 
@@ -84,12 +84,12 @@ func (d *Plugin) StorePrivateKey(ctx context.Context, req *keymanager.StorePriva
 		return nil, err
 	}
 
-	return &keymanager.StorePrivateKeyResponse{}, nil
+	return &keymanagerv0.StorePrivateKeyResponse{}, nil
 }
 
-func (d *Plugin) FetchPrivateKey(context.Context, *keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {
+func (d *Plugin) FetchPrivateKey(context.Context, *keymanagerv0.FetchPrivateKeyRequest) (*keymanagerv0.FetchPrivateKeyResponse, error) {
 	// Start with empty response
-	resp := &keymanager.FetchPrivateKeyResponse{PrivateKey: []byte{}}
+	resp := &keymanagerv0.FetchPrivateKeyResponse{PrivateKey: []byte{}}
 
 	d.mtx.RLock()
 	p := path.Join(d.dir, keyFileName)

--- a/pkg/agent/plugin/keymanager/disk/disk_test.go
+++ b/pkg/agent/plugin/keymanager/disk/disk_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 )
@@ -29,9 +29,9 @@ func TestDisk_GenerateKeyPair(t *testing.T) {
 	plugin := New()
 	plugin.dir = tempDir
 
-	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	genResp, err := plugin.GenerateKeyPair(ctx, &keymanagerv0.GenerateKeyPairRequest{})
 	require.NoError(t, err)
-	_, err = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
+	_, err = plugin.StorePrivateKey(ctx, &keymanagerv0.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
 	require.NoError(t, err)
 	_, err = os.Stat(path.Join(tempDir, keyFileName))
 	assert.False(t, os.IsNotExist(err))
@@ -51,12 +51,12 @@ func TestDisk_FetchPrivateKey(t *testing.T) {
 	plugin := New()
 	plugin.dir = tempDir
 
-	genResp, err := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	genResp, err := plugin.GenerateKeyPair(ctx, &keymanagerv0.GenerateKeyPairRequest{})
 	require.NoError(t, err)
-	_, err = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
+	_, err = plugin.StorePrivateKey(ctx, &keymanagerv0.StorePrivateKeyRequest{PrivateKey: genResp.PrivateKey})
 	require.NoError(t, err)
 
-	fetchResp, err := plugin.FetchPrivateKey(ctx, &keymanager.FetchPrivateKeyRequest{})
+	fetchResp, err := plugin.FetchPrivateKey(ctx, &keymanagerv0.FetchPrivateKeyRequest{})
 	require.NoError(t, err)
 	assert.Equal(t, genResp.PrivateKey, fetchResp.PrivateKey)
 }

--- a/pkg/agent/plugin/keymanager/keymanager.go
+++ b/pkg/agent/plugin/keymanager/keymanager.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 )
 
-// KeyManager is provides a signing key for the agent
+// KeyManager provides a signing key for the agent
 type KeyManager interface {
 	// GenerateKey generates a temporary key. It will not be the key returned
 	// by GetKey until after SetKey has been called.
@@ -14,6 +14,6 @@ type KeyManager interface {
 	// GetKey returns a Key previously set with SetKey.
 	GetKey(ctx context.Context) (crypto.Signer, error)
 
-	// SetKey sets the key is returned by GetKey.
+	// SetKey sets the key that is returned by GetKey.
 	SetKey(ctx context.Context, key crypto.Signer) error
 }

--- a/pkg/agent/plugin/keymanager/keymanager.go
+++ b/pkg/agent/plugin/keymanager/keymanager.go
@@ -1,109 +1,19 @@
-// Provides interfaces and adapters for the KeyManager service
-//
-// Generated code. Do not modify by hand.
 package keymanager
 
 import (
 	"context"
-
-	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/proto/spire/agent/keymanager"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"google.golang.org/grpc"
+	"crypto"
 )
 
-type FetchPrivateKeyRequest = keymanager.FetchPrivateKeyRequest               //nolint: golint
-type FetchPrivateKeyResponse = keymanager.FetchPrivateKeyResponse             //nolint: golint
-type GenerateKeyPairRequest = keymanager.GenerateKeyPairRequest               //nolint: golint
-type GenerateKeyPairResponse = keymanager.GenerateKeyPairResponse             //nolint: golint
-type KeyManagerClient = keymanager.KeyManagerClient                           //nolint: golint
-type KeyManagerServer = keymanager.KeyManagerServer                           //nolint: golint
-type StorePrivateKeyRequest = keymanager.StorePrivateKeyRequest               //nolint: golint
-type StorePrivateKeyResponse = keymanager.StorePrivateKeyResponse             //nolint: golint
-type UnimplementedKeyManagerServer = keymanager.UnimplementedKeyManagerServer //nolint: golint
-type UnsafeKeyManagerServer = keymanager.UnsafeKeyManagerServer               //nolint: golint
-
-const (
-	Type = "KeyManager"
-)
-
-// KeyManager is the client interface for the service type KeyManager interface.
+// KeyManager is provides a signing key for the agent
 type KeyManager interface {
-	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
-	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
-	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
-}
+	// GenerateKey generates a temporary key. It will not be the key returned
+	// by GetKey until after SetKey has been called.
+	GenerateKey(ctx context.Context) (crypto.Signer, error)
 
-// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
-type Plugin interface {
-	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
-	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
-	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
-	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
-	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
-}
+	// GetKey returns a Key previously set with SetKey.
+	GetKey(ctx context.Context) (crypto.Signer, error)
 
-// PluginServer returns a catalog PluginServer implementation for the KeyManager plugin.
-func PluginServer(server KeyManagerServer) catalog.PluginServer {
-	return &pluginServer{
-		server: server,
-	}
-}
-
-type pluginServer struct {
-	server KeyManagerServer
-}
-
-func (s pluginServer) PluginType() string {
-	return Type
-}
-
-func (s pluginServer) PluginClient() catalog.PluginClient {
-	return PluginClient
-}
-
-func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
-	keymanager.RegisterKeyManagerServer(server, s.server)
-	return s.server
-}
-
-// PluginClient is a catalog PluginClient implementation for the KeyManager plugin.
-var PluginClient catalog.PluginClient = pluginClient{}
-
-type pluginClient struct{}
-
-func (pluginClient) PluginType() string {
-	return Type
-}
-
-func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
-	return AdaptPluginClient(keymanager.NewKeyManagerClient(conn))
-}
-
-func AdaptPluginClient(client KeyManagerClient) KeyManager {
-	return pluginClientAdapter{client: client}
-}
-
-type pluginClientAdapter struct {
-	client KeyManagerClient
-}
-
-func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return a.client.Configure(ctx, in)
-}
-
-func (a pluginClientAdapter) FetchPrivateKey(ctx context.Context, in *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
-	return a.client.FetchPrivateKey(ctx, in)
-}
-
-func (a pluginClientAdapter) GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
-	return a.client.GenerateKeyPair(ctx, in)
-}
-
-func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return a.client.GetPluginInfo(ctx, in)
-}
-
-func (a pluginClientAdapter) StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error) {
-	return a.client.StorePrivateKey(ctx, in)
+	// SetKey sets the key is returned by GetKey.
+	SetKey(ctx context.Context, key crypto.Signer) error
 }

--- a/pkg/agent/plugin/keymanager/memory/memory_test.go
+++ b/pkg/agent/plugin/keymanager/memory/memory_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
 
@@ -18,9 +18,9 @@ var (
 
 func TestMemory_GenerateKeyPair(t *testing.T) {
 	plugin := New()
-	data, e := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	data, e := plugin.GenerateKeyPair(ctx, &keymanagerv0.GenerateKeyPairRequest{})
 	require.NoError(t, e)
-	_, e = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
+	_, e = plugin.StorePrivateKey(ctx, &keymanagerv0.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
 	require.NoError(t, e)
 	priv, err := x509.ParseECPrivateKey(data.PrivateKey)
 	require.NoError(t, err)
@@ -29,12 +29,12 @@ func TestMemory_GenerateKeyPair(t *testing.T) {
 
 func TestMemory_FetchPrivateKey(t *testing.T) {
 	plugin := New()
-	data, e := plugin.GenerateKeyPair(ctx, &keymanager.GenerateKeyPairRequest{})
+	data, e := plugin.GenerateKeyPair(ctx, &keymanagerv0.GenerateKeyPairRequest{})
 	require.NoError(t, e)
-	_, e = plugin.StorePrivateKey(ctx, &keymanager.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
+	_, e = plugin.StorePrivateKey(ctx, &keymanagerv0.StorePrivateKeyRequest{PrivateKey: data.PrivateKey})
 	require.NoError(t, e)
 
-	priv, e := plugin.FetchPrivateKey(ctx, &keymanager.FetchPrivateKeyRequest{})
+	priv, e := plugin.FetchPrivateKey(ctx, &keymanagerv0.FetchPrivateKeyRequest{})
 	require.NoError(t, e)
 	assert.Equal(t, priv.PrivateKey, data.PrivateKey)
 }

--- a/pkg/agent/plugin/keymanager/v0.go
+++ b/pkg/agent/plugin/keymanager/v0.go
@@ -25,7 +25,7 @@ func (v0 V0) GenerateKey(ctx context.Context) (crypto.Signer, error) {
 	}
 
 	if resp.PrivateKey == nil {
-		return nil, v0.Error(codes.Internal, "plugin generate key pair response missing private key")
+		return nil, v0.Error(codes.Internal, "plugin response missing private key")
 	}
 
 	ecKey, err := x509.ParseECPrivateKey(resp.PrivateKey)
@@ -43,7 +43,7 @@ func (v0 V0) GetKey(ctx context.Context) (crypto.Signer, error) {
 	}
 
 	if resp.PrivateKey == nil {
-		return nil, v0.Error(codes.NotFound, "key not found")
+		return nil, v0.Error(codes.NotFound, "private key not found")
 	}
 
 	ecKey, err := x509.ParseECPrivateKey(resp.PrivateKey)

--- a/pkg/agent/plugin/keymanager/v0.go
+++ b/pkg/agent/plugin/keymanager/v0.go
@@ -1,0 +1,75 @@
+package keymanager
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/proto/spire/agent/keymanager"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
+	"google.golang.org/grpc/codes"
+)
+
+type V0 struct {
+	plugin.Facade
+
+	Plugin keymanagerv0.KeyManager
+}
+
+func (v0 V0) GenerateKey(ctx context.Context) (crypto.Signer, error) {
+	resp, err := v0.Plugin.GenerateKeyPair(ctx, &keymanagerv0.GenerateKeyPairRequest{})
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+
+	if resp.PrivateKey == nil {
+		return nil, v0.Error(codes.Internal, "plugin generate key pair response missing private key")
+	}
+
+	ecKey, err := x509.ParseECPrivateKey(resp.PrivateKey)
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+
+	return ecKey, nil
+}
+
+func (v0 V0) GetKey(ctx context.Context) (crypto.Signer, error) {
+	resp, err := v0.Plugin.FetchPrivateKey(ctx, &keymanagerv0.FetchPrivateKeyRequest{})
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+
+	if resp.PrivateKey == nil {
+		return nil, v0.Error(codes.NotFound, "key not found")
+	}
+
+	ecKey, err := x509.ParseECPrivateKey(resp.PrivateKey)
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+
+	return ecKey, nil
+}
+
+func (v0 V0) SetKey(ctx context.Context, key crypto.Signer) error {
+	ecKey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return v0.Error(codes.Internal, "v0 key manager only supports ECDSA keys")
+	}
+
+	keyBytes, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		return v0.Errorf(codes.Internal, "failed unexpectedly to marshal private key: %v", err)
+	}
+
+	if _, err := v0.Plugin.StorePrivateKey(context.Background(), &keymanager.StorePrivateKeyRequest{
+		PrivateKey: keyBytes,
+	}); err != nil {
+		return v0.WrapErr(err)
+	}
+
+	return nil
+}

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -1,7 +1,7 @@
 package svid
 
 import (
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/x509"
 	"sync"
 	"time"
@@ -27,7 +27,7 @@ type RotatorConfig struct {
 	ServerAddr  string
 	// Initial SVID and key
 	SVID    []*x509.Certificate
-	SVIDKey *ecdsa.PrivateKey
+	SVIDKey crypto.Signer
 
 	BundleStream *cache.BundleStream
 
@@ -64,7 +64,7 @@ func newRotator(c *RotatorConfig) (*rotator, client.Client) {
 		Log:         c.Log,
 		Addr:        c.ServerAddr,
 		RotMtx:      rotMtx,
-		KeysAndBundle: func() ([]*x509.Certificate, *ecdsa.PrivateKey, []*x509.Certificate) {
+		KeysAndBundle: func() ([]*x509.Certificate, crypto.Signer, []*x509.Certificate) {
 			s := state.Value().(State)
 
 			bsm.RLock()

--- a/pkg/common/telemetry/agent/keymanager/wrapper.go
+++ b/pkg/common/telemetry/agent/keymanager/wrapper.go
@@ -3,35 +3,35 @@ package keymanager
 import (
 	"context"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
 )
 
 type agentKeyManagerWrapper struct {
 	m telemetry.Metrics
-	k keymanager.KeyManager
+	k keymanagerv0.KeyManager
 }
 
-func WithMetrics(km keymanager.KeyManager, metrics telemetry.Metrics) keymanager.KeyManager {
+func WithMetrics(km keymanagerv0.KeyManager, metrics telemetry.Metrics) keymanagerv0.KeyManager {
 	return agentKeyManagerWrapper{
 		m: metrics,
 		k: km,
 	}
 }
 
-func (w agentKeyManagerWrapper) GenerateKeyPair(ctx context.Context, req *keymanager.GenerateKeyPairRequest) (_ *keymanager.GenerateKeyPairResponse, err error) {
+func (w agentKeyManagerWrapper) GenerateKeyPair(ctx context.Context, req *keymanagerv0.GenerateKeyPairRequest) (_ *keymanagerv0.GenerateKeyPairResponse, err error) {
 	callCounter := StartGenerateKeyPairCall(w.m)
 	defer callCounter.Done(&err)
 	return w.k.GenerateKeyPair(ctx, req)
 }
 
-func (w agentKeyManagerWrapper) FetchPrivateKey(ctx context.Context, req *keymanager.FetchPrivateKeyRequest) (_ *keymanager.FetchPrivateKeyResponse, err error) {
+func (w agentKeyManagerWrapper) FetchPrivateKey(ctx context.Context, req *keymanagerv0.FetchPrivateKeyRequest) (_ *keymanagerv0.FetchPrivateKeyResponse, err error) {
 	callCounter := StartFetchPrivateKeyCall(w.m)
 	defer callCounter.Done(&err)
 	return w.k.FetchPrivateKey(ctx, req)
 }
 
-func (w agentKeyManagerWrapper) StorePrivateKey(ctx context.Context, req *keymanager.StorePrivateKeyRequest) (_ *keymanager.StorePrivateKeyResponse, err error) {
+func (w agentKeyManagerWrapper) StorePrivateKey(ctx context.Context, req *keymanagerv0.StorePrivateKeyRequest) (_ *keymanagerv0.StorePrivateKeyResponse, err error) {
 	callCounter := StartStorePrivateKeyCall(w.m)
 	defer callCounter.Done(&err)
 	return w.k.StorePrivateKey(ctx, req)

--- a/pkg/common/telemetry/agent/keymanager/wrapper_test.go
+++ b/pkg/common/telemetry/agent/keymanager/wrapper_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
 	"github.com/spiffe/spire/test/fakes/fakemetrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,15 +14,15 @@ import (
 
 type mockKeyManager struct{}
 
-func (mockKeyManager) GenerateKeyPair(ctx context.Context, req *keymanager.GenerateKeyPairRequest) (*keymanager.GenerateKeyPairResponse, error) {
+func (mockKeyManager) GenerateKeyPair(ctx context.Context, req *keymanagerv0.GenerateKeyPairRequest) (*keymanagerv0.GenerateKeyPairResponse, error) {
 	return nil, nil
 }
 
-func (mockKeyManager) FetchPrivateKey(ctx context.Context, req *keymanager.FetchPrivateKeyRequest) (*keymanager.FetchPrivateKeyResponse, error) {
+func (mockKeyManager) FetchPrivateKey(ctx context.Context, req *keymanagerv0.FetchPrivateKeyRequest) (*keymanagerv0.FetchPrivateKeyResponse, error) {
 	return nil, nil
 }
 
-func (mockKeyManager) StorePrivateKey(ctx context.Context, req *keymanager.StorePrivateKeyRequest) (*keymanager.StorePrivateKeyResponse, error) {
+func (mockKeyManager) StorePrivateKey(ctx context.Context, req *keymanagerv0.StorePrivateKeyRequest) (*keymanagerv0.StorePrivateKeyResponse, error) {
 	return nil, nil
 }
 

--- a/proto/spire/agent/keymanager/v0/keymanager.go
+++ b/proto/spire/agent/keymanager/v0/keymanager.go
@@ -1,0 +1,109 @@
+// Provides interfaces and adapters for the KeyManager service
+//
+// Generated code. Do not modify by hand.
+package v0
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/proto/spire/agent/keymanager"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"google.golang.org/grpc"
+)
+
+type FetchPrivateKeyRequest = keymanager.FetchPrivateKeyRequest               //nolint: golint
+type FetchPrivateKeyResponse = keymanager.FetchPrivateKeyResponse             //nolint: golint
+type GenerateKeyPairRequest = keymanager.GenerateKeyPairRequest               //nolint: golint
+type GenerateKeyPairResponse = keymanager.GenerateKeyPairResponse             //nolint: golint
+type KeyManagerClient = keymanager.KeyManagerClient                           //nolint: golint
+type KeyManagerServer = keymanager.KeyManagerServer                           //nolint: golint
+type StorePrivateKeyRequest = keymanager.StorePrivateKeyRequest               //nolint: golint
+type StorePrivateKeyResponse = keymanager.StorePrivateKeyResponse             //nolint: golint
+type UnimplementedKeyManagerServer = keymanager.UnimplementedKeyManagerServer //nolint: golint
+type UnsafeKeyManagerServer = keymanager.UnsafeKeyManagerServer               //nolint: golint
+
+const (
+	Type = "KeyManager"
+)
+
+// KeyManager is the client interface for the service type KeyManager interface.
+type KeyManager interface {
+	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
+	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
+	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
+}
+
+// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
+type Plugin interface {
+	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
+	FetchPrivateKey(context.Context, *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error)
+	GenerateKeyPair(context.Context, *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error)
+	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+	StorePrivateKey(context.Context, *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error)
+}
+
+// PluginServer returns a catalog PluginServer implementation for the KeyManager plugin.
+func PluginServer(server KeyManagerServer) catalog.PluginServer {
+	return &pluginServer{
+		server: server,
+	}
+}
+
+type pluginServer struct {
+	server KeyManagerServer
+}
+
+func (s pluginServer) PluginType() string {
+	return Type
+}
+
+func (s pluginServer) PluginClient() catalog.PluginClient {
+	return PluginClient
+}
+
+func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
+	keymanager.RegisterKeyManagerServer(server, s.server)
+	return s.server
+}
+
+// PluginClient is a catalog PluginClient implementation for the KeyManager plugin.
+var PluginClient catalog.PluginClient = pluginClient{}
+
+type pluginClient struct{}
+
+func (pluginClient) PluginType() string {
+	return Type
+}
+
+func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
+	return AdaptPluginClient(keymanager.NewKeyManagerClient(conn))
+}
+
+func AdaptPluginClient(client KeyManagerClient) KeyManager {
+	return pluginClientAdapter{client: client}
+}
+
+type pluginClientAdapter struct {
+	client KeyManagerClient
+}
+
+func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return a.client.Configure(ctx, in)
+}
+
+func (a pluginClientAdapter) FetchPrivateKey(ctx context.Context, in *FetchPrivateKeyRequest) (*FetchPrivateKeyResponse, error) {
+	return a.client.FetchPrivateKey(ctx, in)
+}
+
+func (a pluginClientAdapter) GenerateKeyPair(ctx context.Context, in *GenerateKeyPairRequest) (*GenerateKeyPairResponse, error) {
+	return a.client.GenerateKeyPair(ctx, in)
+}
+
+func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return a.client.GetPluginInfo(ctx, in)
+}
+
+func (a pluginClientAdapter) StorePrivateKey(ctx context.Context, in *StorePrivateKeyRequest) (*StorePrivateKeyResponse, error) {
+	return a.client.StorePrivateKey(ctx, in)
+}

--- a/test/fakes/fakeagentcatalog/catalog.go
+++ b/test/fakes/fakeagentcatalog/catalog.go
@@ -15,7 +15,7 @@ func New() *Catalog {
 	return &Catalog{}
 }
 
-func (c *Catalog) SetKeyManager(keyManager catalog.KeyManager) {
+func (c *Catalog) SetKeyManager(keyManager keymanager.KeyManager) {
 	c.KeyManager = keyManager
 }
 
@@ -25,12 +25,6 @@ func (c *Catalog) SetNodeAttestor(nodeAttestor nodeattestor.NodeAttestor) {
 
 func (c *Catalog) SetWorkloadAttestors(workloadAttestors ...catalog.WorkloadAttestor) {
 	c.WorkloadAttestors = workloadAttestors
-}
-
-func KeyManager(keyManager keymanager.KeyManager) catalog.KeyManager {
-	return catalog.KeyManager{
-		KeyManager: keyManager,
-	}
 }
 
 func WorkloadAttestor(name string, workloadAttestor workloadattestor.WorkloadAttestor) catalog.WorkloadAttestor {

--- a/test/fakes/fakeagentkeymanager/keymanager.go
+++ b/test/fakes/fakeagentkeymanager/keymanager.go
@@ -1,0 +1,45 @@
+package fakeagentkeymanager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/disk"
+	"github.com/spiffe/spire/pkg/agent/plugin/keymanager/memory"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	keymanagerv0 "github.com/spiffe/spire/proto/spire/agent/keymanager/v0"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+)
+
+// New returns a fake key manager
+func New(t *testing.T, dir string) keymanager.KeyManager {
+	configuration := ""
+	builtIn := memory.BuiltIn()
+	if dir != "" {
+		builtIn = disk.BuiltIn()
+		configuration = fmt.Sprintf("directory = %q", dir)
+	}
+
+	// This little workaround to get at the configuration interface
+	// won't be required after the catalog system refactor
+	raw := struct {
+		plugin.Facade
+		keymanagerv0.Plugin
+	}{}
+
+	spiretest.LoadPlugin(t, builtIn, &raw)
+
+	_, err := raw.Configure(context.Background(), &spi.ConfigureRequest{
+		Configuration: configuration,
+	})
+	require.NoError(t, err)
+
+	return keymanager.V0{
+		Facade: raw.Facade,
+		Plugin: raw.Plugin,
+	}
+}


### PR DESCRIPTION
This is the next facade introduced as part of #2153. Some of the changes are a little forward thinking towards the eventual adoption of a more server-like keymanager by switching out the use of `*ecdsa.PrivateKey` everywhere with the more generic `crypto.Signer`.