### PR TITLE
Rotate APIService caBundle

### DIFF
--- a/doc/plugin_server_notifier_k8sbundle.md
+++ b/doc/plugin_server_notifier_k8sbundle.md
@@ -14,6 +14,7 @@ The plugin accepts the following configuration options:
 | config_map            | The name of the ConfigMap                   | `spire-bundle`  |
 | config_map_key        | The key within the ConfigMap for the bundle | `bundle.crt`    |
 | kube_config_file_path | The path on disk to the kubeconfig containing configuration to enable interaction with the Kubernetes API server. If unset, it is assumed the notifier is in-cluster and in-cluster credentials will be used. | |
+| api_service_label     | If set, rotate the CA Bundle in API services with this label set to `true`. | |
 | webhook_label         | If set, rotate the CA Bundle in validating and mutating webhooks with this label set to `true`. | |
 
 ## Configuring Kubernetes
@@ -64,8 +65,9 @@ metadata:
   namespace: spire
 ```
 
-### Configuration when Rotating Webhook CA Bundles
-When rotating webhook CA bundles, use the below ClusterRole:
+### Configuration when Rotating Webhook and API Service CA Bundles
+
+When rotating webhook and API Service CA bundles, use the below ClusterRole:
 
 ```yaml
 kind: ClusterRole
@@ -78,6 +80,9 @@ rules:
   verbs: ["get", "patch"]
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "patch", "watch"]
+- apiGroups: ["apiregistration.k8s.io"]
+  resources: ["apiservices"]
   verbs: ["get", "list", "patch", "watch"]
 ```
 
@@ -112,16 +117,19 @@ the credentials found in the `/path/to/kubeconfig` file.
     }
 ```
 
-### Default In-Cluster with Webhook Rotation
+### Default In-Cluster with Webhook and APIService Rotation
+
 The following configuration pushes bundle contents from an in-cluster SPIRE
 server to
 - The `bundle.crt` key in the `spire:spire-bundle` ConfigMap
 - Validating and mutating webhooks with a label of `spiffe.io/webhook: true`
+- API services with a label of `spiffe.io/api_service: true`
 
 ```
     Notifier "k8sbundle" {
         plugin_data {
-            webhook_label = "spiffe.io/webhook"
+            webhook_label    = "spiffe.io/webhook"
+            api_service_label = "spiffe.io/api_service"
         }
     }
 ```

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.2
 	k8s.io/client-go v0.18.2
