### PR TITLE
Introduce Agent WorkloadAttestor Facade interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ plugingen_plugins = \
 	proto/spire/server/noderesolver/noderesolver.proto,pkg/server/plugin/noderesolver,NodeResolver \
 	proto/spire/server/keymanager/keymanager.proto,pkg/server/plugin/keymanager,KeyManager \
 	proto/spire/agent/nodeattestor/nodeattestor.proto,proto/spire/agent/nodeattestor/v0,NodeAttestor \
-	proto/spire/agent/workloadattestor/workloadattestor.proto,pkg/agent/plugin/workloadattestor,WorkloadAttestor \
+	proto/spire/agent/workloadattestor/workloadattestor.proto,proto/spire/agent/workloadattestor/v0,WorkloadAttestor \
 	proto/spire/agent/keymanager/keymanager.proto,proto/spire/agent/keymanager/v0,KeyManager \
 	proto/spire/agent/svidstore/svidstore.proto,pkg/agent/plugin/svidstore,SVIDStore \
 	proto/private/test/catalogtest/test.proto,proto/private/test/catalogtest,Plugin,shared \

--- a/pkg/agent/endpoints/peertracker.go
+++ b/pkg/agent/endpoints/peertracker.go
@@ -20,7 +20,7 @@ func (a peerTrackerAttestor) Attest(ctx context.Context) ([]*common.Selector, er
 		return nil, status.Error(codes.Internal, "peer tracker watcher missing from context")
 	}
 
-	selectors := a.Attestor.Attest(ctx, watcher.PID())
+	selectors := a.Attestor.Attest(ctx, int(watcher.PID()))
 
 	// Ensure that the original caller is still alive so that we know we didn't
 	// attest some other process that happened to be assigned the original PID

--- a/pkg/agent/endpoints/peertracker_test.go
+++ b/pkg/agent/endpoints/peertracker_test.go
@@ -37,8 +37,8 @@ func TestPeerTrackerAttestor(t *testing.T) {
 
 type FakeAttestor struct{}
 
-func (a FakeAttestor) Attest(ctx context.Context, pid int32) []*common.Selector {
-	if int(pid) == os.Getpid() {
+func (a FakeAttestor) Attest(ctx context.Context, pid int) []*common.Selector {
+	if pid == os.Getpid() {
 		return []*common.Selector{{Type: "Type", Value: "Value"}}
 	}
 	return nil

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -13,9 +13,9 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/agent/common/cgroups"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/cgroup"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 )
@@ -32,7 +32,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, workloadattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, workloadattestorv0.PluginServer(p))
 }
 
 // Docker is a subset of the docker client functionality, useful for mocking.
@@ -41,7 +41,7 @@ type Docker interface {
 }
 
 type Plugin struct {
-	workloadattestor.UnsafeWorkloadAttestorServer
+	workloadattestorv0.UnsafeWorkloadAttestorServer
 
 	log     hclog.Logger
 	fs      cgroups.FileSystem
@@ -73,7 +73,7 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
+func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv0.AttestRequest) (*workloadattestorv0.AttestResponse, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
@@ -88,7 +88,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		return nil, err
 	case containerID == "":
 		// Not a docker workload. Nothing more to do.
-		return &workloadattestor.AttestResponse{}, nil
+		return &workloadattestorv0.AttestResponse{}, nil
 	}
 
 	var container types.ContainerJSON
@@ -103,7 +103,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		return nil, err
 	}
 
-	return &workloadattestor.AttestResponse{
+	return &workloadattestorv0.AttestResponse{
 		Selectors: getSelectorsFromConfig(container.Config),
 	}, nil
 }

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/spiffe/spire/pkg/agent/common/cgroups"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/util"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/clock"
@@ -131,7 +131,7 @@ FwOGLt+I3+9beT0vo+pn9Rq0squewFYe3aJbwpkyfP2xOovQCdm4PC8y
 )
 
 type attestResult struct {
-	resp *workloadattestor.AttestResponse
+	resp *workloadattestorv0.AttestResponse
 	err  error
 }
 
