### PR TITLE
Introduce Agent V1 NodeAttestor facade

### DIFF
--- a/pkg/agent/catalog/nodeattestor.go
+++ b/pkg/agent/catalog/nodeattestor.go
@@ -26,7 +26,11 @@ func (repo *nodeAttestorRepository) Constraints() catalog.Constraints {
 }
 
 func (repo *nodeAttestorRepository) Versions() []catalog.Version {
-	return []catalog.Version{nodeAttestorV1{}}
+	return []catalog.Version{
+		nodeAttestorV1{},
+		// TODO: remove v0 once all of the built-ins have been migrated to v1
+		nodeAttestorV0{},
+	}
 }
 
 func (repo *nodeAttestorRepository) LegacyVersion() (catalog.Version, bool) {

--- a/pkg/agent/catalog/nodeattestor.go
+++ b/pkg/agent/catalog/nodeattestor.go
@@ -26,7 +26,7 @@ func (repo *nodeAttestorRepository) Constraints() catalog.Constraints {
 }
 
 func (repo *nodeAttestorRepository) Versions() []catalog.Version {
-	return []catalog.Version{nodeAttestorV0{}}
+	return []catalog.Version{nodeAttestorV1{}}
 }
 
 func (repo *nodeAttestorRepository) LegacyVersion() (catalog.Version, bool) {
@@ -46,7 +46,12 @@ func (repo *nodeAttestorRepository) BuiltIns() []catalog.BuiltIn {
 	}
 }
 
+type nodeAttestorV1 struct{}
+
+func (nodeAttestorV1) New() catalog.Facade { return new(nodeattestor.V1) }
+func (nodeAttestorV1) Deprecated() bool    { return false }
+
 type nodeAttestorV0 struct{}
 
 func (nodeAttestorV0) New() catalog.Facade { return new(nodeattestor.V0) }
-func (nodeAttestorV0) Deprecated() bool    { return false }
+func (nodeAttestorV0) Deprecated() bool    { return true }

--- a/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
@@ -1,12 +1,10 @@
 package jointoken
 
 import (
-	"context"
-	"errors"
-
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	nodeattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/nodeattestor/v0"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -18,25 +16,17 @@ func BuiltIn() catalog.BuiltIn {
 }
 
 func builtin(p *Plugin) catalog.BuiltIn {
-	return catalog.MakeBuiltIn(pluginName, nodeattestorv0.NodeAttestorPluginServer(p))
+	return catalog.MakeBuiltIn(pluginName, nodeattestorv1.NodeAttestorPluginServer(p))
 }
 
 type Plugin struct {
-	nodeattestorv0.UnsafeNodeAttestorServer
+	nodeattestorv1.UnsafeNodeAttestorServer
 }
 
 func New() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
-	return errors.New("join token attestation is currently implemented within the agent")
-}
-
-func (p *Plugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (*Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
+func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) error {
+	return status.Error(codes.Internal, "join token attestation is currently implemented within the agent")
 }

--- a/pkg/agent/plugin/nodeattestor/jointoken_test.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken_test.go
@@ -7,28 +7,26 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 )
 
 func TestJoinToken(t *testing.T) {
+	streamBuilder := nodeattestortest.ServerStream("join_token")
+	payload := []byte("foo")
+
 	log, _ := test.NewNullLogger()
 	attestor := nodeattestor.JoinToken(log, "foo")
 
 	t.Run("success", func(t *testing.T) {
-		err := attestor.Attest(context.Background(), &fakeStream{
-			expectData: nodeattestor.AttestationData{Type: "join_token", Payload: []byte("foo")},
-		})
+		err := attestor.Attest(context.Background(), streamBuilder.ExpectAndBuild(payload))
 		require.NoError(t, err)
 	})
 
 	t.Run("attestation fails", func(t *testing.T) {
-		err := attestor.Attest(context.Background(), &fakeStream{
-			attestationErr: errors.New("ohno"),
-			expectData:     nodeattestor.AttestationData{Type: "join_token", Payload: []byte("bar")},
-			challenges:     challenges("hello"),
-		})
+		err := attestor.Attest(context.Background(), streamBuilder.FailAndBuild(errors.New("ohno")))
 		// ServerStream errors are not the responsibility of the plugin, so
 		// we shouldn't wrap them. ServerStream implementations are responsible
 		// for the shape of those errors.
@@ -36,10 +34,7 @@ func TestJoinToken(t *testing.T) {
 	})
 
 	t.Run("server issues unexpected challenge", func(t *testing.T) {
-		err := attestor.Attest(context.Background(), &fakeStream{
-			expectData: nodeattestor.AttestationData{Type: "join_token", Payload: []byte("foo")},
-			challenges: challenges("hello"),
-		})
+		err := attestor.Attest(context.Background(), streamBuilder.ExpectThenChallenge(payload, []byte("hello")).Build())
 		spiretest.RequireGRPCStatus(t, err, codes.Internal, "nodeattestor(join_token): server issued unexpected challenge")
 	})
 }

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl"
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/k8s"
-	"github.com/spiffe/spire/proto/spire/common"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	nodeattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/nodeattestor/v0"
 	"github.com/zeebo/errs"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -21,16 +21,15 @@ const (
 	defaultTokenPath = "/var/run/secrets/tokens/spire-agent" //nolint: gosec // false positive
 )
 
-var (
-	psatError = errs.Class("k8s-psat")
-)
-
 func BuiltIn() catalog.BuiltIn {
 	return builtin(New())
 }
 
 func builtin(p *AttestorPlugin) catalog.BuiltIn {
-	return catalog.MakeBuiltIn(pluginName, nodeattestorv0.NodeAttestorPluginServer(p))
+	return catalog.MakeBuiltIn(pluginName,
+		nodeattestorv1.NodeAttestorPluginServer(p),
+		configv1.ConfigServiceServer(p),
+	)
 }
 
 // New creates a new PSAT attestor plugin
@@ -40,7 +39,8 @@ func New() *AttestorPlugin {
 
 // AttestorPlugin is a PSAT (projected SAT) attestor plugin
 type AttestorPlugin struct {
-	nodeattestorv0.UnsafeNodeAttestorServer
+	nodeattestorv1.UnsafeNodeAttestorServer
+	configv1.UnsafeConfigServer
 
 	mu     sync.RWMutex
 	config *attestorConfig
@@ -55,13 +55,12 @@ type AttestorConfig struct {
 }
 
 type attestorConfig struct {
-	trustDomain spiffeid.TrustDomain
-	cluster     string
-	tokenPath   string
+	cluster   string
+	tokenPath string
 }
 
-// FetchAttestationData loads PSAT from the configured path and send it to server node attestor
-func (p *AttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor_FetchAttestationDataServer) error {
+// AidAttestation loads the PSAT token from the configured path
+func (p *AttestorPlugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) error {
 	config, err := p.getConfig()
 	if err != nil {
 		return err
@@ -69,69 +68,52 @@ func (p *AttestorPlugin) FetchAttestationData(stream nodeattestorv0.NodeAttestor
 
 	token, err := loadTokenFromFile(config.tokenPath)
 	if err != nil {
-		return psatError.New("unable to load token from %s: %v", config.tokenPath, err)
+		return status.Errorf(codes.InvalidArgument, "unable to load token from %s: %v", config.tokenPath, err)
 	}
 
-	data, err := json.Marshal(k8s.PSATAttestationData{
+	payload, err := json.Marshal(k8s.PSATAttestationData{
 		Cluster: config.cluster,
 		Token:   token,
 	})
 	if err != nil {
-		return psatError.Wrap(err)
+		return status.Errorf(codes.Internal, "unable to marshal PSAT token data: %v", err)
 	}
 
-	return stream.Send(&nodeattestorv0.FetchAttestationDataResponse{
-		AttestationData: &common.AttestationData{
-			Type: pluginName,
-			Data: data,
+	return stream.Send(&nodeattestorv1.PayloadOrChallengeResponse{
+		Data: &nodeattestorv1.PayloadOrChallengeResponse_Payload{
+			Payload: payload,
 		},
 	})
 }
 
 // Configure decodes JSON config from request and populates AttestorPlugin with it
-func (p *AttestorPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (resp *spi.ConfigureResponse, err error) {
+func (p *AttestorPlugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (resp *configv1.ConfigureResponse, err error) {
 	hclConfig := new(AttestorConfig)
-	if err := hcl.Decode(hclConfig, req.Configuration); err != nil {
-		return nil, psatError.New("unable to decode configuration: %v", err)
+	if err := hcl.Decode(hclConfig, req.HclConfiguration); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)
 	}
 
-	if req.GlobalConfig == nil {
-		return nil, psatError.New("global configuration is required")
-	}
-	if req.GlobalConfig.TrustDomain == "" {
-		return nil, psatError.New("global configuration missing trust domain")
-	}
 	if hclConfig.Cluster == "" {
-		return nil, psatError.New("configuration missing cluster")
-	}
-
-	td, err := spiffeid.TrustDomainFromString(req.GlobalConfig.TrustDomain)
-	if err != nil {
-		return nil, err
+		return nil, status.Error(codes.InvalidArgument, "configuration missing cluster")
 	}
 
 	config := &attestorConfig{
-		trustDomain: td,
-		cluster:     hclConfig.Cluster,
-		tokenPath:   hclConfig.TokenPath,
+		cluster:   hclConfig.Cluster,
+		tokenPath: hclConfig.TokenPath,
 	}
 	if config.tokenPath == "" {
 		config.tokenPath = defaultTokenPath
 	}
 
 	p.setConfig(config)
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (p *AttestorPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
+	return &configv1.ConfigureResponse{}, nil
 }
 
 func (p *AttestorPlugin) getConfig() (*attestorConfig, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	if p.config == nil {
-		return nil, psatError.New("not configured")
+		return nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
 	return p.config, nil
 }

--- a/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/psat/psat_test.go
@@ -3,17 +3,15 @@ package psat
 import (
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	sat_common "github.com/spiffe/spire/pkg/common/plugin/k8s"
-	"github.com/spiffe/spire/proto/spire/common/plugin"
-	nodeattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -34,6 +32,10 @@ RcY5rJxm48kUZ12Mr3cQ/kCYvftL7HkYR/4rewIxANdritlIPu4VziaEhYZg7dvz
 pG3eEhiqPxE++QHpwU78O+F1GznOPBvpZOB3GfyjNQ==
 -----END RSA PRIVATE KEY-----`)
 
+var (
+	streamBuilder = nodeattestortest.ServerStream(pluginName)
+)
+
 func TestAttestorPlugin(t *testing.T) {
 	spiretest.Run(t, new(AttestorSuite))
 }
@@ -41,114 +43,68 @@ func TestAttestorPlugin(t *testing.T) {
 type AttestorSuite struct {
 	spiretest.Suite
 
-	dir      string
-	attestor nodeattestorv0.NodeAttestorClient
+	dir string
 }
 
 func (s *AttestorSuite) SetupTest() {
 	s.dir = s.TempDir()
-
-	s.newAttestor()
-	s.configure(AttestorConfig{})
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataNotConfigured() {
-	s.newAttestor()
-	s.requireFetchError("k8s-psat: not configured")
+func (s *AttestorSuite) TestAttestNotConfigured() {
+	na := s.loadPlugin()
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatus(err, codes.FailedPrecondition, "nodeattestor(k8s_psat): not configured")
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataNoToken() {
-	s.configure(AttestorConfig{
-		TokenPath: s.joinPath("token"),
-	})
-	s.requireFetchError("unable to load token from")
+func (s *AttestorSuite) TestAttestNoToken() {
+	na := s.loadPluginWithTokenPath(s.joinPath("token"))
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "nodeattestor(k8s_psat): unable to load token from")
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataSuccess() {
+func (s *AttestorSuite) TestAttestEmptyToken() {
+	na := s.loadPluginWithTokenPath(s.writeValue("token", ""))
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "nodeattestor(k8s_psat): unable to load token from")
+}
+
+func (s *AttestorSuite) TestAttestSuccess() {
 	token, err := createPSAT("NAMESPACE", "POD-NAME")
 	s.Require().NoError(err)
 
-	s.configure(AttestorConfig{
-		TokenPath: s.writeValue("token", token),
-	})
+	na := s.loadPluginWithTokenPath(s.writeValue("token", token))
 
-	stream, err := s.attestor.FetchAttestationData(context.Background())
+	err = na.Attest(context.Background(), streamBuilder.ExpectAndBuild([]byte(fmt.Sprintf(`{"cluster":"production","token":"%s"}`, token))))
 	s.Require().NoError(err)
-	s.Require().NotNil(stream)
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-
-	// assert attestation data
-	s.Require().NotNil(resp.AttestationData)
-	s.Require().Equal("k8s_psat", resp.AttestationData.Type)
-	s.Require().JSONEq(fmt.Sprintf(`{
-		"cluster": "production",
-		"token": "%s"
-	}`, token), string(resp.AttestationData.Data))
-
-	// node attestor should return EOF now
-	_, err = stream.Recv()
-	s.Require().Equal(io.EOF, err)
 }
 
 func (s *AttestorSuite) TestConfigure() {
+	var err error
+
 	// malformed configuration
-	resp, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{},
-		Configuration: "blah",
-	})
-	s.RequireGRPCStatusContains(err, codes.Unknown, "k8s-psat: unable to decode configuration")
-	s.Require().Nil(resp)
-
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{})
-	s.RequireGRPCStatusContains(err, codes.Unknown, "k8s-psat: global configuration is required")
-	s.Require().Nil(resp)
-
-	// missing trust domain
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{}})
-	s.RequireGRPCStatus(err, codes.Unknown, "k8s-psat: global configuration missing trust domain")
-	s.Require().Nil(resp)
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure("malformed"))
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "unable to decode configuration")
 
 	// missing cluster
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
-	})
-	s.RequireGRPCStatus(err, codes.Unknown, "k8s-psat: configuration missing cluster")
-	s.Require().Nil(resp)
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure(""))
+	s.RequireGRPCStatus(err, codes.InvalidArgument, "configuration missing cluster")
 
 	// success
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
-		Configuration: `cluster = "production"`,
-	})
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure(`cluster = "production"`))
 	s.Require().NoError(err)
-	s.RequireProtoEqual(resp, &plugin.ConfigureResponse{})
 }
 
-func (s *AttestorSuite) TestGetPluginInfo() {
-	resp, err := s.attestor.GetPluginInfo(context.Background(), &plugin.GetPluginInfoRequest{})
-	s.Require().NoError(err)
-	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
-}
-
-func (s *AttestorSuite) newAttestor() {
-	attestor := new(nodeattestor.V0)
-	plugintest.Load(s.T(), BuiltIn(), attestor)
-	s.attestor = attestor.NodeAttestorPluginClient
-}
-
-func (s *AttestorSuite) configure(config AttestorConfig) {
-	_, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
-			TrustDomain: "example.org",
-		},
-		Configuration: fmt.Sprintf(`
+func (s *AttestorSuite) loadPluginWithTokenPath(tokenPath string) nodeattestor.NodeAttestor {
+	return s.loadPlugin(plugintest.Configuref(`
 			cluster = "production"
-			token_path = %q`, config.TokenPath),
-	})
-	s.Require().NoError(err)
+			token_path = %q
+	`, tokenPath))
+}
+
+func (s *AttestorSuite) loadPlugin(options ...plugintest.Option) nodeattestor.NodeAttestor {
+	na := new(nodeattestor.V1)
+	plugintest.Load(s.T(), BuiltIn(), na, options...)
+	return na
 }
 
 func (s *AttestorSuite) joinPath(path string) string {
@@ -162,16 +118,6 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	err = ioutil.WriteFile(valuePath, []byte(data), 0600)
 	s.Require().NoError(err)
 	return valuePath
-}
-
-func (s *AttestorSuite) requireFetchError(contains string) {
-	stream, err := s.attestor.FetchAttestationData(context.Background())
-	s.Require().NoError(err)
-	s.Require().NotNil(stream)
-
-	resp, err := stream.Recv()
-	s.RequireErrorContains(err, contains)
-	s.Require().Nil(resp)
 }
 
 // Creates a PSAT using the given namespace and podName (just for testing)

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -2,19 +2,20 @@ package sat
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
-	"github.com/spiffe/spire/proto/spire/common/plugin"
-	nodeattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/nodeattestor/v0"
+	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
+)
+
+var (
+	streamBuilder = nodeattestortest.ServerStream(pluginName)
 )
 
 func TestAttestorPlugin(t *testing.T) {
@@ -24,115 +25,65 @@ func TestAttestorPlugin(t *testing.T) {
 type AttestorSuite struct {
 	spiretest.Suite
 
-	dir      string
-	attestor nodeattestorv0.NodeAttestorClient
+	dir string
 }
 
 func (s *AttestorSuite) SetupTest() {
 	s.dir = s.TempDir()
-
-	s.newAttestor()
-	s.configure(AttestorConfig{})
 }
 
-func (s *AttestorSuite) TearDownTest() {
-	os.RemoveAll(s.dir)
+func (s *AttestorSuite) TestAttestNotConfigured() {
+	na := s.loadPlugin()
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatus(err, codes.FailedPrecondition, "nodeattestor(k8s_sat): not configured")
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataNotConfigured() {
-	s.newAttestor()
-	s.requireFetchError("k8s-sat: not configured")
+func (s *AttestorSuite) TestAttestNoToken() {
+	na := s.loadPluginWithTokenPath(s.joinPath("token"))
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "nodeattestor(k8s_sat): unable to load token from")
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataNoToken() {
-	s.configure(AttestorConfig{
-		TokenPath: s.joinPath("token"),
-	})
-	s.requireFetchError("unable to load token from")
+func (s *AttestorSuite) TestAttestEmptyToken() {
+	na := s.loadPluginWithTokenPath(s.writeValue("token", ""))
+	err := na.Attest(context.Background(), streamBuilder.Build())
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "nodeattestor(k8s_sat): unable to load token from")
 }
 
-func (s *AttestorSuite) TestFetchAttestationDataSuccess() {
-	s.configure(AttestorConfig{
-		TokenPath: s.writeValue("token", "TOKEN"),
-	})
+func (s *AttestorSuite) TestAttestSuccess() {
+	na := s.loadPluginWithTokenPath(s.writeValue("token", "TOKEN"))
 
-	stream, err := s.attestor.FetchAttestationData(context.Background())
+	err := na.Attest(context.Background(), streamBuilder.ExpectAndBuild([]byte(`{"cluster":"production","token":"TOKEN"}`)))
 	s.Require().NoError(err)
-	s.Require().NotNil(stream)
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-
-	// assert attestation data
-	s.Require().NotNil(resp.AttestationData)
-	s.Require().Equal("k8s_sat", resp.AttestationData.Type)
-	s.Require().JSONEq(`{
-		"cluster": "production",
-		"token": "TOKEN"
-	}`, string(resp.AttestationData.Data))
-
-	// node attestor should return EOF now
-	_, err = stream.Recv()
-	s.Require().Equal(io.EOF, err)
 }
 
 func (s *AttestorSuite) TestConfigure() {
+	var err error
+
 	// malformed configuration
-	resp, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{},
-		Configuration: "blah",
-	})
-	s.RequireGRPCStatusContains(err, codes.Unknown, "k8s-sat: unable to decode configuration")
-	s.Require().Nil(resp)
-
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{})
-	s.RequireGRPCStatusContains(err, codes.Unknown, "k8s-sat: global configuration is required")
-	s.Require().Nil(resp)
-
-	// missing trust domain
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{}})
-	s.RequireGRPCStatus(err, codes.Unknown, "k8s-sat: global configuration missing trust domain")
-	s.Require().Nil(resp)
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure("malformed"))
+	s.RequireGRPCStatusContains(err, codes.InvalidArgument, "unable to decode configuration")
 
 	// missing cluster
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
-	})
-	s.RequireGRPCStatus(err, codes.Unknown, "k8s-sat: configuration missing cluster")
-	s.Require().Nil(resp)
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure(""))
+	s.RequireGRPCStatus(err, codes.InvalidArgument, "configuration missing cluster")
 
 	// success
-	resp, err = s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig:  &plugin.ConfigureRequest_GlobalConfig{TrustDomain: "example.org"},
-		Configuration: `cluster = "production"`,
-	})
+	s.loadPlugin(plugintest.CaptureConfigureError(&err), plugintest.Configure(`cluster = "production"`))
 	s.Require().NoError(err)
-	s.RequireProtoEqual(resp, &plugin.ConfigureResponse{})
 }
 
-func (s *AttestorSuite) TestGetPluginInfo() {
-	resp, err := s.attestor.GetPluginInfo(context.Background(), &plugin.GetPluginInfoRequest{})
-	s.Require().NoError(err)
-	s.RequireProtoEqual(resp, &plugin.GetPluginInfoResponse{})
-}
-
-func (s *AttestorSuite) newAttestor() {
-	attestor := new(nodeattestor.V0)
-	plugintest.Load(s.T(), BuiltIn(), attestor)
-	s.attestor = attestor.NodeAttestorPluginClient
-}
-
-func (s *AttestorSuite) configure(config AttestorConfig) {
-	_, err := s.attestor.Configure(context.Background(), &plugin.ConfigureRequest{
-		GlobalConfig: &plugin.ConfigureRequest_GlobalConfig{
-			TrustDomain: "example.org",
-		},
-		Configuration: fmt.Sprintf(`
+func (s *AttestorSuite) loadPluginWithTokenPath(tokenPath string) nodeattestor.NodeAttestor {
+	return s.loadPlugin(plugintest.Configuref(`
 			cluster = "production"
-			token_path = %q`, config.TokenPath),
-	})
-	s.Require().NoError(err)
+			token_path = %q
+	`, tokenPath))
+}
+
+func (s *AttestorSuite) loadPlugin(options ...plugintest.Option) nodeattestor.NodeAttestor {
+	na := new(nodeattestor.V1)
+	plugintest.Load(s.T(), BuiltIn(), na, options...)
+	return na
 }
 
 func (s *AttestorSuite) joinPath(path string) string {
@@ -146,14 +97,4 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	err = ioutil.WriteFile(valuePath, []byte(data), 0600)
 	s.Require().NoError(err)
 	return valuePath
-}
-
-func (s *AttestorSuite) requireFetchError(contains string) {
-	stream, err := s.attestor.FetchAttestationData(context.Background())
-	s.Require().NoError(err)
-	s.Require().NotNil(stream)
-
-	resp, err := stream.Recv()
-	s.RequireErrorContains(err, contains)
-	s.Require().Nil(resp)
 }

--- a/pkg/agent/plugin/nodeattestor/test/serverstream.go
+++ b/pkg/agent/plugin/nodeattestor/test/serverstream.go
@@ -1,0 +1,110 @@
+package nodeattestortest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ServerStreamHandler is a function used to handle payloads or challenge
+// responses sent to the stream.
+type ServerStreamHandler = func(payloadOrChallengeResponse []byte) (challenge []byte, err error)
+
+// ServerStreamBuilder is used to build server streams for testing.
+type ServerStreamBuilder struct {
+	pluginName string
+	handlers   []ServerStreamHandler
+}
+
+// ServerStream initializes a new server stream builder for the given plugin
+// name. Attestation data received by the stream will have its type validated
+// against the plugin name.
+func ServerStream(pluginName string) *ServerStreamBuilder {
+	return &ServerStreamBuilder{
+		pluginName: pluginName,
+	}
+}
+
+// Build builds a stream with the configured handlers
+func (b *ServerStreamBuilder) Build() nodeattestor.ServerStream {
+	return &serverStream{
+		pluginName: b.pluginName,
+		handlers:   b.handlers,
+	}
+}
+
+// Handle adds an arbitrary handler. If the handler returns a challenge then it
+// is expected that the stream will be called again.
+func (b *ServerStreamBuilder) Handle(handler ServerStreamHandler) *ServerStreamBuilder {
+	return b.addHandler(handler)
+}
+
+// ExpectThenChallenge adds an intermediate handler that asserts that the given
+// payload or challenge response is received and then issues the given
+// challenge. It returns a new builder with that handler added.
+func (b *ServerStreamBuilder) ExpectThenChallenge(payloadOrChallengeResponse, challenge []byte) *ServerStreamBuilder {
+	return b.Handle(func(actual []byte) ([]byte, error) {
+		if string(actual) != string(payloadOrChallengeResponse) {
+			return nil, status.Errorf(codes.InvalidArgument, "expected attestation payload %q; got %q", string(payloadOrChallengeResponse), string(actual))
+		}
+		return challenge, nil
+	})
+}
+
+// ExpectAndBuild adds a final handler wherein the server stream expects to
+// receive the given payload or challenge response. It returns a built server
+// stream, since the stream does not issue another challenge at this point and
+// will fail if invoked again.
+func (b *ServerStreamBuilder) ExpectAndBuild(payloadOrChallengeResponse []byte) nodeattestor.ServerStream {
+	return b.ExpectThenChallenge(payloadOrChallengeResponse, nil).Build()
+}
+
+// FailAndBuild adds a final handler wherein the server stream fails with the
+// given error.  It returns a built server stream, since the stream does not
+// issue another challenge at this point and will fail if invoked again.
+func (b *ServerStreamBuilder) FailAndBuild(err error) nodeattestor.ServerStream {
+	return b.addHandler(func([]byte) ([]byte, error) {
+		return nil, err
+	}).Build()
+}
+
+func (b *ServerStreamBuilder) addHandler(handler ServerStreamHandler) *ServerStreamBuilder {
+	handlers := append([]ServerStreamHandler(nil), b.handlers...)
+	handlers = append(handlers, handler)
+	return &ServerStreamBuilder{
+		pluginName: b.pluginName,
+		handlers:   handlers,
+	}
+}
+
+type serverStream struct {
+	pluginName string
+	handlers   []ServerStreamHandler
+}
+
+func (ss *serverStream) SendAttestationData(ctx context.Context, attestationData nodeattestor.AttestationData) ([]byte, error) {
+	if attestationData.Type != ss.pluginName {
+		return nil, fmt.Errorf("expected attestation type %q; got %q", ss.pluginName, attestationData.Type)
+	}
+	if len(ss.handlers) == 0 {
+		return nil, errors.New("stream received unexpected attestation data")
+	}
+	return ss.handle(attestationData.Payload)
+}
+
+func (ss *serverStream) SendChallengeResponse(ctx context.Context, challengeResponse []byte) ([]byte, error) {
+	if len(ss.handlers) == 0 {
+		return nil, errors.New("stream received unexpected challenge response")
+	}
+	return ss.handle(challengeResponse)
+}
+
+func (ss *serverStream) handle(payloadOrChallengeResponse []byte) (challenge []byte, err error) {
+	handler := ss.handlers[0]
+	ss.handlers = ss.handlers[1:]
+	return handler(payloadOrChallengeResponse)
+}

--- a/pkg/agent/plugin/nodeattestor/v1.go
+++ b/pkg/agent/plugin/nodeattestor/v1.go
@@ -1,0 +1,80 @@
+package nodeattestor
+
+import (
+	"context"
+	"io"
+
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"google.golang.org/grpc/codes"
+)
+
+type V1 struct {
+	plugin.Facade
+	nodeattestorv1.NodeAttestorPluginClient
+}
+
+func (v1 *V1) Attest(ctx context.Context, serverStream ServerStream) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pluginStream, err := v1.NodeAttestorPluginClient.AidAttestation(ctx)
+	if err != nil {
+		return v1.WrapErr(err)
+	}
+
+	payloadOrChallengeResponse, err := pluginStream.Recv()
+	switch {
+	case err == io.EOF:
+		return v1.Error(codes.Internal, "plugin closed stream before returning attestation data")
+	case err != nil:
+		return v1.WrapErr(err)
+	}
+
+	payload := payloadOrChallengeResponse.GetPayload()
+	if len(payload) == 0 {
+		return v1.Error(codes.Internal, "plugin response missing attestation payload")
+	}
+
+	challenge, err := serverStream.SendAttestationData(ctx, AttestationData{
+		Type:    v1.Name(),
+		Payload: payload,
+	})
+	if err != nil {
+		return err
+	}
+
+	for {
+		if challenge == nil {
+			return nil
+		}
+
+		err = pluginStream.Send(&nodeattestorv1.Challenge{
+			Challenge: challenge,
+		})
+		switch {
+		case err == io.EOF:
+			return v1.Error(codes.Internal, "plugin closed stream before handling the challenge")
+		case err != nil:
+			return v1.WrapErr(err)
+		}
+
+		payloadOrChallengeResponse, err := pluginStream.Recv()
+		switch {
+		case err == io.EOF:
+			return v1.Error(codes.Internal, "plugin closed stream before handling the challenge")
+		case err != nil:
+			return v1.WrapErr(err)
+		}
+
+		challengeResponse := payloadOrChallengeResponse.GetChallengeResponse()
+		if len(challengeResponse) == 0 {
+			return v1.Error(codes.Internal, "plugin response missing challenge response")
+		}
+
+		challenge, err = serverStream.SendChallengeResponse(ctx, challengeResponse)
+		if err != nil {
+			return err
+		}
+	}
+}

--- a/pkg/agent/plugin/nodeattestor/v1_test.go
+++ b/pkg/agent/plugin/nodeattestor/v1_test.go
@@ -1,0 +1,185 @@
+package nodeattestor_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/nodeattestor/v1"
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
+	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func TestV1(t *testing.T) {
+	streamBuilder := nodeattestortest.ServerStream("test")
+	payload := []byte("payload")
+	challenge := []byte("challenge")
+	challengeResponse := []byte("challengeResponse")
+
+	for _, tt := range []struct {
+		test          string
+		pluginImpl    *fakeV1Plugin
+		streamImpl    nodeattestor.ServerStream
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "plugin closes stream without returning attestation data",
+			pluginImpl:    &fakeV1Plugin{closeStream: true},
+			streamImpl:    streamBuilder.Build(),
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin closed stream before returning attestation data",
+		},
+		{
+			test:          "plugin fails fetching payload",
+			pluginImpl:    &fakeV1Plugin{payloadErr: errors.New("ohno")},
+			streamImpl:    streamBuilder.Build(),
+			expectCode:    codes.Unknown,
+			expectMessage: "nodeattestor(test): ohno",
+		},
+		{
+			test:          "plugin does not return attestation data",
+			pluginImpl:    &fakeV1Plugin{},
+			streamImpl:    streamBuilder.Build(),
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing attestation payload",
+		},
+		{
+			test:          "plugin returns empty payload",
+			pluginImpl:    &fakeV1Plugin{payload: []byte("")},
+			streamImpl:    streamBuilder.Build(),
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing attestation payload",
+		},
+		{
+			test:          "server stream fails sending attestation data",
+			pluginImpl:    &fakeV1Plugin{payload: payload},
+			streamImpl:    streamBuilder.FailAndBuild(errors.New("ohno")),
+			expectCode:    codes.Unknown,
+			expectMessage: "ohno",
+		},
+		{
+			test:          "server stream issues no challenge",
+			pluginImpl:    &fakeV1Plugin{payload: payload},
+			streamImpl:    streamBuilder.ExpectAndBuild(payload),
+			expectCode:    codes.OK,
+			expectMessage: "",
+		},
+		{
+			test:          "plugin ignores server stream issued challenge",
+			pluginImpl:    &fakeV1Plugin{payload: payload},
+			streamImpl:    streamBuilder.ExpectThenChallenge(payload, challenge).Build(),
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin closed stream before handling the challenge",
+		},
+		{
+			test:          "plugin fails responding to challenge",
+			pluginImpl:    &fakeV1Plugin{payload: payload, challengeResponses: challengeResponses(challenge, challengeResponse), challengeResponseErr: errors.New("ohno")},
+			streamImpl:    streamBuilder.ExpectThenChallenge(payload, challenge).Build(),
+			expectCode:    codes.Unknown,
+			expectMessage: "nodeattestor(test): ohno",
+		},
+		{
+			test:          "plugin answers server stream issued challenge correctly",
+			pluginImpl:    &fakeV1Plugin{payload: payload, challengeResponses: challengeResponses(challenge, challengeResponse)},
+			streamImpl:    streamBuilder.ExpectThenChallenge(payload, challenge).ExpectAndBuild(challengeResponse),
+			expectCode:    codes.OK,
+			expectMessage: "",
+		},
+		{
+			test:          "plugin answers server stream issued challenge incorrectly",
+			pluginImpl:    &fakeV1Plugin{payload: payload, challengeResponses: challengeResponses(challenge, []byte("foo"))},
+			streamImpl:    streamBuilder.ExpectThenChallenge(payload, challenge).ExpectAndBuild(challengeResponse),
+			expectCode:    codes.InvalidArgument,
+			expectMessage: `expected attestation payload "challengeResponse"; got "foo"`,
+		},
+		{
+			test:          "plugin response with empty challenge response",
+			pluginImpl:    &fakeV1Plugin{payload: payload, challengeResponses: challengeResponses(challenge, nil)},
+			streamImpl:    streamBuilder.ExpectThenChallenge(payload, challenge).ExpectAndBuild(challengeResponse),
+			expectCode:    codes.Internal,
+			expectMessage: "nodeattestor(test): plugin response missing challenge response",
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			nodeattestor := loadV1Plugin(t, tt.pluginImpl)
+			err := nodeattestor.Attest(context.Background(), tt.streamImpl)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func loadV1Plugin(t *testing.T, fake *fakeV1Plugin) nodeattestor.NodeAttestor {
+	server := nodeattestorv1.NodeAttestorPluginServer(fake)
+
+	v1 := new(nodeattestor.V1)
+	plugintest.Load(t, catalog.MakeBuiltIn("test", server), v1)
+	return v1
+}
+
+type fakeV1Plugin struct {
+	nodeattestorv1.UnimplementedNodeAttestorServer
+
+	closeStream bool
+	payload     []byte
+	payloadErr  error
+
+	challengeResponses   map[string]string
+	challengeResponseErr error
+}
+
+func (plugin *fakeV1Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) error {
+	if plugin.closeStream {
+		return nil
+	}
+	if plugin.payloadErr != nil {
+		return plugin.payloadErr
+	}
+
+	payloadResp := &nodeattestorv1.PayloadOrChallengeResponse{}
+	if plugin.payload != nil {
+		payloadResp.Data = &nodeattestorv1.PayloadOrChallengeResponse_Payload{
+			Payload: plugin.payload,
+		}
+	}
+
+	if err := stream.Send(payloadResp); err != nil {
+		return err
+	}
+
+	for len(plugin.challengeResponses) > 0 {
+		req, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		challenge := string(req.Challenge)
+		if plugin.challengeResponseErr != nil {
+			return plugin.challengeResponseErr
+		}
+		response, ok := plugin.challengeResponses[challenge]
+		if !ok {
+			return fmt.Errorf("test not configured to handle challenge %q", challenge)
+		}
+		delete(plugin.challengeResponses, challenge)
+		if err := stream.Send(&nodeattestorv1.PayloadOrChallengeResponse{
+			Data: &nodeattestorv1.PayloadOrChallengeResponse_ChallengeResponse{
+				ChallengeResponse: []byte(response),
+			},
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
In addition to adding the V1 facade it:

- Adds v1 to the server catalog and deprecates v0.
- Converts the join_token, k8s_sat, and k8s_psat plugins to v1.
- Removes the processing of the TrustDomain configurable from the since it has not been needed by agent-side NodeAttestors for quite some time.
- Updated plugin unit-tests to go through the facade layer.

The rest of the Agent NodeAttestor plugins will be updated in later PRs.

Signed-off-by: Andrew Harding <aharding@vmware.com>