### PR TITLE
Fix the build when CGO_ENABLED=0

### DIFF
--- a/pkg/server/plugin/datastore/sql/sqlite_no_cgo.go
+++ b/pkg/server/plugin/datastore/sql/sqlite_no_cgo.go
@@ -5,12 +5,12 @@ package sql
 import (
 	"errors"
 
-	hclog "github.com/hashicorp/go-hclog"
 	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
 )
 
 type sqliteDB struct {
-	log hclog.Logger
+	log logrus.FieldLogger
 }
 
 func (s sqliteDB) connect(cfg *configuration, isReadOnly bool) (db *gorm.DB, version string, supportsCTE bool, err error) {


### PR DESCRIPTION
A recent change to swap out the logger type in the datastore missed a spot that is only picked up when we build w/o CGO.