### PR TITLE
Introduce Server V1 NodeResolver facade

### DIFF
--- a/pkg/server/catalog/noderesolver.go
+++ b/pkg/server/catalog/noderesolver.go
@@ -19,7 +19,7 @@ func (repo *nodeResolverRepository) Constraints() catalog.Constraints {
 }
 
 func (repo *nodeResolverRepository) Versions() []catalog.Version {
-	return []catalog.Version{nodeResolverV0{}}
+	return []catalog.Version{nodeResolverV1{}}
 }
 
 func (repo *nodeResolverRepository) LegacyVersion() (catalog.Version, bool) {
@@ -32,7 +32,12 @@ func (repo *nodeResolverRepository) BuiltIns() []catalog.BuiltIn {
 	}
 }
 
+type nodeResolverV1 struct{}
+
+func (nodeResolverV1) New() catalog.Facade { return new(noderesolver.V1) }
+func (nodeResolverV1) Deprecated() bool    { return false }
+
 type nodeResolverV0 struct{}
 
 func (nodeResolverV0) New() catalog.Facade { return new(noderesolver.V0) }
-func (nodeResolverV0) Deprecated() bool    { return false }
+func (nodeResolverV0) Deprecated() bool    { return true }

--- a/pkg/server/plugin/noderesolver/azure/msi.go
+++ b/pkg/server/plugin/noderesolver/azure/msi.go
@@ -15,15 +15,15 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
-	"github.com/zeebo/errs"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	noderesolverv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/noderesolver/v1"
+	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/common/telemetry"
-	"github.com/spiffe/spire/proto/spire/common"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
-	noderesolverv0 "github.com/spiffe/spire/proto/spire/plugin/server/noderesolver/v0"
 )
 
 const (
@@ -31,8 +31,6 @@ const (
 )
 
 var (
-	msiError = errs.Class("azure-msi")
-
 	reAgentIDPath            = regexp.MustCompile(`^/spire/agent/azure_msi/([^/]+)/([^/]+)`)
 	reVirtualMachineID       = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Compute/virtualMachines/([^/]+)$`)
 	reNetworkSecurityGroupID = regexp.MustCompile(`^/subscriptions/[^/]+/resourceGroups/([^/]+)/providers/Microsoft.Network/networkSecurityGroups/([^/]+)$`)
@@ -46,7 +44,8 @@ func BuiltIn() catalog.BuiltIn {
 
 func builtin(p *MSIResolverPlugin) catalog.BuiltIn {
 	return catalog.MakeBuiltIn(pluginName,
-		noderesolverv0.NodeResolverPluginServer(p),
+		noderesolverv1.NodeResolverPluginServer(p),
+		configv1.ConfigServiceServer(p),
 	)
 }
 
@@ -62,7 +61,8 @@ type MSIResolverConfig struct {
 }
 
 type MSIResolverPlugin struct {
-	noderesolverv0.UnsafeNodeResolverServer
+	noderesolverv1.UnsafeNodeResolverServer
+	configv1.UnsafeConfigServer
 
 	log           hclog.Logger
 	mu            sync.RWMutex
@@ -86,27 +86,21 @@ func (p *MSIResolverPlugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *MSIResolverPlugin) Resolve(ctx context.Context, req *noderesolverv0.ResolveRequest) (*noderesolverv0.ResolveResponse, error) {
-	resp := &noderesolverv0.ResolveResponse{
-		Map: make(map[string]*common.Selectors),
-	}
-	for _, spiffeID := range req.BaseSpiffeIdList {
-		selectors, err := p.resolveSpiffeID(ctx, spiffeID)
-		if err != nil {
-			return nil, err
-		}
-		if selectors != nil {
-			resp.Map[spiffeID] = selectors
-		}
+func (p *MSIResolverPlugin) Resolve(ctx context.Context, req *noderesolverv1.ResolveRequest) (*noderesolverv1.ResolveResponse, error) {
+	selectorValues, err := p.resolve(ctx, req.AgentId)
+	if err != nil {
+		return nil, err
 	}
 
-	return resp, nil
+	return &noderesolverv1.ResolveResponse{
+		SelectorValues: selectorValues,
+	}, nil
 }
 
-func (p *MSIResolverPlugin) Configure(ctx context.Context, req *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
+func (p *MSIResolverPlugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
 	config := new(MSIResolverConfig)
-	if err := hcl.Decode(config, req.Configuration); err != nil {
-		return nil, msiError.New("unable to decode configuration: %v", err)
+	if err := hcl.Decode(config, req.HclConfiguration); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)
 	}
 
 	var msiClient apiClient
@@ -114,46 +108,42 @@ func (p *MSIResolverPlugin) Configure(ctx context.Context, req *spi.ConfigureReq
 
 	if config.UseMSI {
 		if len(config.Tenants) > 0 {
-			return nil, msiError.New("configuration cannot have tenants when using MSI")
+			return nil, status.Error(codes.InvalidArgument, "configuration cannot have tenants when using MSI")
 		}
 		instanceMetadata, err := p.hooks.fetchInstanceMetadata(ctx, http.DefaultClient)
 		if err != nil {
-			return nil, msiError.Wrap(err)
+			return nil, err
 		}
 		authorizer, err := auth.NewMSIConfig().Authorizer()
 		if err != nil {
-			return nil, msiError.Wrap(err)
+			return nil, status.Errorf(codes.Internal, "unable to get MSI authorizer: %v", err)
 		}
 		msiClient = p.hooks.newClient(instanceMetadata.Compute.SubscriptionID, authorizer)
 	} else {
 		if len(config.Tenants) == 0 {
-			return nil, msiError.New("configuration must have at least one tenant when not using MSI")
+			return nil, status.Error(codes.InvalidArgument, "configuration must have at least one tenant when not using MSI")
 		}
 		tenantClients = make(map[string]apiClient)
 		for tenantID, tenant := range config.Tenants {
 			if tenant.SubscriptionID == "" {
-				return nil, msiError.New("misconfigured tenant %q: missing subscription id", tenantID)
+				return nil, status.Errorf(codes.InvalidArgument, "misconfigured tenant %q: missing subscription id", tenantID)
 			}
 			if tenant.AppID == "" {
-				return nil, msiError.New("misconfigured tenant %q: missing app id", tenantID)
+				return nil, status.Errorf(codes.InvalidArgument, "misconfigured tenant %q: missing app id", tenantID)
 			}
 			if tenant.AppSecret == "" {
-				return nil, msiError.New("misconfigured tenant %q: missing app secret", tenantID)
+				return nil, status.Errorf(codes.InvalidArgument, "misconfigured tenant %q: missing app secret", tenantID)
 			}
 			authorizer, err := auth.NewClientCredentialsConfig(tenant.AppID, tenant.AppSecret, tenantID).Authorizer()
 			if err != nil {
-				return nil, msiError.Wrap(err)
+				return nil, status.Errorf(codes.Internal, "unable to get tenant authorizer: %v", err)
 			}
 			tenantClients[tenantID] = p.hooks.newClient(tenant.SubscriptionID, authorizer)
 		}
 	}
 
 	p.setClients(msiClient, tenantClients)
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (p *MSIResolverPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
+	return &configv1.ConfigureResponse{}, nil
 }
 
 func (p *MSIResolverPlugin) getClient(tenantID string) (apiClient, error) {
@@ -166,11 +156,11 @@ func (p *MSIResolverPlugin) getClient(tenantID string) (apiClient, error) {
 	case p.tenantClients != nil:
 		client, ok := p.tenantClients[tenantID]
 		if !ok {
-			return nil, msiError.New("not configured for tenant %q", tenantID)
+			return nil, status.Errorf(codes.InvalidArgument, "not configured for tenant %q", tenantID)
 		}
 		return client, nil
 	default:
-		return nil, msiError.New("not configured")
+		return nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
 }
 
@@ -181,16 +171,16 @@ func (p *MSIResolverPlugin) setClients(msiClient apiClient, tenantClients map[st
 	p.tenantClients = tenantClients
 }
 
-func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string) (*common.Selectors, error) {
+func (p *MSIResolverPlugin) resolve(ctx context.Context, agentID string) ([]string, error) {
 	// parse out the tenant ID and principal ID from the token
-	u, err := idutil.ParseSpiffeID(spiffeID, idutil.AllowAnyTrustDomainAgent())
+	u, err := idutil.ParseSpiffeID(agentID, idutil.AllowAnyTrustDomainAgent())
 	if err != nil {
-		return nil, msiError.Wrap(err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid agent ID: %v", err)
 	}
 
 	tenantID, principalID, err := parseAgentIDPath(u.Path)
 	if err != nil {
-		p.log.Warn("Unrecognized agent ID", telemetry.SPIFFEID, spiffeID)
+		p.log.Warn("Unrecognized agent ID", telemetry.SPIFFEID, agentID)
 		return nil, nil
 	}
 
@@ -202,7 +192,7 @@ func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string
 	// Retrieve the resource belonging to the principal id.
 	vmResourceID, err := client.GetVirtualMachineResourceID(ctx, principalID)
 	if err != nil {
-		return nil, msiError.New("unable to get resource for principal %q: %v", principalID, err)
+		return nil, status.Errorf(codes.Internal, "unable to get resource for principal %q: %v", principalID, err)
 	}
 
 	// parse out the resource group and vm name from the resource ID
@@ -226,7 +216,7 @@ func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string
 	// pull the VM information and gather selectors
 	vm, err := client.GetVirtualMachine(ctx, vmResourceGroup, vmName)
 	if err != nil {
-		return nil, msiError.New("unable to get virtual machine %q: %v", resourceGroupName(vmResourceGroup, vmName), err)
+		return nil, status.Errorf(codes.Internal, "unable to get virtual machine %q: %v", resourceGroupName(vmResourceGroup, vmName), err)
 	}
 	if vm.NetworkProfile != nil {
 		networkProfileSelectors, err := getNetworkProfileSelectors(ctx, client, vm.NetworkProfile)
@@ -243,15 +233,7 @@ func (p *MSIResolverPlugin) resolveSpiffeID(ctx context.Context, spiffeID string
 	}
 	sort.Strings(selectorValues)
 
-	selectors := &common.Selectors{}
-	for _, selectorValue := range selectorValues {
-		selectors.Entries = append(selectors.Entries, &common.Selector{
-			Type:  pluginName,
-			Value: selectorValue,
-		})
-	}
-
-	return selectors, nil
+	return selectorValues, nil
 }
 
 func getNetworkProfileSelectors(ctx context.Context, client apiClient, networkProfile *compute.NetworkProfile) ([]string, error) {
@@ -270,7 +252,7 @@ func getNetworkProfileSelectors(ctx context.Context, client apiClient, networkPr
 		}
 		networkInterface, err := client.GetNetworkInterface(ctx, niResourceGroup, niName)
 		if err != nil {
-			return nil, msiError.New("unable to get network interface %q: %v", resourceGroupName(niResourceGroup, niName), err)
+			return nil, status.Errorf(codes.Internal, "unable to get network interface %q: %v", resourceGroupName(niResourceGroup, niName), err)
 		}
 
 		networkInterfaceSelectors, err := getNetworkInterfaceSelectors(networkInterface)
@@ -315,7 +297,7 @@ func getNetworkInterfaceSelectors(networkInterface *network.Interface) ([]string
 func parseAgentIDPath(path string) (tenantID, principalID string, err error) {
 	m := reAgentIDPath.FindStringSubmatch(path)
 	if m == nil {
-		return "", "", msiError.New("malformed agent ID path %q", path)
+		return "", "", status.Errorf(codes.InvalidArgument, "malformed agent ID path %q", path)
 	}
 	return m[1], m[2], nil
 }
@@ -323,7 +305,7 @@ func parseAgentIDPath(path string) (tenantID, principalID string, err error) {
 func parseVirtualMachineID(id string) (resourceGroup, name string, err error) {
 	m := reVirtualMachineID.FindStringSubmatch(id)
 	if m == nil {
-		return "", "", msiError.New("malformed virtual machine ID %q", id)
+		return "", "", status.Errorf(codes.Internal, "malformed virtual machine ID %q", id)
 	}
 	return m[1], m[2], nil
 }
@@ -331,7 +313,7 @@ func parseVirtualMachineID(id string) (resourceGroup, name string, err error) {
 func parseNetworkSecurityGroupID(id string) (resourceGroup, name string, err error) {
 	m := reNetworkSecurityGroupID.FindStringSubmatch(id)
 	if m == nil {
-		return "", "", msiError.New("malformed network security group ID %q", id)
+		return "", "", status.Errorf(codes.Internal, "malformed network security group ID %q", id)
 	}
 	return m[1], m[2], nil
 }
@@ -339,7 +321,7 @@ func parseNetworkSecurityGroupID(id string) (resourceGroup, name string, err err
 func parseNetworkInterfaceID(id string) (resourceGroup, name string, err error) {
 	m := reNetworkInterfaceID.FindStringSubmatch(id)
 	if m == nil {
-		return "", "", msiError.New("malformed network interface ID %q", id)
+		return "", "", status.Errorf(codes.Internal, "malformed network interface ID %q", id)
 	}
 	return m[1], m[2], nil
 }
@@ -347,7 +329,7 @@ func parseNetworkInterfaceID(id string) (resourceGroup, name string, err error) 
 func parseVirtualNetworkSubnetID(id string) (resourceGroup, networkName, subnetName string, err error) {
 	m := reVirtualNetworkSubnetID.FindStringSubmatch(id)
 	if m == nil {
-		return "", "", "", msiError.New("malformed virtual network subnet ID %q", id)
+		return "", "", "", status.Errorf(codes.Internal, "malformed virtual network subnet ID %q", id)
 	}
 	return m[1], m[2], m[3], nil
 }

--- a/pkg/server/plugin/noderesolver/v1.go
+++ b/pkg/server/plugin/noderesolver/v1.go
@@ -1,0 +1,34 @@
+package noderesolver
+
+import (
+	"context"
+
+	noderesolverv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/noderesolver/v1"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/proto/spire/common"
+)
+
+type V1 struct {
+	plugin.Facade
+	noderesolverv1.NodeResolverPluginClient
+}
+
+func (v1 *V1) Resolve(ctx context.Context, agentID string) ([]*common.Selector, error) {
+	resp, err := v1.NodeResolverPluginClient.Resolve(ctx, &noderesolverv1.ResolveRequest{
+		AgentId: agentID,
+	})
+	if err != nil {
+		return nil, v1.WrapErr(err)
+	}
+	var selectors []*common.Selector
+	if resp.SelectorValues != nil {
+		selectors = make([]*common.Selector, 0, len(resp.SelectorValues))
+		for _, selectorValue := range resp.SelectorValues {
+			selectors = append(selectors, &common.Selector{
+				Type:  v1.Name(),
+				Value: selectorValue,
+			})
+		}
+	}
+	return selectors, nil
+}

--- a/pkg/server/plugin/noderesolver/v1_test.go
+++ b/pkg/server/plugin/noderesolver/v1_test.go
@@ -1,0 +1,65 @@
+package noderesolver_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	noderesolverv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/noderesolver/v1"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/noderesolver"
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestV1(t *testing.T) {
+	nr := loadV1Plugin(t)
+
+	t.Run("success with selectors", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "with-selectors")
+		assert.NoError(t, err)
+		spiretest.AssertProtoListEqual(t, []*common.Selector{{Type: "test", Value: "VALUE"}}, actualSelectors)
+	})
+
+	t.Run("success without selectors", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "without-selectors")
+		assert.NoError(t, err)
+		assert.Empty(t, actualSelectors)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		actualSelectors, err := nr.Resolve(context.Background(), "bad")
+		spiretest.AssertGRPCStatus(t, err, codes.FailedPrecondition, "noderesolver(test): ohno")
+		assert.Nil(t, actualSelectors)
+	})
+}
+
+func loadV1Plugin(t *testing.T) noderesolver.NodeResolver {
+	server := noderesolverv1.NodeResolverPluginServer(&v1Plugin{})
+
+	v1 := new(noderesolver.V1)
+	plugintest.Load(t, catalog.MakeBuiltIn("test", server), v1)
+	return v1
+}
+
+type v1Plugin struct {
+	noderesolverv1.UnimplementedNodeResolverServer
+}
+
+func (plugin *v1Plugin) Resolve(ctx context.Context, req *noderesolverv1.ResolveRequest) (*noderesolverv1.ResolveResponse, error) {
+	resp := &noderesolverv1.ResolveResponse{}
+	switch req.AgentId {
+	case "with-selectors":
+		resp.SelectorValues = []string{"VALUE"}
+	case "without-selectors":
+	case "bad":
+		return nil, status.Error(codes.FailedPrecondition, "ohno")
+	default:
+		return nil, fmt.Errorf("test setup failure; not agent %q", req.AgentId)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
- adds v1 to the catalog and deprecates v0
- migrates the azure_msi node resolver plugin to v1