-	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
+	k8s.io/kube-aggregator v0.18.2
+	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 	sigs.k8s.io/controller-runtime v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1157,10 +1157,16 @@ k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUc
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
+k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/kube-aggregator v0.18.2 h1:mgsze91nZC27HeJi8bLRyhLINQznEUy4SOTpbOhsZEM=
+k8s.io/kube-aggregator v0.18.2/go.mod h1:ijq6FnNUoKinA6kKbkN6svdTacSoQVNtKqmQ1+XJEYQ=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDNZ16KJtb49HfR3ZHB9qYXM=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c/go.mod h1:GRQhZsXIAJ1xR0C9bd8UpWHZ5plfAS9fzPjJuQ6JL3E=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
+k8s.io/utils v0.0.0-20201110183641-67b214c5f920 h1:CbnUZsM497iRC5QMVkHwyl8s2tB3g7yaSHkYPkpgelw=
+k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	aggregator "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 )
 
 var (
@@ -58,6 +60,7 @@ type pluginConfig struct {
 	ConfigMap          string `hcl:"config_map"`
 	ConfigMapKey       string `hcl:"config_map_key"`
 	WebhookLabel       string `hcl:"webhook_label"`
+	APIServiceLabel    string `hcl:"api_service_label"`
 	KubeConfigFilePath string `hcl:"kube_config_file_path"`
 }
 
@@ -172,7 +175,7 @@ func (p *Plugin) setConfig(config *pluginConfig) error {
 
 	// Start watcher to set CA Bundle in objects created after server has started
 	var cancelWatcher func()
-	if config.WebhookLabel != "" {
+	if config.WebhookLabel != "" || config.APIServiceLabel != "" {
 		ctx, cancel := context.WithCancel(context.Background())
 		watcher, err := newBundleWatcher(ctx, p, config)
 		if err != nil {
@@ -284,12 +287,21 @@ func newKubeClient(c *pluginConfig) ([]kubeClient, error) {
 	if err != nil {
 		return nil, k8sErr.Wrap(err)
 	}
+	aggregatorClientset, err := newAggregatorClientset(c.KubeConfigFilePath)
+	if err != nil {
+		return nil, k8sErr.Wrap(err)
+	}
 
 	clients := []kubeClient{configMapClient{Clientset: clientset}}
 	if c.WebhookLabel != "" {
 		clients = append(clients,
 			mutatingWebhookClient{Clientset: clientset},
 			validatingWebhookClient{Clientset: clientset},
+		)
+	}
+	if c.APIServiceLabel != "" {
+		clients = append(clients,
+			apiServiceClient{Clientset: aggregatorClientset},
 		)
 	}
 
@@ -299,12 +311,25 @@ func newKubeClient(c *pluginConfig) ([]kubeClient, error) {
 func newKubeClientset(configPath string) (*kubernetes.Clientset, error) {
 	config, err := getKubeConfig(configPath)
 	if err != nil {
-		return nil, k8sErr.Wrap(err)
+		return nil, err
 	}
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, k8sErr.Wrap(err)
+		return nil, err
+	}
+	return client, nil
+}
+
+func newAggregatorClientset(configPath string) (*aggregator.Clientset, error) {
+	config, err := getKubeConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := aggregator.NewForConfig(config)
+	if err != nil {
+		return nil, err
 	}
 	return client, nil
 }
@@ -348,7 +373,7 @@ func (c configMapClient) GetList(ctx context.Context, config *pluginConfig) (run
 func (c configMapClient) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *identityproviderv0.FetchX509IdentityResponse) (runtime.Object, error) {
 	configMap, ok := obj.(*corev1.ConfigMap)
 	if !ok {
-		return nil, k8sErr.New("wrong type, expecting ConfigMap")
+		return nil, status.Errorf(codes.InvalidArgument, "wrong type, expecting ConfigMap")
 	}
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -369,6 +394,57 @@ func (c configMapClient) Watch(ctx context.Context, config *pluginConfig) (watch
 	return nil, nil
 }
 
+// apiServiceClient encapsulates the Kubenetes API for updating the CA Bundle in an API Service
+type apiServiceClient struct {
+	*aggregator.Clientset
+}
+
+func (c apiServiceClient) Get(ctx context.Context, namespace, name string) (runtime.Object, error) {
+	return c.ApiregistrationV1().APIServices().Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c apiServiceClient) GetList(ctx context.Context, config *pluginConfig) (runtime.Object, error) {
+	return c.ApiregistrationV1().APIServices().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", config.APIServiceLabel),
+	})
+}
+
+func (c apiServiceClient) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *identityproviderv0.FetchX509IdentityResponse) (runtime.Object, error) {
+	apiService, ok := obj.(*apiregistrationv1.APIService)
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "wrong type, expecting APIService")
+	}
+
+	// Check if APIService needs an update
+	if bytes.Equal(apiService.Spec.CABundle, []byte(bundleData(resp.Bundle))) {
+		return nil, status.Errorf(codes.AlreadyExists, "APIService %s is already up to date", apiService.Name)
+	}
+
+	patch := &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: apiService.ResourceVersion,
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			CABundle:             []byte(bundleData(resp.Bundle)),
+			GroupPriorityMinimum: apiService.Spec.GroupPriorityMinimum,
+			VersionPriority:      apiService.Spec.VersionPriority,
+		},
+	}
+
+	return patch, nil
+}
+
+func (c apiServiceClient) Patch(ctx context.Context, namespace, name string, patchBytes []byte) error {
+	_, err := c.ApiregistrationV1().APIServices().Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
+}
+
+func (c apiServiceClient) Watch(ctx context.Context, config *pluginConfig) (watch.Interface, error) {
+	return c.ApiregistrationV1().APIServices().Watch(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", config.APIServiceLabel),
+	})
+}
+
 // mutatingWebhookClient encapsulates the Kubenetes API for updating the CA Bundle in a mutating webhook
 type mutatingWebhookClient struct {
 	*kubernetes.Clientset
@@ -387,7 +463,7 @@ func (c mutatingWebhookClient) GetList(ctx context.Context, config *pluginConfig
 func (c mutatingWebhookClient) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *identityproviderv0.FetchX509IdentityResponse) (runtime.Object, error) {
 	mutatingWebhook, ok := obj.(*admissionv1.MutatingWebhookConfiguration)
 	if !ok {
-		return nil, k8sErr.New("wrong type, expecting MutatingWebhookConfiguration")
+		return nil, status.Errorf(codes.InvalidArgument, "wrong type, expecting MutatingWebhookConfiguration")
 	}
 
 	// Check if MutatingWebhookConfiguration needs an update
@@ -449,7 +525,7 @@ func (c validatingWebhookClient) GetList(ctx context.Context, config *pluginConf
 func (c validatingWebhookClient) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *identityproviderv0.FetchX509IdentityResponse) (runtime.Object, error) {
 	validatingWebhook, ok := obj.(*admissionv1.ValidatingWebhookConfiguration)
 	if !ok {
-		return nil, k8sErr.New("wrong type, expecting ValidatingWebhookConfiguration")
+		return nil, status.Errorf(codes.InvalidArgument, "wrong type, expecting ValidatingWebhookConfiguration")
 	}
 
 	// Check if ValidatingWebhookConfiguration needs an update

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
@@ -71,7 +71,7 @@ func (s *Suite) SetupTest() {
 	s.LoadPlugin(builtIn(s.raw), &s.p,
 		spiretest.HostService(identityproviderv0.HostServiceServer(s.r)))
 
-	s.withKubeClient(s.k, "")
+	s.withKubeClient([]kubeClient{s.k}, "")
 }
 
 func (s *Suite) TestNotifyFailsIfNotConfigured() {
@@ -216,7 +216,7 @@ func (s *Suite) TestBundleLoadedWithDefaultConfiguration() {
 }
 
 func (s *Suite) TestBundleLoadedWithConfigurationOverrides() {
-	s.withKubeClient(s.k, "/some/file/path")
+	s.withKubeClient([]kubeClient{s.k}, "/some/file/path")
 
 	s.k.setConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -370,7 +370,7 @@ func (s *Suite) TestBundleUpdatedWithDefaultConfiguration() {
 }
 
 func (s *Suite) TestBundleUpdatedWithConfigurationOverrides() {
-	s.withKubeClient(s.k, "/some/file/path")
+	s.withKubeClient([]kubeClient{s.k}, "/some/file/path")
 
 	s.k.setConfigMap(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -432,13 +432,13 @@ func (s *Suite) TestBundleFailsToLoadIfHostServicesUnavailabler() {
 	}
 }
 
-func (s *Suite) withKubeClient(client kubeClient, expectedConfigPath string) {
+func (s *Suite) withKubeClient(client []kubeClient, expectedConfigPath string) {
 	s.raw.hooks.newKubeClient = func(c *pluginConfig) ([]kubeClient, error) {
 		s.Equal(expectedConfigPath, c.KubeConfigFilePath)
 		if client == nil {
 			return nil, errors.New("kube client not configured")
 		}
-		return []kubeClient{client}, nil
+		return client, nil
 	}
 }
 

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
@@ -14,10 +14,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 )
 
 const (
-	testTimeout = time.Second * 2
+	testTimeout = time.Minute
 )
 
 func (s *Suite) TestBundleWatcherErrorsWhenCannotCreateClient() {
@@ -74,30 +75,43 @@ func (s *Suite) TestBundleWatchersStartsAndStops() {
 
 func (s *Suite) TestBundleWatcherUpdateConfig() {
 	w := newFakeWebhook()
-	s.withKubeClient(w, "/some/file/path")
+	a := newFakeAPIService()
+	client := []kubeClient{w, a}
+	s.withKubeClient(client, "/some/file/path")
 
 	s.configure(`
-webhook_label = "LABEL"
+webhook_label = "WEBHOOK_LABEL"
+api_service_label = "API_SERVICE_LABEL"
 kube_config_file_path = "/some/file/path"
 `)
 	s.Require().Eventually(func() bool {
-		return w.getWatchLabel() == "LABEL"
+		return w.getWatchLabel() == "WEBHOOK_LABEL"
+	}, testTimeout, time.Second)
+
+	s.Require().Eventually(func() bool {
+		return a.getWatchLabel() == "API_SERVICE_LABEL"
 	}, testTimeout, time.Second)
 
 	s.configure(`
-webhook_label = "LABEL2"
+webhook_label = "WEBHOOK_LABEL2"
+api_service_label = "API_SERVICE_LABEL2"
 kube_config_file_path = "/some/file/path"
 `)
 	s.Require().Eventually(func() bool {
-		return w.getWatchLabel() == "LABEL2"
+		return w.getWatchLabel() == "WEBHOOK_LABEL2"
+	}, testTimeout, time.Second)
+
+	s.Require().Eventually(func() bool {
+		return a.getWatchLabel() == "API_SERVICE_LABEL2"
 	}, testTimeout, time.Second)
 }
 
-func (s *Suite) TestBundleWatcherAddEvent() {
+func (s *Suite) TestBundleWatcherAddWebhookEvent() {
 	w := newFakeWebhook()
-	s.withKubeClient(w, "/some/file/path")
+	s.withKubeClient([]kubeClient{w}, "/some/file/path")
+
 	s.configure(`
-webhook_label = "LABEL"
+webhook_label = "WEBHOOK_LABEL"
 kube_config_file_path = "/some/file/path"
 `)
 
@@ -105,11 +119,10 @@ kube_config_file_path = "/some/file/path"
 	s.r.AppendBundle(testBundle)
 	w.setWebhook(webhook)
 	w.addWatchEvent(webhook)
-
 	s.Require().Eventually(func() bool {
 		return s.Equal(&admissionv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            "spire-webhook",
+				Name:            webhook.Name,
 				ResourceVersion: "2",
 			},
 			Webhooks: []admissionv1.MutatingWebhook{
@@ -119,7 +132,33 @@ kube_config_file_path = "/some/file/path"
 					},
 				},
 			},
-		}, w.getWebhook("spire-webhook"))
+		}, w.getWebhook(webhook.Name))
+	}, testTimeout, time.Second)
+}
+
+func (s *Suite) TestBundleWatcherAddAPIServiceEvent() {
+	a := newFakeAPIService()
+	s.withKubeClient([]kubeClient{a}, "/some/file/path")
+
+	s.configure(`
+api_service_label = "API_SERVICE_LABEL"
+kube_config_file_path = "/some/file/path"
+`)
+	s.r.AppendBundle(testBundle)
+
+	apiService := newAPIService()
+	a.setAPIService(apiService)
+	a.addWatchEvent(apiService)
+	s.Require().Eventually(func() bool {
+		return s.Equal(&apiregistrationv1.APIService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            apiService.Name,
+				ResourceVersion: "2",
+			},
+			Spec: apiregistrationv1.APIServiceSpec{
+				CABundle: []byte(testBundleData),
+			},
+		}, a.getAPIService(apiService.Name))
 	}, testTimeout, time.Second)
 }
 
@@ -145,6 +184,7 @@ func (w *fakeWebhook) Get(ctx context.Context, namespace, name string) (runtime.
 	}
 	return entry, nil
 }
