### PR TITLE
Introduce Notifier Facade Interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ serviceprotos := \
 # "shared" means that the interface shares a package with other interfaces, which
 # impacts the code generation (adds stutter to disambiguate names)
 plugingen_plugins = \
-	proto/spire/server/notifier/notifier.proto,pkg/server/plugin/notifier,Notifier \
+	proto/spire/server/notifier/notifier.proto,proto/spire/server/notifier/v0,Notifier \
 	proto/spire/server/nodeattestor/nodeattestor.proto,proto/spire/server/nodeattestor/v0,NodeAttestor \
 	proto/spire/server/datastore/datastore.proto,pkg/server/plugin/datastore,DataStore \
 	proto/spire/server/upstreamauthority/upstreamauthority.proto,pkg/server/plugin/upstreamauthority,UpstreamAuthority \

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -743,14 +743,7 @@ func (m *Manager) notifyBundleLoaded(ctx context.Context) error {
 			return err
 		},
 		func(ctx context.Context, n notifier.Notifier) error {
-			_, err := n.NotifyAndAdvise(ctx, &notifier.NotifyAndAdviseRequest{
-				Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-					BundleLoaded: &notifier.BundleLoaded{
-						Bundle: bundle,
-					},
-				},
-			})
-			return err
+			return n.NotifyAndAdviseBundleLoaded(ctx, bundle)
 		},
 	)
 }
@@ -763,14 +756,7 @@ func (m *Manager) notifyBundleUpdated(ctx context.Context) error {
 			return err
 		},
 		func(ctx context.Context, n notifier.Notifier) error {
-			_, err := n.Notify(ctx, &notifier.NotifyRequest{
-				Event: &notifier.NotifyRequest_BundleUpdated{
-					BundleUpdated: &notifier.BundleUpdated{
-						Bundle: bundle,
-					},
-				},
-			})
-			return err
+			return n.NotifyBundleUpdated(ctx, bundle)
 		},
 	)
 }
