### PR TITLE
Rename master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
             branches:
-              only: master  # Unstable images are only pushed from master
+              only: main  # Unstable images are only pushed from main
           requires:
             - unit-test-linux
             - integration-test

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 1. If this is your first PR, please read our contributor guidelines
 https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
-https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
+https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md
 
 2. Please remember to include a DCO on every commit (`git commit -s`)
 https://github.com/apps/dco

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,12 @@ cache:
     # cache the Go module cache
     - $HOME/go/pkg/mod
 
-# Only build for master and branches that look like versions. This also covers
+# Only build for main and branches that look like versions. This also covers
 # tags, which keeps us from building (and deploying) from the extra tags we set
 # during a release for go multi-module repo support (i.e. proto/spire/v1.2.3).
 branches:
   only:
-    - master
+    - main
     - /^v\d+\.\d+(\.\d+)?$/
 
 stages:
@@ -93,7 +93,7 @@ jobs:
             condition: $GITHUB_TOKEN != ""
 
     - stage: publish images
-      if: type = push AND (tag IS present OR branch = master)
+      if: type = push AND (tag IS present OR branch = main)
       os: linux
       dist: xenial
       before_script:

--- a/.travis/publish-images.sh
+++ b/.travis/publish-images.sh
@@ -41,8 +41,8 @@ if [ -n "${TRAVIS_TAG}" ]; then
 	docker push gcr.io/spiffe-io/k8s-workload-registrar:"${TRAVIS_TAG}"
 	docker tag oidc-discovery-provider gcr.io/spiffe-io/oidc-discovery-provider:"${TRAVIS_TAG}"
 	docker push gcr.io/spiffe-io/oidc-discovery-provider:"${TRAVIS_TAG}"
-elif [ x"${TRAVIS_BRANCH}" = x"master" ]; then
-	# This is an untagged build for master. Tag and push as unstable
+elif [ x"${TRAVIS_BRANCH}" = x"main" ]; then
+	# This is an untagged build for main. Tag and push as unstable
 	docker tag spire-server gcr.io/spiffe-io/spire-server:unstable
 	docker push gcr.io/spiffe-io/spire-server:unstable
 	docker tag spire-agent gcr.io/spiffe-io/spire-agent:unstable

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -65,16 +65,16 @@ While reviewing, SPIRE maintainers should ask questions similar to the following
 The above list is advisory, and is meant only to get the mind going.
 
 ## Release and Branch Management
-The SPIRE project maintains active support for both the current and the previous major versions. All active development occurs in the `master` branch. Version branches are used for minor releases of the previous major version when necessary.
+The SPIRE project maintains active support for both the current and the previous major versions. All active development occurs in the `main` branch. Version branches are used for minor releases of the previous major version when necessary.
 
 ### Version Branches
 When a bug is discovered in the latest release that also affects releases of the prior major version, it is necessary to backport the fix.
 
-If it is the first time that the prior major version is receiving a backported patch, then a version branch is created to track it. The version branch is named `vX.Y` where X and Y are the two most significant digits in the semantic version number. Its base is the last tag present in master for the release in question. For example, if SPIRE is on version 0.9.3, and the last 0.8 release was 0.8.4, then a `v0.8` branch is created with its base being the master commit tagged with `v0.8.4`.
+If it is the first time that the prior major version is receiving a backported patch, then a version branch is created to track it. The version branch is named `vX.Y` where X and Y are the two most significant digits in the semantic version number. Its base is the last tag present in main for the release in question. For example, if SPIRE is on version 0.9.3, and the last 0.8 release was 0.8.4, then a `v0.8` branch is created with its base being the main commit tagged with `v0.8.4`.
 
-Once the version branch is created, the patch is either cherry picked or backported into a PR against the version branch. The version branch is maintained via the same process as the master branch, including PR approval process etc.
+Once the version branch is created, the patch is either cherry picked or backported into a PR against the version branch. The version branch is maintained via the same process as the main branch, including PR approval process etc.
 
-Releases for the previous major version are made directly from its version branch. Ensure that the CHANGELOG is updated in both the master and the version branch to reflect the new release.
+Releases for the previous major version are made directly from its version branch. Ensure that the CHANGELOG is updated in both the main and the version branch to reflect the new release.
 
 ### Releasing
 The SPIRE release machinery is tag-driven. When the maintainers are ready to release, a tag is pushed referencing the release commit. While the CI/CD pipeline takes care of the rest, it is important to keep an eye on its progress. If an error is encountered during this process, the release is aborted.
@@ -91,9 +91,9 @@ This section summarizes the steps necessary to execute a SPIRE release. Unless e
 The following steps must be completed one week prior to release:
 * Ensure all changes intended to be included in the release are fully merged.
 * Identify a specific commit as the release candidate.