+
 func (w *fakeWebhook) GetList(ctx context.Context, config *pluginConfig) (runtime.Object, error) {
 	list := w.getWebhookList()
 	if list.Items == nil {
@@ -246,5 +286,121 @@ func newWebhook() *admissionv1.MutatingWebhookConfiguration {
 				ClientConfig: admissionv1.WebhookClientConfig{},
 			},
 		},
+	}
+}
+
+type fakeAPIService struct {
+	mu          sync.RWMutex
+	fakeWatch   *watch.FakeWatcher
+	apiServices map[string]*apiregistrationv1.APIService
+	watchLabel  string
+}
+
+func newFakeAPIService() *fakeAPIService {
+	return &fakeAPIService{
+		fakeWatch:   watch.NewFake(),
+		apiServices: make(map[string]*apiregistrationv1.APIService),
+	}
+}
+
+func (a *fakeAPIService) Get(ctx context.Context, namespace, name string) (runtime.Object, error) {
+	entry := a.getAPIService(name)
+	if entry == nil {
+		return nil, errors.New("not found")
+	}
+	return entry, nil
+}
+
+func (a *fakeAPIService) GetList(ctx context.Context, config *pluginConfig) (runtime.Object, error) {
+	list := a.getAPIServiceList()
+	if list.Items == nil {
+		return nil, errors.New("not found")
+	}
+	return list, nil
+}
+
+func (a *fakeAPIService) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *hostservices.FetchX509IdentityResponse) (runtime.Object, error) {
+	webhook, ok := obj.(*apiregistrationv1.APIService)
+	if !ok {
+		return nil, k8sErr.New("wrong type, expecting API service")
+	}
+	return &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: webhook.ResourceVersion,
+		},
+		Spec: apiregistrationv1.APIServiceSpec{
+			CABundle: []byte(bundleData(resp.Bundle)),
+		},
+	}, nil
+}
+
+func (a *fakeAPIService) Patch(ctx context.Context, namespace, name string, patchBytes []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	entry, ok := a.apiServices[name]
+	if !ok {
+		return errors.New("not found")
+	}
+
+	patchedAPIService := new(apiregistrationv1.APIService)
+	if err := json.Unmarshal(patchBytes, patchedAPIService); err != nil {
+		return err
+	}
+	resourceVersion, err := strconv.Atoi(patchedAPIService.ResourceVersion)
+	if err != nil {
+		return errors.New("patch does not have resource version")
+	}
+	entry.ResourceVersion = fmt.Sprint(resourceVersion + 1)
+	entry.Spec.CABundle = patchedAPIService.Spec.CABundle
+	return nil
+}
+
+func (a *fakeAPIService) Watch(ctx context.Context, config *pluginConfig) (watch.Interface, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.watchLabel = config.APIServiceLabel
+	return a.fakeWatch, nil
+}
+
+func (a *fakeAPIService) getAPIService(name string) *apiregistrationv1.APIService {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.apiServices[name]
+}
+
+func (a *fakeAPIService) getAPIServiceList() *apiregistrationv1.APIServiceList {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	apiServiceList := &apiregistrationv1.APIServiceList{}
+	for _, apiService := range a.apiServices {
+		apiServiceList.Items = append(apiServiceList.Items, *apiService)
+	}
+	return apiServiceList
+}
+
+func (a *fakeAPIService) setAPIService(apiService *apiregistrationv1.APIService) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.apiServices[apiService.Name] = apiService
+}
+
+func (a *fakeAPIService) addWatchEvent(obj runtime.Object) {
+	a.fakeWatch.Add(obj)
+}
+
+func (a *fakeAPIService) getWatchLabel() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.watchLabel
+}
+
+func newAPIService() *apiregistrationv1.APIService {
+	return &apiregistrationv1.APIService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "spire-api-service",
+			ResourceVersion: "1",
+		},
+		Spec: apiregistrationv1.APIServiceSpec{},
 	}
 }

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
@@ -319,7 +319,7 @@ func (a *fakeAPIService) GetList(ctx context.Context, config *pluginConfig) (run
 	return list, nil
 }
 
-func (a *fakeAPIService) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *hostservices.FetchX509IdentityResponse) (runtime.Object, error) {
+func (a *fakeAPIService) CreatePatch(ctx context.Context, config *pluginConfig, obj runtime.Object, resp *identityproviderv0.FetchX509IdentityResponse) (runtime.Object, error) {
 	webhook, ok := obj.(*apiregistrationv1.APIService)
 	if !ok {
 		return nil, k8sErr.New("wrong type, expecting API service")


### PR DESCRIPTION
This changeset extends [PR 2022](https://github.com/spiffe/spire/pull/2022) that added support for SPIRE rotating the caBundle in Kubernetes Mutating and Validating Webhooks. The changes here add support for rotating the caBundle in the APIService object, which is used to extend the Kubernetes API Server with additional APIs. [More info on APIService](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/apiserver-aggregation/).
