### PR TITLE
Fix typo in server_full.conf and UpstreamAuthority plugin doc

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -207,7 +207,7 @@ plugins {
     #         region: AWS Region to use.
     #         region = ""
     #
-    #         key_metadata_file: A file path location where information about generated keys will be persisted 
+    #         key_metadata_file: A file path location where information about generated keys will be persisted
     #         key_metadata_file = "./file_path"
     #     }
     # }
@@ -494,7 +494,7 @@ plugins {
             key_file_path = "./conf/server/dummy_upstream_ca.key"
 
             # cert_file_path: If SPIRE is using a self-signed CA, cert_file_path
-            # should specify the path to a a single PEM encoded certificate
+            # should specify the path to a single PEM encoded certificate
             # representing the upstream CA certificate. If not self-signed,
             # cert_file_path should specify the path to a file that must contain
             # one or more certificates necessary to establish a valid certificate

--- a/doc/plugin_server_upstreamauthority_disk.md
+++ b/doc/plugin_server_upstreamauthority_disk.md
@@ -16,7 +16,7 @@ The plugin accepts the following configuration options:
 
 | Configuration   | Description                                          |
 | ----------------| ---------------------------------------------------- |
-| cert_file_path  | If SPIRE is using a self-signed CA, `cert_file_path` should specify the path to a a single PEM encoded certificate representing the upstream CA certificate. If not self-signed, `cert_file_path` should specify the path to a file that must contain one or more certificates necessary to establish a valid certificate chain up the root certificates defined in `bundle_file_path`. |
+| cert_file_path  | If SPIRE is using a self-signed CA, `cert_file_path` should specify the path to a single PEM encoded certificate representing the upstream CA certificate. If not self-signed, `cert_file_path` should specify the path to a file that must contain one or more certificates necessary to establish a valid certificate chain up the root certificates defined in `bundle_file_path`. |
 | key_file_path   | Path to the "upstream" CA key file. Key files must contain a single PEM encoded key. The supported key types are EC (ASN.1 or PKCS8 encoded) or RSA (PKCS1 or PKCS8 encoded).|
 | bundle_file_path| If SPIRE is using a self-signed CA, `bundle_file_path` can be left unset. If not self-signed, then `bundle_file_path` should be the path to a file that must contain one or more certificates representing the upstream root certificates and the file at cert_file_path contains one or more certificates necessary to chain up the the root certificates in bundle_file_path (where the first certificate in cert_file_path is the upstream CA certificate). |
 
@@ -25,8 +25,8 @@ The `disk` plugin is able to function as either a root CA, or join an existing P
 When joining an existing PKI, the trust bundle for that PKI MUST be set explicitly
 using the `bundle_file_path` option; this MUST contain the certificates of the trusted
 roots for the PKI being joined in PEM format. When using the `bundle_file_path` option
-`cert_file_path` MUST contain a chain of certificates, in PEM format, up to the trusted 
-root. 
+`cert_file_path` MUST contain a chain of certificates, in PEM format, up to the trusted
+root.
 
 When functioning as a root CA, the trust bundle is unused. The `cert_file_path` MUST contain
 exactly one certificate which is self-signed and `key_file_path` MUST contain the key for


### PR DESCRIPTION
Signed-off-by: Alexander Viktorov <aviktorov@uber.com>

**Affected functionality**
None, comment/doc fix

**Description of change**
Fix typo (duplicate 'a')

