### PR TITLE
k8s-workload-registrar: Use SPIRE generated Parent IDs

### DIFF
--- a/support/k8s/k8s-workload-registrar/config_crd.go
+++ b/support/k8s/k8s-workload-registrar/config_crd.go
@@ -105,13 +105,10 @@ func (c *CRDMode) Run(ctx context.Context) error {
 
 	if c.PodController {
 		err = controllers.NewNodeReconciler(controllers.NodeReconcilerConfig{
-			Client:      mgr.GetClient(),
-			Cluster:     c.Cluster,
-			Ctx:         ctx,
-			Log:         log,
-			Namespace:   myNamespace,
-			Scheme:      mgr.GetScheme(),
-			TrustDomain: c.TrustDomain,
+			Client:    mgr.GetClient(),
+			Ctx:       ctx,
+			Log:       log,
+			Namespace: myNamespace,
 		}).SetupWithManager(mgr)
 		if err != nil {
 			return err

--- a/support/k8s/k8s-workload-registrar/config_crd.go
+++ b/support/k8s/k8s-workload-registrar/config_crd.go
@@ -107,6 +107,7 @@ func (c *CRDMode) Run(ctx context.Context) error {
 		err = controllers.NewNodeReconciler(controllers.NodeReconcilerConfig{
 			Client:    mgr.GetClient(),
 			Ctx:       ctx,
+			E:         entryClient,
 			Log:       log,
 			Namespace: myNamespace,
 		}).SetupWithManager(mgr)

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/endpoint_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/endpoint_controller_test.go
@@ -40,6 +40,16 @@ type EndpointControllerTestSuite struct {
 
 func (s *EndpointControllerTestSuite) SetupSuite() {
 	s.CommonControllerTestSuite = NewCommonControllerTestSuite(s.T())
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			UID:  "12345",
+		},
+		Spec: corev1.NodeSpec{},
+	}
+	err := s.k8sClient.Create(s.ctx, &node)
+	s.Require().NoError(err)
 }
 
 // TestAddDNSName deploys and endpoint and checks if the SPIFFE ID is updated

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/node_controller.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/node_controller.go
@@ -19,14 +19,10 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire/pkg/common/idutil"
 	spiffeidv1beta1 "github.com/spiffe/spire/support/k8s/k8s-workload-registrar/mode-crd/api/spiffeid/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,13 +30,10 @@ import (
 
 // NodeReconcilerConfig holds the config passed in when creating the reconciler
 type NodeReconcilerConfig struct {
-	Client      client.Client
-	Cluster     string
-	Ctx         context.Context
-	Log         logrus.FieldLogger
-	Namespace   string
-	Scheme      *runtime.Scheme
-	TrustDomain string
+	Client    client.Client
+	Ctx       context.Context
+	Log       logrus.FieldLogger
+	Namespace string
 }
 
 // NodeReconciler holds the runtime configuration and state of this controller
@@ -64,72 +57,21 @@ func (n *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(n)
 }
 
-// Reconcile creates a SPIFFE ID for each node, used to parent SPIFFE IDs for pods
-// running on that node
+// Reconcile removes the deprecated SPIFFE ID custom resource created for each node. PSAT parents
+// are now used instead.
 func (n *NodeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	node := corev1.Node{}
-	ctx := n.c.Ctx
-
-	if err := n.Get(ctx, req.NamespacedName, &node); err != nil {
-		if !errors.IsNotFound(err) {
-			n.c.Log.WithError(err).Error("Unable to fetch Node")
-			return ctrl.Result{}, err
-		}
-
-		return ctrl.Result{}, client.IgnoreNotFound(err)
-	}
-
-	return n.updateorCreateNodeEntry(n.c.Ctx, &node)
-}
-
-// updateorCreateNodeEntry attempts to create a new SpiffeID resource.
-func (n *NodeReconciler) updateorCreateNodeEntry(ctx context.Context, node *corev1.Node) (ctrl.Result, error) {
-	trustDomain, err := spiffeid.TrustDomainFromString(n.c.TrustDomain)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	// Set up new SPIFFE ID
-	spiffeID := &spiffeidv1beta1.SpiffeID{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      node.Name,
-			Namespace: n.c.Namespace,
-			Labels: map[string]string{
-				"nodeUid": string(node.ObjectMeta.UID),
-			},
-		},
-		Spec: spiffeidv1beta1.SpiffeIDSpec{
-			ParentId: idutil.ServerID(trustDomain).String(),
-			SpiffeId: n.nodeID(node.ObjectMeta.Name),
-			Selector: spiffeidv1beta1.Selector{
-				Cluster:      n.c.Cluster,
-				AgentNodeUid: node.ObjectMeta.UID,
-			},
-		},
-	}
-	err = setOwnerRef(node, spiffeID, n.c.Scheme)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Check for existing entry
-	existing := spiffeidv1beta1.SpiffeID{}
-	err = n.Get(ctx, types.NamespacedName{
-		Name:      spiffeID.ObjectMeta.Name,
-		Namespace: spiffeID.ObjectMeta.Namespace,
-	}, &existing)
+	spiffeID := spiffeidv1beta1.SpiffeID{}
+	err := n.Get(n.c.Ctx, types.NamespacedName{
+		Name:      req.NamespacedName.Name,
+		Namespace: n.c.Namespace,
+	}, &spiffeID)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			// Create new entry
-			return ctrl.Result{}, n.Create(ctx, spiffeID)
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 
 		return ctrl.Result{}, err
 	}
 
-	// Nothing to do
-	return ctrl.Result{}, nil
-}
-
-func (n *NodeReconciler) nodeID(nodeName string) string {
-	return makeID(n.c.TrustDomain, "k8s-workload-registrar/%s/node/%s", n.c.Cluster, nodeName)
+	return ctrl.Result{}, n.Delete(n.c.Ctx, &spiffeID)
 }

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/node_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/node_controller_test.go
@@ -50,6 +50,7 @@ func (s *NodeControllerTestSuite) TestNodeSpiffeIDCleanup() {
 	n := NewNodeReconciler(NodeReconcilerConfig{
 		Client:    s.k8sClient,
 		Ctx:       s.ctx,
+		E:         s.entryClient,
 		Log:       s.log,
 		Namespace: NodeNamespace,
 	})

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/pod_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/pod_controller_test.go
@@ -45,6 +45,16 @@ type PodControllerTestSuite struct {
 
 func (s *PodControllerTestSuite) SetupSuite() {
 	s.CommonControllerTestSuite = NewCommonControllerTestSuite(s.T())
+
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			UID:  "12345",
+		},
+		Spec: corev1.NodeSpec{},
+	}
+	err := s.k8sClient.Create(s.ctx, &node)
+	s.Require().NoError(err)
 }
 
 // TestPodLabel adds a label to a pod and check if the SPIFFE ID is generated correctly.

--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/utils.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/utils.go
@@ -26,12 +26,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func NewManager(leaderElection bool, metricsBindAddr, webhookCertDir string, webhookPort int) (ctrl.Manager, error) {
@@ -53,23 +50,6 @@ func NewManager(leaderElection bool, metricsBindAddr, webhookCertDir string, web
 	}
 
 	return mgr, nil
-}
-
-// setOwnerRef sets the owner object as owner of a new SPIFFE ID resource locally
-func setOwnerRef(owner metav1.Object, spiffeID *spiffeidv1beta1.SpiffeID, scheme *runtime.Scheme) error {
-	err := controllerutil.SetControllerReference(owner, spiffeID, scheme)
-	if err != nil {
-		return err
-	}
-
-	// Make owner reference non-blocking, so object can be deleted if registrar is down
-	ownerRef := metav1.GetControllerOfNoCopy(spiffeID)
-	if ownerRef == nil {
-		return err
-	}
-	ownerRef.BlockOwnerDeletion = pointer.BoolPtr(false)
-
-	return nil
 }
 
 // deleteRegistrationEntry deletes an entry on the SPIRE Server


### PR DESCRIPTION
Signed-off-by: Faisal Memon <f.memon@f5.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
CRD mode k8s-workload-registrar

**Description of change**
Currently the k8s-workload-registrar creates its own set of parent entries, one per node, using a node controller. Auto generated entries are then parented to the entry corresponding to the node the pod is running on. I realized recently that it isnt necessary to create parent entries because they are already created as part of the PSAT process.

This changeset switches to using the PSAT parents and starts the process of deprecating the node controller. To maintain backwards compatibility:
- Entries using the old node controller parent will be updated in place to use the SPIRE generated PSAT parent
- The node controller will stick around to delete the existing parents it created in an older version. In a future version this should be removed.


