### PR TITLE
Remove docker login in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,6 @@ jobs:
             # CircleCI is silly and doesn't provide this incredibly helpful
             # environment variable. Requests for it go back years. For shame.
             CIRCLE_TARGET_BRANCH=$(.circleci/determine-target-branch.sh)
-            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
             cd test/integration
             circleci tests glob "suites/*" | circleci tests split | CICD_TARGET_BRANCH="${CIRCLE_TARGET_BRANCH}" xargs ./test.sh
 


### PR DESCRIPTION
Unlike Travis, on CircleCI we run integration tests on PRs, but CircleCI  does not make envvars available to PRs from forked repo's for good reason, so we can't log into docker to get a reprieve from dockerhub limits.
