### PR TITLE
Make the IAM policy example for the aws_iid NodeAttestor valid

### DIFF
--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -44,7 +44,10 @@ The following is an example for a IAM policy needed to get instance's info from 
         {
             "Sid": "VisualEditor0",
             "Effect": "Allow",
-            "Action": "ec2:DescribeInstances",
+            "Action": [
+                "ec2:DescribeInstances",
+                "iam:GetInstanceProfile"
+            ],
             "Resource": "*"
         }
     ]


### PR DESCRIPTION
An allowed action was missing from the example policy which was
preventing it to work by default.

Fixes #2212


<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Docs update.

**Description of change**
<!-- Please provide a description of the change -->
Make the default example working.
**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
fixes #2212
