### PR TITLE
k8s-workload-registrar: Update README to clarify that k8s psat node attestor is not a requirement

### DIFF
--- a/support/k8s/k8s-workload-registrar/README.md
+++ b/support/k8s/k8s-workload-registrar/README.md
@@ -28,7 +28,7 @@ The configuration file is a **required** by the registrar. It contains
 | `agent_socket_path`        | string   | optional | Path to the Unix domain socket of the SPIRE agent. Required if server_address is not a unix domain socket address. | |
 | `server_address`           | string   | required | Address of the spire server. A local socket can be specified using unix:///path/to/socket. This is not the same as the agent socket. | |
 | `server_socket_path`       | string   | optional | Path to the Unix domain socket of the SPIRE server, equivalent to specifying a server_address with a "unix://..." prefix | |
-| `cluster`                  | string   | required | Logical cluster to register nodes/workloads under. Must match the SPIRE SERVER PSAT node attestor configuration. | |
+| `cluster`                  | string   | required | Logical cluster to register nodes/workloads under. Must match the SPIRE SERVER PSAT node attestor configuration if the plugin is enabled. | |
 | `pod_label`                | string   | optional | The pod label used for [Label Based Workload Registration](#label-based-workload-registration) | |
 | `pod_annotation`           | string   | optional | The pod annotation used for [Annotation Based Workload Registration](#annotation-based-workload-registration) | |
 | `mode`                     | string   | optional | How to run the registrar, either using a `"webhook"`, `"reconcile`" or `"crd"`. See [Differences](#differences-between-modes) for more details. | `"webhook"` |


### PR DESCRIPTION
The current wording is misleading according to https://tools.ietf.org/html/rfc2119

Signed-off-by: Brian Barnes <bgb@uber.com>