### PR TITLE
Only deprecate built-in noop node resolver

### DIFF
--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -179,7 +179,7 @@ func Load(ctx context.Context, config Config) (*Repository, error) {
 		return nil, err
 	}
 
-	if _, ok := config.PluginConfig[nodeResolverType]["noop"]; ok {
+	if noopConfig, ok := config.PluginConfig[nodeResolverType]["noop"]; ok && noopConfig.PluginCmd == "" {
 		// TODO: remove in 1.1.0
 		delete(config.PluginConfig[nodeResolverType], "noop")
 		config.Log.Warn(`The "noop" NodeResolver is not required, is deprecated, and will be removed from a future release`)


### PR DESCRIPTION
#2189 removed the noop noderesolver plugin and added a deprecation warning. However, as written it would prevent external plugins named "noop" from loading, which although unlikely to exist, would break those deployments.