### PR TITLE
Introduce Agent V1 WorkloadAttestor Facade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spiffe/go-spiffe/v2 v2.0.0-beta.5
 	github.com/spiffe/spire-api-sdk v1.0.0-pre.0.20210318220945-7ff3eb0759ce
-	github.com/spiffe/spire-plugin-sdk v1.0.0-pre
+	github.com/spiffe/spire-plugin-sdk v1.0.0-pre.0.20210429190523-165234a66136
 	github.com/stretchr/testify v1.7.0
 	github.com/uber-go/tally v3.3.12+incompatible
 	github.com/zeebo/errs v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ github.com/spiffe/go-spiffe/v2 v2.0.0-beta.5 h1:FKeGzmMtP079mo/7jH3UFOnBUO30j/tm
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.5/go.mod h1:TEfgrEcyFhuSuvqohJt6IxENUNeHfndWCCV1EX7UaVk=
 github.com/spiffe/spire-api-sdk v1.0.0-pre.0.20210318220945-7ff3eb0759ce h1:wrf+FoYq8Q5i9R1Z+9n2C15Lm0UT2U+I4zj7nfFgTH8=
 github.com/spiffe/spire-api-sdk v1.0.0-pre.0.20210318220945-7ff3eb0759ce/go.mod h1:2wSTZ6oEnKqI3uBST05Mmm751+yoHEvgxomYKYOQ6Ko=
-github.com/spiffe/spire-plugin-sdk v1.0.0-pre h1:UDf5Nez6wy29uXOxpUAC41D0tIO0PF1mPkpGvHgXzBs=
-github.com/spiffe/spire-plugin-sdk v1.0.0-pre/go.mod h1:Uom4/GWCt3M9zj12lZs8eiX4oxpvd1w43B6QrOCakNM=
+github.com/spiffe/spire-plugin-sdk v1.0.0-pre.0.20210429190523-165234a66136 h1:UoWkKlTFxs/J+zavId0bRxhUuQp4fVYjmQJ0inRFRcM=
+github.com/spiffe/spire-plugin-sdk v1.0.0-pre.0.20210429190523-165234a66136/go.mod h1:Uom4/GWCt3M9zj12lZs8eiX4oxpvd1w43B6QrOCakNM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=

--- a/pkg/agent/catalog/workloadattestor.go
+++ b/pkg/agent/catalog/workloadattestor.go
@@ -21,7 +21,7 @@ func (repo *workloadAttestorRepository) Constraints() catalog.Constraints {
 }
 
 func (repo *workloadAttestorRepository) Versions() []catalog.Version {
-	return []catalog.Version{workloadAttestorV0{}}
+	return []catalog.Version{workloadAttestorV1{}}
 }
 
 func (repo *workloadAttestorRepository) LegacyVersion() (catalog.Version, bool) {
@@ -36,7 +36,12 @@ func (repo *workloadAttestorRepository) BuiltIns() []catalog.BuiltIn {
 	}
 }
 
+type workloadAttestorV1 struct{}
+
+func (workloadAttestorV1) New() catalog.Facade { return new(workloadattestor.V1) }
+func (workloadAttestorV1) Deprecated() bool    { return false }
+
 type workloadAttestorV0 struct{}
 
 func (workloadAttestorV0) New() catalog.Facade { return new(workloadattestor.V0) }
-func (workloadAttestorV0) Deprecated() bool    { return false }
+func (workloadAttestorV0) Deprecated() bool    { return true }

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -12,12 +12,11 @@ import (
 	dockerclient "github.com/docker/docker/client"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
+	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/common/cgroups"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/cgroup"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/proto/spire/common"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	workloadattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/workloadattestor/v0"
 )
 
 const (
@@ -32,7 +31,10 @@ func BuiltIn() catalog.BuiltIn {
 }
 
 func builtin(p *Plugin) catalog.BuiltIn {
-	return catalog.MakeBuiltIn(pluginName, workloadattestorv0.WorkloadAttestorPluginServer(p))
+	return catalog.MakeBuiltIn(pluginName,
+		workloadattestorv1.WorkloadAttestorPluginServer(p),
+		configv1.ConfigServiceServer(p),
+	)
 }
 
 // Docker is a subset of the docker client functionality, useful for mocking.
@@ -41,7 +43,8 @@ type Docker interface {
 }
 
 type Plugin struct {
-	workloadattestorv0.UnsafeWorkloadAttestorServer
+	workloadattestorv1.UnsafeWorkloadAttestorServer
+	configv1.UnsafeConfigServer
 
 	log     hclog.Logger
 	fs      cgroups.FileSystem
@@ -73,7 +76,7 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv0.AttestRequest) (*workloadattestorv0.AttestResponse, error) {
+func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
@@ -88,7 +91,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv0.AttestReque
 		return nil, err
 	case containerID == "":
 		// Not a docker workload. Nothing more to do.
-		return &workloadattestorv0.AttestResponse{}, nil
+		return &workloadattestorv1.AttestResponse{}, nil
 	}
 
 	var container types.ContainerJSON
@@ -103,38 +106,29 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv0.AttestReque
 		return nil, err
 	}
 
