### PR TITLE
Fix node selector query split-response

### DIFF
--- a/pkg/server/cache/entrycache/fullcache_ds.go
+++ b/pkg/server/cache/entrycache/fullcache_ds.go
@@ -92,14 +92,18 @@ func (it *entryIteratorDS) Err() error {
 	return it.err
 }
 
+type agentDS interface {
+	ListNodeSelectors(context.Context, *datastore.ListNodeSelectorsRequest) (*datastore.ListNodeSelectorsResponse, error)
+}
+
 type agentIteratorDS struct {
-	ds     datastore.DataStore
+	ds     agentDS
 	agents []Agent
 	next   int
 	err    error
 }
 
-func makeAgentIteratorDS(ds datastore.DataStore) AgentIterator {
+func makeAgentIteratorDS(ds agentDS) AgentIterator {
 	return &agentIteratorDS{
 		ds: ds,
 	}
@@ -144,15 +148,23 @@ func (it *agentIteratorDS) fetchAgents(ctx context.Context) ([]Agent, error) {
 		return nil, err
 	}
 
-	agents := make([]Agent, 0, len(resp.Selectors))
+	// Aggregate selectors by agent ID. This is a defensive measure in case a
+	// datastore bug causes it to return agent selectors split across multiple
+	// response records.
+	agentSelectors := make(map[spiffeid.ID][]*common.Selector, len(resp.Selectors))
 	for _, selector := range resp.Selectors {
 		agentID, err := spiffeid.FromString(selector.SpiffeId)
 		if err != nil {
 			return nil, err
 		}
+		agentSelectors[agentID] = append(agentSelectors[agentID], selector.Selectors...)
+	}
+
+	agents := make([]Agent, 0, len(agentSelectors))
+	for agentID, selectors := range agentSelectors {
 		agents = append(agents, Agent{
 			ID:        agentID,
-			Selectors: api.ProtoFromSelectors(selector.Selectors),
+			Selectors: api.ProtoFromSelectors(selectors),
 		})
 	}
 	return agents, nil

--- a/pkg/server/cache/entrycache/fullcache_ds_test.go
+++ b/pkg/server/cache/entrycache/fullcache_ds_test.go
@@ -3,7 +3,6 @@ package entrycache
 import (
 	"context"
 	"errors"
-	"sort"
 	"strconv"
 	"testing"
 	"time"
@@ -141,44 +140,9 @@ func TestAgentIteratorDS(t *testing.T) {
 		// it.Next() returns false after encountering an error on previous call to Next()
 		assert.False(t, it.Next(ctx))
 	})
-
-	t.Run("agent split across multiple results", func(t *testing.T) {
-		it := makeAgentIteratorDS(fixedNodeSelectors{
-			{SpiffeId: "spiffe://example.org/node3", Selectors: []*common.Selector{{Type: "A", Value: "a"}}},
-			{SpiffeId: "spiffe://example.org/node2", Selectors: []*common.Selector{{Type: "B", Value: "b"}}},
-			{SpiffeId: "spiffe://example.org/node3", Selectors: []*common.Selector{{Type: "C", Value: "c"}}},
-			{SpiffeId: "spiffe://example.org/node1", Selectors: []*common.Selector{{Type: "D", Value: "d"}}},
-			{SpiffeId: "spiffe://example.org/node2", Selectors: []*common.Selector{{Type: "E", Value: "e"}}},
-			{SpiffeId: "spiffe://example.org/node3", Selectors: []*common.Selector{{Type: "F", Value: "f"}}},
-		})
-
-		var agents []Agent
-		for it.Next(ctx) {
-			agents = append(agents, it.Agent())
-		}
-
-		sort.Slice(agents, func(i, j int) bool {
-			return agents[i].ID.String() < agents[j].ID.String()
-		})
-
-		require.NoError(t, it.Err())
-		require.ElementsMatch(t, []Agent{
-			{ID: spiffeid.RequireFromString("spiffe://example.org/node1"), Selectors: []*types.Selector{{Type: "D", Value: "d"}}},
-			{ID: spiffeid.RequireFromString("spiffe://example.org/node2"), Selectors: []*types.Selector{{Type: "B", Value: "b"}, {Type: "E", Value: "e"}}},
-			{ID: spiffeid.RequireFromString("spiffe://example.org/node3"), Selectors: []*types.Selector{{Type: "A", Value: "a"}, {Type: "C", Value: "c"}, {Type: "F", Value: "f"}}},
-		}, agents)
-	})
 }
 
 func createAttestedNode(t testing.TB, ds datastore.DataStore, node *common.AttestedNode) {
 	_, err := ds.CreateAttestedNode(context.Background(), node)
 	require.NoError(t, err)
-}
-
-type fixedNodeSelectors []*datastore.NodeSelectors
-
-func (fixed fixedNodeSelectors) ListNodeSelectors(ctx context.Context, req *datastore.ListNodeSelectorsRequest) (*datastore.ListNodeSelectorsResponse, error) {
-	return &datastore.ListNodeSelectorsResponse{
-		Selectors: fixed,
-	}, nil
 }

--- a/pkg/server/plugin/datastore/datastore.go
+++ b/pkg/server/plugin/datastore/datastore.go
@@ -148,7 +148,7 @@ type ListNodeSelectorsRequest struct {
 }
 
 type ListNodeSelectorsResponse struct {
-	Selectors []*NodeSelectors
+	Selectors map[string][]*common.Selector
 }
 
 type ListRegistrationEntriesRequest struct {

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -1621,7 +1621,7 @@ func listNodeSelectors(ctx context.Context, db *sqlDB, req *datastore.ListNodeSe
 		case spiffeID != currentID:
 			resp.Selectors[currentID] = append(resp.Selectors[currentID], selectors...)
 			currentID = spiffeID
-			selectors = nil
+			selectors = selectors[:0]
 		}
 		selectors = append(selectors, selector)
 	}

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -1654,13 +1654,13 @@ func listNodeSelectors(ctx context.Context, db *sqlDB, req *datastore.ListNodeSe
 
 func buildListNodeSelectorsQuery(req *datastore.ListNodeSelectorsRequest) (query string, args []interface{}) {
 	var sb strings.Builder
-	sb.WriteString("SELECT nre.id, nre.spiffe_id, nre.type, nre.value FROM node_resolver_map_entries nre")
+	sb.WriteString("SELECT nre.spiffe_id, nre.type, nre.value FROM node_resolver_map_entries nre")
 	if req.ValidAt != nil {
 		sb.WriteString(" INNER JOIN attested_node_entries ane ON nre.spiffe_id=ane.spiffe_id WHERE ane.expires_at > ?")
 		args = append(args, time.Unix(req.ValidAt.Seconds, 0))
 	}
 
-	sb.WriteString(" ORDER BY nre.id ASC")
+	sb.WriteString(" ORDER BY nre.spiffe_id ASC")
 
 	return sb.String(), args
 }
@@ -2791,7 +2791,6 @@ func fillNodeFromRow(node *common.AttestedNode, r *nodeRow) error {
 }
 
 type nodeSelectorRow struct {
-	EId      uint64
 	SpiffeID sql.NullString
 	Type     sql.NullString
 	Value    sql.NullString
@@ -2799,7 +2798,6 @@ type nodeSelectorRow struct {
 
 func scanNodeSelectorRow(rs *sql.Rows, r *nodeSelectorRow) error {
 	return sqlError.Wrap(rs.Scan(
-		&r.EId,
 		&r.SpiffeID,
 		&r.Type,
 		&r.Value,


### PR DESCRIPTION
The DataStore query that returns the list of agent node selectors is currently sorted by row ID, which under certain circumstances can cause it to split the selectors for a given agent ID into more than one entry in the aggregated results. The only caller is the full entry cache, which does not handle this well, which can cause agents to not be associated with a node alias whose selectors end up spanning these splits.

This change fixes the query to order by SPIFFE ID instead of row ID so that the selectors for a given agent are grouped together and returned in a single entry in the aggregated results.

~It also adds a defensive measure in the full cache layer to also implement robust handling of the results so that a bug like this does not impact cache correctness in the future. This has a small temporary memory cost while aggregating the results, but it should be minimal compared to the cost of the full cache itself.~

UPDATE: 
It also aggregates the results differently such that the order does not matter for correctness so that the code is resilient against a similar bug in the future.