### PR TITLE
Fix premature stream closure handling in v0 nodeattestor shim

### DIFF
--- a/pkg/agent/plugin/nodeattestor/v0.go
+++ b/pkg/agent/plugin/nodeattestor/v0.go
@@ -59,13 +59,15 @@ func (v0 V0) Attest(ctx context.Context, serverStream ServerStream) error {
 		})
 		switch {
 		case err == io.EOF:
-			return v0.Error(codes.Internal, "plugin closed stream after being issued a challenge")
+			return v0.Error(codes.Internal, "plugin closed stream before handling the challenge")
 		case err != nil:
 			return v0.WrapErr(err)
 		}
 
 		resp, err := pluginStream.Recv()
 		switch {
+		case err == io.EOF:
+			return v0.Error(codes.Internal, "plugin closed stream before handling the challenge")
 		case err != nil:
 			return v0.WrapErr(err)
 		case resp.Response == nil:

--- a/pkg/agent/plugin/nodeattestor/v0_test.go
+++ b/pkg/agent/plugin/nodeattestor/v0_test.go
@@ -83,7 +83,7 @@ func TestV0(t *testing.T) {
 			pluginImpl:    &fakeV0Plugin{attestationData: &attestationData},
 			streamImpl:    &fakeStream{expectData: attestationData, challenges: challenges("echo")},
 			expectCode:    codes.Internal,
-			expectMessage: "nodeattestor(test): plugin closed stream after being issued a challenge",
+			expectMessage: "nodeattestor(test): plugin closed stream before handling the challenge",
 		},
 		{
 			test:          "plugin fails responding to challenge",


### PR DESCRIPTION
There is a unit-test that asserts that the shim properly identifies and handles instances where a plugin closes the stream prematurely and therefore cannot handle a challenge issued by the server.

The test harness facilitates this by having the plugin close the stream right after sending the initial attestation data. The shim would detect the condition by checking for io.EOF when sending the challenge on the stream. However, if timing is just right, the shim may not observe the stream closure until attempting to receive the challenge response.

This code fixes the shim to also detect the EOF condition on the receive path. Note that nothing was "broken" in that attestation would still fail, but the error message isn't as helpful without the fix.