-	return &workloadattestorv0.AttestResponse{
-		Selectors: getSelectorsFromConfig(container.Config),
+	return &workloadattestorv1.AttestResponse{
+		SelectorValues: getSelectorValuesFromConfig(container.Config),
 	}, nil
 }
 
-func getSelectorsFromConfig(cfg *container.Config) []*common.Selector {
-	var selectors []*common.Selector
+func getSelectorValuesFromConfig(cfg *container.Config) []string {
+	var selectorValues []string
 	for label, value := range cfg.Labels {
-		selectors = append(selectors, &common.Selector{
-			Type:  pluginName,
-			Value: fmt.Sprintf("%s:%s:%s", subselectorLabel, label, value),
-		})
+		selectorValues = append(selectorValues, fmt.Sprintf("%s:%s:%s", subselectorLabel, label, value))
 	}
 	for _, e := range cfg.Env {
-		selectors = append(selectors, &common.Selector{
-			Type:  pluginName,
-			Value: fmt.Sprintf("%s:%s", subselectorEnv, e),
-		})
+		selectorValues = append(selectorValues, fmt.Sprintf("%s:%s", subselectorEnv, e))
 	}
 	if cfg.Image != "" {
-		selectors = append(selectors, &common.Selector{
-			Type:  pluginName,
-			Value: fmt.Sprintf("%s:%s", subselectorImageID, cfg.Image),
-		})
+		selectorValues = append(selectorValues, fmt.Sprintf("%s:%s", subselectorImageID, cfg.Image))
 	}
-	return selectors
+	return selectorValues
 }
 
-func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
 	var err error
 	config := &dockerPluginConfig{}
-	if err = hcl.Decode(config, req.Configuration); err != nil {
+	if err = hcl.Decode(config, req.HclConfiguration); err != nil {
 		return nil, err
 	}
 
@@ -166,11 +160,7 @@ func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi
 	defer p.mtx.Unlock()
 	p.docker = docker
 	p.containerIDFinder = containerIDFinder
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (*Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
+	return &configv1.ConfigureResponse{}, nil
 }
 
 // getContainerIDFromCGroups returns the container ID from a set of cgroups

--- a/pkg/agent/plugin/workloadattestor/unix/unix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	workloadattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/workloadattestor/v0"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -32,57 +30,50 @@ type Suite struct {
 	spiretest.Suite
 
 	dir     string
-	p       workloadattestorv0.WorkloadAttestorClient
+	log     logrus.FieldLogger
 	logHook *test.Hook
 }
 
 func (s *Suite) SetupTest() {
+	log, logHook := test.NewNullLogger()
+	s.log = log
+	s.logHook = logHook
+
 	s.dir = s.TempDir()
-
-	p := New()
-	p.hooks.newProcess = func(pid int32) (processInfo, error) {
-		return newFakeProcess(pid, s.dir), nil
-	}
-	p.hooks.lookupUserByID = fakeLookupUserByID
-	p.hooks.lookupGroupByID = fakeLookupGroupByID
-	log, hook := test.NewNullLogger()
-	s.logHook = hook
-
-	v0 := new(workloadattestor.V0)
-	plugintest.Load(s.T(), builtin(p), v0, plugintest.Log(log))
-	s.p = v0.WorkloadAttestorPluginClient
-
-	s.configure("")
 }
 
 func (s *Suite) TestAttest() {
 	testCases := []struct {
-		name         string
-		pid          int32
-		err          string
-		selectors    []string
-		config       string
-		expectedLogs []spiretest.LogEntry
+		name           string
+		pid            int
+		selectorValues []string
+		config         string
+		expectCode     codes.Code
+		expectMsg      string
+		expectLogs     []spiretest.LogEntry
 	}{
 		{
-			name: "pid with no uids",
-			pid:  1,
-			err:  "unix: UIDs lookup: no UIDs for process",
+			name:       "pid with no uids",
+			pid:        1,
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): UIDs lookup: no UIDs for process",
 		},
 		{
-			name: "fail to get uids",
-			pid:  2,
-			err:  "unix: UIDs lookup: unable to get UIDs for PID 2",
+			name:       "fail to get uids",
+			pid:        2,
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): UIDs lookup: unable to get UIDs for PID 2",
 		},
 		{
 			name: "user lookup fails",
 			pid:  3,
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1999",
 				"gid:2000",
 				"group:g2000",
 			},
-			expectedLogs: []spiretest.LogEntry{
+			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.WarnLevel,
 					Message: "Failed to lookup user name by uid",
@@ -94,24 +85,27 @@ func (s *Suite) TestAttest() {
 			},
 		},
 		{
-			name: "pid with no gids",
-			pid:  4,
-			err:  "unix: GIDs lookup: no GIDs for process",
+			name:       "pid with no gids",
+			pid:        4,
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): GIDs lookup: no GIDs for process",
 		},
 		{
-			name: "fail to get gids",
-			pid:  5,
-			err:  "unix: GIDs lookup: unable to get GIDs for PID 5",
+			name:       "fail to get gids",
+			pid:        5,
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): GIDs lookup: unable to get GIDs for PID 5",
 		},
 		{
 			name: "group lookup fails",
 			pid:  6,
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2999",
 			},
