### PR TITLE
k8s-workload-registrar: Set page size of 1000 for registration entry list requests

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/utils.go
+++ b/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/utils.go
@@ -16,7 +16,7 @@ func listEntries(ctx context.Context, client entryv1.EntryClient, filter *entryv
 	nextPageToken := ""
 	var entries []*spiretypes.Entry
 	for {
-		listResponse, err := client.ListEntries(ctx, &entryv1.ListEntriesRequest{Filter: filter, PageToken: nextPageToken})
+		listResponse, err := client.ListEntries(ctx, &entryv1.ListEntriesRequest{Filter: filter, PageToken: nextPageToken, PageSize: 1000})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Brian Barnes <bgb@uber.com>

We are observing the following error from the registrar (running in reconcile mode):
```
2021-04-16T19:37:51.380Z	INFO	controllers.Pod	Syncing spire entries
2021-04-16T19:37:53.392Z	ERROR	controllers.Pod	Unable to fetch entries	{"error": "rpc error: code = ResourceExhausted desc = grpc: received message larger than max (12538213 vs. 4194304)"}
```

It seems the node controller is attempting to retrieve every registration entry in a single round trip, causing the response to exceed the configured grpc max message size (our prod clusters contain O(1000s) of nodes with O(10,000)s of pods).

Setting the page size to 1000 eliminates these errors (4194304/1000 ~= 4KB, which is a safe upper bound for the average size of a registration entry).


