### PR TITLE
Introduce NodeResolver Facade Interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ plugingen_plugins = \
 	proto/spire/server/nodeattestor/nodeattestor.proto,proto/spire/server/nodeattestor/v0,NodeAttestor \
 	proto/spire/server/datastore/datastore.proto,pkg/server/plugin/datastore,DataStore \
 	proto/spire/server/upstreamauthority/upstreamauthority.proto,pkg/server/plugin/upstreamauthority,UpstreamAuthority \
-	proto/spire/server/noderesolver/noderesolver.proto,pkg/server/plugin/noderesolver,NodeResolver \
+	proto/spire/server/noderesolver/noderesolver.proto,proto/spire/server/noderesolver/v0,NodeResolver \
 	proto/spire/server/keymanager/keymanager.proto,proto/spire/server/keymanager/v0,KeyManager \
 	proto/spire/agent/nodeattestor/nodeattestor.proto,proto/spire/agent/nodeattestor/v0,NodeAttestor \
 	proto/spire/agent/workloadattestor/workloadattestor.proto,proto/spire/agent/workloadattestor/v0,WorkloadAttestor \

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -15,14 +15,12 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	agentv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
-	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/api/agent/v1"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
@@ -1728,14 +1726,6 @@ func TestAttestAgent(t *testing.T) {
 			},
 			expectLogs: []spiretest.LogEntry{
 				{
-					Level:   logrus.DebugLevel,
-					Message: "Could not find node resolver",
-					Data: logrus.Fields{
-						telemetry.NodeAttestorType: "join_token",
-						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
-					},
-				},
-				{
 					Level:   logrus.ErrorLevel,
 					Message: "Failed to update selectors",
 
@@ -1761,14 +1751,6 @@ func TestAttestAgent(t *testing.T) {
 				errors.New("some error"),
 			},
 			expectLogs: []spiretest.LogEntry{
-				{
-					Level:   logrus.DebugLevel,
-					Message: "Could not find node resolver",
-					Data: logrus.Fields{
-						telemetry.NodeAttestorType: "join_token",
-						telemetry.AgentID:          td.NewID("/spire/agent/join_token/test_token").String(),
-					},
-				},
 				{
 					Level:   logrus.ErrorLevel,
 					Message: "Failed to create attested agent",
@@ -1947,32 +1929,13 @@ func (s *serviceTest) setupAttestor(t *testing.T) {
 }
 
 func (s *serviceTest) setupResolver(t *testing.T) {
-	resolverConfig := fakenoderesolver.Config{
-		Selectors: map[string][]string{
-			td.NewID("/spire/agent/test_type/id_with_result").String():    {"resolved"},
-			td.NewID("/spire/agent/test_type/id_with_challenge").String(): {"resolved_too"},
-		},
+	selectors := map[string][]string{
+		td.NewID("/spire/agent/test_type/id_with_result").String():    {"resolved"},
+		td.NewID("/spire/agent/test_type/id_with_challenge").String(): {"resolved_too"},
 	}
 
-	fakeServerAttestor := fakenoderesolver.New("test_type", resolverConfig)
-	fakeServerPlugin := noderesolver.PluginServer(fakeServerAttestor)
-	fakeCatalogPlugin := catalog.MakePlugin("test_type", fakeServerPlugin)
-
-	loadedPlugin, err := catalog.LoadBuiltInPlugin(context.Background(), catalog.BuiltInPlugin{
-		Log:          nil,
-		Plugin:       fakeCatalogPlugin,
-		HostServices: nil,
-	})
-	require.NoError(t, err, "unable to load plugin")
-
-	var fakeNodeResolverClient noderesolver.NodeResolver
-	if err := loadedPlugin.Fill(&fakeNodeResolverClient); err != nil {
-		loadedPlugin.Close()
-		require.NoError(t, err, "unable to satisfy plugin client")
-	}
-
-	s.pluginCloser = loadedPlugin.Close
-	s.cat.AddNodeResolverNamed("test_type", fakeNodeResolverClient)
+	fakeNodeResolver := fakenoderesolver.New(t, "test_type", selectors)
+	s.cat.AddNodeResolverNamed(fakeNodeResolver)
 }
 
 func (s *serviceTest) setupNodes(ctx context.Context, t *testing.T) {

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -45,6 +45,7 @@ import (
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	keymanagerv0 "github.com/spiffe/spire/proto/spire/server/keymanager/v0"
 	nodeattestorv0 "github.com/spiffe/spire/proto/spire/server/nodeattestor/v0"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 )
 
 var (
@@ -95,7 +96,7 @@ type HCLPluginConfigMap = catalog.HCLPluginConfigMap
 func KnownPlugins() []catalog.PluginClient {
 	return []catalog.PluginClient{
 		nodeattestorv0.PluginClient,
-		noderesolver.PluginClient,
+		noderesolverv0.PluginClient,
 		upstreamauthority.PluginClient,
 		keymanagerv0.PluginClient,
 		notifier.PluginClient,
@@ -218,11 +219,16 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 		nodeAttestors[na.Name()] = na
 	}
 
+	nodeResolvers := make(map[string]noderesolver.NodeResolver)
+	for _, nr := range p.NodeResolvers {
+		nodeResolvers[nr.Name()] = nr
+	}
+
 	return &Repository{
 		Catalog: &Plugins{
 			DataStore:         ds,
 			NodeAttestors:     nodeAttestors,
-			NodeResolvers:     p.NodeResolvers,
+			NodeResolvers:     nodeResolvers,
 			UpstreamAuthority: p.UpstreamAuthority,
 			KeyManager:        p.KeyManager,
 			Notifiers:         p.Notifiers,
@@ -238,7 +244,7 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 // native versioning support (see issue #2153).
 type versionedPlugins struct {
 	NodeAttestors     map[string]nodeattestor.V0
-	NodeResolvers     map[string]noderesolver.NodeResolver
+	NodeResolvers     map[string]noderesolver.V0
 	UpstreamAuthority *UpstreamAuthority
 	KeyManager        keymanager.V0
 	Notifiers         []Notifier

--- a/pkg/server/plugin/noderesolver/aws/iid.go
+++ b/pkg/server/plugin/noderesolver/aws/iid.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 )
 
 func BuiltIn() catalog.Plugin {
@@ -16,13 +16,13 @@ func BuiltIn() catalog.Plugin {
 
 func builtin(p *IIDResolverPlugin) catalog.Plugin {
 	return catalog.MakePlugin(caws.PluginName,
-		noderesolver.PluginServer(p),
+		noderesolverv0.PluginServer(p),
 	)
 }
 
 // IIDResolverPlugin implements node resolution for agents running in aws.
 type IIDResolverPlugin struct {
-	noderesolver.UnsafeNodeResolverServer
+	noderesolverv0.UnsafeNodeResolverServer
 
 	log hclog.Logger
 }
@@ -49,6 +49,6 @@ func (p *IIDResolverPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoReq
 }
 
 // Resolve handles the given resolve request
-func (p *IIDResolverPlugin) Resolve(ctx context.Context, req *noderesolver.ResolveRequest) (*noderesolver.ResolveResponse, error) {
-	return &noderesolver.ResolveResponse{}, nil
+func (p *IIDResolverPlugin) Resolve(ctx context.Context, req *noderesolverv0.ResolveRequest) (*noderesolverv0.ResolveResponse, error) {
+	return &noderesolverv0.ResolveResponse{}, nil
 }

--- a/pkg/server/plugin/noderesolver/aws/iid_test.go
+++ b/pkg/server/plugin/noderesolver/aws/iid_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/pkg/common/telemetry"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 	"github.com/spiffe/spire/test/spiretest"
 )
 
@@ -25,7 +25,7 @@ type IIDResolverSuite struct {
 	spiretest.Suite
 
 	env      map[string]string
-	resolver noderesolver.Plugin
+	resolver noderesolverv0.Plugin
 	logHook  *test.Hook
 }
 
@@ -40,7 +40,7 @@ func (s *IIDResolverSuite) TestResolveWhenNotConfigured() {
 
 func (s *IIDResolverSuite) TestResolve() {
 	// nothing to resolve
-	resp, err := s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{})
+	resp, err := s.resolver.Resolve(context.Background(), &noderesolverv0.ResolveRequest{})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().Empty(resp.Map)
@@ -92,14 +92,14 @@ func (s *IIDResolverSuite) newResolver() {
 }
 
 func (s *IIDResolverSuite) assertResolveSuccess() {
-	expected := &noderesolver.ResolveResponse{}
+	expected := &noderesolverv0.ResolveResponse{}
 	actual, err := s.doResolve(awsAgentID)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(expected, actual)
 }
 
-func (s *IIDResolverSuite) doResolve(spiffeID string) (*noderesolver.ResolveResponse, error) {
-	return s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{
+func (s *IIDResolverSuite) doResolve(spiffeID string) (*noderesolverv0.ResolveResponse, error) {
+	return s.resolver.Resolve(context.Background(), &noderesolverv0.ResolveRequest{
 		BaseSpiffeIdList: []string{spiffeID},
 	})
 }

--- a/pkg/server/plugin/noderesolver/azure/msi.go
+++ b/pkg/server/plugin/noderesolver/azure/msi.go
@@ -21,9 +21,9 @@ import (
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/telemetry"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 )
 
 const (
@@ -46,7 +46,7 @@ func BuiltIn() catalog.Plugin {
 
 func builtin(p *MSIResolverPlugin) catalog.Plugin {
 	return catalog.MakePlugin(pluginName,
-		noderesolver.PluginServer(p),
+		noderesolverv0.PluginServer(p),
 	)
 }
 
@@ -62,7 +62,7 @@ type MSIResolverConfig struct {
 }
 
 type MSIResolverPlugin struct {
-	noderesolver.UnsafeNodeResolverServer
+	noderesolverv0.UnsafeNodeResolverServer
 
 	log           hclog.Logger
 	mu            sync.RWMutex
@@ -86,8 +86,8 @@ func (p *MSIResolverPlugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *MSIResolverPlugin) Resolve(ctx context.Context, req *noderesolver.ResolveRequest) (*noderesolver.ResolveResponse, error) {
-	resp := &noderesolver.ResolveResponse{
+func (p *MSIResolverPlugin) Resolve(ctx context.Context, req *noderesolverv0.ResolveRequest) (*noderesolverv0.ResolveResponse, error) {
+	resp := &noderesolverv0.ResolveResponse{
 		Map: make(map[string]*common.Selectors),
 	}
 	for _, spiffeID := range req.BaseSpiffeIdList {

--- a/pkg/server/plugin/noderesolver/azure/msi_test.go
+++ b/pkg/server/plugin/noderesolver/azure/msi_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/proto/spire/common/plugin"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
 )
@@ -50,7 +50,7 @@ type MSIResolverSuite struct {
 
 	api *fakeAPIClient
 
-	resolver noderesolver.Plugin
+	resolver noderesolverv0.Plugin
 }
 
 func (s *MSIResolverSuite) SetupTest() {
@@ -73,7 +73,7 @@ func (s *MSIResolverSuite) SetupTest() {
 }
 
 func (s *MSIResolverSuite) TestResolveWithEmptyRequest() {
-	resp, err := s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{})
+	resp, err := s.resolver.Resolve(context.Background(), &noderesolverv0.ResolveRequest{})
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.Require().Empty(resp.Map)
@@ -86,7 +86,7 @@ func (s *MSIResolverSuite) TestResolveWithNonAgentID() {
 
 func (s *MSIResolverSuite) TestResolveWithNonAzureAgentID() {
 	// agent ID's that aren't recognized by the resolver are simply ignored
-	resp, err := s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{
+	resp, err := s.resolver.Resolve(context.Background(), &noderesolverv0.ResolveRequest{
 		BaseSpiffeIdList: []string{"spiffe://example.org/spire/agent/whatever"},
 	})
 	s.Require().NoError(err)
@@ -289,7 +289,7 @@ func (s *MSIResolverSuite) assertResolveSuccess(selectorValueSets ...[]string) {
 		})
 	}
 
-	expected := &noderesolver.ResolveResponse{
+	expected := &noderesolverv0.ResolveResponse{
 		Map: map[string]*common.Selectors{
 			azureAgentID: selectors,
 		},
@@ -306,8 +306,8 @@ func (s *MSIResolverSuite) assertResolveFailure(spiffeID, containsErr string) {
 	s.Require().Nil(resp)
 }
 
-func (s *MSIResolverSuite) doResolve(spiffeID string) (*noderesolver.ResolveResponse, error) {
-	return s.resolver.Resolve(context.Background(), &noderesolver.ResolveRequest{
+func (s *MSIResolverSuite) doResolve(spiffeID string) (*noderesolverv0.ResolveResponse, error) {
+	return s.resolver.Resolve(context.Background(), &noderesolverv0.ResolveRequest{
 		BaseSpiffeIdList: []string{spiffeID},
 	})
 }

--- a/pkg/server/plugin/noderesolver/noderesolver.go
+++ b/pkg/server/plugin/noderesolver/noderesolver.go
@@ -1,93 +1,14 @@
-// Provides interfaces and adapters for the NodeResolver service
-//
-// Generated code. Do not modify by hand.
 package noderesolver
 
 import (
 	"context"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"github.com/spiffe/spire/proto/spire/server/noderesolver"
-	"google.golang.org/grpc"
+	"github.com/spiffe/spire/proto/spire/common"
 )
 
-type NodeResolverClient = noderesolver.NodeResolverClient                           //nolint: golint
-type NodeResolverServer = noderesolver.NodeResolverServer                           //nolint: golint
-type ResolveRequest = noderesolver.ResolveRequest                                   //nolint: golint
-type ResolveResponse = noderesolver.ResolveResponse                                 //nolint: golint
-type UnimplementedNodeResolverServer = noderesolver.UnimplementedNodeResolverServer //nolint: golint
-type UnsafeNodeResolverServer = noderesolver.UnsafeNodeResolverServer               //nolint: golint
-
-const (
-	Type = "NodeResolver"
-)
-
-// NodeResolver is the client interface for the service type NodeResolver interface.
 type NodeResolver interface {
-	Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error)
-}
+	catalog.PluginInfo
 
-// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
-type Plugin interface {
-	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
-	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
-	Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error)
-}
-
-// PluginServer returns a catalog PluginServer implementation for the NodeResolver plugin.
-func PluginServer(server NodeResolverServer) catalog.PluginServer {
-	return &pluginServer{
-		server: server,
-	}
-}
-
-type pluginServer struct {
-	server NodeResolverServer
-}
-
-func (s pluginServer) PluginType() string {
-	return Type
-}
-
-func (s pluginServer) PluginClient() catalog.PluginClient {
-	return PluginClient
-}
-
-func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
-	noderesolver.RegisterNodeResolverServer(server, s.server)
-	return s.server
-}
-
-// PluginClient is a catalog PluginClient implementation for the NodeResolver plugin.
-var PluginClient catalog.PluginClient = pluginClient{}
-
-type pluginClient struct{}
-
-func (pluginClient) PluginType() string {
-	return Type
-}
-
-func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
-	return AdaptPluginClient(noderesolver.NewNodeResolverClient(conn))
-}
-
-func AdaptPluginClient(client NodeResolverClient) NodeResolver {
-	return pluginClientAdapter{client: client}
-}
-
-type pluginClientAdapter struct {
-	client NodeResolverClient
-}
-
-func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return a.client.Configure(ctx, in)
-}
-
-func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return a.client.GetPluginInfo(ctx, in)
-}
-
-func (a pluginClientAdapter) Resolve(ctx context.Context, in *ResolveRequest) (*ResolveResponse, error) {
-	return a.client.Resolve(ctx, in)
+	Resolve(ctx context.Context, agentID string) ([]*common.Selector, error)
 }

--- a/pkg/server/plugin/noderesolver/noop/noop.go
+++ b/pkg/server/plugin/noderesolver/noop/noop.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
 )
 
 func BuiltIn() catalog.Plugin {
@@ -14,12 +14,12 @@ func BuiltIn() catalog.Plugin {
 
 func builtin(p *NoOp) catalog.Plugin {
 	return catalog.MakePlugin("noop",
-		noderesolver.PluginServer(p),
+		noderesolverv0.PluginServer(p),
 	)
 }
 
 type NoOp struct {
-	noderesolver.UnsafeNodeResolverServer
+	noderesolverv0.UnsafeNodeResolverServer
 }
 
 func New() *NoOp {
@@ -34,6 +34,6 @@ func (NoOp) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetP
 	return &spi.GetPluginInfoResponse{}, nil
 }
 
-func (NoOp) Resolve(context.Context, *noderesolver.ResolveRequest) (*noderesolver.ResolveResponse, error) {
-	return &noderesolver.ResolveResponse{}, nil
+func (NoOp) Resolve(context.Context, *noderesolverv0.ResolveRequest) (*noderesolverv0.ResolveResponse, error) {
+	return &noderesolverv0.ResolveResponse{}, nil
 }

--- a/pkg/server/plugin/noderesolver/v0.go
+++ b/pkg/server/plugin/noderesolver/v0.go
@@ -1,0 +1,29 @@
+package noderesolver
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/proto/spire/common"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
+)
+
+type V0 struct {
+	plugin.Facade
+
+	Plugin noderesolverv0.NodeResolver
+}
+
+func (v0 V0) Resolve(ctx context.Context, agentID string) ([]*common.Selector, error) {
+	resp, err := v0.Plugin.Resolve(ctx, &noderesolverv0.ResolveRequest{
+		BaseSpiffeIdList: []string{agentID},
+	})
+	if err != nil {
+		return nil, v0.WrapErr(err)
+	}
+	selectors := resp.Map[agentID]
+	if selectors == nil {
+		return nil, nil
+	}
+	return selectors.Entries, nil
+}

--- a/pkg/server/plugin/noderesolver/v0_test.go
+++ b/pkg/server/plugin/noderesolver/v0_test.go
@@ -74,11 +74,11 @@ func (plugin *v0Plugin) Resolve(ctx context.Context, req *noderesolverv0.Resolve
 	switch agentID := req.BaseSpiffeIdList[0]; agentID {
 	case "with-selectors":
 		resp.Map = map[string]*common.Selectors{
-			agentID: &common.Selectors{Entries: expectedSelectors},
+			agentID: {Entries: expectedSelectors},
 		}
 	case "without-selectors":
 		resp.Map = map[string]*common.Selectors{
-			agentID: &common.Selectors{},
+			agentID: {},
 		}
 	case "nil-map":
 	case "nil-selectors-in-map":

--- a/pkg/server/plugin/noderesolver/v0_test.go
+++ b/pkg/server/plugin/noderesolver/v0_test.go
@@ -1,0 +1,94 @@
+package noderesolver_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
+	"github.com/spiffe/spire/proto/spire/common"
+	noderesolverv0 "github.com/spiffe/spire/proto/spire/server/noderesolver/v0"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	expectedSelectors = []*common.Selector{{Type: "TYPE", Value: "VALUE"}}
+)
+
+func TestV0(t *testing.T) {
+	nr := loadV0Plugin(t)
+
+	t.Run("success with selectors", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "with-selectors")
+		assert.NoError(t, err)
+		spiretest.AssertProtoListEqual(t, expectedSelectors, actualSelectors)
+	})
+
+	t.Run("success without selectors", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "without-selectors")
+		assert.NoError(t, err)
+		assert.Empty(t, actualSelectors)
+	})
+
+	t.Run("success with nil map", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "nil-map")
+		assert.NoError(t, err)
+		assert.Empty(t, actualSelectors)
+	})
+
+	t.Run("success with nil selectors in map", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "nil-selectors-in-map")
+		assert.NoError(t, err)
+		assert.Empty(t, actualSelectors)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "bad")
+		spiretest.AssertGRPCStatus(t, err, codes.FailedPrecondition, "noderesolver(test): ohno")
+		assert.Nil(t, actualSelectors)
+	})
+}
+
+func loadV0Plugin(t *testing.T) noderesolver.NodeResolver {
+	server := noderesolverv0.PluginServer(&v0Plugin{})
+
+	var v0 noderesolver.V0
+	spiretest.LoadPlugin(t, catalog.MakePlugin("test", server), &v0)
+	return v0
+}
+
+type v0Plugin struct {
+	noderesolverv0.UnimplementedNodeResolverServer
+}
+
+func (plugin *v0Plugin) Resolve(ctx context.Context, req *noderesolverv0.ResolveRequest) (*noderesolverv0.ResolveResponse, error) {
+	if len(req.BaseSpiffeIdList) != 1 {
+		return nil, errors.New("v0 shim did not provide the agent ID")
+	}
+
+	resp := &noderesolverv0.ResolveResponse{}
+	switch agentID := req.BaseSpiffeIdList[0]; agentID {
+	case "with-selectors":
+		resp.Map = map[string]*common.Selectors{
+			agentID: &common.Selectors{Entries: expectedSelectors},
+		}
+	case "without-selectors":
+		resp.Map = map[string]*common.Selectors{
+			agentID: &common.Selectors{},
+		}
+	case "nil-map":
+	case "nil-selectors-in-map":
+		resp.Map = map[string]*common.Selectors{
+			agentID: nil,
+		}
+	case "bad":
+		return nil, status.Error(codes.FailedPrecondition, "ohno")
+	default:
+		return nil, errors.New("test setup failure")
+	}
+	return resp, nil
+}

--- a/proto/spire/server/noderesolver/v0/noderesolver.go
+++ b/proto/spire/server/noderesolver/v0/noderesolver.go
@@ -1,0 +1,93 @@
+// Provides interfaces and adapters for the NodeResolver service
+//
+// Generated code. Do not modify by hand.
+package v0
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/proto/spire/server/noderesolver"
+	"google.golang.org/grpc"
+)
+
+type NodeResolverClient = noderesolver.NodeResolverClient                           //nolint: golint
+type NodeResolverServer = noderesolver.NodeResolverServer                           //nolint: golint
+type ResolveRequest = noderesolver.ResolveRequest                                   //nolint: golint
+type ResolveResponse = noderesolver.ResolveResponse                                 //nolint: golint
+type UnimplementedNodeResolverServer = noderesolver.UnimplementedNodeResolverServer //nolint: golint
+type UnsafeNodeResolverServer = noderesolver.UnsafeNodeResolverServer               //nolint: golint
+
+const (
+	Type = "NodeResolver"
+)
+
+// NodeResolver is the client interface for the service type NodeResolver interface.
+type NodeResolver interface {
+	Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error)
+}
+
+// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
+type Plugin interface {
+	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
+	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+	Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error)
+}
+
+// PluginServer returns a catalog PluginServer implementation for the NodeResolver plugin.
+func PluginServer(server NodeResolverServer) catalog.PluginServer {
+	return &pluginServer{
+		server: server,
+	}
+}
+
+type pluginServer struct {
+	server NodeResolverServer
+}
+
+func (s pluginServer) PluginType() string {
+	return Type
+}
+
+func (s pluginServer) PluginClient() catalog.PluginClient {
+	return PluginClient
+}
+
+func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
+	noderesolver.RegisterNodeResolverServer(server, s.server)
+	return s.server
+}
+
+// PluginClient is a catalog PluginClient implementation for the NodeResolver plugin.
+var PluginClient catalog.PluginClient = pluginClient{}
+
+type pluginClient struct{}
+
+func (pluginClient) PluginType() string {
+	return Type
+}
+
+func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
+	return AdaptPluginClient(noderesolver.NewNodeResolverClient(conn))
+}
+
+func AdaptPluginClient(client NodeResolverClient) NodeResolver {
+	return pluginClientAdapter{client: client}
+}
+
+type pluginClientAdapter struct {
+	client NodeResolverClient
+}
+
+func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return a.client.Configure(ctx, in)
+}
+
+func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return a.client.GetPluginInfo(ctx, in)
+}
+
+func (a pluginClientAdapter) Resolve(ctx context.Context, in *ResolveRequest) (*ResolveResponse, error) {
+	return a.client.Resolve(ctx, in)
+}

--- a/test/fakes/fakeservercatalog/catalog.go
+++ b/test/fakes/fakeservercatalog/catalog.go
@@ -31,8 +31,8 @@ func (c *Catalog) AddNodeAttestor(nodeAttestor nodeattestor.NodeAttestor) {
 	c.NodeAttestors[nodeAttestor.Name()] = nodeAttestor
 }
 
-func (c *Catalog) AddNodeResolverNamed(name string, nodeResolver noderesolver.NodeResolver) {
-	c.NodeResolvers[name] = nodeResolver
+func (c *Catalog) AddNodeResolverNamed(nodeResolver noderesolver.NodeResolver) {
+	c.NodeResolvers[nodeResolver.Name()] = nodeResolver
 }
 
 func (c *Catalog) SetUpstreamAuthority(upstreamAuthority *catalog.UpstreamAuthority) {


### PR DESCRIPTION
This is the next facade introduced as part of #2153. This one is fairly straightforward.

One notably change is that I removed a debug log line when a node resolver is not found since it is a normal circumstance.