-			expectedLogs: []spiretest.LogEntry{
+			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.WarnLevel,
 					Message: "Failed to lookup group name by gid",
@@ -125,46 +119,51 @@ func (s *Suite) TestAttest() {
 		{
 			name: "primary user and gid",
 			pid:  7,
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2000",
 				"group:g2000",
 			},
+			expectCode: codes.OK,
 		},
 		{
 			name: "effective user and gid",
 			pid:  8,
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1100",
 				"user:u1100",
 				"gid:2100",
 				"group:g2100",
 			},
+			expectCode: codes.OK,
 		},
 		{
-			name:   "fail to get process binary path",
-			pid:    9,
-			config: "discover_workload_path = true",
-			err:    "unix: path lookup: unable to get EXE for PID 9",
+			name:       "fail to get process binary path",
+			pid:        9,
+			config:     "discover_workload_path = true",
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): path lookup: unable to get EXE for PID 9",
 		},
 		{
-			name:   "fail to hash process binary",
-			pid:    10,
-			config: "discover_workload_path = true",
-			err:    "unix: SHA256 digest: open /proc/10/unreadable-exe: no such file or directory",
+			name:       "fail to hash process binary",
+			pid:        10,
+			config:     "discover_workload_path = true",
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): SHA256 digest: open /proc/10/unreadable-exe: no such file or directory",
 		},
 		{
-			name:   "process binary exceeds size limits",
-			pid:    11,
-			config: "discover_workload_path = true\nworkload_size_limit = 2",
-			err:    fmt.Sprintf("unix: SHA256 digest: workload %s exceeds size limit (4 > 2)", filepath.Join(s.dir, "exe")),
+			name:       "process binary exceeds size limits",
+			pid:        11,
+			config:     "discover_workload_path = true\nworkload_size_limit = 2",
+			expectCode: codes.Internal,
+			expectMsg:  fmt.Sprintf("workloadattestor(unix): SHA256 digest: workload %s exceeds size limit (4 > 2)", filepath.Join(s.dir, "exe")),
 		},
 		{
 			name:   "success getting path and hashing process binary",
 			pid:    12,
 			config: "discover_workload_path = true",
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2000",
@@ -172,12 +171,13 @@ func (s *Suite) TestAttest() {
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
 				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
 			},
+			expectCode: codes.OK,
 		},
 		{
 			name:   "success getting path and hashing process binary",
 			pid:    12,
 			config: "discover_workload_path = true",
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2000",
@@ -185,23 +185,25 @@ func (s *Suite) TestAttest() {
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
 				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
 			},
+			expectCode: codes.OK,
 		},
 		{
 			name:   "success getting path, disabled hashing process binary",
 			pid:    12,
 			config: "discover_workload_path = true\nworkload_size_limit = -1",
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2000",
 				"group:g2000",
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
 			},
