### PR TITLE
k8sbundle notifier: Docs cleanup and bug fix

### DIFF
--- a/doc/plugin_server_notifier_k8sbundle.md
+++ b/doc/plugin_server_notifier_k8sbundle.md
@@ -2,7 +2,7 @@
 
 The `k8sbundle` plugin responds to bundle loaded/updated events by fetching and
 pushing the latest root CA certificates from the trust bundle to a Kubernetes
-ConfigMap.
+ConfigMap, Webhook, and/or APIService.
 
 The certificates in the ConfigMap can be used to bootstrap SPIRE agents.
 
@@ -13,6 +13,7 @@ The plugin accepts the following configuration options:
 | namespace             | The namespace containing the ConfigMap      | `spire`         |
 | config_map            | The name of the ConfigMap                   | `spire-bundle`  |
 | config_map_key        | The key within the ConfigMap for the bundle | `bundle.crt`    |
+| config_map_enable     | Enable rotating bundle in ConfigMap         | `true`          |
 | kube_config_file_path | The path on disk to the kubeconfig containing configuration to enable interaction with the Kubernetes API server. If unset, it is assumed the notifier is in-cluster and in-cluster credentials will be used. | |
 | api_service_label     | If set, rotate the CA Bundle in API services with this label set to `true`. | |
 | webhook_label         | If set, rotate the CA Bundle in validating and mutating webhooks with this label set to `true`. | |
@@ -21,11 +22,13 @@ The plugin accepts the following configuration options:
 
 The following actions are required to set up the plugin.
 
-- Bind ClusterRole or Role that can `get` and `patch` the ConfigMap to Service Account
+- Bind ClusterRole or Role to Service Account
     - In the case of in-cluster SPIRE server, it is Service Account that runs the SPIRE server
     - In the case of out-of-cluster SPIRE server, it is Service Account that interacts with the Kubernetes API server
-    - In the case of setting `webhook_label`, the ClusterRole additionally needs permissions to `get`, `list`, `patch`, and `watch` `mutatingwebhookconfigurations` and `validatingwebhookconfigurations`.
-- Create the ConfigMap that the plugin pushes
+    - If `config_map_enable` is `true` the ClusterRole or Role needs permissions to `get` and `patch` the ConfigMap
+    - In the case of setting `webhook_label`, the ClusterRole or Role needs permissions to `get`, `list`, `patch`, and `watch` `mutatingwebhookconfigurations` and `validatingwebhookconfigurations`.
+    - In the case of setting `api_service_label`, the ClusterRole or Role needs permissions to `get`, `list`, `patch`, and `watch` `apiservices`.
+- Create the ConfigMap that the plugin pushes if `config_map_enable` is `true`
 
 For example:
 
@@ -117,7 +120,7 @@ the credentials found in the `/path/to/kubeconfig` file.
     }
 ```
 
-### Default In-Cluster with Webhook and APIService Rotation
+### Default In-Cluster with ConfigMap, Webhook, and APIService Rotation
 
 The following configuration pushes bundle contents from an in-cluster SPIRE
 server to
@@ -130,6 +133,20 @@ server to
         plugin_data {
             webhook_label    = "spiffe.io/webhook"
             api_service_label = "spiffe.io/api_service"
+        }
+    }
+```
+
+### Default In-Cluster with only Webhook Rotation
+
+The following configuration pushes bundle contents from an in-cluster SPIRE
+server to validating and mutating webhooks with a label of `spiffe.io/webhook: true`
+
+```
+    Notifier "k8sbundle" {
+        plugin_data {
+            config_map_enable = false
+            webhook_label    = "spiffe.io/webhook"
         }
     }
 ```

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -195,7 +195,7 @@ func (p *Plugin) setConfig(config *pluginConfig) error {
 		p.cancelWatcher()
 		p.cancelWatcher = nil
 	}
