### PR TITLE
Make caller* labels consistent. Address #2254.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ As a counter example, DO NOT do the following:
 var callCounter telemetry.CallCounter
 ...
 if caller != "" {
-  callCounter.AddLabel("caller_id", caller)
+  callCounter.AddLabel(telemetry.CallerID, caller)
 }
 ...
 if x > 5000 {
@@ -185,9 +185,9 @@ Instead, the following would be more acceptable:
 var callCounter telemetry.CallCounter
 ...
 if caller != "" {
-  callCounter.AddLabel("caller_id", caller)
+  callCounter.AddLabel(telemetry.CallerID, caller)
 } else {
-  callCounter.AddLabel("caller_id", "someDefault")
+  callCounter.AddLabel(telemetry.CallerID, "someDefault")
 }
 ...
 if x > 5000 {

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -125,6 +125,9 @@ const (
 	// Audience tags some audience for a token
 	Audience = "audience"
 
+	// CallerAddr labels an API caller address
+	CallerAddr = "caller_addr"
+
 	// CallerID tags an API caller; should be used with other tags
 	// to add clarity
 	CallerID = "caller_id"

--- a/pkg/server/api/middleware/authorization.go
+++ b/pkg/server/api/middleware/authorization.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/api/middleware"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -41,10 +42,10 @@ func (m *authorizationMiddleware) Preprocess(ctx context.Context, methodName str
 
 	fields := make(logrus.Fields)
 	if !rpccontext.CallerIsLocal(ctx) {
-		fields["caller-addr"] = rpccontext.CallerAddr(ctx).String()
+		fields[telemetry.CallerAddr] = rpccontext.CallerAddr(ctx).String()
 	}
 	if id, ok := rpccontext.CallerID(ctx); ok {
-		fields["caller-id"] = id.String()
+		fields[telemetry.CallerID] = id.String()
 	}
 	if len(fields) > 0 {
 		ctx = rpccontext.WithLogger(ctx, rpccontext.Logger(ctx).WithFields(fields))

--- a/pkg/server/api/middleware/authorization_test.go
+++ b/pkg/server/api/middleware/authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/api/middleware"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
 	"github.com/spiffe/spire/test/spiretest"
@@ -84,7 +85,7 @@ func TestWithAuthorizationPreprocess(t *testing.T) {
 					Level:   logrus.InfoLevel,
 					Message: "Authorizer called",
 					Data: logrus.Fields{
-						"caller-addr": "1.1.1.1:1",
+						telemetry.CallerAddr: "1.1.1.1:1",
 					},
 				},
 			},
@@ -99,8 +100,8 @@ func TestWithAuthorizationPreprocess(t *testing.T) {
 					Level:   logrus.InfoLevel,
 					Message: "Authorizer called",
 					Data: logrus.Fields{
-						"caller-addr": "2.2.2.2:2",
-						"caller-id":   "spiffe://example.org/workload",
+						telemetry.CallerAddr: "2.2.2.2:2",
+						telemetry.CallerID:   "spiffe://example.org/workload",
 					},
 				},
 			},


### PR DESCRIPTION
**Affected functionality**
Correct log field names which contained `-` instead of `_` as is the convention in spiffe/spire.

**Description of change**
Add a `CallerAddr` constant to the telemetry package. Use the `telemetry.CallerID` and `telemetry.CallerAddr` constants from the `server/api/middleware` package. Update example in CONTRIBUTING.md.

**Which issue this PR fixes**
Fixes #2254.