@@ -144,7 +144,7 @@ type Suite struct {
 
 	dir   string
 	clock *clock.Mock
-	p     workloadattestor.Plugin
+	p     workloadattestorv0.Plugin
 
 	podList [][]byte
 	env     map[string]string
@@ -234,7 +234,7 @@ func (s *Suite) TestAttestWithPidNotInPodCancelsEarly() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	resp, err := s.p.Attest(ctx, &workloadattestor.AttestRequest{
+	resp, err := s.p.Attest(ctx, &workloadattestorv0.AttestRequest{
 		Pid: int32(pid),
 	})
 	s.RequireGRPCStatus(err, codes.Canceled, "context canceled")
@@ -276,7 +276,7 @@ func (s *Suite) TestAttestWithPidNotInPod() {
 	s.configureInsecure()
 	s.addCgroupsResponse(cgPidNotInPodFilePath)
 
-	resp, err := s.p.Attest(context.Background(), &workloadattestor.AttestRequest{
+	resp, err := s.p.Attest(context.Background(), &workloadattestorv0.AttestRequest{
 		Pid: int32(pid),
 	})
 	s.Require().NoError(err)
@@ -347,7 +347,7 @@ func (s *Suite) TestAttestAgainstNodeOverride() {
 	s.configureInsecure()
 	s.addCgroupsResponse(cgPidNotInPodFilePath)
 
-	resp, err := s.p.Attest(context.Background(), &workloadattestor.AttestRequest{
+	resp, err := s.p.Attest(context.Background(), &workloadattestorv0.AttestRequest{
 		Pid: int32(pid),
 	})
 	s.Require().NoError(err)
@@ -626,7 +626,7 @@ func (s *Suite) TestGetPluginInfo() {
 	s.AssertProtoEqual(&spi.GetPluginInfoResponse{}, resp)
 }
 
-func (s *Suite) newPlugin() (*Plugin, workloadattestor.Plugin) {
+func (s *Suite) newPlugin() (*Plugin, workloadattestorv0.Plugin) {
 	p := New()
 	p.fs = testFS(s.dir)
 	p.clock = s.clock
@@ -634,7 +634,7 @@ func (s *Suite) newPlugin() (*Plugin, workloadattestor.Plugin) {
 		return s.env[key]
 	}
 
-	var wp workloadattestor.Plugin
+	var wp workloadattestorv0.Plugin
 	s.LoadPlugin(builtin(p), &wp)
 	return p, wp
 }
@@ -824,7 +824,7 @@ func (s *Suite) requireAttestSuccessWithInitPod() {
 }
 
 func (s *Suite) requireAttestSuccess(expectedSelectors []*common.Selector) {
-	resp, err := s.p.Attest(context.Background(), &workloadattestor.AttestRequest{
+	resp, err := s.p.Attest(context.Background(), &workloadattestorv0.AttestRequest{
 		Pid: int32(pid),
 	})
 	s.Require().NoError(err)
@@ -832,7 +832,7 @@ func (s *Suite) requireAttestSuccess(expectedSelectors []*common.Selector) {
 }
 
 func (s *Suite) requireAttestFailure(contains string) {
-	resp, err := s.p.Attest(context.Background(), &workloadattestor.AttestRequest{
+	resp, err := s.p.Attest(context.Background(), &workloadattestorv0.AttestRequest{
 		Pid: int32(pid),
 	})
 	s.RequireGRPCStatusContains(err, codes.Unknown, contains)
@@ -848,7 +848,7 @@ func (s *Suite) requireSelectorsEqual(expected, actual []*common.Selector) {
 func (s *Suite) goAttest() <-chan attestResult {
 	resultCh := make(chan attestResult, 1)
 	go func() {
-		resp, err := s.p.Attest(context.Background(), &workloadattestor.AttestRequest{
+		resp, err := s.p.Attest(context.Background(), &workloadattestorv0.AttestRequest{
 			Pid: int32(pid),
 		})
 		resultCh <- attestResult{

--- a/pkg/agent/plugin/workloadattestor/unix/unix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix.go
@@ -18,8 +18,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/shirou/gopsutil/process"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/zeebo/errs"
@@ -38,7 +38,7 @@ func BuiltIn() catalog.Plugin {
 }
 
 func builtin(p *Plugin) catalog.Plugin {
-	return catalog.MakePlugin(pluginName, workloadattestor.PluginServer(p))
+	return catalog.MakePlugin(pluginName, workloadattestorv0.PluginServer(p))
 }
 
 type processInfo interface {
@@ -101,7 +101,7 @@ type Configuration struct {
 }
 
 type Plugin struct {
-	workloadattestor.UnsafeWorkloadAttestorServer
+	workloadattestorv0.UnsafeWorkloadAttestorServer
 
 	mu     sync.Mutex
 	config *Configuration
@@ -127,7 +127,7 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest) (*workloadattestor.AttestResponse, error) {
+func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv0.AttestRequest) (*workloadattestorv0.AttestResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestor.AttestRequest
 		}
 	}
 
-	return &workloadattestor.AttestResponse{
+	return &workloadattestorv0.AttestResponse{
 		Selectors: selectors,
 	}, nil
 }

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -31,7 +31,7 @@ type Suite struct {
 	spiretest.Suite
 
 	dir     string
-	p       workloadattestor.Plugin
+	p       workloadattestorv0.Plugin
 	logHook *test.Hook
 }
 
@@ -229,7 +229,7 @@ func (s *Suite) TestAttest() {
 		s.T().Run(testCase.name, func(t *testing.T) {
 			defer s.logHook.Reset()
 			s.configure(testCase.config)
-			resp, err := s.p.Attest(ctx, &workloadattestor.AttestRequest{
+			resp, err := s.p.Attest(ctx, &workloadattestorv0.AttestRequest{
 				Pid: testCase.pid,
 			})
 

--- a/pkg/agent/plugin/workloadattestor/v0.go
+++ b/pkg/agent/plugin/workloadattestor/v0.go
@@ -1,0 +1,25 @@
+package workloadattestor
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
+	"github.com/spiffe/spire/proto/spire/common"
+)
+
+type V0 struct {
+	plugin.Facade
+
+	Plugin workloadattestorv0.WorkloadAttestor
+}
+
+func (v0 V0) Attest(ctx context.Context, pid int) ([]*common.Selector, error) {
+	resp, err := v0.Plugin.Attest(ctx, &workloadattestorv0.AttestRequest{
+		Pid: int32(pid),
+	})
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+	return resp.Selectors, nil
+}

--- a/pkg/agent/plugin/workloadattestor/v0_test.go
+++ b/pkg/agent/plugin/workloadattestor/v0_test.go
@@ -33,7 +33,7 @@ func TestV0(t *testing.T) {
 		require.Empty(t, actual)
 	})
 
-	t.Run("no selectors for pid", func(t *testing.T) {
+	t.Run("with selectors for pid", func(t *testing.T) {
 		workloadAttestor := makeFakeV0Plugin(t, expected)
 		actual, err := workloadAttestor.Attest(context.Background(), 2)
 		require.NoError(t, err)

--- a/pkg/agent/plugin/workloadattestor/v0_test.go
+++ b/pkg/agent/plugin/workloadattestor/v0_test.go
@@ -1,0 +1,68 @@
+package workloadattestor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestV0(t *testing.T) {
+	expected := map[int][]*common.Selector{
+		1: {},
+		2: {{Type: "not", Value: "relevant"}},
+	}
+
+	t.Run("attest fails", func(t *testing.T) {
+		workloadAttestor := makeFakeV0Plugin(t, expected)
+		_, err := workloadAttestor.Attest(context.Background(), 0)
+		spiretest.RequireGRPCStatus(t, err, codes.InvalidArgument, "workloadattestor(test): ohno")
+	})
+
+	t.Run("no selectors for pid", func(t *testing.T) {
+		workloadAttestor := makeFakeV0Plugin(t, expected)
+		actual, err := workloadAttestor.Attest(context.Background(), 1)
+		require.NoError(t, err)
+		require.Empty(t, actual)
+	})
+
+	t.Run("no selectors for pid", func(t *testing.T) {
+		workloadAttestor := makeFakeV0Plugin(t, expected)
+		actual, err := workloadAttestor.Attest(context.Background(), 2)
+		require.NoError(t, err)
+		spiretest.RequireProtoListEqual(t, expected[2], actual)
+	})
+}
+
+func makeFakeV0Plugin(t *testing.T, selectors map[int][]*common.Selector) workloadattestor.WorkloadAttestor {
+	fake := &fakePluginV0{selectors: selectors}
+	server := workloadattestorv0.PluginServer(fake)
+
+	var plugin workloadattestor.V0
+	spiretest.LoadPlugin(t, catalog.MakePlugin("test", server), &plugin)
+	return plugin
+}
+
+type fakePluginV0 struct {
+	workloadattestorv0.UnimplementedWorkloadAttestorServer
+	selectors map[int][]*common.Selector
+}
+
+func (plugin fakePluginV0) Attest(ctx context.Context, req *workloadattestorv0.AttestRequest) (*workloadattestorv0.AttestResponse, error) {
+	selectors, ok := plugin.selectors[int(req.Pid)]
+	if !ok {
+		// Just return something to test the error wrapping. This is not
+		// necessarily an indication of what real plugins should produce.
+		return nil, status.Error(codes.InvalidArgument, "ohno")
+	}
+	return &workloadattestorv0.AttestResponse{
+		Selectors: selectors,
+	}, nil
+}

--- a/pkg/agent/plugin/workloadattestor/workloadattestor.go
+++ b/pkg/agent/plugin/workloadattestor/workloadattestor.go
@@ -1,93 +1,14 @@
-// Provides interfaces and adapters for the WorkloadAttestor service
-//
-// Generated code. Do not modify by hand.
 package workloadattestor
 
 import (
 	"context"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/proto/spire/agent/workloadattestor"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"google.golang.org/grpc"
+	"github.com/spiffe/spire/proto/spire/common"
 )
 
-type AttestRequest = workloadattestor.AttestRequest                                             //nolint: golint
-type AttestResponse = workloadattestor.AttestResponse                                           //nolint: golint
-type UnimplementedWorkloadAttestorServer = workloadattestor.UnimplementedWorkloadAttestorServer //nolint: golint
-type UnsafeWorkloadAttestorServer = workloadattestor.UnsafeWorkloadAttestorServer               //nolint: golint
-type WorkloadAttestorClient = workloadattestor.WorkloadAttestorClient                           //nolint: golint
-type WorkloadAttestorServer = workloadattestor.WorkloadAttestorServer                           //nolint: golint
-
-const (
-	Type = "WorkloadAttestor"
-)
-
-// WorkloadAttestor is the client interface for the service type WorkloadAttestor interface.
 type WorkloadAttestor interface {
-	Attest(context.Context, *AttestRequest) (*AttestResponse, error)
-}
+	catalog.PluginInfo
 
-// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
-type Plugin interface {
-	Attest(context.Context, *AttestRequest) (*AttestResponse, error)
-	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
-	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
-}
-
-// PluginServer returns a catalog PluginServer implementation for the WorkloadAttestor plugin.
-func PluginServer(server WorkloadAttestorServer) catalog.PluginServer {
-	return &pluginServer{
-		server: server,
-	}
-}
-
-type pluginServer struct {
-	server WorkloadAttestorServer
-}
-
-func (s pluginServer) PluginType() string {
-	return Type
-}
-
-func (s pluginServer) PluginClient() catalog.PluginClient {
-	return PluginClient
-}
-
-func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
-	workloadattestor.RegisterWorkloadAttestorServer(server, s.server)
-	return s.server
-}
-
-// PluginClient is a catalog PluginClient implementation for the WorkloadAttestor plugin.
-var PluginClient catalog.PluginClient = pluginClient{}
-
-type pluginClient struct{}
-
-func (pluginClient) PluginType() string {
-	return Type
-}
-
-func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
-	return AdaptPluginClient(workloadattestor.NewWorkloadAttestorClient(conn))
-}
-
-func AdaptPluginClient(client WorkloadAttestorClient) WorkloadAttestor {
-	return pluginClientAdapter{client: client}
-}
-
-type pluginClientAdapter struct {
-	client WorkloadAttestorClient
-}
-
-func (a pluginClientAdapter) Attest(ctx context.Context, in *AttestRequest) (*AttestResponse, error) {
-	return a.client.Attest(ctx, in)
-}
-
-func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return a.client.Configure(ctx, in)
-}
-
-func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return a.client.GetPluginInfo(ctx, in)
+	Attest(ctx context.Context, pid int) ([]*common.Selector, error)
 }

--- a/proto/spire/agent/workloadattestor/v0/workloadattestor.go
+++ b/proto/spire/agent/workloadattestor/v0/workloadattestor.go
@@ -1,0 +1,93 @@
+// Provides interfaces and adapters for the WorkloadAttestor service
+//
+// Generated code. Do not modify by hand.
+package v0
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/proto/spire/agent/workloadattestor"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"google.golang.org/grpc"
+)
+
+type AttestRequest = workloadattestor.AttestRequest                                             //nolint: golint
+type AttestResponse = workloadattestor.AttestResponse                                           //nolint: golint
+type UnimplementedWorkloadAttestorServer = workloadattestor.UnimplementedWorkloadAttestorServer //nolint: golint
+type UnsafeWorkloadAttestorServer = workloadattestor.UnsafeWorkloadAttestorServer               //nolint: golint
+type WorkloadAttestorClient = workloadattestor.WorkloadAttestorClient                           //nolint: golint
+type WorkloadAttestorServer = workloadattestor.WorkloadAttestorServer                           //nolint: golint
+
+const (
+	Type = "WorkloadAttestor"
+)
+
+// WorkloadAttestor is the client interface for the service type WorkloadAttestor interface.
+type WorkloadAttestor interface {
+	Attest(context.Context, *AttestRequest) (*AttestResponse, error)
+}
+
+// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
+type Plugin interface {
+	Attest(context.Context, *AttestRequest) (*AttestResponse, error)
+	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
+	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+}
+
+// PluginServer returns a catalog PluginServer implementation for the WorkloadAttestor plugin.
+func PluginServer(server WorkloadAttestorServer) catalog.PluginServer {
+	return &pluginServer{
+		server: server,
+	}
+}
+
+type pluginServer struct {
+	server WorkloadAttestorServer
+}
+
+func (s pluginServer) PluginType() string {
+	return Type
+}
+
+func (s pluginServer) PluginClient() catalog.PluginClient {
+	return PluginClient
+}
+
+func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
+	workloadattestor.RegisterWorkloadAttestorServer(server, s.server)
+	return s.server
+}
+
+// PluginClient is a catalog PluginClient implementation for the WorkloadAttestor plugin.
+var PluginClient catalog.PluginClient = pluginClient{}
+
+type pluginClient struct{}
+
+func (pluginClient) PluginType() string {
+	return Type
+}
+
+func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
+	return AdaptPluginClient(workloadattestor.NewWorkloadAttestorClient(conn))
+}
+
+func AdaptPluginClient(client WorkloadAttestorClient) WorkloadAttestor {
+	return pluginClientAdapter{client: client}
+}
+
+type pluginClientAdapter struct {
+	client WorkloadAttestorClient
+}
+
+func (a pluginClientAdapter) Attest(ctx context.Context, in *AttestRequest) (*AttestResponse, error) {
+	return a.client.Attest(ctx, in)
+}
+
+func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return a.client.Configure(ctx, in)
+}
+
+func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return a.client.GetPluginInfo(ctx, in)
+}

--- a/test/fakes/fakeagentcatalog/catalog.go
+++ b/test/fakes/fakeagentcatalog/catalog.go
@@ -23,30 +23,6 @@ func (c *Catalog) SetNodeAttestor(nodeAttestor nodeattestor.NodeAttestor) {
 	c.NodeAttestor = nodeAttestor
 }
 
-func (c *Catalog) SetWorkloadAttestors(workloadAttestors ...catalog.WorkloadAttestor) {
+func (c *Catalog) SetWorkloadAttestors(workloadAttestors ...workloadattestor.WorkloadAttestor) {
 	c.WorkloadAttestors = workloadAttestors
-}
-
-func WorkloadAttestor(name string, workloadAttestor workloadattestor.WorkloadAttestor) catalog.WorkloadAttestor {
-	return catalog.WorkloadAttestor{
-		PluginInfo:       pluginInfo{name: name, typ: workloadattestor.Type},
-		WorkloadAttestor: workloadAttestor,
-	}
-}
-
-type pluginInfo struct {
-	name string
-	typ  string
-}
-
-func (pi pluginInfo) Name() string {
-	return pi.name
-}
-
-func (pi pluginInfo) Type() string {
-	return pi.typ
-}
-
-func (pi pluginInfo) BuiltIn() bool {
-	return true
 }

--- a/test/fakes/fakeservercatalog/catalog.go
+++ b/test/fakes/fakeservercatalog/catalog.go
@@ -1,7 +1,6 @@
 package fakeservercatalog
 
 import (
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/server/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
@@ -51,10 +50,10 @@ func (c *Catalog) AddNotifier(notifier catalog.Notifier) {
 	c.Notifiers = append(c.Notifiers, notifier)
 }
 
-func Notifier(name string, notifier notifier.Notifier) catalog.Notifier {
+func Notifier(name string, n notifier.Notifier) catalog.Notifier {
 	return catalog.Notifier{
-		PluginInfo: pluginInfo{name: name, typ: workloadattestor.Type},
-		Notifier:   notifier,
+		PluginInfo: pluginInfo{name: name, typ: notifier.Type},
+		Notifier:   n,
 	}
 }
 

--- a/tools/plugintest/main.go
+++ b/tools/plugintest/main.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	agent_catalog "github.com/spiffe/spire/pkg/agent/catalog"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	workloadattestorv0 "github.com/spiffe/spire/proto/spire/agent/workloadattestor/v0"
 	"github.com/zeebo/errs"
 )
 
@@ -72,13 +72,13 @@ func run(ctx context.Context) error {
 	pluginConfig := []catalog.PluginConfig{
 		{
 			Name: pluginName,
-			Type: workloadattestor.Type,
+			Type: workloadattestorv0.Type,
 			Path: pluginPath,
 			Data: config,
 		},
 	}
 
-	var plugin workloadattestor.WorkloadAttestor
+	var plugin workloadattestorv0.WorkloadAttestor
 	closer, err := catalog.Fill(ctx, catalog.Config{
 		Log:           log,
 		KnownPlugins:  agent_catalog.KnownPlugins(),
@@ -94,7 +94,7 @@ func run(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	res, err := plugin.Attest(ctx, &workloadattestor.AttestRequest{Pid: int32(pid)})
+	res, err := plugin.Attest(ctx, &workloadattestorv0.AttestRequest{Pid: int32(pid)})
 	if err != nil {
 		return fmt.Errorf("failed to attest pid %d: %v", pid, err)
 	}


### PR DESCRIPTION
This is the next facade introduced as part of #2153. Should be pretty straightforward. The `facade` uses an `int` for the PID, matching the type returned by the `os` package, instead of `int32`. The `v1` workload attestor interface will probably depart and choose `int64` to not be tied to the limit so of a particular platform. Outside of that, this PR should be mostly mechanical. 
