### PR TITLE
datastore interface update, prune, set, append

### DIFF
--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -21,10 +21,10 @@ type metricsWrapper struct {
 	m  telemetry.Metrics
 }
 
-func (w metricsWrapper) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (_ *datastore.AppendBundleResponse, err error) {
+func (w metricsWrapper) AppendBundle(ctx context.Context, bundle *common.Bundle) (_ *common.Bundle, err error) {
 	callCounter := StartAppendBundleCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.AppendBundle(ctx, req)
+	return w.ds.AppendBundle(ctx, bundle)
 }
 
 func (w metricsWrapper) CreateAttestedNode(ctx context.Context, node *common.AttestedNode) (_ *common.AttestedNode, err error) {
@@ -147,10 +147,10 @@ func (w metricsWrapper) CountRegistrationEntries(ctx context.Context) (_ int32, 
 	return w.ds.CountRegistrationEntries(ctx)
 }
 
-func (w metricsWrapper) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (_ *datastore.PruneBundleResponse, err error) {
+func (w metricsWrapper) PruneBundle(ctx context.Context, trustDomainID string, expiresBefore time.Time) (_ bool, err error) {
 	callCounter := StartPruneBundleCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.PruneBundle(ctx, req)
+	return w.ds.PruneBundle(ctx, trustDomainID, expiresBefore)
 }
 
 func (w metricsWrapper) PruneJoinTokens(ctx context.Context, expiresBefore time.Time) (err error) {
@@ -159,16 +159,16 @@ func (w metricsWrapper) PruneJoinTokens(ctx context.Context, expiresBefore time.
 	return w.ds.PruneJoinTokens(ctx, expiresBefore)
 }
 
-func (w metricsWrapper) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (_ *datastore.PruneRegistrationEntriesResponse, err error) {
+func (w metricsWrapper) PruneRegistrationEntries(ctx context.Context, expiresBefore time.Time) (err error) {
 	callCounter := StartPruneRegistrationCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.PruneRegistrationEntries(ctx, req)
+	return w.ds.PruneRegistrationEntries(ctx, expiresBefore)
 }
 
-func (w metricsWrapper) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (_ *datastore.SetBundleResponse, err error) {
+func (w metricsWrapper) SetBundle(ctx context.Context, bundle *common.Bundle) (_ *common.Bundle, err error) {
 	callCounter := StartSetBundleCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.SetBundle(ctx, req)
+	return w.ds.SetBundle(ctx, bundle)
 }
 
 func (w metricsWrapper) SetNodeSelectors(ctx context.Context, req *datastore.SetNodeSelectorsRequest) (_ *datastore.SetNodeSelectorsResponse, err error) {
@@ -177,20 +177,20 @@ func (w metricsWrapper) SetNodeSelectors(ctx context.Context, req *datastore.Set
 	return w.ds.SetNodeSelectors(ctx, req)
 }
 
-func (w metricsWrapper) UpdateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest) (_ *datastore.UpdateAttestedNodeResponse, err error) {
+func (w metricsWrapper) UpdateAttestedNode(ctx context.Context, node *common.AttestedNode, mask *common.AttestedNodeMask) (_ *common.AttestedNode, err error) {
 	callCounter := StartUpdateNodeCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.UpdateAttestedNode(ctx, req)
+	return w.ds.UpdateAttestedNode(ctx, node, mask)
 }
 
-func (w metricsWrapper) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (_ *datastore.UpdateBundleResponse, err error) {
+func (w metricsWrapper) UpdateBundle(ctx context.Context, bundle *common.Bundle, mask *common.BundleMask) (_ *common.Bundle, err error) {
 	callCounter := StartUpdateBundleCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.UpdateBundle(ctx, req)
+	return w.ds.UpdateBundle(ctx, bundle, mask)
 }
 
-func (w metricsWrapper) UpdateRegistrationEntry(ctx context.Context, req *datastore.UpdateRegistrationEntryRequest) (_ *datastore.UpdateRegistrationEntryResponse, err error) {
+func (w metricsWrapper) UpdateRegistrationEntry(ctx context.Context, entry *common.RegistrationEntry, mask *common.RegistrationEntryMask) (_ *common.RegistrationEntry, err error) {
 	callCounter := StartUpdateRegistrationCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.UpdateRegistrationEntry(ctx, req)
+	return w.ds.UpdateRegistrationEntry(ctx, entry, mask)
 }

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -231,8 +231,8 @@ func (ds *fakeDataStore) SetError(err error) {
 	ds.err = err
 }
 
-func (ds *fakeDataStore) AppendBundle(context.Context, *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
-	return &datastore.AppendBundleResponse{}, ds.err
+func (ds *fakeDataStore) AppendBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	return &common.Bundle{}, ds.err
 }
 
 func (ds *fakeDataStore) CountAttestedNodes(context.Context) (int32, error) {
@@ -315,34 +315,34 @@ func (ds *fakeDataStore) ListRegistrationEntries(context.Context, *datastore.Lis
 	return &datastore.ListRegistrationEntriesResponse{}, ds.err
 }
 
-func (ds *fakeDataStore) PruneBundle(context.Context, *datastore.PruneBundleRequest) (*datastore.PruneBundleResponse, error) {
-	return &datastore.PruneBundleResponse{}, ds.err
+func (ds *fakeDataStore) PruneBundle(context.Context, string, time.Time) (bool, error) {
+	return false, ds.err
 }
 
 func (ds *fakeDataStore) PruneJoinTokens(context.Context, time.Time) error {
 	return ds.err
 }
 
-func (ds *fakeDataStore) PruneRegistrationEntries(context.Context, *datastore.PruneRegistrationEntriesRequest) (*datastore.PruneRegistrationEntriesResponse, error) {
-	return &datastore.PruneRegistrationEntriesResponse{}, ds.err
+func (ds *fakeDataStore) PruneRegistrationEntries(context.Context, time.Time) error {
+	return ds.err
 }
 
-func (ds *fakeDataStore) SetBundle(context.Context, *datastore.SetBundleRequest) (*datastore.SetBundleResponse, error) {
-	return &datastore.SetBundleResponse{}, ds.err
+func (ds *fakeDataStore) SetBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	return &common.Bundle{}, ds.err
 }
 
 func (ds *fakeDataStore) SetNodeSelectors(context.Context, *datastore.SetNodeSelectorsRequest) (*datastore.SetNodeSelectorsResponse, error) {
 	return &datastore.SetNodeSelectorsResponse{}, ds.err
 }
 
-func (ds *fakeDataStore) UpdateAttestedNode(context.Context, *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
-	return &datastore.UpdateAttestedNodeResponse{}, ds.err
+func (ds *fakeDataStore) UpdateAttestedNode(context.Context, *common.AttestedNode, *common.AttestedNodeMask) (*common.AttestedNode, error) {
+	return &common.AttestedNode{}, ds.err
 }
 
-func (ds *fakeDataStore) UpdateBundle(context.Context, *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
-	return &datastore.UpdateBundleResponse{}, ds.err
+func (ds *fakeDataStore) UpdateBundle(context.Context, *common.Bundle, *common.BundleMask) (*common.Bundle, error) {
+	return &common.Bundle{}, ds.err
 }
 
-func (ds *fakeDataStore) UpdateRegistrationEntry(context.Context, *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
-	return &datastore.UpdateRegistrationEntryResponse{}, ds.err
+func (ds *fakeDataStore) UpdateRegistrationEntry(context.Context, *common.RegistrationEntry, *common.RegistrationEntryMask) (*common.RegistrationEntry, error) {
+	return &common.RegistrationEntry{}, ds.err
 }

--- a/pkg/server/api/bundle/v1/service_test.go
+++ b/pkg/server/api/bundle/v1/service_test.go
@@ -483,10 +483,8 @@ func TestAppendBundle(t *testing.T) {
 			test.ds.SetNextError(tt.dsError)
 
 			if tt.invalidEntry {
-				_, err := test.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
-					Bundle: &common.Bundle{
-						TrustDomainId: "malformed",
-					},
+				_, err := test.ds.AppendBundle(ctx, &common.Bundle{
+					TrustDomainId: "malformed",
 				})
 				require.NoError(t, err)
 			}
@@ -1924,11 +1922,7 @@ func assertBundleWithMask(t *testing.T, expected, actual *types.Bundle, m *types
 }
 
 func (c *serviceTest) setBundle(t *testing.T, b *common.Bundle) {
-	req := &datastore.SetBundleRequest{
-		Bundle: b,
-	}
-
-	_, err := c.ds.SetBundle(context.Background(), req)
+	_, err := c.ds.SetBundle(context.Background(), b)
 	require.NoError(t, err)
 }
 

--- a/pkg/server/api/entry/v1/service.go
+++ b/pkg/server/api/entry/v1/service.go
@@ -411,23 +411,22 @@ func (s *Service) updateEntry(ctx context.Context, e *types.Entry, inputMask *ty
 		}
 	}
 
-	var resp *datastore.UpdateRegistrationEntryResponse
+	var dsEntry *common.RegistrationEntry
 	if inputMask != nil {
-		resp, err = s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
-			Entry: convEntry,
-			Mask: &common.RegistrationEntryMask{
-				SpiffeId:      inputMask.SpiffeId,
-				ParentId:      inputMask.ParentId,
-				Ttl:           inputMask.Ttl,
-				FederatesWith: inputMask.FederatesWith,
-				Admin:         inputMask.Admin,
-				Downstream:    inputMask.Downstream,
-				EntryExpiry:   inputMask.ExpiresAt,
-				DnsNames:      inputMask.DnsNames,
-				Selectors:     inputMask.Selectors,
-			}})
+		mask := &common.RegistrationEntryMask{
+			SpiffeId:      inputMask.SpiffeId,
+			ParentId:      inputMask.ParentId,
+			Ttl:           inputMask.Ttl,
+			FederatesWith: inputMask.FederatesWith,
+			Admin:         inputMask.Admin,
+			Downstream:    inputMask.Downstream,
+			EntryExpiry:   inputMask.ExpiresAt,
+			DnsNames:      inputMask.DnsNames,
+			Selectors:     inputMask.Selectors,
+		}
+		dsEntry, err = s.ds.UpdateRegistrationEntry(ctx, convEntry, mask)
 	} else {
-		resp, err = s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{Entry: convEntry})
+		dsEntry, err = s.ds.UpdateRegistrationEntry(ctx, convEntry, nil)
 	}
 
 	if err != nil {
@@ -436,7 +435,7 @@ func (s *Service) updateEntry(ctx context.Context, e *types.Entry, inputMask *ty
 		}
 	}
 
-	tEntry, err := api.RegistrationEntryToProto(resp.Entry)
+	tEntry, err := api.RegistrationEntryToProto(dsEntry)
 	if err != nil {
 		return &entryv1.BatchUpdateEntryResponse_Result{
 			Status: api.MakeStatus(log, codes.Internal, "failed to convert entry in updateEntry", err),

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -1014,14 +1014,12 @@ func TestNewDownstreamX509CA(t *testing.T) {
 			test.logHook.Reset()
 			test.ef.err = tt.fetcherErr
 			if !tt.failDataStore {
-				_, err := test.ds.AppendBundle(context.Background(), &datastore.AppendBundleRequest{
-					Bundle: &common.Bundle{
-						// The SPIFFE ID of the bundle in the datastore needs to match the SPIFFE ID
-						// provided by the client
-						TrustDomainId: td.IDString(),
-						RootCas: []*common.Certificate{
-							{DerBytes: []byte("RootCa1")},
-						},
+				_, err := test.ds.AppendBundle(context.Background(), &common.Bundle{
+					// The SPIFFE ID of the bundle in the datastore needs to match the SPIFFE ID
+					// provided by the client
+					TrustDomainId: td.IDString(),
+					RootCas: []*common.Certificate{
+						{DerBytes: []byte("RootCa1")},
 					},
 				})
 				require.NoError(t, err)

--- a/pkg/server/bundle/client/updater.go
+++ b/pkg/server/bundle/client/updater.go
@@ -66,9 +66,7 @@ func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*bundleutil.Bundle, *
 		return localBundleOrNil, nil, nil
 	}
 
-	_, err = u.c.DataStore.SetBundle(ctx, &datastore.SetBundleRequest{
-		Bundle: endpointBundle.Proto(),
-	})
+	_, err = u.c.DataStore.SetBundle(ctx, endpointBundle.Proto())
 	if err != nil {
 		return localBundleOrNil, nil, fmt.Errorf("failed to store endpoint bundle: %v", err)
 	}

--- a/pkg/server/cache/dscache/cache.go
+++ b/pkg/server/cache/dscache/cache.go
@@ -68,23 +68,23 @@ func (ds *DatastoreCache) FetchBundle(ctx context.Context, trustDomain string) (
 	return entry.bundle, nil
 }
 
-func (ds *DatastoreCache) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (resp *datastore.PruneBundleResponse, err error) {
-	if resp, err = ds.DataStore.PruneBundle(ctx, req); err == nil {
-		ds.invalidateBundleEntry(req.TrustDomainId)
+func (ds *DatastoreCache) PruneBundle(ctx context.Context, trustDomainID string, expiresBefore time.Time) (changed bool, err error) {
+	if changed, err = ds.DataStore.PruneBundle(ctx, trustDomainID, expiresBefore); err == nil {
+		ds.invalidateBundleEntry(trustDomainID)
 	}
 	return
 }
 
-func (ds *DatastoreCache) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (resp *datastore.AppendBundleResponse, err error) {
-	if resp, err = ds.DataStore.AppendBundle(ctx, req); err == nil {
-		ds.invalidateBundleEntry(req.Bundle.TrustDomainId)
+func (ds *DatastoreCache) AppendBundle(ctx context.Context, b *common.Bundle) (bundle *common.Bundle, err error) {
+	if bundle, err = ds.DataStore.AppendBundle(ctx, b); err == nil {
+		ds.invalidateBundleEntry(b.TrustDomainId)
 	}
 	return
 }
 
-func (ds *DatastoreCache) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (resp *datastore.UpdateBundleResponse, err error) {
-	if resp, err = ds.DataStore.UpdateBundle(ctx, req); err == nil {
-		ds.invalidateBundleEntry(req.Bundle.TrustDomainId)
+func (ds *DatastoreCache) UpdateBundle(ctx context.Context, b *common.Bundle, mask *common.BundleMask) (bundle *common.Bundle, err error) {
+	if bundle, err = ds.DataStore.UpdateBundle(ctx, b, mask); err == nil {
+		ds.invalidateBundleEntry(b.TrustDomainId)
 	}
 	return
 }
@@ -96,9 +96,9 @@ func (ds *DatastoreCache) DeleteBundle(ctx context.Context, td string, mode data
 	return
 }
 
-func (ds *DatastoreCache) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (resp *datastore.SetBundleResponse, err error) {
-	if resp, err = ds.DataStore.SetBundle(ctx, req); err == nil {
-		ds.invalidateBundleEntry(req.Bundle.TrustDomainId)
+func (ds *DatastoreCache) SetBundle(ctx context.Context, b *common.Bundle) (bundle *common.Bundle, err error) {
+	if bundle, err = ds.DataStore.SetBundle(ctx, b); err == nil {
+		ds.invalidateBundleEntry(b.TrustDomainId)
 	}
 	return
 }

--- a/pkg/server/cache/dscache/cache_test.go
+++ b/pkg/server/cache/dscache/cache_test.go
@@ -34,9 +34,7 @@ func TestFetchBundleCache(t *testing.T) {
 	require.Nil(t, bundle)
 
 	// Add bundle
-	_, err = ds.SetBundle(ctxWithCache, &datastore.SetBundleRequest{
-		Bundle: bundle1,
-	})
+	_, err = ds.SetBundle(ctxWithCache, bundle1)
 	require.NoError(t, err)
 
 	// Assert that we didn't cache the bundle miss and that the newly added
@@ -46,9 +44,7 @@ func TestFetchBundleCache(t *testing.T) {
 	spiretest.RequireProtoEqual(t, bundle1, bundle)
 
 	// Change bundle
-	_, err = ds.SetBundle(context.Background(), &datastore.SetBundleRequest{
-		Bundle: bundle2,
-	})
+	_, err = ds.SetBundle(context.Background(), bundle2)
 	require.NoError(t, err)
 
 	// Assert bundle contents unchanged since cache is still valid
@@ -63,9 +59,7 @@ func TestFetchBundleCache(t *testing.T) {
 	spiretest.RequireProtoEqual(t, bundle2, bundle)
 
 	// Change bundle
-	_, err = ds.SetBundle(context.Background(), &datastore.SetBundleRequest{
-		Bundle: bundle1,
-	})
+	_, err = ds.SetBundle(context.Background(), bundle1)
 	require.NoError(t, err)
 
 	// If a context without cache is used, FetchBundle must fetch a fresh bundle
@@ -90,52 +84,40 @@ func TestBundleInvalidations(t *testing.T) {
 		{
 			name: "UpdateBundle invalidates cache if succeeds",
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.UpdateBundle(context.Background(), &datastore.UpdateBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.UpdateBundle(context.Background(), bundle1, nil)
 			},
 		},
 		{
 			name:      "UpdateBundle keeps cache if fails",
 			dsFailure: true,
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.UpdateBundle(context.Background(), &datastore.UpdateBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.UpdateBundle(context.Background(), bundle1, nil)
 			},
 		},
 		{
 			name: "AppendBundle invalidates cache if succeeds",
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.AppendBundle(context.Background(), &datastore.AppendBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.AppendBundle(context.Background(), bundle1)
 			},
 		},
 		{
 			name:      "AppendBundle keeps cache if fails",
 			dsFailure: true,
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.AppendBundle(context.Background(), &datastore.AppendBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.AppendBundle(context.Background(), bundle1)
 			},
 		},
 		{
 			name: "PruneBundle invalidates cache if succeeds",
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.PruneBundle(context.Background(), &datastore.PruneBundleRequest{
-					TrustDomainId: td,
-				})
+				_, _ = cache.PruneBundle(context.Background(), td, time.Now().Add(-time.Hour))
 			},
 		},
 		{
 			name:      "PruneBundle keeps cache if fails",
 			dsFailure: true,
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.PruneBundle(context.Background(), &datastore.PruneBundleRequest{
-					TrustDomainId: td,
-				})
+				_, _ = cache.PruneBundle(context.Background(), td, time.Now())
 			},
 		},
 		{
@@ -154,18 +136,14 @@ func TestBundleInvalidations(t *testing.T) {
 		{
 			name: "SetBundle invalidates cache if succeeds",
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.SetBundle(context.Background(), &datastore.SetBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.SetBundle(context.Background(), bundle1)
 			},
 		},
 		{
 			name:      "SetBundle keeps cache if fails",
 			dsFailure: true,
 			invalidatingFunc: func(cache *DatastoreCache) {
-				_, _ = cache.SetBundle(context.Background(), &datastore.SetBundleRequest{
-					Bundle: bundle1,
-				})
+				_, _ = cache.SetBundle(context.Background(), bundle1)
 			},
 		},
 	} {
@@ -177,7 +155,7 @@ func TestBundleInvalidations(t *testing.T) {
 			ctxWithCache := WithCache(context.Background())
 
 			// Add bundle (bundle1)
-			_, err := ds.SetBundle(context.Background(), &datastore.SetBundleRequest{Bundle: bundle1})
+			_, err := ds.SetBundle(context.Background(), bundle1)
 			require.NoError(t, err)
 
 			// Make an initial fetch call to store the bundle in cache
@@ -192,7 +170,7 @@ func TestBundleInvalidations(t *testing.T) {
 			tt.invalidatingFunc(cache)
 
 			// Change the bundle (bundle1 -> bundle2)
-			_, err = ds.SetBundle(context.Background(), &datastore.SetBundleRequest{Bundle: bundle2})
+			_, err = ds.SetBundle(context.Background(), bundle2)
 			require.NoError(t, err)
 
 			// If invalidatingFunc fails, we keep the current cache value,

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spiffe/spire/pkg/server/api/middleware"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/plugin/datastore"
+	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/clock"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -136,11 +137,11 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 		case attestedNode.NewCertSerialNumber == agentSVID.SerialNumber.String():
 			// AgentSVID matches the new serial number, access granted
 			// Also update the attested node agent serial number from 'new' to 'current'
-			_, err := ds.UpdateAttestedNode(ctx, &datastore.UpdateAttestedNodeRequest{
+			_, err := ds.UpdateAttestedNode(ctx, &common.AttestedNode{
 				SpiffeId:         attestedNode.SpiffeId,
 				CertNotAfter:     attestedNode.NewCertNotAfter,
 				CertSerialNumber: attestedNode.NewCertSerialNumber,
-			})
+			}, nil)
 			if err != nil {
 				log.WithFields(logrus.Fields{
 					telemetry.SVIDSerialNumber: agentSVID.SerialNumber.String(),

--- a/pkg/server/endpoints/registration/handler.go
+++ b/pkg/server/endpoints/registration/handler.go
@@ -176,9 +176,7 @@ func (h *Handler) UpdateEntry(ctx context.Context, request *registration.UpdateE
 	}
 
 	ds := h.getDataStore()
-	resp, err := ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
-		Entry: request.Entry,
-	})
+	entry, err := ds.UpdateRegistrationEntry(ctx, request.Entry, nil)
 	if err != nil {
 		log.WithError(err).Error("Failed to update registration entry")
 		return nil, status.Errorf(codes.Internal, "failed to update registration entry: %v", err)
@@ -186,11 +184,11 @@ func (h *Handler) UpdateEntry(ctx context.Context, request *registration.UpdateE
 
 	telemetry_registrationapi.IncrRegistrationAPIUpdatedEntryCounter(h.Metrics)
 	log.WithFields(logrus.Fields{
-		telemetry.ParentID: resp.Entry.ParentId,
-		telemetry.SPIFFEID: resp.Entry.SpiffeId,
+		telemetry.ParentID: entry.ParentId,
+		telemetry.SPIFFEID: entry.SpiffeId,
 	}).Debug("Workload registration successfully updated")
 
-	return resp.Entry, nil
+	return entry, nil
 }
 
 // ListByParentID Returns all the Entries associated with the ParentID value
@@ -452,9 +450,7 @@ func (h *Handler) UpdateFederatedBundle(ctx context.Context, request *registrati
 	}
 
 	ds := h.getDataStore()
-	if _, err := ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
-		Bundle: bundle,
-	}); err != nil {
+	if _, err := ds.UpdateBundle(ctx, bundle, nil); err != nil {
 		log.WithError(err).Error("Failed to update federated bundle")
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/pkg/server/plugin/datastore/datastore.go
+++ b/pkg/server/plugin/datastore/datastore.go
@@ -9,18 +9,18 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-// DataStore is the data storage interface.
+// DataStore defines the data storage interface.
 type DataStore interface {
 	// Bundles
-	AppendBundle(context.Context, *AppendBundleRequest) (*AppendBundleResponse, error)
+	AppendBundle(context.Context, *common.Bundle) (*common.Bundle, error)
 	CountBundles(context.Context) (int32, error)
 	CreateBundle(context.Context, *common.Bundle) (*common.Bundle, error)
 	DeleteBundle(ctx context.Context, trustDomainID string, mode DeleteMode) error
 	FetchBundle(ctx context.Context, trustDomainID string) (*common.Bundle, error)
 	ListBundles(context.Context, *ListBundlesRequest) (*ListBundlesResponse, error)
-	PruneBundle(context.Context, *PruneBundleRequest) (*PruneBundleResponse, error)
-	SetBundle(context.Context, *SetBundleRequest) (*SetBundleResponse, error)
-	UpdateBundle(context.Context, *UpdateBundleRequest) (*UpdateBundleResponse, error)
+	PruneBundle(ctx context.Context, trustDomainID string, expiresBefore time.Time) (changed bool, err error)
+	SetBundle(context.Context, *common.Bundle) (*common.Bundle, error)
+	UpdateBundle(context.Context, *common.Bundle, *common.BundleMask) (*common.Bundle, error)
 
 	// Entries
 	CountRegistrationEntries(context.Context) (int32, error)
@@ -28,16 +28,16 @@ type DataStore interface {
 	DeleteRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
 	FetchRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
 	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
-	PruneRegistrationEntries(context.Context, *PruneRegistrationEntriesRequest) (*PruneRegistrationEntriesResponse, error)
-	UpdateRegistrationEntry(context.Context, *UpdateRegistrationEntryRequest) (*UpdateRegistrationEntryResponse, error)
+	PruneRegistrationEntries(ctx context.Context, expiresBefore time.Time) error
+	UpdateRegistrationEntry(context.Context, *common.RegistrationEntry, *common.RegistrationEntryMask) (*common.RegistrationEntry, error)
 
 	// Nodes
 	CountAttestedNodes(context.Context) (int32, error)
 	CreateAttestedNode(context.Context, *common.AttestedNode) (*common.AttestedNode, error)
-	DeleteAttestedNode(context.Context, string) (*common.AttestedNode, error)
-	FetchAttestedNode(context.Context, string) (*common.AttestedNode, error)
+	DeleteAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error)
+	FetchAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error)
 	ListAttestedNodes(context.Context, *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error)
-	UpdateAttestedNode(context.Context, *UpdateAttestedNodeRequest) (*UpdateAttestedNodeResponse, error)
+	UpdateAttestedNode(context.Context, *common.AttestedNode, *common.AttestedNodeMask) (*common.AttestedNode, error)
 
 	// Node selectors
 	GetNodeSelectors(context.Context, *GetNodeSelectorsRequest) (*GetNodeSelectorsResponse, error)
@@ -46,8 +46,8 @@ type DataStore interface {
 
 	// Tokens
 	CreateJoinToken(context.Context, *JoinToken) error
-	DeleteJoinToken(context.Context, string) error
-	FetchJoinToken(context.Context, string) (*JoinToken, error)
+	DeleteJoinToken(ctx context.Context, token string) error
+	FetchJoinToken(ctx context.Context, token string) (*JoinToken, error)
 	PruneJoinTokens(context.Context, time.Time) error
 }
 
@@ -82,14 +82,6 @@ const (
 	Exact  MatchBehavior = 0
 	Subset MatchBehavior = 1
 )
-
-type AppendBundleRequest struct {
-	Bundle *common.Bundle
-}
-
-type AppendBundleResponse struct {
-	Bundle *common.Bundle
-}
 
 type ByFederatesWith struct {
 	TrustDomains []string
@@ -178,65 +170,9 @@ type Pagination struct {
 	PageSize int32
 }
 
-type PruneBundleRequest struct {
-	// Trust domain of the bundle to prune
-	TrustDomainId string //nolint: golint
-	// Expiration time
-	ExpiresBefore int64
-}
-type PruneBundleResponse struct {
-	BundleChanged bool
-}
-
-type PruneRegistrationEntriesRequest struct {
-	ExpiresBefore int64
-}
-
-type PruneRegistrationEntriesResponse struct {
-}
-
-type SetBundleRequest struct {
-	Bundle *common.Bundle
-}
-
-type SetBundleResponse struct {
-	Bundle *common.Bundle
-}
-
 type SetNodeSelectorsRequest struct {
 	Selectors *NodeSelectors
 }
 
 type SetNodeSelectorsResponse struct {
-}
-
-type UpdateAttestedNodeRequest struct {
-	SpiffeId            string //nolint: golint
-	CertSerialNumber    string
-	CertNotAfter        int64
-	NewCertSerialNumber string
-	NewCertNotAfter     int64
-	InputMask           *common.AttestedNodeMask
-}
-
-type UpdateAttestedNodeResponse struct {
-	Node *common.AttestedNode
-}
-
-type UpdateBundleRequest struct {
-	Bundle    *common.Bundle
-	InputMask *common.BundleMask
-}
-
-type UpdateBundleResponse struct {
-	Bundle *common.Bundle
-}
-
-type UpdateRegistrationEntryRequest struct {
-	Entry *common.RegistrationEntry
-	Mask  *common.RegistrationEntryMask
-}
-
-type UpdateRegistrationEntryResponse struct {
-	Entry *common.RegistrationEntry
 }

--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -111,36 +111,36 @@ func (ds *Plugin) CreateBundle(ctx context.Context, b *common.Bundle) (bundle *c
 
 // UpdateBundle updates an existing bundle with the given CAs. Overwrites any
 // existing certificates.
-func (ds *Plugin) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (resp *datastore.UpdateBundleResponse, err error) {
+func (ds *Plugin) UpdateBundle(ctx context.Context, b *common.Bundle, mask *common.BundleMask) (bundle *common.Bundle, err error) {
 	if err = ds.withReadModifyWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = updateBundle(tx, req)
+		bundle, err = updateBundle(tx, b, mask)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return bundle, nil
 }
 
 // SetBundle sets bundle contents. If no bundle exists for the trust domain, it is created.
-func (ds *Plugin) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (resp *datastore.SetBundleResponse, err error) {
+func (ds *Plugin) SetBundle(ctx context.Context, b *common.Bundle) (bundle *common.Bundle, err error) {
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = setBundle(tx, req)
+		bundle, err = setBundle(tx, b)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return bundle, nil
 }
 
 // AppendBundle append bundle contents to the existing bundle (by trust domain). If no existing one is present, create it.
-func (ds *Plugin) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (resp *datastore.AppendBundleResponse, err error) {
+func (ds *Plugin) AppendBundle(ctx context.Context, b *common.Bundle) (bundle *common.Bundle, err error) {
 	if err = ds.withReadModifyWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = appendBundle(tx, req)
+		bundle, err = appendBundle(tx, b)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return bundle, nil
 }
 
 // DeleteBundle deletes the bundle with the matching TrustDomain. Any CACert data passed is ignored.
@@ -188,15 +188,15 @@ func (ds *Plugin) ListBundles(ctx context.Context, req *datastore.ListBundlesReq
 }
 
 // PruneBundle removes expired certs and keys from a bundle
-func (ds *Plugin) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (resp *datastore.PruneBundleResponse, err error) {
+func (ds *Plugin) PruneBundle(ctx context.Context, trustDomainID string, expiresBefore time.Time) (changed bool, err error) {
 	if err = ds.withReadModifyWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = pruneBundle(tx, req, ds.log)
+		changed, err = pruneBundle(tx, trustDomainID, expiresBefore, ds.log)
 		return err
 	}); err != nil {
-		return nil, err
+		return false, err
 	}
 
-	return resp, nil
+	return changed, nil
 }
 
 // CreateAttestedNode stores the given attested node
@@ -250,15 +250,14 @@ func (ds *Plugin) ListAttestedNodes(ctx context.Context,
 }
 
 // UpdateAttestedNode updates the given node's cert serial and expiration.
-func (ds *Plugin) UpdateAttestedNode(ctx context.Context,
-	req *datastore.UpdateAttestedNodeRequest) (resp *datastore.UpdateAttestedNodeResponse, err error) {
+func (ds *Plugin) UpdateAttestedNode(ctx context.Context, n *common.AttestedNode, mask *common.AttestedNodeMask) (node *common.AttestedNode, err error) {
 	if err = ds.withReadModifyWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = updateAttestedNode(tx, req)
+		node, err = updateAttestedNode(tx, n, mask)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return node, nil
 }
 
 // DeleteAttestedNode deletes the given attested node
@@ -350,15 +349,14 @@ func (ds *Plugin) ListRegistrationEntries(ctx context.Context,
 }
 
 // UpdateRegistrationEntry updates an existing registration entry
-func (ds *Plugin) UpdateRegistrationEntry(ctx context.Context,
-	req *datastore.UpdateRegistrationEntryRequest) (resp *datastore.UpdateRegistrationEntryResponse, err error) {
+func (ds *Plugin) UpdateRegistrationEntry(ctx context.Context, e *common.RegistrationEntry, mask *common.RegistrationEntryMask) (entry *common.RegistrationEntry, err error) {
 	if err = ds.withReadModifyWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = updateRegistrationEntry(tx, req)
+		entry, err = updateRegistrationEntry(tx, e, mask)
 		return err
 	}); err != nil {
 		return nil, err
 	}
-	return resp, nil
+	return entry, nil
 }
 
 // DeleteRegistrationEntry deletes the given registration
@@ -375,14 +373,14 @@ func (ds *Plugin) DeleteRegistrationEntry(ctx context.Context,
 
 // PruneRegistrationEntries takes a registration entry message, and deletes all entries which have expired
 // before the date in the message
-func (ds *Plugin) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (resp *datastore.PruneRegistrationEntriesResponse, err error) {
+func (ds *Plugin) PruneRegistrationEntries(ctx context.Context, expiresBefore time.Time) (err error) {
 	if err = ds.withWriteTx(ctx, func(tx *gorm.DB) (err error) {
-		resp, err = pruneRegistrationEntries(tx, req)
+		err = pruneRegistrationEntries(tx, expiresBefore)
 		return err
 	}); err != nil {
-		return nil, err
+		return err
 	}
-	return resp, nil
+	return nil
 }
 
 // CreateJoinToken takes a Token message and stores it
@@ -682,8 +680,7 @@ func createBundle(tx *gorm.DB, bundle *common.Bundle) (*common.Bundle, error) {
 	return bundle, nil
 }
 
-func updateBundle(tx *gorm.DB, req *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
-	newBundle := req.Bundle
+func updateBundle(tx *gorm.DB, newBundle *common.Bundle, mask *common.BundleMask) (*common.Bundle, error) {
 	newModel, err := bundleToModel(newBundle)
 	if err != nil {
 		return nil, err
@@ -694,7 +691,7 @@ func updateBundle(tx *gorm.DB, req *datastore.UpdateBundleRequest) (*datastore.U
 		return nil, sqlError.Wrap(err)
 	}
 
-	model.Data, newBundle, err = applyBundleMask(model, newBundle, req.InputMask)
+	model.Data, newBundle, err = applyBundleMask(model, newBundle, mask)
 	if err != nil {
 		return nil, sqlError.Wrap(err)
 	}
@@ -703,9 +700,7 @@ func updateBundle(tx *gorm.DB, req *datastore.UpdateBundleRequest) (*datastore.U
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.UpdateBundleResponse{
-		Bundle: newBundle,
-	}, nil
+	return newBundle, nil
 }
 
 func applyBundleMask(model *Bundle, newBundle *common.Bundle, inputMask *common.BundleMask) ([]byte, *common.Bundle, error) {
@@ -738,8 +733,8 @@ func applyBundleMask(model *Bundle, newBundle *common.Bundle, inputMask *common.
 	return newModel.Data, bundle, nil
 }
 
-func setBundle(tx *gorm.DB, req *datastore.SetBundleRequest) (*datastore.SetBundleResponse, error) {
-	newModel, err := bundleToModel(req.Bundle)
+func setBundle(tx *gorm.DB, b *common.Bundle) (*common.Bundle, error) {
+	newModel, err := bundleToModel(b)
 	if err != nil {
 		return nil, err
 	}
@@ -748,28 +743,24 @@ func setBundle(tx *gorm.DB, req *datastore.SetBundleRequest) (*datastore.SetBund
 	model := &Bundle{}
 	result := tx.Find(model, "trust_domain = ?", newModel.TrustDomain)
 	if result.RecordNotFound() {
-		bundle, err := createBundle(tx, req.Bundle)
+		bundle, err := createBundle(tx, b)
 		if err != nil {
 			return nil, err
 		}
-		return &datastore.SetBundleResponse{
-			Bundle: bundle,
-		}, nil
+		return bundle, nil
 	} else if result.Error != nil {
 		return nil, sqlError.Wrap(result.Error)
 	}
 
-	resp, err := updateBundle(tx, &datastore.UpdateBundleRequest{Bundle: req.Bundle})
+	bundle, err := updateBundle(tx, b, nil)
 	if err != nil {
 		return nil, err
 	}
-	return &datastore.SetBundleResponse{
-		Bundle: resp.Bundle,
-	}, nil
+	return bundle, nil
 }
 
-func appendBundle(tx *gorm.DB, req *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
-	newModel, err := bundleToModel(req.Bundle)
+func appendBundle(tx *gorm.DB, b *common.Bundle) (*common.Bundle, error) {
+	newModel, err := bundleToModel(b)
 	if err != nil {
 		return nil, err
 	}
@@ -778,13 +769,11 @@ func appendBundle(tx *gorm.DB, req *datastore.AppendBundleRequest) (*datastore.A
 	model := &Bundle{}
 	result := tx.Find(model, "trust_domain = ?", newModel.TrustDomain)
 	if result.RecordNotFound() {
-		bundle, err := createBundle(tx, req.Bundle)
+		bundle, err := createBundle(tx, b)
 		if err != nil {
 			return nil, err
 		}
-		return &datastore.AppendBundleResponse{
-			Bundle: bundle,
-		}, nil
+		return bundle, nil
 	} else if result.Error != nil {
 		return nil, sqlError.Wrap(result.Error)
 	}
@@ -795,7 +784,7 @@ func appendBundle(tx *gorm.DB, req *datastore.AppendBundleRequest) (*datastore.A
 		return nil, err
 	}
 
-	bundle, changed := bundleutil.MergeBundles(bundle, req.Bundle)
+	bundle, changed := bundleutil.MergeBundles(bundle, b)
 	if changed {
 		newModel, err := bundleToModel(bundle)
 		if err != nil {
@@ -807,9 +796,7 @@ func appendBundle(tx *gorm.DB, req *datastore.AppendBundleRequest) (*datastore.A
 		}
 	}
 
-	return &datastore.AppendBundleResponse{
-		Bundle: bundle,
-	}, nil
+	return bundle, nil
 }
 
 func deleteBundle(tx *gorm.DB, trustDomainID string, mode datastore.DeleteMode) error {
@@ -940,35 +927,33 @@ func listBundles(tx *gorm.DB, req *datastore.ListBundlesRequest) (*datastore.Lis
 	return resp, nil
 }
 
-func pruneBundle(tx *gorm.DB, req *datastore.PruneBundleRequest, log logrus.FieldLogger) (*datastore.PruneBundleResponse, error) {
+func pruneBundle(tx *gorm.DB, trustDomainID string, expiry time.Time, log logrus.FieldLogger) (bool, error) {
 	// Get current bundle
-	currentBundle, err := fetchBundle(tx, req.TrustDomainId)
+	currentBundle, err := fetchBundle(tx, trustDomainID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to fetch current bundle: %v", err)
+		return false, fmt.Errorf("unable to fetch current bundle: %v", err)
 	}
 
 	if currentBundle == nil {
 		// No bundle to prune
-		return &datastore.PruneBundleResponse{}, nil
+		return false, nil
 	}
 
 	// Prune
-	newBundle, changed, err := bundleutil.PruneBundle(currentBundle, time.Unix(req.ExpiresBefore, 0), log)
+	newBundle, changed, err := bundleutil.PruneBundle(currentBundle, expiry, log)
 	if err != nil {
-		return nil, fmt.Errorf("prune failed: %v", err)
+		return false, fmt.Errorf("prune failed: %v", err)
 	}
 
 	// Update only if bundle was modified
 	if changed {
-		_, err := updateBundle(tx, &datastore.UpdateBundleRequest{
-			Bundle: newBundle,
-		})
+		_, err := updateBundle(tx, newBundle, nil)
 		if err != nil {
-			return nil, fmt.Errorf("unable to write new bundle: %v", err)
+			return false, fmt.Errorf("unable to write new bundle: %v", err)
 		}
 	}
 
-	return &datastore.PruneBundleResponse{BundleChanged: changed}, nil
+	return changed, nil
 }
 
 func createAttestedNode(tx *gorm.DB, node *common.AttestedNode) (*common.AttestedNode, error) {
@@ -1487,37 +1472,35 @@ FROM attested_node_entries N
 	return builder.String(), args, nil
 }
 
-func updateAttestedNode(tx *gorm.DB, req *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+func updateAttestedNode(tx *gorm.DB, n *common.AttestedNode, mask *common.AttestedNodeMask) (*common.AttestedNode, error) {
 	var model AttestedNode
-	if err := tx.Find(&model, "spiffe_id = ?", req.SpiffeId).Error; err != nil {
+	if err := tx.Find(&model, "spiffe_id = ?", n.SpiffeId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	if req.InputMask == nil {
-		req.InputMask = protoutil.AllTrueCommonAgentMask
+	if mask == nil {
+		mask = protoutil.AllTrueCommonAgentMask
 	}
 
 	updates := make(map[string]interface{})
-	if req.InputMask.CertNotAfter {
-		updates["expires_at"] = time.Unix(req.CertNotAfter, 0)
+	if mask.CertNotAfter {
+		updates["expires_at"] = time.Unix(n.CertNotAfter, 0)
 	}
-	if req.InputMask.CertSerialNumber {
-		updates["serial_number"] = req.CertSerialNumber
+	if mask.CertSerialNumber {
+		updates["serial_number"] = n.CertSerialNumber
 	}
-	if req.InputMask.NewCertNotAfter {
-		updates["new_expires_at"] = nullableUnixTimeToDBTime(req.NewCertNotAfter)
+	if mask.NewCertNotAfter {
+		updates["new_expires_at"] = nullableUnixTimeToDBTime(n.NewCertNotAfter)
 	}
-	if req.InputMask.NewCertSerialNumber {
-		updates["new_serial_number"] = req.NewCertSerialNumber
+	if mask.NewCertSerialNumber {
+		updates["new_serial_number"] = n.NewCertSerialNumber
 	}
 
 	if err := tx.Model(&model).Updates(updates).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
 
-	return &datastore.UpdateAttestedNodeResponse{
-		Node: modelToAttestedNode(model),
-	}, nil
+	return modelToAttestedNode(model), nil
 }
 
 func deleteAttestedNode(tx *gorm.DB, spiffeID string) (*common.AttestedNode, error) {
@@ -2917,25 +2900,24 @@ func applyPagination(p *datastore.Pagination, entryTx *gorm.DB) (*gorm.DB, error
 	return entryTx, nil
 }
 
-func updateRegistrationEntry(tx *gorm.DB,
-	req *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
-	if err := validateRegistrationEntryForUpdate(req.Entry, req.Mask); err != nil {
+func updateRegistrationEntry(tx *gorm.DB, e *common.RegistrationEntry, mask *common.RegistrationEntryMask) (*common.RegistrationEntry, error) {
+	if err := validateRegistrationEntryForUpdate(e, mask); err != nil {
 		return nil, err
 	}
 
 	// Get the existing entry
 	entry := RegisteredEntry{}
-	if err := tx.Find(&entry, "entry_id = ?", req.Entry.EntryId).Error; err != nil {
+	if err := tx.Find(&entry, "entry_id = ?", e.EntryId).Error; err != nil {
 		return nil, sqlError.Wrap(err)
 	}
-	if req.Mask == nil || req.Mask.Selectors {
+	if mask == nil || mask.Selectors {
 		// Delete existing selectors - we will write new ones
 		if err := tx.Exec("DELETE FROM selectors WHERE registered_entry_id = ?", entry.ID).Error; err != nil {
 			return nil, sqlError.Wrap(err)
 		}
 
 		selectors := []Selector{}
-		for _, s := range req.Entry.Selectors {
+		for _, s := range e.Selectors {
 			selector := Selector{
 				Type:  s.Type,
 				Value: s.Value,
@@ -2946,14 +2928,14 @@ func updateRegistrationEntry(tx *gorm.DB,
 		entry.Selectors = selectors
 	}
 
-	if req.Mask == nil || req.Mask.DnsNames {
+	if mask == nil || mask.DnsNames {
 		// Delete existing DNSs - we will write new ones
 		if err := tx.Exec("DELETE FROM dns_names WHERE registered_entry_id = ?", entry.ID).Error; err != nil {
 			return nil, sqlError.Wrap(err)
 		}
 
 		dnsList := []DNSName{}
-		for _, d := range req.Entry.DnsNames {
+		for _, d := range e.DnsNames {
 			dns := DNSName{
 				Value: d,
 			}
@@ -2963,23 +2945,23 @@ func updateRegistrationEntry(tx *gorm.DB,
 		entry.DNSList = dnsList
 	}
 
-	if req.Mask == nil || req.Mask.SpiffeId {
-		entry.SpiffeID = req.Entry.SpiffeId
+	if mask == nil || mask.SpiffeId {
+		entry.SpiffeID = e.SpiffeId
 	}
-	if req.Mask == nil || req.Mask.ParentId {
-		entry.ParentID = req.Entry.ParentId
+	if mask == nil || mask.ParentId {
+		entry.ParentID = e.ParentId
 	}
-	if req.Mask == nil || req.Mask.Ttl {
-		entry.TTL = req.Entry.Ttl
+	if mask == nil || mask.Ttl {
+		entry.TTL = e.Ttl
 	}
-	if req.Mask == nil || req.Mask.Admin {
-		entry.Admin = req.Entry.Admin
+	if mask == nil || mask.Admin {
+		entry.Admin = e.Admin
 	}
-	if req.Mask == nil || req.Mask.Downstream {
-		entry.Downstream = req.Entry.Downstream
+	if mask == nil || mask.Downstream {
+		entry.Downstream = e.Downstream
 	}
-	if req.Mask == nil || req.Mask.EntryExpiry {
-		entry.Expiry = req.Entry.EntryExpiry
+	if mask == nil || mask.EntryExpiry {
+		entry.Expiry = e.EntryExpiry
 	}
 
 	// Revision number is increased by 1 on every update call
@@ -2989,8 +2971,8 @@ func updateRegistrationEntry(tx *gorm.DB,
 		return nil, sqlError.Wrap(err)
 	}
 
-	if req.Mask == nil || req.Mask.FederatesWith {
-		federatesWith, err := makeFederatesWith(tx, req.Entry.FederatesWith)
+	if mask == nil || mask.FederatesWith {
+		federatesWith, err := makeFederatesWith(tx, e.FederatesWith)
 		if err != nil {
 			return nil, err
 		}
@@ -3006,9 +2988,7 @@ func updateRegistrationEntry(tx *gorm.DB,
 		return nil, err
 	}
 
-	return &datastore.UpdateRegistrationEntryResponse{
-		Entry: returnEntry,
-	}, nil
+	return returnEntry, nil
 }
 
 func deleteRegistrationEntry(tx *gorm.DB, entryID string) (*common.RegistrationEntry, error) {
@@ -3047,19 +3027,19 @@ func deleteRegistrationEntrySupport(tx *gorm.DB, entry RegisteredEntry) error {
 	return nil
 }
 
-func pruneRegistrationEntries(tx *gorm.DB, req *datastore.PruneRegistrationEntriesRequest) (*datastore.PruneRegistrationEntriesResponse, error) {
+func pruneRegistrationEntries(tx *gorm.DB, expiresBefore time.Time) error {
 	var registrationEntries []RegisteredEntry
-	if err := tx.Where("expiry != 0").Where("expiry < ?", req.ExpiresBefore).Find(&registrationEntries).Error; err != nil {
-		return nil, err
+	if err := tx.Where("expiry != 0").Where("expiry < ?", expiresBefore.Unix()).Find(&registrationEntries).Error; err != nil {
+		return err
 	}
 
 	for _, entry := range registrationEntries {
 		if err := deleteRegistrationEntrySupport(tx, entry); err != nil {
-			return nil, err
+			return err
 		}
 	}
 
-	return &datastore.PruneRegistrationEntriesResponse{}, nil
+	return nil
 }
 
 func createJoinToken(tx *gorm.DB, token *datastore.JoinToken) error {

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -221,7 +221,7 @@ func (s *PluginSuite) TestBundleCRUD() {
 	s.Require().Nil(fb)
 
 	// update non-existent
-	_, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{Bundle: bundle})
+	_, err = s.ds.UpdateBundle(ctx, bundle, nil)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 
 	// delete non-existent
@@ -257,38 +257,29 @@ func (s *PluginSuite) TestBundleCRUD() {
 		[]*x509.Certificate{s.cert, s.cacert})
 
 	// append
-	aresp, err := s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
-		Bundle: bundle2,
-	})
+	ab, err := s.ds.AppendBundle(ctx, bundle2)
 	s.Require().NoError(err)
-	s.Require().NotNil(aresp.Bundle)
-	s.AssertProtoEqual(appendedBundle, aresp.Bundle)
+	s.Require().NotNil(ab)
+	s.AssertProtoEqual(appendedBundle, ab)
 
 	// append identical
-	aresp, err = s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
-		Bundle: bundle2,
-	})
+	ab, err = s.ds.AppendBundle(ctx, bundle2)
 	s.Require().NoError(err)
-	s.Require().NotNil(aresp.Bundle)
-	s.AssertProtoEqual(appendedBundle, aresp.Bundle)
+	s.Require().NotNil(ab)
+	s.AssertProtoEqual(appendedBundle, ab)
 
 	// append on a new bundle
 	bundle3 := bundleutil.BundleProtoFromRootCA("spiffe://bar", s.cacert)
-	anresp, err := s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{
-		Bundle: bundle3,
-	})
+	ab, err = s.ds.AppendBundle(ctx, bundle3)
 	s.Require().NoError(err)
-	s.AssertProtoEqual(bundle3, anresp.Bundle)
+	s.AssertProtoEqual(bundle3, ab)
 
 	// update with mask: RootCas
-	uresp, err := s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
-		Bundle: bundle,
-		InputMask: &common.BundleMask{
-			RootCas: true,
-		},
+	updatedBundle, err := s.ds.UpdateBundle(ctx, bundle, &common.BundleMask{
+		RootCas: true,
 	})
 	s.Require().NoError(err)
-	s.AssertProtoEqual(bundle, uresp.Bundle)
+	s.AssertProtoEqual(bundle, updatedBundle)
 
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
 	s.Require().NoError(err)
@@ -296,14 +287,11 @@ func (s *PluginSuite) TestBundleCRUD() {
 
 	// update with mask: RefreshHint
 	bundle.RefreshHint = 60
-	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
-		Bundle: bundle,
-		InputMask: &common.BundleMask{
-			RefreshHint: true,
-		},
+	updatedBundle, err = s.ds.UpdateBundle(ctx, bundle, &common.BundleMask{
+		RefreshHint: true,
 	})
 	s.Require().NoError(err)
-	s.AssertProtoEqual(bundle, uresp.Bundle)
+	s.AssertProtoEqual(bundle, updatedBundle)
 
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
 	s.Require().NoError(err)
@@ -311,25 +299,20 @@ func (s *PluginSuite) TestBundleCRUD() {
 
 	// update with mask: JwtSingingKeys
 	bundle.JwtSigningKeys = []*common.PublicKey{{Kid: "jwt-key-1"}}
-	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
-		Bundle: bundle,
-		InputMask: &common.BundleMask{
-			JwtSigningKeys: true,
-		},
+	updatedBundle, err = s.ds.UpdateBundle(ctx, bundle, &common.BundleMask{
+		JwtSigningKeys: true,
 	})
 	s.Require().NoError(err)
-	s.AssertProtoEqual(bundle, uresp.Bundle)
+	s.AssertProtoEqual(bundle, updatedBundle)
 
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
 	s.Require().NoError(err)
 	assertBundlesEqual(s.T(), []*common.Bundle{bundle, bundle3}, lresp.Bundles)
 
 	// update without mask
-	uresp, err = s.ds.UpdateBundle(ctx, &datastore.UpdateBundleRequest{
-		Bundle: bundle2,
-	})
+	updatedBundle, err = s.ds.UpdateBundle(ctx, bundle2, nil)
 	s.Require().NoError(err)
-	s.AssertProtoEqual(bundle2, uresp.Bundle)
+	s.AssertProtoEqual(bundle2, updatedBundle)
 
 	lresp, err = s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{})
 	s.Require().NoError(err)
@@ -562,16 +545,12 @@ func (s *PluginSuite) TestSetBundle() {
 	s.Require().Nil(s.fetchBundle("spiffe://foo"))
 
 	// set the bundle and make sure it is created
-	_, err := s.ds.SetBundle(ctx, &datastore.SetBundleRequest{
-		Bundle: bundle,
-	})
+	_, err := s.ds.SetBundle(ctx, bundle)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(bundle, s.fetchBundle("spiffe://foo"))
 
 	// set the bundle and make sure it is updated
-	_, err = s.ds.SetBundle(ctx, &datastore.SetBundleRequest{
-		Bundle: bundle2,
-	})
+	_, err = s.ds.SetBundle(ctx, bundle2)
 	s.Require().NoError(err)
 	s.RequireProtoEqual(bundle2, s.fetchBundle("spiffe://foo"))
 }
@@ -603,31 +582,21 @@ func (s *PluginSuite) TestBundlePrune() {
 
 	// Prune
 	// prune non existent bundle should not return error, no bundle to prune
-	expiration := time.Now().Unix()
-	presp, err := s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
-		TrustDomainId: "spiffe://notexistent",
-		ExpiresBefore: expiration,
-	})
+	expiration := time.Now()
+	changed, err := s.ds.PruneBundle(ctx, "spiffe://notexistent", expiration)
 	s.NoError(err)
-	s.Equal(presp, &datastore.PruneBundleResponse{})
+	s.False(changed)
 
 	// prune fails if internal prune bundle fails. For instance, if all certs are expired
-	expiration = time.Now().Unix()
-	presp, err = s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
-		TrustDomainId: bundle.TrustDomainId,
-		ExpiresBefore: expiration,
-	})
+	expiration = time.Now()
+	changed, err = s.ds.PruneBundle(ctx, bundle.TrustDomainId, expiration)
 	s.AssertGRPCStatus(err, codes.Unknown, "prune failed: would prune all certificates")
-	s.Nil(presp)
+	s.False(changed)
 
 	// prune should remove expired certs
-	presp, err = s.ds.PruneBundle(ctx, &datastore.PruneBundleRequest{
-		TrustDomainId: bundle.TrustDomainId,
-		ExpiresBefore: middleTime.Unix(),
-	})
+	changed, err = s.ds.PruneBundle(ctx, bundle.TrustDomainId, middleTime)
 	s.NoError(err)
-	s.NotNil(presp)
-	s.True(presp.BundleChanged)
+	s.True(changed)
 
 	// Fetch and verify pruned bundle is the expected
 	expectedPrunedBundle := bundleutil.BundleProtoFromRootCAs("spiffe://foo", []*x509.Certificate{s.cert})
@@ -1200,14 +1169,15 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 
 	for _, tt := range []struct {
 		name           string
-		updateReq      *datastore.UpdateAttestedNodeRequest
+		updateNode     *common.AttestedNode
+		updateNodeMask *common.AttestedNodeMask
 		expUpdatedNode *common.AttestedNode
 		expCode        codes.Code
 		expMsg         string
 	}{
 		{
 			name: "update non-existing attested node",
-			updateReq: &datastore.UpdateAttestedNodeRequest{
+			updateNode: &common.AttestedNode{
 				SpiffeId:         "non-existent-node-id",
 				CertSerialNumber: updatedSerial,
 				CertNotAfter:     updatedExpires,
@@ -1217,14 +1187,14 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 		},
 		{
 			name: "update attested node with all false mask",
-			updateReq: &datastore.UpdateAttestedNodeRequest{
+			updateNode: &common.AttestedNode{
 				SpiffeId:            nodeID,
 				CertSerialNumber:    updatedSerial,
 				CertNotAfter:        updatedExpires,
 				NewCertNotAfter:     updatedNewExpires,
 				NewCertSerialNumber: updatedNewSerial,
-				InputMask:           &common.AttestedNodeMask{},
 			},
+			updateNodeMask: &common.AttestedNodeMask{},
 			expUpdatedNode: &common.AttestedNode{
 				SpiffeId:            nodeID,
 				AttestationDataType: attestationType,
@@ -1236,16 +1206,16 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 		},
 		{
 			name: "update attested node with mask set only some fields: 'CertSerialNumber', 'NewCertNotAfter'",
-			updateReq: &datastore.UpdateAttestedNodeRequest{
+			updateNode: &common.AttestedNode{
 				SpiffeId:            nodeID,
 				CertSerialNumber:    updatedSerial,
 				CertNotAfter:        updatedExpires,
 				NewCertNotAfter:     updatedNewExpires,
 				NewCertSerialNumber: updatedNewSerial,
-				InputMask: &common.AttestedNodeMask{
-					CertSerialNumber: true,
-					NewCertNotAfter:  true,
-				},
+			},
+			updateNodeMask: &common.AttestedNodeMask{
+				CertSerialNumber: true,
+				NewCertNotAfter:  true,
 			},
 			expUpdatedNode: &common.AttestedNode{
 				SpiffeId:            nodeID,
@@ -1258,7 +1228,7 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 		},
 		{
 			name: "update attested node with nil mask",
-			updateReq: &datastore.UpdateAttestedNodeRequest{
+			updateNode: &common.AttestedNode{
 				SpiffeId:            nodeID,
 				CertSerialNumber:    updatedSerial,
 				CertNotAfter:        updatedExpires,
@@ -1291,18 +1261,18 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 			s.Require().NoError(err)
 
 			// Update attested node
-			uresp, err := s.ds.UpdateAttestedNode(ctx, tt.updateReq)
+			updatedNode, err := s.ds.UpdateAttestedNode(ctx, tt.updateNode, tt.updateNodeMask)
 			s.RequireGRPCStatus(err, tt.expCode, tt.expMsg)
 			if tt.expCode != codes.OK {
-				s.Require().Nil(uresp)
+				s.Require().Nil(updatedNode)
 				return
 			}
 			s.Require().NoError(err)
-			s.Require().NotNil(uresp)
-			s.RequireProtoEqual(tt.expUpdatedNode, uresp.Node)
+			s.Require().NotNil(updatedNode)
+			s.RequireProtoEqual(tt.expUpdatedNode, updatedNode)
 
 			// Check a fresh fetch shows the updated attested node
-			attestedNode, err := s.ds.FetchAttestedNode(ctx, tt.updateReq.SpiffeId)
+			attestedNode, err := s.ds.FetchAttestedNode(ctx, tt.updateNode.SpiffeId)
 			s.Require().NoError(err)
 			s.Require().NotNil(attestedNode)
 			s.RequireProtoEqual(tt.expUpdatedNode, attestedNode)
@@ -1549,7 +1519,7 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 }
 
 func (s *PluginSuite) TestPruneRegistrationEntries() {
-	now := time.Now().Unix()
+	now := time.Now()
 	entry := &common.RegistrationEntry{
 		Selectors: []*common.Selector{
 			{Type: "Type1", Value: "Value1"},
@@ -1559,16 +1529,14 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 		SpiffeId:    "SpiffeId",
 		ParentId:    "ParentId",
 		Ttl:         1,
-		EntryExpiry: now,
+		EntryExpiry: now.Unix(),
 	}
 
 	createdRegistrationEntry, err := s.ds.CreateRegistrationEntry(ctx, entry)
 	s.Require().NoError(err)
 
 	// Ensure we don't prune valid entries, wind clock back 10s
-	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
-		ExpiresBefore: now - 10,
-	})
+	err = s.ds.PruneRegistrationEntries(ctx, now.Add(-10*time.Second))
 	s.Require().NoError(err)
 
 	fetchedRegistrationEntry, err := s.ds.FetchRegistrationEntry(ctx, createdRegistrationEntry.EntryId)
@@ -1576,9 +1544,7 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 	s.Equal(createdRegistrationEntry, fetchedRegistrationEntry)
 
 	// Ensure we don't prune on the exact ExpiresBefore
-	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
-		ExpiresBefore: now,
-	})
+	err = s.ds.PruneRegistrationEntries(ctx, now)
 	s.Require().NoError(err)
 
 	fetchedRegistrationEntry, err = s.ds.FetchRegistrationEntry(ctx, createdRegistrationEntry.EntryId)
@@ -1586,9 +1552,7 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 	s.Equal(createdRegistrationEntry, fetchedRegistrationEntry)
 
 	// Ensure we prune old entries
-	_, err = s.ds.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
-		ExpiresBefore: now + 10,
-	})
+	err = s.ds.PruneRegistrationEntries(ctx, now.Add(10*time.Second))
 	s.Require().NoError(err)
 
 	fetchedRegistrationEntry, err = s.ds.FetchRegistrationEntry(ctx, createdRegistrationEntry.EntryId)
@@ -1985,21 +1949,16 @@ func (s *PluginSuite) TestUpdateRegistrationEntry() {
 	entry.Admin = true
 	entry.Downstream = true
 
-	updateRegistrationEntryResponse, err := s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
-		Entry: entry,
-	})
+	updatedRegistrationEntry, err := s.ds.UpdateRegistrationEntry(ctx, entry, nil)
 	s.Require().NoError(err)
-	s.Require().NotNil(updateRegistrationEntryResponse)
 
 	registrationEntry, err := s.ds.FetchRegistrationEntry(ctx, entry.EntryId)
 	s.Require().NoError(err)
 	s.Require().NotNil(registrationEntry)
-	s.RequireProtoEqual(updateRegistrationEntryResponse.Entry, registrationEntry)
+	s.RequireProtoEqual(updatedRegistrationEntry, registrationEntry)
 
 	entry.EntryId = "badid"
-	_, err = s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
-		Entry: entry,
-	})
+	_, err = s.ds.UpdateRegistrationEntry(ctx, entry, nil)
 	s.RequireGRPCStatus(err, codes.NotFound, _notFoundErrMsg)
 }
 
@@ -2171,10 +2130,7 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 			updateEntry := &common.RegistrationEntry{}
 			tt.update(updateEntry)
 			updateEntry.EntryId = id
-			updateRegistrationEntryResponse, err := s.ds.UpdateRegistrationEntry(ctx, &datastore.UpdateRegistrationEntryRequest{
-				Entry: updateEntry,
-				Mask:  tt.mask,
-			})
+			updatedRegistrationEntry, err := s.ds.UpdateRegistrationEntry(ctx, updateEntry, tt.mask)
 
 			if tt.err != nil {
 				s.Require().Error(tt.err)
@@ -2182,12 +2138,11 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 			}
 
 			s.Require().NoError(err)
-			s.Require().NotNil(updateRegistrationEntryResponse)
 			expectedResult := proto.Clone(oldEntry).(*common.RegistrationEntry)
 			tt.result(expectedResult)
 			expectedResult.EntryId = id
 			expectedResult.RevisionNumber++
-			s.RequireProtoEqual(expectedResult, updateRegistrationEntryResponse.Entry)
+			s.RequireProtoEqual(expectedResult, updatedRegistrationEntry)
 
 			// Fetch and check the results match expectations
 			registrationEntry, err = s.ds.FetchRegistrationEntry(ctx, id)
@@ -2664,9 +2619,7 @@ func (s *PluginSuite) TestMigration() {
 			s.Require().False(resp.Entries[0].Admin)
 
 			resp.Entries[0].Admin = true
-			_, err = s.ds.UpdateRegistrationEntry(context.Background(), &datastore.UpdateRegistrationEntryRequest{
-				Entry: resp.Entries[0],
-			})
+			_, err = s.ds.UpdateRegistrationEntry(context.Background(), resp.Entries[0], nil)
 			s.Require().NoError(err)
 
 			resp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
@@ -2680,9 +2633,7 @@ func (s *PluginSuite) TestMigration() {
 			s.Require().False(resp.Entries[0].Downstream)
 
 			resp.Entries[0].Downstream = true
-			_, err = s.ds.UpdateRegistrationEntry(context.Background(), &datastore.UpdateRegistrationEntryRequest{
-				Entry: resp.Entries[0],
-			})
+			_, err = s.ds.UpdateRegistrationEntry(context.Background(), resp.Entries[0], nil)
 			s.Require().NoError(err)
 
 			resp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
@@ -2698,9 +2649,7 @@ func (s *PluginSuite) TestMigration() {
 
 			expiryVal := time.Now().Unix()
 			resp.Entries[0].EntryExpiry = expiryVal
-			_, err = s.ds.UpdateRegistrationEntry(context.Background(), &datastore.UpdateRegistrationEntryRequest{
-				Entry: resp.Entries[0],
-			})
+			_, err = s.ds.UpdateRegistrationEntry(context.Background(), resp.Entries[0], nil)
 			s.Require().NoError(err)
 
 			resp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})
@@ -2715,9 +2664,7 @@ func (s *PluginSuite) TestMigration() {
 			s.Require().Empty(resp.Entries[0].DnsNames)
 
 			resp.Entries[0].DnsNames = []string{"abcd.efg"}
-			_, err = s.ds.UpdateRegistrationEntry(context.Background(), &datastore.UpdateRegistrationEntryRequest{
-				Entry: resp.Entries[0],
-			})
+			_, err = s.ds.UpdateRegistrationEntry(context.Background(), resp.Entries[0], nil)
 			s.Require().NoError(err)
 
 			resp, err = s.ds.ListRegistrationEntries(context.Background(), &datastore.ListRegistrationEntriesRequest{})

--- a/pkg/server/registration/manager.go
+++ b/pkg/server/registration/manager.go
@@ -71,8 +71,6 @@ func (m *Manager) prune(ctx context.Context) (err error) {
 	counter := telemetry_server.StartRegistrationManagerPruneEntryCall(m.c.Metrics)
 	defer counter.Done(&err)
 
-	_, err = m.c.DataStore.PruneRegistrationEntries(ctx, &datastore.PruneRegistrationEntriesRequest{
-		ExpiresBefore: m.c.Clock.Now().Unix(),
-	})
+	err = m.c.DataStore.PruneRegistrationEntries(ctx, m.c.Clock.Now())
 	return err
 }

--- a/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/pod_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-reconcile/controllers/pod_controller_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-logr/logr"
 	spiretypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
-	"github.com/spiffe/spire/pkg/server/plugin/datastore"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/fakes/fakeentryclient"
@@ -120,7 +119,7 @@ func (s *PodControllerTestSuite) TestAddChangeRemovePod() {
 				},
 			}
 
-			_, err := s.ds.AppendBundle(ctx, &datastore.AppendBundleRequest{Bundle: &common.Bundle{TrustDomainId: "spiffe://example.io"}})
+			_, err := s.ds.AppendBundle(ctx, &common.Bundle{TrustDomainId: "spiffe://example.io"})
 			s.Assert().NoError(err)
 
 			err = s.k8sClient.Create(ctx, &pod)

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -51,25 +51,25 @@ func (s *DataStore) CreateBundle(ctx context.Context, bundle *common.Bundle) (*c
 	return s.ds.CreateBundle(ctx, bundle)
 }
 
-func (s *DataStore) UpdateBundle(ctx context.Context, req *datastore.UpdateBundleRequest) (*datastore.UpdateBundleResponse, error) {
+func (s *DataStore) UpdateBundle(ctx context.Context, bundle *common.Bundle, mask *common.BundleMask) (*common.Bundle, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.UpdateBundle(ctx, req)
+	return s.ds.UpdateBundle(ctx, bundle, mask)
 }
 
-func (s *DataStore) SetBundle(ctx context.Context, req *datastore.SetBundleRequest) (*datastore.SetBundleResponse, error) {
+func (s *DataStore) SetBundle(ctx context.Context, bundle *common.Bundle) (*common.Bundle, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.SetBundle(ctx, req)
+	return s.ds.SetBundle(ctx, bundle)
 }
 
-func (s *DataStore) AppendBundle(ctx context.Context, req *datastore.AppendBundleRequest) (*datastore.AppendBundleResponse, error) {
+func (s *DataStore) AppendBundle(ctx context.Context, bundle *common.Bundle) (*common.Bundle, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.AppendBundle(ctx, req)
+	return s.ds.AppendBundle(ctx, bundle)
 }
 
 func (s *DataStore) CountBundles(ctx context.Context) (int32, error) {
@@ -108,11 +108,11 @@ func (s *DataStore) ListBundles(ctx context.Context, req *datastore.ListBundlesR
 	return resp, err
 }
 
-func (s *DataStore) PruneBundle(ctx context.Context, req *datastore.PruneBundleRequest) (*datastore.PruneBundleResponse, error) {
+func (s *DataStore) PruneBundle(ctx context.Context, trustDomainID string, expiresBefore time.Time) (bool, error) {
 	if err := s.getNextError(); err != nil {
-		return nil, err
+		return false, err
 	}
-	return s.ds.PruneBundle(ctx, req)
+	return s.ds.PruneBundle(ctx, trustDomainID, expiresBefore)
 }
 
 func (s *DataStore) CountAttestedNodes(ctx context.Context) (int32, error) {
@@ -143,11 +143,11 @@ func (s *DataStore) ListAttestedNodes(ctx context.Context, req *datastore.ListAt
 	return s.ds.ListAttestedNodes(ctx, req)
 }
 
-func (s *DataStore) UpdateAttestedNode(ctx context.Context, req *datastore.UpdateAttestedNodeRequest) (*datastore.UpdateAttestedNodeResponse, error) {
+func (s *DataStore) UpdateAttestedNode(ctx context.Context, node *common.AttestedNode, mask *common.AttestedNodeMask) (*common.AttestedNode, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.UpdateAttestedNode(ctx, req)
+	return s.ds.UpdateAttestedNode(ctx, node, mask)
 }
 
 func (s *DataStore) DeleteAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error) {
@@ -216,11 +216,11 @@ func (s *DataStore) ListRegistrationEntries(ctx context.Context, req *datastore.
 	return resp, err
 }
 
-func (s *DataStore) UpdateRegistrationEntry(ctx context.Context, req *datastore.UpdateRegistrationEntryRequest) (*datastore.UpdateRegistrationEntryResponse, error) {
+func (s *DataStore) UpdateRegistrationEntry(ctx context.Context, entry *common.RegistrationEntry, mask *common.RegistrationEntryMask) (*common.RegistrationEntry, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.UpdateRegistrationEntry(ctx, req)
+	return s.ds.UpdateRegistrationEntry(ctx, entry, mask)
 }
 
 func (s *DataStore) DeleteRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error) {
@@ -230,11 +230,11 @@ func (s *DataStore) DeleteRegistrationEntry(ctx context.Context, entryID string)
 	return s.ds.DeleteRegistrationEntry(ctx, entryID)
 }
 
-func (s *DataStore) PruneRegistrationEntries(ctx context.Context, req *datastore.PruneRegistrationEntriesRequest) (*datastore.PruneRegistrationEntriesResponse, error) {
+func (s *DataStore) PruneRegistrationEntries(ctx context.Context, expiresBefore time.Time) error {
 	if err := s.getNextError(); err != nil {
-		return nil, err
+		return err
 	}
-	return s.ds.PruneRegistrationEntries(ctx, req)
+	return s.ds.PruneRegistrationEntries(ctx, expiresBefore)
 }
 
 func (s *DataStore) CreateJoinToken(ctx context.Context, token *datastore.JoinToken) error {


### PR DESCRIPTION
Signed-off-by: Brian Martin <bri365@gmail.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
AppendBundle, PruneBundle, SetBundle, UpdateBundle, PruneRegistrationEntry, UpdateRegistrationEntry, UpdateAttestedNode

**Description of change**
Remove unneeded gRPC request and response structures
Consolidate update design pattern to <object>, <object mask>