@@ -789,7 +775,7 @@ func (m *Manager) notify(ctx context.Context, event string, advise bool, pre fun
 
 	errsCh := make(chan error, len(notifiers))
 	for _, n := range notifiers {
-		go func(n catalog.Notifier) {
+		go func(n notifier.Notifier) {
 			err := do(ctx, n)
 			f := m.c.Log.WithFields(logrus.Fields{
 				telemetry.Notifier: n.Name(),

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle.go
@@ -13,9 +13,9 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
-	"github.com/spiffe/spire/pkg/server/plugin/notifier"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
 	"github.com/zeebo/errs"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -29,7 +29,7 @@ func BuiltIn() catalog.Plugin {
 
 func builtIn(p *Plugin) catalog.Plugin {
 	return catalog.MakePlugin("gcs_bundle",
-		notifier.PluginServer(p),
+		notifierv0.PluginServer(p),
 	)
 }
 
@@ -46,7 +46,7 @@ type pluginConfig struct {
 }
 
 type Plugin struct {
-	notifier.UnsafeNotifierServer
+	notifierv0.UnsafeNotifierServer
 
 	mu               sync.RWMutex
 	log              hclog.Logger
@@ -79,34 +79,34 @@ func (p *Plugin) BrokerHostServices(broker catalog.HostServiceBroker) error {
 	return nil
 }
 
-func (p *Plugin) Notify(ctx context.Context, req *notifier.NotifyRequest) (*notifier.NotifyResponse, error) {
+func (p *Plugin) Notify(ctx context.Context, req *notifierv0.NotifyRequest) (*notifierv0.NotifyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := req.Event.(*notifier.NotifyRequest_BundleUpdated); ok {
+	if _, ok := req.Event.(*notifierv0.NotifyRequest_BundleUpdated); ok {
 		// ignore the bundle presented in the request. see updateBundleObject for details on why.
 		if err := p.updateBundleObject(ctx, config); err != nil {
 			return nil, err
 		}
 	}
-	return &notifier.NotifyResponse{}, nil
+	return &notifierv0.NotifyResponse{}, nil
 }
 
-func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifier.NotifyAndAdviseRequest) (*notifier.NotifyAndAdviseResponse, error) {
+func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndAdviseRequest) (*notifierv0.NotifyAndAdviseResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := req.Event.(*notifier.NotifyAndAdviseRequest_BundleLoaded); ok {
+	if _, ok := req.Event.(*notifierv0.NotifyAndAdviseRequest_BundleLoaded); ok {
 		// ignore the bundle presented in the request. see updateBundleObject for details on why.
 		if err := p.updateBundleObject(ctx, config); err != nil {
 			return nil, err
 		}
 	}
-	return &notifier.NotifyAndAdviseResponse{}, nil
+	return &notifierv0.NotifyAndAdviseResponse{}, nil
 }
 
 func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (resp *spi.ConfigureResponse, err error) {

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
-	"github.com/spiffe/spire/pkg/server/plugin/notifier"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
 	"github.com/spiffe/spire/test/fakes/fakeidentityprovider"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -83,7 +83,7 @@ func TestConfigure(t *testing.T) {
 			idp := fakeidentityprovider.New()
 
 			raw := New()
-			var plugin notifier.Plugin
+			var plugin notifierv0.Plugin
 			spiretest.LoadPlugin(t, builtIn(raw), &plugin,
 				spiretest.HostService(hostservices.IdentityProviderHostServiceServer(idp)))
 
@@ -105,10 +105,10 @@ func TestGetPluginInfo(t *testing.T) {
 }
 
 func TestNotify(t *testing.T) {
-	testUpdateBundleObject(t, func(plugin notifier.Plugin) error {
-		_, err := plugin.Notify(context.Background(), &notifier.NotifyRequest{
-			Event: &notifier.NotifyRequest_BundleUpdated{
-				BundleUpdated: &notifier.BundleUpdated{},
+	testUpdateBundleObject(t, func(plugin notifierv0.Plugin) error {
+		_, err := plugin.Notify(context.Background(), &notifierv0.NotifyRequest{
+			Event: &notifierv0.NotifyRequest_BundleUpdated{
+				BundleUpdated: &notifierv0.BundleUpdated{},
 			},
 		})
 		return err
@@ -116,17 +116,17 @@ func TestNotify(t *testing.T) {
 }
 
 func TestNotifyAndAdvise(t *testing.T) {
-	testUpdateBundleObject(t, func(plugin notifier.Plugin) error {
-		_, err := plugin.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-			Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-				BundleLoaded: &notifier.BundleLoaded{},
+	testUpdateBundleObject(t, func(plugin notifierv0.Plugin) error {
+		_, err := plugin.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+			Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+				BundleLoaded: &notifierv0.BundleLoaded{},
 			},
 		})
 		return err
 	})
 }
 
-func testUpdateBundleObject(t *testing.T, notify func(plugin notifier.Plugin) error) {
+func testUpdateBundleObject(t *testing.T, notify func(plugin notifierv0.Plugin) error) {
 	bundle1 := &common.Bundle{RootCas: []*common.Certificate{{DerBytes: []byte("1")}}}
 	bundle2 := &common.Bundle{RootCas: []*common.Certificate{{DerBytes: []byte("2")}}}
 
@@ -236,7 +236,7 @@ func testUpdateBundleObject(t *testing.T, notify func(plugin notifier.Plugin) er
 			}
 
 			// Load the instance as a plugin
-			var plugin notifier.Plugin
+			var plugin notifierv0.Plugin
 			spiretest.LoadPlugin(t, builtIn(raw), &plugin,
 				spiretest.HostService(hostservices.IdentityProviderHostServiceServer(idp)))
 

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
-	"github.com/spiffe/spire/pkg/server/plugin/notifier"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
 	"github.com/zeebo/errs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -49,7 +49,7 @@ func BuiltIn() catalog.Plugin {
 
 func builtIn(p *Plugin) catalog.Plugin {
 	return catalog.MakePlugin("k8sbundle",
-		notifier.PluginServer(p),
+		notifierv0.PluginServer(p),
 	)
 }
 
@@ -62,7 +62,7 @@ type pluginConfig struct {
 }
 
 type Plugin struct {
-	notifier.UnsafeNotifierServer
+	notifierv0.UnsafeNotifierServer
 
 	mu               sync.RWMutex
 	log              hclog.Logger
@@ -96,34 +96,34 @@ func (p *Plugin) BrokerHostServices(broker catalog.HostServiceBroker) error {
 	return nil
 }
 
-func (p *Plugin) Notify(ctx context.Context, req *notifier.NotifyRequest) (*notifier.NotifyResponse, error) {
+func (p *Plugin) Notify(ctx context.Context, req *notifierv0.NotifyRequest) (*notifierv0.NotifyResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := req.Event.(*notifier.NotifyRequest_BundleUpdated); ok {
+	if _, ok := req.Event.(*notifierv0.NotifyRequest_BundleUpdated); ok {
 		// ignore the bundle presented in the request. see updateBundle for details on why.
 		if err := p.updateBundles(ctx, config); err != nil {
 			return nil, err
 		}
 	}
-	return &notifier.NotifyResponse{}, nil
+	return &notifierv0.NotifyResponse{}, nil
 }
 
-func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifier.NotifyAndAdviseRequest) (*notifier.NotifyAndAdviseResponse, error) {
+func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndAdviseRequest) (*notifierv0.NotifyAndAdviseResponse, error) {
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	if _, ok := req.Event.(*notifier.NotifyAndAdviseRequest_BundleLoaded); ok {
+	if _, ok := req.Event.(*notifierv0.NotifyAndAdviseRequest_BundleLoaded); ok {
 		// ignore the bundle presented in the request. see updateBundle for details on why.
 		if err := p.updateBundles(ctx, config); err != nil {
 			return nil, err
 		}
 	}
-	return &notifier.NotifyAndAdviseResponse{}, nil
+	return &notifierv0.NotifyAndAdviseResponse{}, nil
 }
 
 func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (resp *spi.ConfigureResponse, err error) {

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/hostservices"
-	"github.com/spiffe/spire/pkg/server/plugin/notifier"
 	"github.com/spiffe/spire/proto/spire/common"
 	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
 	"github.com/spiffe/spire/test/fakes/fakeidentityprovider"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -60,7 +60,7 @@ type Suite struct {
 	k *fakeKubeClient
 
 	raw *Plugin
-	p   notifier.Plugin
+	p   notifierv0.Plugin
 }
 
 func (s *Suite) SetupTest() {
@@ -75,7 +75,7 @@ func (s *Suite) SetupTest() {
 }
 
 func (s *Suite) TestNotifyFailsIfNotConfigured() {
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{})
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{})
 	s.RequireGRPCStatus(err, codes.Unknown, "k8s-bundle: not configured")
 	s.Nil(resp)
 }
@@ -83,13 +83,13 @@ func (s *Suite) TestNotifyFailsIfNotConfigured() {
 func (s *Suite) TestNotifyIgnoresUnknownEvents() {
 	s.configure("")
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{})
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{})
 	s.NoError(err)
-	s.AssertProtoEqual(&notifier.NotifyResponse{}, resp)
+	s.AssertProtoEqual(&notifierv0.NotifyResponse{}, resp)
 }
 
 func (s *Suite) TestNotifyAndAdviseFailsIfNotConfigured() {
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{})
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{})
 	s.RequireGRPCStatus(err, codes.Unknown, "k8s-bundle: not configured")
 	s.Nil(resp)
 }
@@ -97,9 +97,9 @@ func (s *Suite) TestNotifyAndAdviseFailsIfNotConfigured() {
 func (s *Suite) TestNotifyAndAdviseIgnoresUnknownEvents() {
 	s.configure("")
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{})
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{})
 	s.NoError(err)
-	s.AssertProtoEqual(&notifier.NotifyAndAdviseResponse{}, resp)
+	s.AssertProtoEqual(&notifierv0.NotifyAndAdviseResponse{}, resp)
 }
 
 func (s *Suite) TestBundleLoadedWhenCannotCreateClient() {
@@ -107,9 +107,9 @@ func (s *Suite) TestBundleLoadedWhenCannotCreateClient() {
 
 	s.configure("")
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
@@ -121,9 +121,9 @@ func (s *Suite) TestBundleLoadedWhenCannotCreateClient() {
 func (s *Suite) TestBundleLoadedConfigMapGetFailure() {
 	s.configure("")
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
@@ -144,9 +144,9 @@ func (s *Suite) TestBundleLoadedConfigMapPatchFailure() {
 
 	s.configure("")
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
@@ -171,15 +171,15 @@ func (s *Suite) TestBundleLoadedConfigMapUpdateConflict() {
 
 	s.configure("")
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
 	})
 	s.NoError(err)
-	s.AssertProtoEqual(&notifier.NotifyAndAdviseResponse{}, resp)
+	s.AssertProtoEqual(&notifierv0.NotifyAndAdviseResponse{}, resp)
 
 	// make sure the config map contains the second bundle data
 	configMap := s.k.getConfigMap("spire", "spire-bundle")
@@ -193,15 +193,15 @@ func (s *Suite) TestBundleLoadedWithDefaultConfiguration() {
 	s.k.setConfigMap(newConfigMap())
 	s.r.AppendBundle(testBundle)
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
 	})
 	s.Require().NoError(err)
-	s.RequireProtoEqual(&notifier.NotifyAndAdviseResponse{}, resp)
+	s.RequireProtoEqual(&notifierv0.NotifyAndAdviseResponse{}, resp)
 
 	s.Require().Equal(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -234,9 +234,9 @@ config_map_key = "CONFIGMAPKEY"
 kube_config_file_path = "/some/file/path"
 `)
 
-	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifier.NotifyAndAdviseRequest{
-		Event: &notifier.NotifyAndAdviseRequest_BundleLoaded{
-			BundleLoaded: &notifier.BundleLoaded{
+	resp, err := s.p.NotifyAndAdvise(context.Background(), &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
 				Bundle: testBundle,
 			},
 		},
@@ -261,9 +261,9 @@ func (s *Suite) TestBundleUpdatedWhenCannotCreateClient() {
 
 	s.configure("")
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},
@@ -275,9 +275,9 @@ func (s *Suite) TestBundleUpdatedWhenCannotCreateClient() {
 func (s *Suite) TestBundleUpdatedConfigMapGetFailure() {
 	s.configure("")
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},
@@ -298,9 +298,9 @@ func (s *Suite) TestBundleUpdatedConfigMapPatchFailure() {
 
 	s.configure("")
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},
@@ -325,15 +325,15 @@ func (s *Suite) TestBundleUpdatedConfigMapUpdateConflict() {
 
 	s.configure("")
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},
 	})
 	s.NoError(err)
-	s.AssertProtoEqual(&notifier.NotifyResponse{}, resp)
+	s.AssertProtoEqual(&notifierv0.NotifyResponse{}, resp)
 
 	// make sure the config map contains the second bundle data
 	configMap := s.k.getConfigMap("spire", "spire-bundle")
@@ -347,15 +347,15 @@ func (s *Suite) TestBundleUpdatedWithDefaultConfiguration() {
 	s.k.setConfigMap(newConfigMap())
 	s.r.AppendBundle(testBundle)
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},
 	})
 	s.Require().NoError(err)
-	s.RequireProtoEqual(&notifier.NotifyResponse{}, resp)
+	s.RequireProtoEqual(&notifierv0.NotifyResponse{}, resp)
 
 	s.Equal(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -388,9 +388,9 @@ config_map_key = "CONFIGMAPKEY"
 kube_config_file_path = "/some/file/path"
 `)
 
-	resp, err := s.p.Notify(context.Background(), &notifier.NotifyRequest{
-		Event: &notifier.NotifyRequest_BundleUpdated{
-			BundleUpdated: &notifier.BundleUpdated{
+	resp, err := s.p.Notify(context.Background(), &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
 				Bundle: testBundle,
 			},
 		},

--- a/pkg/server/plugin/notifier/notifier.go
+++ b/pkg/server/plugin/notifier/notifier.go
@@ -1,105 +1,15 @@
-// Provides interfaces and adapters for the Notifier service
-//
-// Generated code. Do not modify by hand.
 package notifier
 
 import (
 	"context"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	"github.com/spiffe/spire/proto/spire/server/notifier"
-	"google.golang.org/grpc"
+	"github.com/spiffe/spire/proto/spire/common"
 )
 
-type BundleLoaded = notifier.BundleLoaded                                               //nolint: golint
-type BundleUpdated = notifier.BundleUpdated                                             //nolint: golint
-type NotifierClient = notifier.NotifierClient                                           //nolint: golint
-type NotifierServer = notifier.NotifierServer                                           //nolint: golint
-type NotifyAndAdviseRequest = notifier.NotifyAndAdviseRequest                           //nolint: golint
-type NotifyAndAdviseRequest_BundleLoaded = notifier.NotifyAndAdviseRequest_BundleLoaded //nolint: golint
-type NotifyAndAdviseResponse = notifier.NotifyAndAdviseResponse                         //nolint: golint
-type NotifyRequest = notifier.NotifyRequest                                             //nolint: golint
-type NotifyRequest_BundleUpdated = notifier.NotifyRequest_BundleUpdated                 //nolint: golint
-type NotifyResponse = notifier.NotifyResponse                                           //nolint: golint
-type UnimplementedNotifierServer = notifier.UnimplementedNotifierServer                 //nolint: golint
-type UnsafeNotifierServer = notifier.UnsafeNotifierServer                               //nolint: golint
-
-const (
-	Type = "Notifier"
-)
-
-// Notifier is the client interface for the service type Notifier interface.
 type Notifier interface {
-	Notify(context.Context, *NotifyRequest) (*NotifyResponse, error)
-	NotifyAndAdvise(context.Context, *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error)
-}
+	catalog.PluginInfo
 
-// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
-type Plugin interface {
-	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
-	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
-	Notify(context.Context, *NotifyRequest) (*NotifyResponse, error)
-	NotifyAndAdvise(context.Context, *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error)
-}
-
-// PluginServer returns a catalog PluginServer implementation for the Notifier plugin.
-func PluginServer(server NotifierServer) catalog.PluginServer {
-	return &pluginServer{
-		server: server,
-	}
-}
-
-type pluginServer struct {
-	server NotifierServer
-}
-
-func (s pluginServer) PluginType() string {
-	return Type
-}
-
-func (s pluginServer) PluginClient() catalog.PluginClient {
-	return PluginClient
-}
-
-func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
-	notifier.RegisterNotifierServer(server, s.server)
-	return s.server
-}
-
-// PluginClient is a catalog PluginClient implementation for the Notifier plugin.
-var PluginClient catalog.PluginClient = pluginClient{}
-
-type pluginClient struct{}
-
-func (pluginClient) PluginType() string {
-	return Type
-}
-
-func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
-	return AdaptPluginClient(notifier.NewNotifierClient(conn))
-}
-
-func AdaptPluginClient(client NotifierClient) Notifier {
-	return pluginClientAdapter{client: client}
-}
-
-type pluginClientAdapter struct {
-	client NotifierClient
-}
-
-func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return a.client.Configure(ctx, in)
-}
-
-func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return a.client.GetPluginInfo(ctx, in)
-}
-
-func (a pluginClientAdapter) Notify(ctx context.Context, in *NotifyRequest) (*NotifyResponse, error) {
-	return a.client.Notify(ctx, in)
-}
-
-func (a pluginClientAdapter) NotifyAndAdvise(ctx context.Context, in *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error) {
-	return a.client.NotifyAndAdvise(ctx, in)
+	NotifyAndAdviseBundleLoaded(ctx context.Context, bundle *common.Bundle) error
+	NotifyBundleUpdated(ctx context.Context, bundle *common.Bundle) error
 }

--- a/pkg/server/plugin/notifier/v0.go
+++ b/pkg/server/plugin/notifier/v0.go
@@ -1,0 +1,37 @@
+package notifier
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/proto/spire/common"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
+)
+
+type V0 struct {
+	plugin.Facade
+
+	Plugin notifierv0.Notifier
+}
+
+func (v0 V0) NotifyAndAdviseBundleLoaded(ctx context.Context, bundle *common.Bundle) error {
+	_, err := v0.Plugin.NotifyAndAdvise(ctx, &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
+				Bundle: bundle,
+			},
+		},
+	})
+	return v0.WrapErr(err)
+}
+
+func (v0 V0) NotifyBundleUpdated(ctx context.Context, bundle *common.Bundle) error {
+	_, err := v0.Plugin.Notify(ctx, &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
+				Bundle: bundle,
+			},
+		},
+	})
+	return v0.WrapErr(err)
+}

--- a/pkg/server/plugin/notifier/v0_test.go
+++ b/pkg/server/plugin/notifier/v0_test.go
@@ -1,0 +1,94 @@
+package notifier_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/notifier"
+	"github.com/spiffe/spire/proto/spire/common"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestV0(t *testing.T) {
+	bundle := &common.Bundle{TrustDomainId: "spiffe://example.org"}
+
+	bundleLoaded := &notifierv0.NotifyAndAdviseRequest{
+		Event: &notifierv0.NotifyAndAdviseRequest_BundleLoaded{
+			BundleLoaded: &notifierv0.BundleLoaded{
+				Bundle: bundle,
+			},
+		},
+	}
+
+	bundleUpdated := &notifierv0.NotifyRequest{
+		Event: &notifierv0.NotifyRequest_BundleUpdated{
+			BundleUpdated: &notifierv0.BundleUpdated{
+				Bundle: bundle,
+			},
+		},
+	}
+
+	t.Run("notify and advise bundle loaded success", func(t *testing.T) {
+		notifier := loadV0Plugin(t, bundleLoaded, nil)
+		err := notifier.NotifyAndAdviseBundleLoaded(context.Background(), bundle)
+		assert.NoError(t, err)
+	})
+
+	t.Run("notify and advise bundle loaded failure", func(t *testing.T) {
+		notifier := loadV0Plugin(t, bundleLoaded, status.Error(codes.FailedPrecondition, "ohno"))
+		err := notifier.NotifyAndAdviseBundleLoaded(context.Background(), bundle)
+		spiretest.AssertGRPCStatus(t, err, codes.FailedPrecondition, "notifier(test): ohno")
+	})
+
+	t.Run("notify bundle updated success", func(t *testing.T) {
+		notifier := loadV0Plugin(t, bundleUpdated, nil)
+		err := notifier.NotifyBundleUpdated(context.Background(), bundle)
+		assert.NoError(t, err)
+	})
+
+	t.Run("notify bundle updated failure", func(t *testing.T) {
+		notifier := loadV0Plugin(t, bundleUpdated, status.Error(codes.FailedPrecondition, "ohno"))
+		err := notifier.NotifyBundleUpdated(context.Background(), bundle)
+		spiretest.AssertGRPCStatus(t, err, codes.FailedPrecondition, "notifier(test): ohno")
+	})
+}
+
+func loadV0Plugin(t *testing.T, expectedReq proto.Message, err error) notifier.Notifier {
+	server := notifierv0.PluginServer(&v0Plugin{
+		expectedReq: expectedReq,
+		err:         err,
+	})
+
+	var v0 notifier.V0
+	spiretest.LoadPlugin(t, catalog.MakePlugin("test", server), &v0)
+	return v0
+}
+
+type v0Plugin struct {
+	notifierv0.UnimplementedNotifierServer
+	expectedReq proto.Message
+	err         error
+}
+
+func (v0 v0Plugin) Notify(ctx context.Context, req *notifierv0.NotifyRequest) (*notifierv0.NotifyResponse, error) {
+	if diff := cmp.Diff(v0.expectedReq, req, protocmp.Transform()); diff != "" {
+		return nil, fmt.Errorf("v0 shim issued an unexpected request:\n%s", diff)
+	}
+	return &notifierv0.NotifyResponse{}, v0.err
+}
+
+func (v0 v0Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndAdviseRequest) (*notifierv0.NotifyAndAdviseResponse, error) {
+	if diff := cmp.Diff(v0.expectedReq, req, protocmp.Transform()); diff != "" {
+		return nil, fmt.Errorf("v0 shim issued an unexpected request:\n%s", diff)
+	}
+	return &notifierv0.NotifyAndAdviseResponse{}, v0.err
+}

--- a/proto/spire/server/notifier/v0/notifier.go
+++ b/proto/spire/server/notifier/v0/notifier.go
@@ -1,0 +1,105 @@
+// Provides interfaces and adapters for the Notifier service
+//
+// Generated code. Do not modify by hand.
+package v0
+
+import (
+	"context"
+
+	"github.com/spiffe/spire/pkg/common/catalog"
+	spi "github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/proto/spire/server/notifier"
+	"google.golang.org/grpc"
+)
+
+type BundleLoaded = notifier.BundleLoaded                                               //nolint: golint
+type BundleUpdated = notifier.BundleUpdated                                             //nolint: golint
+type NotifierClient = notifier.NotifierClient                                           //nolint: golint
+type NotifierServer = notifier.NotifierServer                                           //nolint: golint
+type NotifyAndAdviseRequest = notifier.NotifyAndAdviseRequest                           //nolint: golint
+type NotifyAndAdviseRequest_BundleLoaded = notifier.NotifyAndAdviseRequest_BundleLoaded //nolint: golint
+type NotifyAndAdviseResponse = notifier.NotifyAndAdviseResponse                         //nolint: golint
+type NotifyRequest = notifier.NotifyRequest                                             //nolint: golint
+type NotifyRequest_BundleUpdated = notifier.NotifyRequest_BundleUpdated                 //nolint: golint
+type NotifyResponse = notifier.NotifyResponse                                           //nolint: golint
+type UnimplementedNotifierServer = notifier.UnimplementedNotifierServer                 //nolint: golint
+type UnsafeNotifierServer = notifier.UnsafeNotifierServer                               //nolint: golint
+
+const (
+	Type = "Notifier"
+)
+
+// Notifier is the client interface for the service type Notifier interface.
+type Notifier interface {
+	Notify(context.Context, *NotifyRequest) (*NotifyResponse, error)
+	NotifyAndAdvise(context.Context, *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error)
+}
+
+// Plugin is the client interface for the service with the plugin related methods used by the catalog to initialize the plugin.
+type Plugin interface {
+	Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error)
+	GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error)
+	Notify(context.Context, *NotifyRequest) (*NotifyResponse, error)
+	NotifyAndAdvise(context.Context, *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error)
+}
+
+// PluginServer returns a catalog PluginServer implementation for the Notifier plugin.
+func PluginServer(server NotifierServer) catalog.PluginServer {
+	return &pluginServer{
+		server: server,
+	}
+}
+
+type pluginServer struct {
+	server NotifierServer
+}
+
+func (s pluginServer) PluginType() string {
+	return Type
+}
+
+func (s pluginServer) PluginClient() catalog.PluginClient {
+	return PluginClient
+}
+
+func (s pluginServer) RegisterPluginServer(server *grpc.Server) interface{} {
+	notifier.RegisterNotifierServer(server, s.server)
+	return s.server
+}
+
+// PluginClient is a catalog PluginClient implementation for the Notifier plugin.
+var PluginClient catalog.PluginClient = pluginClient{}
+
+type pluginClient struct{}
+
+func (pluginClient) PluginType() string {
+	return Type
+}
+
+func (pluginClient) NewPluginClient(conn grpc.ClientConnInterface) interface{} {
+	return AdaptPluginClient(notifier.NewNotifierClient(conn))
+}
+
+func AdaptPluginClient(client NotifierClient) Notifier {
+	return pluginClientAdapter{client: client}
+}
+
+type pluginClientAdapter struct {
+	client NotifierClient
+}
+
+func (a pluginClientAdapter) Configure(ctx context.Context, in *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+	return a.client.Configure(ctx, in)
+}
+
+func (a pluginClientAdapter) GetPluginInfo(ctx context.Context, in *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
+	return a.client.GetPluginInfo(ctx, in)
+}
+
+func (a pluginClientAdapter) Notify(ctx context.Context, in *NotifyRequest) (*NotifyResponse, error) {
+	return a.client.Notify(ctx, in)
+}
+
+func (a pluginClientAdapter) NotifyAndAdvise(ctx context.Context, in *NotifyAndAdviseRequest) (*NotifyAndAdviseResponse, error) {
+	return a.client.NotifyAndAdvise(ctx, in)
+}

--- a/test/fakes/fakenotifier/notifier.go
+++ b/test/fakes/fakenotifier/notifier.go
@@ -2,60 +2,56 @@ package fakenotifier
 
 import (
 	"context"
+	"testing"
 
+	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/server/plugin/notifier"
-	"github.com/spiffe/spire/proto/spire/common/plugin"
+	"github.com/spiffe/spire/proto/spire/common"
+	notifierv0 "github.com/spiffe/spire/proto/spire/server/notifier/v0"
+	"github.com/spiffe/spire/test/spiretest"
 )
 
 type Config struct {
-	OnNotify          func(*notifier.NotifyRequest) (*notifier.NotifyResponse, error)
-	OnNotifyAndAdvise func(*notifier.NotifyAndAdviseRequest) (*notifier.NotifyAndAdviseResponse, error)
+	OnNotifyBundleUpdated         func(*common.Bundle) error
+	OnNotifyAndAdviseBundleLoaded func(*common.Bundle) error
 }
 
-type Notifier struct {
-	notifier.UnsafeNotifierServer
+func New(t *testing.T, config Config) notifier.Notifier {
+	server := notifierv0.PluginServer(&fakeNotifer{config: config})
+
+	var v0 notifier.V0
+	spiretest.LoadPlugin(t, catalog.MakePlugin("fake", server), &v0)
+	return v0
+}
+
+type fakeNotifer struct {
+	notifierv0.UnimplementedNotifierServer
 
 	config Config
 }
 
-func New(config Config) *Notifier {
-	return &Notifier{
-		config: config,
+func (n *fakeNotifer) Notify(ctx context.Context, req *notifierv0.NotifyRequest) (*notifierv0.NotifyResponse, error) {
+	var err error
+	if event := req.GetBundleUpdated(); event != nil && n.config.OnNotifyBundleUpdated != nil {
+		err = n.config.OnNotifyBundleUpdated(event.Bundle)
 	}
+	return &notifierv0.NotifyResponse{}, err
 }
 
-func (n *Notifier) Notify(ctx context.Context, req *notifier.NotifyRequest) (*notifier.NotifyResponse, error) {
-	if n.config.OnNotify != nil {
-		return n.config.OnNotify(req)
+func (n *fakeNotifer) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndAdviseRequest) (*notifierv0.NotifyAndAdviseResponse, error) {
+	var err error
+	if event := req.GetBundleLoaded(); event != nil && n.config.OnNotifyAndAdviseBundleLoaded != nil {
+		err = n.config.OnNotifyAndAdviseBundleLoaded(event.Bundle)
 	}
-	return &notifier.NotifyResponse{}, nil
+	return &notifierv0.NotifyAndAdviseResponse{}, err
 }
 
-func (n *Notifier) NotifyAndAdvise(ctx context.Context, req *notifier.NotifyAndAdviseRequest) (*notifier.NotifyAndAdviseResponse, error) {
-	if n.config.OnNotifyAndAdvise != nil {
-		return n.config.OnNotifyAndAdvise(req)
-	}
-	return &notifier.NotifyAndAdviseResponse{}, nil
-}
-
-func (n *Notifier) Configure(ctx context.Context, req *plugin.ConfigureRequest) (*plugin.ConfigureResponse, error) {
-	return &plugin.ConfigureResponse{}, nil
-}
-
-func (n *Notifier) GetPluginInfo(ctx context.Context, req *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error) {
-	return &plugin.GetPluginInfoResponse{}, nil
-}
-
-func NotifyWaiter() (*Notifier, <-chan *notifier.NotifyRequest) {
-	ch := make(chan *notifier.NotifyRequest)
-	return New(Config{
-		OnNotify: SendOnNotify(ch),
+func NotifyBundleUpdatedWaiter(t *testing.T) (notifier.Notifier, <-chan *common.Bundle) {
+	ch := make(chan *common.Bundle)
+	return New(t, Config{
+		OnNotifyBundleUpdated: func(bundle *common.Bundle) error {
+			ch <- bundle
+			return nil
+		},
 	}), ch
-}
-
-func SendOnNotify(ch chan<- *notifier.NotifyRequest) func(req *notifier.NotifyRequest) (*notifier.NotifyResponse, error) {
-	return func(req *notifier.NotifyRequest) (*notifier.NotifyResponse, error) {
-		ch <- req
-		return &notifier.NotifyResponse{}, nil
-	}
 }

--- a/test/fakes/fakeservercatalog/catalog.go
+++ b/test/fakes/fakeservercatalog/catalog.go
@@ -43,15 +43,8 @@ func (c *Catalog) SetKeyManager(keyManager keymanager.KeyManager) {
 	c.KeyManager = keyManager
 }
 
-func (c *Catalog) AddNotifier(notifier catalog.Notifier) {
+func (c *Catalog) AddNotifier(notifier notifier.Notifier) {
 	c.Notifiers = append(c.Notifiers, notifier)
-}
-
-func Notifier(name string, n notifier.Notifier) catalog.Notifier {
-	return catalog.Notifier{
-		PluginInfo: pluginInfo{name: name, typ: notifier.Type},
-		Notifier:   n,
-	}
 }
 
 func UpstreamAuthority(name string, ua upstreamauthority.UpstreamAuthority) *catalog.UpstreamAuthority {


### PR DESCRIPTION
This is the next facade introduced as part of #2153.

There was a tiny bit of churn in the tests due to the fakenotifier now being loaded as an actual plugin (for example, a previously ignored canceled context caused a different error to return in test). Other than that it should be a straightforward transition.