### PR TITLE
Use ca_key_type for the server SVID

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -469,6 +469,9 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		}
 		sc.CAKeyType = keyType
 		sc.JWTKeyType = keyType
+	} else {
+		sc.CAKeyType = keymanager.ECP256
+		sc.JWTKeyType = keymanager.ECP256
 	}
 
 	if c.Server.JWTKeyType != "" {

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -756,6 +756,15 @@ func TestNewServerConfig(t *testing.T) {
 			},
 		},
 		{
+			msg: "ca_key_type and jwt_key_type are set as default",
+			input: func(c *Config) {
+			},
+			test: func(t *testing.T, c *server.Config) {
+				require.Equal(t, keymanager.ECP256, c.CAKeyType)
+				require.Equal(t, keymanager.ECP256, c.JWTKeyType)
+			},
+		},
+		{
 			msg: "rsa-2048 ca_key_type is correctly parsed and is set as default for jwt key",
 			input: func(c *Config) {
 				c.Server.CAKeyType = "rsa-2048"
@@ -811,7 +820,7 @@ func TestNewServerConfig(t *testing.T) {
 				c.Server.JWTKeyType = "rsa-2048"
 			},
 			test: func(t *testing.T, c *server.Config) {
-				require.Equal(t, keymanager.KeyTypeUnset, c.CAKeyType)
+				require.Equal(t, keymanager.ECP256, c.CAKeyType)
 				require.Equal(t, keymanager.RSA2048, c.JWTKeyType)
 			},
 		},
@@ -821,7 +830,7 @@ func TestNewServerConfig(t *testing.T) {
 				c.Server.JWTKeyType = "rsa-4096"
 			},
 			test: func(t *testing.T, c *server.Config) {
-				require.Equal(t, keymanager.KeyTypeUnset, c.CAKeyType)
+				require.Equal(t, keymanager.ECP256, c.CAKeyType)
 				require.Equal(t, keymanager.RSA4096, c.JWTKeyType)
 			},
 		},
@@ -831,7 +840,7 @@ func TestNewServerConfig(t *testing.T) {
 				c.Server.JWTKeyType = "ec-p256"
 			},
 			test: func(t *testing.T, c *server.Config) {
-				require.Equal(t, keymanager.KeyTypeUnset, c.CAKeyType)
+				require.Equal(t, keymanager.ECP256, c.CAKeyType)
 				require.Equal(t, keymanager.ECP256, c.JWTKeyType)
 			},
 		},
