### PR TITLE
Fix broken pagination when last page gets filtered

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -1033,6 +1033,13 @@ func listAttestedNodes(ctx context.Context, db *sqlDB, req *datastore.ListAttest
 			return resp, nil
 		}
 
+		if resp.Pagination.Token == req.Pagination.Token {
+			// We've filtered out all of the results and are on the last page.
+			// Clear the pagination token and return the empty results.
+			resp.Pagination.Token = ""
+			return resp, nil
+		}
+
 		req.Pagination = resp.Pagination
 	}
 }
@@ -2027,6 +2034,13 @@ func listRegistrationEntries(ctx context.Context, db *sqlDB, req *datastore.List
 
 		resp.Entries = filterEntriesBySelectorSet(resp.Entries, req.BySelectors.Selectors)
 		if len(resp.Entries) > 0 || resp.Pagination == nil || len(resp.Pagination.Token) == 0 {
+			return resp, nil
+		}
+
+		if resp.Pagination.Token == req.Pagination.Token {
+			// We've filtered out all of the results and are on the last page.
+			// Clear the pagination token and return the empty results.
+			resp.Pagination.Token = ""
 			return resp, nil
 		}
 

--- a/test/spiretest/assertions.go
+++ b/test/spiretest/assertions.go
@@ -113,15 +113,13 @@ func AssertProtoListEqual(tb testing.TB, expected, actual interface{}) bool {
 	}
 
 	if !assert.Equal(tb, ev.Len(), av.Len(), "expected %d elements in list; got %d", ev.Len(), av.Len()) {
-		// get the nice output
-		return assert.Equal(tb, expected, actual)
+		return false
 	}
 	for i := 0; i < ev.Len(); i++ {
 		e := ev.Index(i).Interface().(proto.Message)
 		a := av.Index(i).Interface().(proto.Message)
 		if !AssertProtoEqual(tb, e, a, "proto %d in list is not equal", i) {
-			// get the nice output
-			return assert.Equal(tb, expected, actual)
+			return false
 		}
 	}
 


### PR DESCRIPTION
Both registration entry and attested node list operations do some post filtering of the paged results to enforce exact/subset matching. There is some mishandling of the last page if results from that page get filtered that can cause either the response to erroneously return a page token (if the filtered last page has at least one result) or, even worse, get stuck querying in a loop (if the filtered last page does not have a result).

Fixes: #2236