### PR TITLE
Avoid Docker Hub pull limits on integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,7 @@ jobs:
             # CircleCI is silly and doesn't provide this incredibly helpful
             # environment variable. Requests for it go back years. For shame.
             CIRCLE_TARGET_BRANCH=$(.circleci/determine-target-branch.sh)
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
             cd test/integration
             circleci tests glob "suites/*" | circleci tests split | CICD_TARGET_BRANCH="${CIRCLE_TARGET_BRANCH}" xargs ./test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ jobs:
       script:
         - make images
         - make scratch-images
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - CICD_TARGET_BRANCH="$TRAVIS_BRANCH" make integration
         - .travis/publish-images.sh
 
@@ -112,6 +113,7 @@ jobs:
       script:
         - make images
         - make scratch-images
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - CICD_TARGET_BRANCH="$TRAVIS_BRANCH" make integration
 
 notifications:


### PR DESCRIPTION
Credentials have been added to both the Travis and CircleCI project settings.

Logging in to Docker Hub will bump our pull limits.