### PR TITLE
Azure Bug Fix: Node Attestation was failing due to pagination if VMs in a subscription is more than 1000

### DIFF
--- a/pkg/server/plugin/noderesolver/azure/client.go
+++ b/pkg/server/plugin/noderesolver/azure/client.go
@@ -58,6 +58,13 @@ func (c *azureClient) GetVirtualMachineResourceID(ctx context.Context, principal
 	}
 
 	values := result.Values()
+	for len(values) == 0 {
+		nerr := result.NextWithContext(ctx)
+		if nerr != nil {
+			return "", errs.Wrap(nerr)
+		}
+		values = result.Values()
+	}
 	if len(values) == 0 {
 		return "", errs.New("principal %q not found", principalID)
 	}


### PR DESCRIPTION

Signed-off-by: mayur040993 <rastogi.mayur04@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
@rturner3 Azure SDK sometimes gives you an empty response with page id if the num of the VMs in a Subscription is more than 1000.
so to handle this you have to traverse to different pages as well.

Currently, this is not been taken care of by the Azure SDK.

So if you are getting an empty response with some next page ID, it means that there are some data on the next page.
We have to look at the next pages as well before saying the "Principal ID is not found"

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