-	if config.WebhookLabel != "" {
+	if config.WebhookLabel != "" || config.APIServiceLabel != "" {
 		p.cancelWatcher = cancelWatcher
 	}
 

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -41,9 +41,10 @@ var (
 )
 
 const (
-	defaultNamespace    = "spire"
-	defaultConfigMap    = "spire-bundle"
-	defaultConfigMapKey = "bundle.crt"
+	defaultNamespace       = "spire"
+	defaultConfigMap       = "spire-bundle"
+	defaultConfigMapKey    = "bundle.crt"
+	defaultConfigMapEnable = true
 )
 
 func BuiltIn() catalog.BuiltIn {
@@ -60,6 +61,7 @@ type pluginConfig struct {
 	Namespace          string `hcl:"namespace"`
 	ConfigMap          string `hcl:"config_map"`
 	ConfigMapKey       string `hcl:"config_map_key"`
+	ConfigMapEnable    bool   `hcl:"config_map_enable"`
 	WebhookLabel       string `hcl:"webhook_label"`
 	APIServiceLabel    string `hcl:"api_service_label"`
 	KubeConfigFilePath string `hcl:"kube_config_file_path"`
@@ -128,6 +130,7 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndA
 
 func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (resp *spi.ConfigureResponse, err error) {
 	config := new(pluginConfig)
+	config.ConfigMapEnable = defaultConfigMapEnable
 	if err := hcl.Decode(&config, req.Configuration); err != nil {
 		return nil, k8sErr.New("unable to decode configuration: %v", err)
 	}
@@ -285,7 +288,12 @@ func newKubeClient(c *pluginConfig) ([]kubeClient, error) {
 		return nil, k8sErr.Wrap(err)
 	}
 
-	clients := []kubeClient{configMapClient{Clientset: clientset}}
+	clients := []kubeClient{}
+	if c.ConfigMapEnable {
+		clients = append(clients,
+			configMapClient{Clientset: clientset},
+		)
+	}
 	if c.WebhookLabel != "" {
 		clients = append(clients,
 			mutatingWebhookClient{Clientset: clientset},

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -41,10 +41,9 @@ var (
 )
 
 const (
-	defaultNamespace       = "spire"
-	defaultConfigMap       = "spire-bundle"
-	defaultConfigMapKey    = "bundle.crt"
-	defaultConfigMapEnable = true
+	defaultNamespace    = "spire"
+	defaultConfigMap    = "spire-bundle"
+	defaultConfigMapKey = "bundle.crt"
 )
 
 func BuiltIn() catalog.BuiltIn {
@@ -61,7 +60,6 @@ type pluginConfig struct {
 	Namespace          string `hcl:"namespace"`
 	ConfigMap          string `hcl:"config_map"`
 	ConfigMapKey       string `hcl:"config_map_key"`
-	ConfigMapEnable    bool   `hcl:"config_map_enable"`
 	WebhookLabel       string `hcl:"webhook_label"`
 	APIServiceLabel    string `hcl:"api_service_label"`
 	KubeConfigFilePath string `hcl:"kube_config_file_path"`
@@ -130,7 +128,6 @@ func (p *Plugin) NotifyAndAdvise(ctx context.Context, req *notifierv0.NotifyAndA
 
 func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (resp *spi.ConfigureResponse, err error) {
 	config := new(pluginConfig)
-	config.ConfigMapEnable = defaultConfigMapEnable
 	if err := hcl.Decode(&config, req.Configuration); err != nil {
 		return nil, k8sErr.New("unable to decode configuration: %v", err)
 	}
@@ -288,12 +285,7 @@ func newKubeClient(c *pluginConfig) ([]kubeClient, error) {
 		return nil, k8sErr.Wrap(err)
 	}
 
-	clients := []kubeClient{}
-	if c.ConfigMapEnable {
-		clients = append(clients,
-			configMapClient{Clientset: clientset},
-		)
-	}
+	clients := []kubeClient{configMapClient{Clientset: clientset}}
 	if c.WebhookLabel != "" {
 		clients = append(clients,
 			mutatingWebhookClient{Clientset: clientset},

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_watcher_test.go
@@ -84,6 +84,7 @@ webhook_label = "WEBHOOK_LABEL"
 api_service_label = "API_SERVICE_LABEL"
 kube_config_file_path = "/some/file/path"
 `)
+	s.Require().NotNil(s.raw.cancelWatcher)
 	s.Require().Eventually(func() bool {
 		return w.getWatchLabel() == "WEBHOOK_LABEL"
 	}, testTimeout, time.Second)
@@ -97,6 +98,7 @@ webhook_label = "WEBHOOK_LABEL2"
 api_service_label = "API_SERVICE_LABEL2"
 kube_config_file_path = "/some/file/path"
 `)
+	s.Require().NotNil(s.raw.cancelWatcher)
 	s.Require().Eventually(func() bool {
 		return w.getWatchLabel() == "WEBHOOK_LABEL2"
 	}, testTimeout, time.Second)
@@ -114,6 +116,7 @@ func (s *Suite) TestBundleWatcherAddWebhookEvent() {
 webhook_label = "WEBHOOK_LABEL"
 kube_config_file_path = "/some/file/path"
 `)
+	s.Require().NotNil(s.raw.cancelWatcher)
 
 	webhook := newWebhook()
 	s.r.AppendBundle(testBundle)
@@ -144,6 +147,7 @@ func (s *Suite) TestBundleWatcherAddAPIServiceEvent() {
 api_service_label = "API_SERVICE_LABEL"
 kube_config_file_path = "/some/file/path"
 `)
+	s.Require().NotNil(s.raw.cancelWatcher)
 	s.r.AppendBundle(testBundle)
 
 	apiService := newAPIService()


### PR DESCRIPTION
Signed-off-by: Faisal Memon <f.memon@f5.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
k8sbundle notifier

**Description of change**
~~With previous PRs to update k8sbundle notifier to rotate webhooks and apiservices, we forgot to add an option to disable ConfigMap rotation. So that, for example, you could rotate webhook caBundles without setting up the ConfigMap.~~

~~This PR adds a `config_map_enable` flag to control whether or not to rotate the bundle in the ConfigMap. The default value is true to preserve backwards compatibility.~~

Contains:
- Some docs cleanup
- Bug fix where cancelWatcher is not being setup for APIService
