### PR TITLE
Fix join_token plugin error message

### DIFF
--- a/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
+++ b/pkg/agent/plugin/nodeattestor/jointoken/join_token.go
@@ -28,5 +28,13 @@ func New() *Plugin {
 }
 
 func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) error {
-	return status.Error(codes.Internal, "join token attestation is currently implemented within the agent")
+	// The agent handles the case where the join token is set using special
+	// cased code. The special code is only activated when the join token has
+	// been provided via CLI flag or HCL configuration, whether or not the
+	// join_token node attestor has been configured. If the join token is not
+	// set, but the join_token node attestor is configured, then the special
+	// case code will not be activated and this plugin will end up being
+	// invoked. The message we return here should educate operators that they
+	// failed to provide a join token.
+	return status.Error(codes.InvalidArgument, "join token was not provided")
 }


### PR DESCRIPTION
The agent handles the case where the join token is set using special cased code. The special code is only activated when the join token has been provided via CLI flag or HCL configuration, whether or not the join_token node attestor has been configured. If the join token is not set, but the join_token node attestor is configured, then the special case code will not be activated and this plugin will end up being invoked.

This change update the error message returned by the plugin to inform operators that the join token was not provided.
