### PR TITLE
Backport fix node selector query split-response to 0.12 (#2242)

### DIFF
--- a/pkg/server/plugin/datastore/sql/sql.go
+++ b/pkg/server/plugin/datastore/sql/sql.go
@@ -1661,7 +1661,7 @@ func listNodeSelectors(ctx context.Context, db *sqlDB, req *datastore.ListNodeSe
 	}
 	defer rows.Close()
 
-	selectorsById := make(map[string][]*common.Selector)
+	selectorsByID := make(map[string][]*common.Selector)
 
 	var currentID string
 	selectors := make([]*common.Selector, 0, 64)
@@ -1671,7 +1671,7 @@ func listNodeSelectors(ctx context.Context, db *sqlDB, req *datastore.ListNodeSe
 		case currentID == "":
 			currentID = spiffeID
 		case spiffeID != currentID:
-			selectorsById[currentID] = append(selectorsById[currentID], selectors...)
+			selectorsByID[currentID] = append(selectorsByID[currentID], selectors...)
 			currentID = spiffeID
 			selectors = selectors[:0]
 		}
@@ -1701,7 +1701,7 @@ func listNodeSelectors(ctx context.Context, db *sqlDB, req *datastore.ListNodeSe
 	}
 
 	resp := new(datastore.ListNodeSelectorsResponse)
-	for spiffeID, selectors := range selectorsById {
+	for spiffeID, selectors := range selectorsByID {
 		resp.Selectors = append(resp.Selectors, &datastore.NodeSelectors{
 			SpiffeId:  spiffeID,
 			Selectors: selectors,

--- a/pkg/server/plugin/datastore/sql/sql_test.go
+++ b/pkg/server/plugin/datastore/sql/sql_test.go
@@ -1422,7 +1422,7 @@ func (s *PluginSuite) TestListNodeSelectors() {
 	s.T().Run("no selectors exist", func(t *testing.T) {
 		req := &datastore.ListNodeSelectorsRequest{}
 		resp := s.listNodeSelectors(req)
-		s.Assert().Empty(resp.Selectors)
+		assertSelectorsEqual(t, nil, resp.Selectors)
 	})
 
 	const numNonExpiredAttNodes = 3
@@ -1482,7 +1482,7 @@ func (s *PluginSuite) TestListNodeSelectors() {
 	s.T().Run("list all", func(t *testing.T) {
 		req := &datastore.ListNodeSelectorsRequest{}
 		resp := s.listNodeSelectors(req)
-		s.Require().Len(resp.Selectors, len(selectorMap))
+		assertSelectorsEqual(t, selectorMap, resp.Selectors)
 	})
 
 	s.T().Run("list unexpired", func(t *testing.T) {
@@ -1491,15 +1491,33 @@ func (s *PluginSuite) TestListNodeSelectors() {
 				Seconds: time.Now().Unix(),
 			},
 		}
-
 		resp := s.listNodeSelectors(req)
-		s.Assert().Len(resp.Selectors, len(nonExpiredSelectorsMap))
-		for _, n := range resp.Selectors {
-			expectedSelectors, ok := nonExpiredSelectorsMap[n.SpiffeId]
-			s.Assert().True(ok)
-			s.AssertProtoListEqual(expectedSelectors, n.Selectors)
-		}
+		assertSelectorsEqual(t, nonExpiredSelectorsMap, resp.Selectors)
 	})
+}
+
+func (s *PluginSuite) TestListNodeSelectorsGroupsBySpiffeID() {
+	insertSelector := func(id int, spiffeID, selectorType, selectorValue string) {
+		query := maybeRebind(s.sqlPlugin.db.databaseType, "INSERT INTO node_resolver_map_entries(id, spiffe_id, type, value) VALUES (?, ?, ?, ?)")
+		_, err := s.sqlPlugin.db.raw.Exec(query, id, spiffeID, selectorType, selectorValue)
+		s.Require().NoError(err)
+	}
+
+	// Insert selectors out of order in respect to the SPIFFE ID so
+	// that we can assert that the datastore aggregates the results correctly.
+	insertSelector(1, "spiffe://example.org/node3", "A", "a")
+	insertSelector(2, "spiffe://example.org/node2", "B", "b")
+	insertSelector(3, "spiffe://example.org/node3", "C", "c")
+	insertSelector(4, "spiffe://example.org/node1", "D", "d")
+	insertSelector(5, "spiffe://example.org/node2", "E", "e")
+	insertSelector(6, "spiffe://example.org/node3", "F", "f")
+
+	resp := s.listNodeSelectors(&datastore.ListNodeSelectorsRequest{})
+	assertSelectorsEqual(s.T(), map[string][]*common.Selector{
+		"spiffe://example.org/node1": {{Type: "D", Value: "d"}},
+		"spiffe://example.org/node2": {{Type: "B", Value: "b"}, {Type: "E", Value: "e"}},
+		"spiffe://example.org/node3": {{Type: "A", Value: "a"}, {Type: "C", Value: "c"}, {Type: "F", Value: "f"}},
+	}, resp.Selectors)
 }
 
 func (s *PluginSuite) TestSetNodeSelectorsUnderLoad() {
@@ -6757,4 +6775,30 @@ func dropTablesInRows(t *testing.T, db *sql.DB, rows *sql.Rows) {
 
 func cloneAttestedNode(aNode *common.AttestedNode) *common.AttestedNode {
 	return proto.Clone(aNode).(*common.AttestedNode)
+}
+
+// assertSelectorsEqual compares two selector maps for equality
+// TODO: replace this with calls to Equal when we replace common.Selector with
+// a normal struct that doesn't require special comparison (i.e. not a
+// protobuf)
+func assertSelectorsEqual(t *testing.T, expected map[string][]*common.Selector, actual []*datastore.NodeSelectors) {
+	type selector struct {
+		Type  string
+		Value string
+	}
+
+	actualMap := make(map[string][]selector)
+	for _, nodeSelector := range actual {
+		for _, s := range nodeSelector.Selectors {
+			actualMap[nodeSelector.SpiffeId] = append(actualMap[nodeSelector.SpiffeId], selector{Type: s.Type, Value: s.Value})
+		}
+	}
+
+	expectedMap := make(map[string][]selector)
+	for spiffeID, selectors := range expected {
+		for _, s := range selectors {
+			expectedMap[spiffeID] = append(expectedMap[spiffeID], selector{Type: s.Type, Value: s.Value})
+		}
+	}
+	assert.Equal(t, expectedMap, actualMap)
 }


### PR DESCRIPTION
The DataStore query that returns the list of agent node selectors is currently sorted by row ID, which under certain circumstances can cause it to split the selectors for a given agent ID into more than one entry in the aggregated results. The only caller is the full entry cache, which does not handle this well, which can cause agents to not be associated with a node alias whose selectors end up spanning these splits.

This change fixes the query to order by SPIFFE ID instead of row ID so that the selectors for a given agent are grouped together and returned in a single entry in the aggregated results.

It also aggregates the results differently such that the order does not matter for correctness so that the code is resilient against a similar bug in the future.

Co-Authored-By: Andrew Harding <aharding@vmware.com>
Signed-off-by: Jonathan Oddy <jonathan.oddy@transferwise.com>