-* Create a draft pull request against master branch with the updates to the CHANGELOG following [these guidelines](doc/changelog_guidelines.md). This allows those tracking the project to have early visibility into what will be included in the upcoming release and an opportunity to provide feedback. The release date can be set as "TBD" while it is a draft.
+* Create a draft pull request against the main branch with the updates to the CHANGELOG following [these guidelines](doc/changelog_guidelines.md). This allows those tracking the project to have early visibility into what will be included in the upcoming release and an opportunity to provide feedback. The release date can be set as "TBD" while it is a draft.
 * Raise an issue "Release SPIRE X.Y.Z", and include the release candidate commit hash. Reference the pull request with the updates to the CHANGELOG.
-* If the current state of the master branch has diverged from the candidate commit due to other changes than the ones from the CHANGELOG:
+* If the current state of the main branch has diverged from the candidate commit due to other changes than the ones from the CHANGELOG:
   * If there is not a version branch for this release, create a branch following the guidelines described in [Version branches](#version-branches).
   * Create a GitHub project named `Release vX.X.X` to identify the PRs that will be cherry-picked. The project should have two statuses to track the progress: one to identify the PRs to be cherry-picked and one for those that have been merged in the version branch.
   * Make sure that the [version in the branch](pkg/common/version/version.go) has been bumped to the version that is being released.
@@ -107,7 +107,7 @@ The following steps must be completed one week prior to release:
 
 The following steps must be completed to perform a release:
 * Mark the pull request to update the CHANGELOG as "Ready for review". Make sure that it is updated with the final release date. **At least two approvals from maintainers are required in order to be able to merge it**. If a version branch was created for the realease, cherry-pick the final CHANGELOG changes into the version branch once they are merged.
-* If releasing from master and the current state of the master branch has diverged from the candidate commit due to just the CHANGELOG changes, the candidate commit is now the one that includes the updated CHANGELOG. If releasing from a version branch, the candidate commit is now the one that has the CHANGELOG changes cherry-picked in the branch.
+* If releasing from main and the current state of the main branch has diverged from the candidate commit due to just the CHANGELOG changes, the candidate commit is now the one that includes the updated CHANGELOG. If releasing from a version branch, the candidate commit is now the one that has the CHANGELOG changes cherry-picked in the branch.
 * Cut two annotated tags against the release candidate named `vX.X.X` and `proto/spire/vX.X.X`, where `X.X.X` is the semantic version number of SPIRE.
   * The first line of the annotation should be `X.X.X` followed by the CHANGELOG. Refer to previous annotated tags as an example.
   * The `proto/spire/vX.X.X` tag is needed for proper versioning of the github.com/spiffe/spire/proto/spire go module and can be omitted if/when that go module is no longer in the SPIRE repository.
@@ -189,6 +189,6 @@ The responsibilities of the community chair are as follows:
 [1]: https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md
 [2]: https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md#maintainers
 [3]: https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md#change-review-process
-[4]: https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md
-[5]: https://github.com/spiffe/spire/blob/master/doc/upgrading.md
+[4]: https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md
+[5]: https://github.com/spiffe/spire/blob/main/doc/upgrading.md
 [6]: https://github.com/spiffe/spiffe/blob/master/CODE-OF-CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![SPIRE Logo](/doc/images/spire_logo.png)
 
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3303/badge)](https://bestpractices.coreinfrastructure.org/projects/3303)
-[![Build Status](https://travis-ci.com/spiffe/spire.svg?branch=master)](https://travis-ci.com/github/spiffe/spire)
-[![Coverage Status](https://coveralls.io/repos/github/spiffe/spire/badge.svg?branch=master)](https://coveralls.io/github/spiffe/spire?branch=master)
+[![Build Status](https://travis-ci.com/spiffe/spire.svg?branch=main)](https://travis-ci.com/github/spiffe/spire)
+[![Coverage Status](https://coveralls.io/repos/github/spiffe/spire/badge.svg?branch=main)](https://coveralls.io/github/spiffe/spire?branch=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/spiffe/spire)](https://goreportcard.com/report/github.com/spiffe/spire)
 [![Slack Status](https://slack.spiffe.io/badge.svg)](https://slack.spiffe.io)
 
-SPIRE (the [SPIFFE](https://github.com/spiffe/spiffe) Runtime Environment) is a toolchain of APIs for establishing trust between software systems across a wide variety of hosting platforms. SPIRE exposes the [SPIFFE Workload API](https://github.com/spiffe/go-spiffe/blob/master/v2/proto/spiffe/workload/workload.proto), which can attest running software systems and issue [SPIFFE IDs](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) and [SVID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md)s to them.  This in turn allows two workloads to establish trust between each other, for example by establishing an mTLS connection or by signing and verifying a JWT token. SPIRE can also enable workloads to securely authenticate to a secret store, a database, or a cloud provider service.
+SPIRE (the [SPIFFE](https://github.com/spiffe/spiffe) Runtime Environment) is a toolchain of APIs for establishing trust between software systems across a wide variety of hosting platforms. SPIRE exposes the [SPIFFE Workload API](https://github.com/spiffe/go-spiffe/blob/main/v2/proto/spiffe/workload/workload.proto), which can attest running software systems and issue [SPIFFE IDs](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) and [SVID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md)s to them.  This in turn allows two workloads to establish trust between each other, for example by establishing an mTLS connection or by signing and verifying a JWT token. SPIRE can also enable workloads to securely authenticate to a secret store, a database, or a cloud provider service.
 
 
 - [Get SPIRE](#get-spire)
@@ -38,7 +38,7 @@ SPIRE is hosted by the [Cloud Native Computing Foundation](https://cncf.io) (CNC
 ## Integrate with SPIRE
 
 - See [Extend SPIRE](https://spiffe.io/spire/docs/extending/) to learn about the highly extensible SPIRE plugin framework.
-- Client libraries for interacting with the [SPIFFE Workload API](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_API.md) are available in [Go](https://github.com/spiffe/go-spiffe/tree/master/v2), [Java](https://github.com/spiffe/java-spiffe) and [C++](https://github.com/spiffe/c-spiffe) languages. See [SPIFFE Library Usage Examples](https://spiffe.io/spire/try/spiffe-library-usage-examples/) for code samples.
+- Client libraries for interacting with the [SPIFFE Workload API](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_API.md) are available in [Go](https://github.com/spiffe/go-spiffe/tree/main/v2), [Java](https://github.com/spiffe/java-spiffe) and [C++](https://github.com/spiffe/c-spiffe) languages. See [SPIFFE Library Usage Examples](https://spiffe.io/spire/try/spiffe-library-usage-examples/) for code samples.
 - SPIRE provides an implementation of the [Envoy](https://envoyproxy.io) [Secret Discovery Service](https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret) (SDS) for use with [Envoy Proxy](https://envoyproxy.io).  SDS can be used to transparently install and rotate TLS certificates and trust bundles in Envoy. See [Using SPIRE with Envoy](https://spiffe.io/spire/docs/envoy/) for more information.
 
 For supported integration versions, see [Supported Integrations](/doc/supported_integrations.md).
@@ -48,7 +48,7 @@ For supported integration versions, see [Supported Integrations](/doc/supported_
 The SPIFFE community maintains the SPIRE project. Information on the various SIGs and relevant standards can be found in
 https://github.com/spiffe/spiffe.
 
-- See [CONTRIBUTING](https://github.com/spiffe/spire/blob/master/CONTRIBUTING.md) to get started.
+- See [CONTRIBUTING](https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md) to get started.
 - Use [GitHub Issues](https://github.com/spiffe/spire/issues) to request features or file bugs.
 - See [GOVERNANCE](https://github.com/spiffe/spiffe/blob/master/GOVERNANCE.md) for SPIFFE and SPIRE governance policies.
 

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This walkthrough will guide you through the steps needed to setup a running example of a SPIRE Server and SPIRE Agent. Interaction with the [Workload API](https://github.com/spiffe/go-spiffe/blob/master/v2/proto/spiffe/workload/workload.proto) will be simulated via a command line tool.
+This walkthrough will guide you through the steps needed to setup a running example of a SPIRE Server and SPIRE Agent. Interaction with the [Workload API](https://github.com/spiffe/go-spiffe/blob/main/v2/proto/spiffe/workload/workload.proto) will be simulated via a command line tool.
 
 
  ![SPIRE101](images/SPIRE101.png)

--- a/doc/plugin_server_upstreamauthority_vault.md
+++ b/doc/plugin_server_upstreamauthority_vault.md
@@ -24,7 +24,7 @@ The plugin supports **Client Certificate**, **Token** and **AppRole** authentica
 - **Token** method authenticates to Vault using the token in a HTTP Request header.
 - **AppRole** method authenticates to Vault using a RoleID and SecretID that are issued from Vault.
 
-the [`ca_ttl` SPIRE Server configurable](https://github.com/spiffe/spire/blob/master/doc/spire_server.md#server-configuration-file) should be less than or equal to the Vault's PKI secret engine TTL.
+the [`ca_ttl` SPIRE Server configurable](https://github.com/spiffe/spire/blob/main/doc/spire_server.md#server-configuration-file) should be less than or equal to the Vault's PKI secret engine TTL.
 To configure the TTL value, either increase the default TTL of the Engine or set the `max_ttl` in the Role configuration.
 
 e.g. increase the default TTL

--- a/doc/scaling_spire.md
+++ b/doc/scaling_spire.md
@@ -12,7 +12,7 @@ To support larger numbers of Agents and Workloads within a given deployment (ten
 
 To scale the SPIRE Server horizontally, be it for high availability or load distribution purposes, configure all servers in same trust domain to read and write to the same shared datastore.
 
-The datastore is where SPIRE Server persists dynamic configuration information such as registration entries and identity mapping policies. SQLite is bundled with SPIRE Server and it is the default datastore. A number of compatible SQL databases are supported, as well as one plugin for Kubernetes using Kubernetes CRDs. When scaling SPIRE servers horizontally, choose a datastore that fits your requirements and configure all SPIRE servers to use the selected datastore. For details please refer to the [datastore plugin configuration reference](https://github.com/spiffe/spire/blob/master/doc/plugin_server_datastore_sql.md).
+The datastore is where SPIRE Server persists dynamic configuration information such as registration entries and identity mapping policies. SQLite is bundled with SPIRE Server and it is the default datastore. A number of compatible SQL databases are supported, as well as one plugin for Kubernetes using Kubernetes CRDs. When scaling SPIRE servers horizontally, choose a datastore that fits your requirements and configure all SPIRE servers to use the selected datastore. For details please refer to the [datastore plugin configuration reference](https://github.com/spiffe/spire/blob/main/doc/plugin_server_datastore_sql.md).
 
 In High Availability mode, each server maintains its own Certificate Authority, which may be either self-signed certificates or an intermediate certificate off of a shared root authority (i.e. when configured with an UpstreamAuthority).
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -434,7 +434,7 @@ A JSON object passed to `-data` for `entry create/update` expects the following 
 }
 ```
 
-The entry object is described by `RegistrationEntry` in the [common protobuf file](https://github.com/spiffe/spire/blob/master/proto/spire/common/common.proto).
+The entry object is described by `RegistrationEntry` in the [common protobuf file](https://github.com/spiffe/spire/blob/main/proto/spire/common/common.proto).
 
 _Note: to create node entries, set `parent_id` to the special value `spiffe://<your-trust-domain>/spire/server`.
 That's what the code does when the `-node` flag is passed on the cli._

--- a/pkg/server/endpoints/deprecation.go
+++ b/pkg/server/endpoints/deprecation.go
@@ -31,7 +31,7 @@ func wrapWithDeprecationLogging(log logrus.FieldLogger, unary grpc.UnaryServerIn
 
 func maybeLogDeprecation(log logrus.FieldLogger, fullMethod string) {
 	if shouldLogDeprecation(fullMethod) {
-		log.WithField("method", fullMethod).Warn("This API is deprecated and will be removed in a future release (see https://github.com/spiffe/spire/blob/master/doc/migrating_registration_api_clients.md)")
+		log.WithField("method", fullMethod).Warn("This API is deprecated and will be removed in a future release (see https://github.com/spiffe/spire/blob/main/doc/migrating_registration_api_clients.md)")
 	}
 }
 

--- a/pkg/server/endpoints/deprecation_test.go
+++ b/pkg/server/endpoints/deprecation_test.go
@@ -37,7 +37,7 @@ func TestWrapWithDeprecationLogging(t *testing.T) {
 	expectLogs := []spiretest.LogEntry{
 		{
 			Level:   logrus.WarnLevel,
-			Message: "This API is deprecated and will be removed in a future release (see https://github.com/spiffe/spire/blob/master/doc/migrating_registration_api_clients.md)",
+			Message: "This API is deprecated and will be removed in a future release (see https://github.com/spiffe/spire/blob/main/doc/migrating_registration_api_clients.md)",
 			Data: logrus.Fields{
 				"method": "/spire.api.registration.Registration/FetchEntry",
 			},

--- a/release/spire-extras/README.md
+++ b/release/spire-extras/README.md
@@ -1,7 +1,7 @@
 = SPIRE Extras
 
-- [SPIRE Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/master/support/k8s/k8s-workload-registrar/README.md)
-- [SPIRE OIDC Discovery Provider](https://github.com/spiffe/spire/blob/master/support/oidc-discovery-provider/README.md)
+- [SPIRE Kubernetes Workload Registrar](https://github.com/spiffe/spire/blob/main/support/k8s/k8s-workload-registrar/README.md)
+- [SPIRE OIDC Discovery Provider](https://github.com/spiffe/spire/blob/main/support/oidc-discovery-provider/README.md)
 
 The configuration files included in this release are intended for evaluation
 purposes only and are **NOT** production ready.


### PR DESCRIPTION
Updates scripts and docs to reference main instead of master.

This PR partly addresses changes necessary for completing #2003.