@@ -841,7 +850,7 @@ func TestNewServerConfig(t *testing.T) {
 				c.Server.JWTKeyType = "ec-p384"
 			},
 			test: func(t *testing.T, c *server.Config) {
-				require.Equal(t, keymanager.KeyTypeUnset, c.CAKeyType)
+				require.Equal(t, keymanager.ECP256, c.CAKeyType)
 				require.Equal(t, keymanager.ECP384, c.JWTKeyType)
 			},
 		},

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -97,12 +97,6 @@ func NewManager(c ManagerConfig) *Manager {
 	if c.Clock == nil {
 		c.Clock = clock.New()
 	}
-	if c.X509CAKeyType == keymanager.KeyTypeUnset {
-		c.X509CAKeyType = keymanager.ECP256
-	}
-	if c.JWTKeyType == keymanager.KeyTypeUnset {
-		c.JWTKeyType = keymanager.ECP256
-	}
 
 	m := &Manager{
 		c:               c,

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -576,11 +576,6 @@ func (s *ManagerSuite) TestAlternateKeyTypes() {
 		checkJWTKey       func(*testing.T, crypto.Signer)
 	}{
 		{
-			name:        "self-signed with defaults",
-			checkX509CA: expectEC256,
-			checkJWTKey: expectEC256,
-		},
-		{
 			name:          "self-signed with RSA 2048",
 			x509CAKeyType: keymanager.RSA2048,
 			jwtKeyType:    keymanager.RSA2048,
@@ -614,12 +609,6 @@ func (s *ManagerSuite) TestAlternateKeyTypes() {
 			jwtKeyType:    keymanager.RSA2048,
 			checkX509CA:   expectEC384,
 			checkJWTKey:   expectRSA2048,
-		},
-		{
-			name:              "upstream-signed with defaults",
-			upstreamAuthority: upstreamAuthority,
-			checkX509CA:       expectEC256,
-			checkJWTKey:       expectEC256,
 		},
 		{
 			name:              "upstream-signed with RSA 2048",
@@ -697,7 +686,7 @@ func (s *ManagerSuite) setNotifier(notifier notifier.Notifier) {
 }
 
 func (s *ManagerSuite) selfSignedConfig() ManagerConfig {
-	return s.selfSignedConfigWithKeyTypes(0, 0)
+	return s.selfSignedConfigWithKeyTypes(keymanager.ECP256, keymanager.ECP256)
 }
 
 func (s *ManagerSuite) selfSignedConfigWithKeyTypes(x509CAKeyType, jwtKeyType keymanager.KeyType) ManagerConfig {

--- a/pkg/server/plugin/keymanager/keymanager.go
+++ b/pkg/server/plugin/keymanager/keymanager.go
@@ -3,6 +3,11 @@ package keymanager
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
 
 	"github.com/spiffe/spire/pkg/common/catalog"
 )
@@ -41,4 +46,20 @@ type KeyManager interface {
 
 	// GetKeys returns all keys managed by the KeyManager.
 	GetKeys(ctx context.Context) ([]Key, error)
+}
+
+func (keyType KeyType) GenerateSigner() (crypto.Signer, error) {
+	switch keyType {
+	case ECP256:
+		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case ECP384:
+		return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case RSA1024:
+		return nil, fmt.Errorf("unsupported key type %q", keyType)
+	case RSA2048:
+		return rsa.GenerateKey(rand.Reader, 2048)
+	case RSA4096:
+		return rsa.GenerateKey(rand.Reader, 4096)
+	}
+	return nil, fmt.Errorf("unknown key type %q", keyType)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -296,6 +296,7 @@ func (s *Server) newSVIDRotator(ctx context.Context, serverCA ca.ServerCA, metri
 		Log:         s.config.Log.WithField(telemetry.SubsystemName, telemetry.SVIDRotator),
 		Metrics:     metrics,
 		TrustDomain: s.config.TrustDomain,
+		KeyType:     s.config.CAKeyType,
 	})
 	if err := svidRotator.Initialize(ctx); err != nil {
 		return nil, err

--- a/pkg/server/svid/rotator_config.go
+++ b/pkg/server/svid/rotator_config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/ca"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 )
 
 const (
@@ -21,6 +22,7 @@ type RotatorConfig struct {
 	TrustDomain spiffeid.TrustDomain
 	ServerCA    ca.ServerCA
 	Clock       clock.Clock
+	KeyType     keymanager.KeyType
 
 	// How long to wait between expiry checks
 	Interval time.Duration

--- a/pkg/server/svid/rotator_test.go
+++ b/pkg/server/svid/rotator_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakeserverca"
 	"github.com/spiffe/spire/test/spiretest"
@@ -55,6 +56,7 @@ func (s *RotatorTestSuite) SetupTest() {
 		Metrics:     telemetry.Blackhole{},
 		TrustDomain: trustDomain,
 		Clock:       s.clock,
+		KeyType:     keymanager.ECP256,
 	})
 }
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Issuing a SVID for the SPIRE server.

**Description of change**
Use `ca_key_type` for the key used for the SPIRE server SVID.
Currently that has a fixed type, EC with P384, which is different
from the default key type and different from what an operator
might configure.

Since this is visible to other systems interacting with the SPIRE
server, it would be nice if it uses what was specified in the config
for the server

**Which issue this PR fixes**
https://github.com/spiffe/spire/issues/2127