+			expectCode: codes.OK,
 		},
 		{
 			name: "pid with supplementary gids",
 			pid:  13,
-			selectors: []string{
+			selectorValues: []string{
 				"uid:1000",
 				"user:u1000",
 				"gid:2000",
@@ -217,9 +219,10 @@ func (s *Suite) TestAttest() {
 			},
 		},
 		{
-			name: "fail to get supplementary gids",
-			pid:  14,
-			err:  "unix: supplementary GIDs lookup: some error for PID 14",
+			name:       "fail to get supplementary gids",
+			pid:        14,
+			expectCode: codes.Internal,
+			expectMsg:  "workloadattestor(unix): supplementary GIDs lookup: some error for PID 14",
 		},
 	}
 
@@ -230,52 +233,51 @@ func (s *Suite) TestAttest() {
 		testCase := testCase
 		s.T().Run(testCase.name, func(t *testing.T) {
 			defer s.logHook.Reset()
-			s.configure(testCase.config)
-			resp, err := s.p.Attest(ctx, &workloadattestorv0.AttestRequest{
-				Pid: testCase.pid,
-			})
 
-			if testCase.err != "" {
-				spiretest.RequireGRPCStatus(t, err, codes.Unknown, testCase.err)
-				require.Nil(t, resp)
+			p := s.loadPlugin(t, testCase.config)
+			selectors, err := p.Attest(ctx, testCase.pid)
+			spiretest.RequireGRPCStatus(t, err, testCase.expectCode, testCase.expectMsg)
+			if testCase.expectCode != codes.OK {
+				require.Nil(t, selectors)
 				return
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, resp)
-			var selectors []string
-			for _, selector := range resp.Selectors {
+			require.NotNil(t, selectors)
+			var selectorValues []string
+			for _, selector := range selectors {
 				require.Equal(t, "unix", selector.Type)
-				selectors = append(selectors, selector.Value)
+				selectorValues = append(selectorValues, selector.Value)
 			}
 
-			require.Equal(t, testCase.selectors, selectors)
-			spiretest.AssertLogs(t, s.logHook.AllEntries(), testCase.expectedLogs)
+			require.Equal(t, testCase.selectorValues, selectorValues)
+			spiretest.AssertLogs(t, s.logHook.AllEntries(), testCase.expectLogs)
 		})
 	}
 }
 
-func (s *Suite) TestConfigure() {
-	resp, err := s.p.Configure(ctx, &spi.ConfigureRequest{})
-	s.NoError(err)
-	s.AssertProtoEqual(&spi.ConfigureResponse{}, resp)
-}
-
-func (s *Suite) TestGetPluginInfo() {
-	resp, e := s.p.GetPluginInfo(ctx, &spi.GetPluginInfoRequest{})
-	s.NoError(e)
-	s.AssertProtoEqual(&spi.GetPluginInfoResponse{}, resp)
-}
-
-func (s *Suite) configure(config string) {
-	_, err := s.p.Configure(ctx, &spi.ConfigureRequest{
-		Configuration: config,
-	})
-	s.Require().NoError(err)
-}
-
 func (s *Suite) writeFile(path string, data []byte) {
 	s.Require().NoError(ioutil.WriteFile(filepath.Join(s.dir, path), data, 0600))
+}
+
+func (s *Suite) loadPlugin(t *testing.T, config string) workloadattestor.WorkloadAttestor {
+	p := s.newPlugin()
+
+	v1 := new(workloadattestor.V1)
+	plugintest.Load(t, builtin(p), v1,
+		plugintest.Log(s.log),
+		plugintest.Configure(config))
+	return v1
+}
+
+func (s *Suite) newPlugin() *Plugin {
+	p := New()
+	p.hooks.newProcess = func(pid int32) (processInfo, error) {
+		return newFakeProcess(pid, s.dir), nil
+	}
+	p.hooks.lookupUserByID = fakeLookupUserByID
+	p.hooks.lookupGroupByID = fakeLookupGroupByID
+	return p
 }
 
 type fakeProcess struct {

--- a/pkg/agent/plugin/workloadattestor/v1.go
+++ b/pkg/agent/plugin/workloadattestor/v1.go
@@ -1,0 +1,35 @@
+package workloadattestor
+
+import (
+	"context"
+
+	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/proto/spire/common"
+)
+
+type V1 struct {
+	plugin.Facade
+	workloadattestorv1.WorkloadAttestorPluginClient
+}
+
+func (v1 *V1) Attest(ctx context.Context, pid int) ([]*common.Selector, error) {
+	resp, err := v1.WorkloadAttestorPluginClient.Attest(ctx, &workloadattestorv1.AttestRequest{
+		Pid: int32(pid),
+	})
+	if err != nil {
+		return nil, v1.WrapErr(err)
+	}
+
+	var selectors []*common.Selector
+	if resp.SelectorValues != nil {
+		selectors = make([]*common.Selector, 0, len(resp.SelectorValues))
+		for _, selectorValue := range resp.SelectorValues {
+			selectors = append(selectors, &common.Selector{
+				Type:  v1.Name(),
+				Value: selectorValue,
+			})
+		}
+	}
+	return selectors, nil
+}

--- a/pkg/agent/plugin/workloadattestor/v1_test.go
+++ b/pkg/agent/plugin/workloadattestor/v1_test.go
@@ -1,0 +1,74 @@
+package workloadattestor_test
+
+import (
+	"context"
+	"testing"
+
+	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
+	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestV1(t *testing.T) {
+	selectorValues := map[int][]string{
+		1: {},
+		2: {"someValue"},
+	}
+
+	expected := map[int][]*common.Selector{
+		1: {},
+		2: {{Type: "test", Value: "someValue"}},
+	}
+
+	t.Run("attest fails", func(t *testing.T) {
+		workloadAttestor := makeFakeV1Plugin(t, selectorValues)
+		_, err := workloadAttestor.Attest(context.Background(), 0)
+		spiretest.RequireGRPCStatus(t, err, codes.InvalidArgument, "workloadattestor(test): ohno")
+	})
+
+	t.Run("no selectors for pid", func(t *testing.T) {
+		workloadAttestor := makeFakeV1Plugin(t, selectorValues)
+		actual, err := workloadAttestor.Attest(context.Background(), 1)
+		require.NoError(t, err)
+		require.Empty(t, actual)
+	})
+
+	t.Run("with selectors for pid", func(t *testing.T) {
+		workloadAttestor := makeFakeV1Plugin(t, selectorValues)
+		actual, err := workloadAttestor.Attest(context.Background(), 2)
+		require.NoError(t, err)
+		spiretest.RequireProtoListEqual(t, expected[2], actual)
+	})
+}
+
+func makeFakeV1Plugin(t *testing.T, selectorValues map[int][]string) workloadattestor.WorkloadAttestor {
+	fake := &fakePluginV1{selectorValues: selectorValues}
+	server := workloadattestorv1.WorkloadAttestorPluginServer(fake)
+
+	plugin := new(workloadattestor.V1)
+	plugintest.Load(t, catalog.MakeBuiltIn("test", server), plugin)
+	return plugin
+}
+
+type fakePluginV1 struct {
+	workloadattestorv1.UnimplementedWorkloadAttestorServer
+	selectorValues map[int][]string
+}
+
+func (plugin fakePluginV1) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
+	selectorValues, ok := plugin.selectorValues[int(req.Pid)]
+	if !ok {
+		// Just return something to test the error wrapping. This is not
+		// necessarily an indication of what real plugins should produce.
+		return nil, status.Error(codes.InvalidArgument, "ohno")
+	}
+	return &workloadattestorv1.AttestResponse{
+		SelectorValues: selectorValues,
+	}, nil
+}


### PR DESCRIPTION
In addition to adding the V1 facade it:
- Marks the V0 interface as deprecated
- Updates all plugins to conform to the new interface
- Removes the "error class" error generation in the k8s and unix plugins since the facade already prefixes errors
- Converts the unit-tests to test through the facade instead of directly against gRPC. It just did the bare minimum work here though, there is a lot of room for general cleanup in these unit tests.