### PR TITLE
Use allow list over whitelist

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -267,9 +267,9 @@ plugins {
     # using a GCP Instance Identity Token.
     # NodeAttestor "gcp_iit" {
     #     plugin_data {
-    #         # projectid_whitelist: List of whitelisted ProjectIDs from which
+    #         # projectid_allow_list: List of allowed ProjectIDs from which
     #         # nodes can be attested.
-    #         # projectid_whitelist = ["project-123"]
+    #         # projectid_allow_list = ["project-123"]
 
     #         # use_instance_metadata: If true, instance metadata is fetched from
     #         # the Google Compute Engine API and used to augment the node
@@ -307,12 +307,12 @@ plugins {
     #         # authorized for attestation.
     #         # clusters = {
     #             # "<arbitrary ID>" = {
-    #                 # service_account_whitelist: A list of service account names,
+    #                 # service_account_allow_list: A list of service account names,
     #                 # qualified by namespace (for example, "default:blog" or
     #                 # "production:web") to allow for node attestation. Attestation
     #                 # will be rejected for tokens bound to service accounts that
-    #                 # aren't in the whitelist.
-    #                 # service_account_whitelist = []
+    #                 # aren't in the allow list.
+    #                 # service_account_allow_list = []
 
     #                 # audience: Audience for token validation. If it is set to an
     #                 # empty array ([]), Kubernetes API server audience is used.
@@ -345,12 +345,12 @@ plugins {
     #         # authorized for attestation.
     #         # clusters = {
     #             # "<arbitrary ID>" = {
-    #                 # service_account_whitelist: A list of service account names,
+    #                 # service_account_allow_list: A list of service account names,
     #                 # qualified by namespace (for example, "default:blog" or
     #                 # "production:web") to allow for node attestation. Attestation
     #                 # will be rejected for tokens bound to service accounts that
-    #                 # aren't in the whitelist.
-    #                 # service_account_whitelist = []
+    #                 # aren't in the allow list.
+    #                 # service_account_allow_list = []
 
     #                 # use_token_review_api_validation: Specifies how the service
     #                 # account token is validated. If false, validation is done

--- a/doc/plugin_agent_nodeattestor_k8s_sat.md
+++ b/doc/plugin_agent_nodeattestor_k8s_sat.md
@@ -37,7 +37,7 @@ A sample configuration with the default token path:
 
 At this time, the service account token does not contain claims that could be
 used to strongly identify the node/daemonset/pod running the agent. This means
-that any container running in a whitelisted service account can masquerade as
+that any container running in an allowed service account can masquerade as
 an agent, giving it access to any identity the agent is capable of issuing. It
 is **STRONGLY** recommended that agents run under a dedicated service account.
 

--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -4,13 +4,13 @@
 
 The `gcp_iit` plugin automatically attests instances using the [GCP Instance Identity Token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity). It also allows an operator to use GCP Instance IDs when defining SPIFFE ID attestation policies.
 Agents attested by the gcp_iit attestor will be issued a SPIFFE ID like `spiffe://TRUST_DOMAIN/spire/agent/gcp_iit/PROJECT_ID/INSTANCE_ID`
-This plugin requires a whitelist of ProjectID from which nodes can be attested. This also means that you shouldn't run multiple trust domains from the same GCP project.
+This plugin requires an allow list of ProjectID from which nodes can be attested. This also means that you shouldn't run multiple trust domains from the same GCP project.
 
 ## Configuration
 
 | Configuration             | Description                                                                                        | Default                                    |
 |---------------------------|----------------------------------------------------------------------------------------------------|--------------------------------------------|
-| `projectid_whitelist`     | List of whitelisted ProjectIDs from which nodes can be attested.  |         |
+| `projectid_allow_list`     | List of ProjectIDs from which nodes can be attested.  |         |
 | `use_instance_metadata`   | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false |
 | `service_account_file`  | Path to the service account file used to authenticate with the Google Compute Engine API |     |
 | `allowed_label_keys`      | Instance label keys considered for selectors | |
@@ -22,7 +22,7 @@ A sample configuration:
 ```
     NodeAttestor "gcp_iit" {
         plugin_data {
-            projectid_whitelist = ["project-123"]
+            projectid_allow_list = ["project-123"]
         }
     }
 ```

--- a/doc/plugin_server_nodeattestor_k8s_psat.md
+++ b/doc/plugin_server_nodeattestor_k8s_psat.md
@@ -25,7 +25,7 @@ Each cluster in the main configuration requires the following configuration:
 
 | Configuration | Description | Default                 |
 | ------------- | ----------- | ----------------------- |
-| `service_account_whitelist` | A list of service account names, qualified by namespace (for example, "default:blog" or "production:web") to allow for node attestation. Attestation will be rejected for tokens bound to service accounts that aren't in the whitelist. | |
+| `service_account_allow_list` | A list of service account names, qualified by namespace (for example, "default:blog" or "production:web") to allow for node attestation. Attestation will be rejected for tokens bound to service accounts that aren't in the allow list. | |
 | `audience` | Audience for token validation. If it is set to an empty array (`[]`), Kubernetes API server audience is used | ["spire-server"] |
 | `kube_config_file` | Path to a k8s configuration file for API Server authentication. A kubernetes configuration file must be specified if SPIRE server runs outside of the k8s cluster. If empty, SPIRE server is assumed to be running inside the cluster and in-cluster configuration is used. | ""|
 | `allowed_node_label_keys` | Node label keys considered for selectors | |
@@ -38,7 +38,7 @@ A sample configuration for SPIRE server running inside of a kubernetes cluster:
         plugin_data {
             clusters = {
                 "MyCluster" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_allow_list = ["production:spire-agent"]
                 }
         }
     }
@@ -51,7 +51,7 @@ A sample configuration for SPIRE server running outside of a kubernetes cluster:
         plugin_data {
             clusters = {
                 "MyCluster" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_allow_list = ["production:spire-agent"]
                     kube_config_file = "path/to/kubeconfig/file"
                 }
         }

--- a/doc/plugin_server_nodeattestor_k8s_sat.md
+++ b/doc/plugin_server_nodeattestor_k8s_sat.md
@@ -31,7 +31,7 @@ Each cluster in the main configuration requires the following configuration:
 
 | Configuration | Description | Default                 |
 | ------------- | ----------- | ----------------------- |
-| `service_account_whitelist` | A list of service account names, qualified by namespace (for example, "default:blog" or "production:web") to allow for node attestation. Attestation will be rejected for tokens bound to service accounts that aren't in the whitelist. | |
+| `service_account_allow_list` | A list of service account names, qualified by namespace (for example, "default:blog" or "production:web") to allow for node attestation. Attestation will be rejected for tokens bound to service accounts that aren't in the allow list. | |
 | `use_token_review_api_validation` | Specifies how the service account token is validated. If false, validation is done locally using the provided key. If true, validation is done using token review API.  | false |
 | `service_account_key_file` | It is only used if `use_token_review_api_validation` is set to `false`. Path on disk to a PEM encoded file containing public keys used in validating tokens for that cluster. RSA and ECDSA keys are supported. For RSA, X509 certificates, PKCS1, and PKIX encoded public keys are accepted. For ECDSA, X509 certificates, and PKIX encoded public keys are accepted. | |
 | `kube_config_file` | It is only used if `use_token_review_api_validation` is set to `true`. Path to a k8s configuration file for API Server authentication. A kubernetes configuration file must be specified if SPIRE server runs outside of the k8s cluster. If empty, SPIRE server is assumed to be running inside the cluster and in-cluster configuration is used. | "" |
@@ -43,7 +43,7 @@ A sample configuration for SPIRE server running inside or outside of a Kubernete
         plugin_data {
             clusters = {
                 "MyCluster" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_allow_list = ["production:spire-agent"]
                     service_account_key_file = "/run/k8s-certs/sa.pub"
                 }
         }
@@ -56,7 +56,7 @@ A sample configuration for SPIRE server running inside of a Kubernetes cluster a
         plugin_data {
             clusters = {
                 "MyCluster" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_allow_list = ["production:spire-agent"]
                     use_token_review_api_validation = true
                 }
         }
@@ -69,7 +69,7 @@ A sample configuration for SPIRE server running outside of a Kubernetes cluster 
         plugin_data {
             clusters = {
                 "MyCluster" = {
-                    service_account_whitelist = ["production:spire-agent"]
+                    service_account_allow_list = ["production:spire-agent"]
                     use_token_review_api_validation = true
                     kube_config_file = "path/to/kubeconfig/file"
                 }
@@ -89,7 +89,7 @@ In addition, this plugin generates the following selectors:
 
 At this time, the service account token does not contain claims that could be
 used to strongly identify the node/daemonset/pod running the agent. This means
-that any container running in a whitelisted service account can masquerade as
+that any container running in an allowed service account can masquerade as
 an agent, giving it access to any identity the agent is capable of issuing. It
 is **STRONGLY** recommended that agents run under a dedicated service account.
 

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -158,7 +158,7 @@ func (s *IITAttestorSuite) TestErrorOnProjectIdMismatch() {
 		Data: s.signToken(token),
 	}
 	_, err := s.attest(&nodeattestorv0.AttestRequest{AttestationData: data})
-	s.RequireErrorContains(err, `gcp-iit: identity token project ID "project-whatever" is not in the whitelist`)
+	s.RequireErrorContains(err, `gcp-iit: identity token project ID "project-whatever" is not in the allow list`)
 }
 
 func (s *IITAttestorSuite) TestErrorOnInvalidAlgorithm() {
@@ -178,7 +178,7 @@ func (s *IITAttestorSuite) TestErrorOnInvalidAlgorithm() {
 func (s *IITAttestorSuite) TestErrorOnBadSVIDTemplate() {
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["test-project"]
+projectid_allow_list = ["test-project"]
 agent_path_template = "{{ .InstanceID "
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
@@ -191,7 +191,7 @@ func (s *IITAttestorSuite) TestErrorOnServiceAccountFileMismatch() {
 	s.client.setInstance(&compute.Instance{})
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["test-project"]
+projectid_allow_list = ["test-project"]
 use_instance_metadata = true
 service_account_file = "error_sa.json"
 `,
@@ -343,7 +343,7 @@ func (s *IITAttestorSuite) TestAttestFailureDueToMissingInstanceMetadata() {
 func (s *IITAttestorSuite) TestAttestSuccessWithCustomSPIFFEIDTemplate() {
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["test-project"]
+projectid_allow_list = ["test-project"]
 agent_path_template = "{{ .InstanceID }}"
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
@@ -377,7 +377,7 @@ func (s *IITAttestorSuite) TestConfigure() {
 	// missing global configuration
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["bar"]
+projectid_allow_list = ["bar"]
 `})
 	s.RequireErrorContains(err, "gcp-iit: global configuration is required")
 	require.Nil(resp)
@@ -385,23 +385,23 @@ projectid_whitelist = ["bar"]
 	// missing trust domain
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["bar"]
+projectid_allow_list = ["bar"]
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{}})
 	s.RequireErrorContains(err, "gcp-iit: trust_domain is required")
 	require.Nil(resp)
 
-	// missing projectID whitelist
+	// missing projectID allow list
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: ``,
 		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
-	s.RequireErrorContains(err, "gcp-iit: projectid_whitelist is required")
+	s.RequireErrorContains(err, "gcp-iit: projectid_allow_list is required")
 	require.Nil(resp)
 	// success
 	resp, err = s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["bar"]
+projectid_allow_list = ["bar"]
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"}})
 	require.NoError(err)
@@ -437,7 +437,7 @@ func (s *IITAttestorSuite) newPlugin() nodeattestorv0.NodeAttestorClient {
 func (s *IITAttestorSuite) configure() {
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["test-project"]
+projectid_allow_list = ["test-project"]
 `,
 		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
 	})
@@ -465,7 +465,7 @@ func (s *IITAttestorSuite) configureForInstanceMetadata(instance *compute.Instan
 	s.client.setInstance(instance)
 	_, err := s.p.Configure(context.Background(), &plugin.ConfigureRequest{
 		Configuration: `
-projectid_whitelist = ["test-project"]
+projectid_allow_list = ["test-project"]
 use_instance_metadata = true
 allowed_label_keys = ["allowed", "allowed-no-value"]
 allowed_metadata_keys = ["allowed", "allowed-no-value"]

--- a/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
@@ -42,9 +43,12 @@ type AttestorConfig struct {
 
 // ClusterConfig holds a single cluster configuration
 type ClusterConfig struct {
-	// Array of whitelisted service accounts names
+	// Array of allowed service accounts names
 	// Attestation is denied if coming from a service account that is not in the list
-	ServiceAccountWhitelist []string `hcl:"service_account_whitelist"`
+	ServiceAccountAllowList []string `hcl:"service_account_allow_list"`
+
+	// TODO: Remove this in 1.1.0
+	ServiceAccountAllowListDeprecated []string `hcl:"service_account_whitelist"`
 
 	// Audience for PSAT token validation
 	// If audience is not configured, defaultAudience will be used
@@ -81,6 +85,7 @@ type AttestorPlugin struct {
 
 	mu     sync.RWMutex
 	config *attestorConfig
+	log    hclog.Logger
 }
 
 // New creates a new PSAT node attestor plugin
@@ -89,6 +94,11 @@ func New() *AttestorPlugin {
 }
 
 var _ nodeattestorv0.NodeAttestorServer = (*AttestorPlugin)(nil)
+
+// SetLogger sets up plugin logging
+func (p *AttestorPlugin) SetLogger(log hclog.Logger) {
+	p.log = log
+}
 
 func (p *AttestorPlugin) Attest(stream nodeattestorv0.NodeAttestor_AttestServer) error {
 	req, err := stream.Recv()
@@ -147,7 +157,7 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv0.NodeAttestor_AttestServer)
 	fullServiceAccountName := fmt.Sprintf("%v:%v", namespace, serviceAccountName)
 
 	if !cluster.serviceAccounts[fullServiceAccountName] {
-		return psatError.New("%q is not a whitelisted service account", fullServiceAccountName)
+		return psatError.New("%q is not an allowed service account", fullServiceAccountName)
 	}
 
 	podName, err := k8s.GetPodNameFromTokenStatus(tokenStatus)
@@ -226,12 +236,18 @@ func (p *AttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReques
 	}
 
 	for name, cluster := range hclConfig.Clusters {
-		if len(cluster.ServiceAccountWhitelist) == 0 {
-			return nil, psatError.New("cluster %q configuration must have at least one service account whitelisted", name)
+		// TODO: Remove this in 1.1.0
+		if len(cluster.ServiceAccountAllowListDeprecated) > 0 {
+			p.log.Warn("The `service_account_whitelist` configurable is deprecated and will be removed in a future release. Please use `service_account_allow_list` instead.")
+			cluster.ServiceAccountAllowList = cluster.ServiceAccountAllowListDeprecated
+		}
+
+		if len(cluster.ServiceAccountAllowList) == 0 {
+			return nil, psatError.New("cluster %q configuration must have at least one service account allowed", name)
 		}
 
 		serviceAccounts := make(map[string]bool)
-		for _, serviceAccount := range cluster.ServiceAccountWhitelist {
+		for _, serviceAccount := range cluster.ServiceAccountAllowList {
 			serviceAccounts[serviceAccount] = true
 		}
 

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/gofrs/uuid"
+	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
@@ -49,9 +50,12 @@ type ClusterConfig struct {
 	// If use_token_review_api_validation is true, then this path is ignored and TokenReview API is used for validation
 	ServiceAccountKeyFile string `hcl:"service_account_key_file"`
 
-	// ServiceAccountWhitelist is a list of service account names, qualified by
+	// ServiceAccountAllowList is a list of service account names, qualified by
 	// namespace (for example, "default:blog" or "production:web") to allow for node attestation
-	ServiceAccountWhitelist []string `hcl:"service_account_whitelist"`
+	ServiceAccountAllowList []string `hcl:"service_account_allow_list"`
+
+	// TODO: Remove this in 1.1.0
+	ServiceAccountAllowListDeprecated []string `hcl:"service_account_whitelist"`
 
 	// UseTokenReviewAPI
 	//   If true token review API will be used for token validation
@@ -84,6 +88,7 @@ type AttestorPlugin struct {
 
 	mu     sync.RWMutex
 	config *attestorConfig
+	log    hclog.Logger
 
 	hooks struct {
 		newUUID func() (string, error)
@@ -102,6 +107,11 @@ func New() *AttestorPlugin {
 		return u.String(), nil
 	}
 	return p
+}
+
+// SetLogger sets up plugin logging
+func (p *AttestorPlugin) SetLogger(log hclog.Logger) {
+	p.log = log
 }
 
 func (p *AttestorPlugin) Attest(stream nodeattestorv0.NodeAttestor_AttestServer) error {
@@ -210,7 +220,7 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv0.NodeAttestor_AttestServer)
 
 	fullServiceAccountName := fmt.Sprintf("%v:%v", namespace, serviceAccountName)
 	if !cluster.serviceAccounts[fullServiceAccountName] {
-		return satError.New("%q is not a whitelisted service account", fullServiceAccountName)
+		return satError.New("%q is not an allowed service account", fullServiceAccountName)
 	}
 
 	return stream.Send(&nodeattestorv0.AttestResponse{
@@ -265,12 +275,18 @@ func (p *AttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureReques
 			}
 		}
 
-		if len(cluster.ServiceAccountWhitelist) == 0 {
-			return nil, satError.New("cluster %q configuration must have at least one service account whitelisted", name)
+		// TODO: Remove this in 1.1.0
+		if len(cluster.ServiceAccountAllowListDeprecated) > 0 {
+			p.log.Warn("The `service_account_whitelist` configurable is deprecated and will be removed in a future release. Please use `service_account_allow_list` instead.")
+			cluster.ServiceAccountAllowList = cluster.ServiceAccountAllowListDeprecated
+		}
+
+		if len(cluster.ServiceAccountAllowList) == 0 {
+			return nil, satError.New("cluster %q configuration must have at least one service account allowed", name)
 		}
 
 		serviceAccounts := make(map[string]bool)
-		for _, serviceAccount := range cluster.ServiceAccountWhitelist {
+		for _, serviceAccount := range cluster.ServiceAccountAllowList {
 			serviceAccounts[serviceAccount] = true
 		}
 

--- a/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
@@ -136,7 +136,7 @@ data:
         plugin_data {
           clusters = {
             "example-cluster" = {
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }

--- a/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
@@ -126,7 +126,7 @@ data:
         plugin_data {
           clusters = {
             "example-cluster" = {
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }

--- a/test/integration/suites/k8s/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s/conf/server/spire-server.yaml
@@ -126,7 +126,7 @@ data:
         plugin_data {
           clusters = {
             "example-cluster" = {
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }


### PR DESCRIPTION
This commit updates all docs and code to remove the use of the term
whitelist in favor of allow list. Where necessary, deprecation warnings
are now logged.

Signed-off-by: Evan Gilman <egilman@vmware.com>