### PR TITLE
Add V1 AgentStore service server to server

### DIFF
--- a/pkg/server/hostservice/agentstore/agentstore.go
+++ b/pkg/server/hostservice/agentstore/agentstore.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync"
 
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/server/datastore"
 	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"google.golang.org/grpc/codes"
@@ -17,8 +18,6 @@ type Deps struct {
 }
 
 type AgentStore struct {
-	agentstorev0.UnsafeAgentStoreServer
-
 	mu   sync.RWMutex
 	deps *Deps
 }
@@ -46,8 +45,22 @@ func (s *AgentStore) getDeps() (*Deps, error) {
 	return s.deps, nil
 }
 
-func (s *AgentStore) GetAgentInfo(ctx context.Context, req *agentstorev0.GetAgentInfoRequest) (*agentstorev0.GetAgentInfoResponse, error) {
-	deps, err := s.getDeps()
+func (s *AgentStore) V0() agentstorev0.AgentStoreServer {
+	return &agentStoreV0{s: s}
+}
+
+func (s *AgentStore) V1() agentstorev1.AgentStoreServer {
+	return &agentStoreV1{s: s}
+}
+
+type agentStoreV0 struct {
+	agentstorev0.UnsafeAgentStoreServer
+
+	s *AgentStore
+}
+
+func (v0 *agentStoreV0) GetAgentInfo(ctx context.Context, req *agentstorev0.GetAgentInfoRequest) (*agentstorev0.GetAgentInfoResponse, error) {
+	deps, err := v0.s.getDeps()
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +75,33 @@ func (s *AgentStore) GetAgentInfo(ctx context.Context, req *agentstorev0.GetAgen
 
 	return &agentstorev0.GetAgentInfoResponse{
 		Info: &agentstorev0.AgentInfo{
+			AgentId: req.AgentId,
+		},
+	}, nil
+}
+
+type agentStoreV1 struct {
+	agentstorev1.UnsafeAgentStoreServer
+
+	s *AgentStore
+}
+
+func (v1 *agentStoreV1) GetAgentInfo(ctx context.Context, req *agentstorev1.GetAgentInfoRequest) (*agentstorev1.GetAgentInfoResponse, error) {
+	deps, err := v1.s.getDeps()
+	if err != nil {
+		return nil, err
+	}
+
+	attestedNode, err := deps.DataStore.FetchAttestedNode(ctx, req.AgentId)
+	if err != nil {
+		return nil, err
+	}
+	if attestedNode == nil {
+		return nil, status.Error(codes.NotFound, "no such agent")
+	}
+
+	return &agentstorev1.GetAgentInfoResponse{
+		Info: &agentstorev1.AgentInfo{
 			AgentId: req.AgentId,
 		},
 	}, nil

--- a/pkg/server/hostservice/agentstore/agentstore_test.go
+++ b/pkg/server/hostservice/agentstore/agentstore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/proto/spire/common"
 	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
@@ -71,17 +72,32 @@ func TestAgentStore(t *testing.T) {
 				}
 			}
 
-			resp, err := s.GetAgentInfo(context.Background(), &agentstorev0.GetAgentInfoRequest{
-				AgentId: testCase.agentID,
+			t.Run("v0", func(t *testing.T) {
+				resp, err := s.V0().GetAgentInfo(context.Background(), &agentstorev0.GetAgentInfoRequest{
+					AgentId: testCase.agentID,
+				})
+				if testCase.getErr != "" {
+					spiretest.AssertGRPCStatusContains(t, err, testCase.code, testCase.getErr)
+					assert.Nil(resp)
+					return
+				}
+				require.NoError(err)
+				require.NotNil(t, resp)
+				assert.Equal(resp.Info.AgentId, testCase.agentID)
 			})
-			if testCase.getErr != "" {
-				spiretest.AssertGRPCStatusContains(t, err, testCase.code, testCase.getErr)
-				assert.Nil(resp)
-				return
-			}
-			require.NoError(err)
-			require.NotNil(t, resp)
-			assert.Equal(resp.Info.AgentId, testCase.agentID)
+			t.Run("v1", func(t *testing.T) {
+				resp, err := s.V1().GetAgentInfo(context.Background(), &agentstorev1.GetAgentInfoRequest{
+					AgentId: testCase.agentID,
+				})
+				if testCase.getErr != "" {
+					spiretest.AssertGRPCStatusContains(t, err, testCase.code, testCase.getErr)
+					assert.Nil(resp)
+					return
+				}
+				require.NoError(err)
+				require.NotNil(t, resp)
+				assert.Equal(resp.Info.AgentId, testCase.agentID)
+			})
 		})
 	}
 }

--- a/pkg/server/hostservice/agentstore/attestation.go
+++ b/pkg/server/hostservice/agentstore/attestation.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func EnsureNotAttested(ctx context.Context, store agentstorev0.AgentStoreClient, agentID string) error {
+func EnsureNotAttested(ctx context.Context, store agentstorev1.AgentStoreClient, agentID string) error {
 	attested, err := IsAttested(ctx, store, agentID)
 	switch {
 	case err != nil:
@@ -22,8 +22,8 @@ func EnsureNotAttested(ctx context.Context, store agentstorev0.AgentStoreClient,
 	}
 }
 
-func IsAttested(ctx context.Context, store agentstorev0.AgentStoreClient, agentID string) (bool, error) {
-	_, err := store.GetAgentInfo(ctx, &agentstorev0.GetAgentInfoRequest{
+func IsAttested(ctx context.Context, store agentstorev1.AgentStoreClient, agentID string) (bool, error) {
+	_, err := store.GetAgentInfo(ctx, &agentstorev1.GetAgentInfoRequest{
 		AgentId: agentID,
 	})
 	switch status.Code(err) {

--- a/pkg/server/hostservice/agentstore/attestation_test.go
+++ b/pkg/server/hostservice/agentstore/attestation_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -45,11 +45,11 @@ func TestIsAttested(t *testing.T) {
 
 type fakeAgentStore struct{}
 
-func (fakeAgentStore) GetAgentInfo(ctx context.Context, in *agentstorev0.GetAgentInfoRequest, dialOpts ...grpc.CallOption) (*agentstorev0.GetAgentInfoResponse, error) {
+func (fakeAgentStore) GetAgentInfo(ctx context.Context, in *agentstorev1.GetAgentInfoRequest, dialOpts ...grpc.CallOption) (*agentstorev1.GetAgentInfoResponse, error) {
 	switch in.AgentId {
 	case "spiffe://domain.test/spire/agent/test/attested":
-		return &agentstorev0.GetAgentInfoResponse{
-			Info: &agentstorev0.AgentInfo{
+		return &agentstorev1.GetAgentInfoResponse{
+			Info: &agentstorev1.AgentInfo{
 				AgentId: in.AgentId,
 			},
 		}, nil

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/golang/mock/gomock"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
 	mock_aws "github.com/spiffe/spire/test/mock/server/aws"
 	"github.com/spiffe/spire/test/plugintest"
@@ -85,7 +85,7 @@ func (s *IIDAttestorSuite) SetupTest() {
 	s.agentStore = fakeagentstore.New()
 
 	s.plugin, s.attestor = s.loadPlugin(nil, plugintest.Configure(`skip_block_device=true`),
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
@@ -95,7 +95,7 @@ func (s *IIDAttestorSuite) SetupTest() {
 func (s *IIDAttestorSuite) TestErrorWhenNotConfigured() {
 	attestor := new(nodeattestor.V1)
 	plugintest.Load(s.T(), BuiltIn(), attestor,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 	)
 
 	s.attestor = attestor
@@ -123,7 +123,7 @@ func (s *IIDAttestorSuite) TestErrorOnAlreadyAttested() {
 	clients := newClientsCache(mockGetEC2Client)
 
 	plugin, attestor := s.loadPlugin(clients, plugintest.Configure(`skip_block_device=true`),
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}))
@@ -131,7 +131,7 @@ func (s *IIDAttestorSuite) TestErrorOnAlreadyAttested() {
 	plugin.config.awsCaCertPublicKey = &s.rsaKey.PublicKey
 
 	agentID := "spiffe://example.org/spire/agent/aws_iid/test-account/test-region/test-instance"
-	s.agentStore.SetAgentInfo(&agentstorev0.AgentInfo{
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
 		AgentId: agentID,
 	})
 
@@ -433,7 +433,7 @@ func (s *IIDAttestorSuite) TestClientAndIDReturns() {
 			}
 
 			plugin, attestor := s.loadPlugin(clients, plugintest.Configure(configStr),
-				plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+				plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 				plugintest.CoreConfig(catalog.CoreConfig{
 					TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 				}))
@@ -469,7 +469,7 @@ func (s *IIDAttestorSuite) TestErrorOnBadSVIDTemplate() {
 	var err error
 	plugintest.Load(s.T(), BuiltIn(), nil,
 		plugintest.CaptureConfigureError(&err),
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
@@ -492,7 +492,7 @@ func (s *IIDAttestorSuite) TestConfigure() {
 
 		plugintest.Load(t, builtin(attestor), nil,
 			plugintest.CaptureConfigureError(&err),
-			plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+			plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 			plugintest.CoreConfig(coreConfig),
 			plugintest.Configure(config),
 		)

--- a/pkg/server/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/server/plugin/nodeattestor/azure/msi_test.go
@@ -10,12 +10,12 @@ import (
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/jwtutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/plugin/azure"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
@@ -76,7 +76,7 @@ func (s *MSIAttestorSuite) SetupTest() {
 func (s *MSIAttestorSuite) TestAttestFailsWhenNotConfigured() {
 	attestor := new(nodeattestor.V1)
 	plugintest.Load(s.T(), BuiltIn(), attestor,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 	)
 	s.attestor = attestor
 	s.requireAttestError(s.T(), []byte("payload"), codes.FailedPrecondition, "nodeattestor(azure_msi): not configured")
@@ -224,7 +224,7 @@ func (s *MSIAttestorSuite) TestAttestFailsWhenAttestedBefore() {
 	s.addKey()
 
 	agentID := "spiffe://example.org/spire/agent/azure_msi/TENANTID/PRINCIPALID"
-	s.agentStore.SetAgentInfo(&agentstorev0.AgentInfo{
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
 		AgentId: agentID,
 	})
 	s.requireAttestError(s.T(), s.signAttestPayload("KEYID", resourceID, "TENANTID", "PRINCIPALID"),
@@ -237,7 +237,7 @@ func (s *MSIAttestorSuite) TestConfigure() {
 		var err error
 		plugintest.Load(t, BuiltIn(), nil,
 			plugintest.CaptureConfigureError(&err),
-			plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+			plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 			plugintest.CoreConfig(coreConfig),
 			plugintest.Configure(config),
 		)
@@ -341,7 +341,7 @@ func (s *MSIAttestorSuite) loadPlugin() nodeattestor.NodeAttestor {
 	v1 := new(nodeattestor.V1)
 
 	plugintest.Load(s.T(), builtin(attestor), v1,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),

--- a/pkg/server/plugin/nodeattestor/base/base.go
+++ b/pkg/server/plugin/nodeattestor/base/base.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/server/hostservice/agentstore"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 )
 
 type Base struct {
-	store agentstorev0.AgentStoreServiceClient
+	store agentstorev1.AgentStoreServiceClient
 }
 
 var _ pluginsdk.NeedsHostServices = (*Base)(nil)

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -9,13 +9,13 @@ import (
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
@@ -60,7 +60,7 @@ func (s *IITAttestorSuite) SetupTest() {
 func (s *IITAttestorSuite) TestErrorWhenNotConfigured() {
 	attestor := new(nodeattestor.V1)
 	plugintest.Load(s.T(), BuiltIn(), attestor,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 	)
 	s.attestor = attestor
 	s.requireAttestError(s.T(), []byte("payload"), codes.FailedPrecondition, "nodeattestor(gcp_iit): not configured")
@@ -99,7 +99,7 @@ func (s *IITAttestorSuite) TestErrorOnAttestedBefore() {
 	token := buildToken()
 	payload := s.signToken(token)
 
-	s.agentStore.SetAgentInfo(&agentstorev0.AgentInfo{
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
 		AgentId: testAgentID,
 	})
 
@@ -270,7 +270,7 @@ func (s *IITAttestorSuite) TestConfigure() {
 		var err error
 		plugintest.Load(t, BuiltIn(), nil,
 			plugintest.CaptureConfigureError(&err),
-			plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+			plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 			plugintest.CoreConfig(coreConfig),
 			plugintest.Configure(config),
 		)
@@ -332,11 +332,11 @@ func (s *IITAttestorSuite) loadPluginWithConfig(config string) nodeattestor.Node
 
 	v1 := new(nodeattestor.V1)
 	plugintest.Load(s.T(), builtin(p), v1,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.Configure(config),
 	)
 

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -20,11 +20,11 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
 	k8s_apiserver_mock "github.com/spiffe/spire/test/mock/common/plugin/k8s/apiserver"
 	"github.com/spiffe/spire/test/plugintest"
@@ -127,7 +127,7 @@ func (s *AttestorSuite) TearDownTest() {
 func (s *AttestorSuite) TestAttestFailsWhenNotConfigured() {
 	attestor := new(nodeattestor.V1)
 	plugintest.Load(s.T(), BuiltIn(), attestor,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 	)
 	s.attestor = attestor
 	s.requireAttestError([]byte("payload"), codes.FailedPrecondition, "nodeattestor(k8s_sat): not configured")
@@ -135,7 +135,7 @@ func (s *AttestorSuite) TestAttestFailsWhenNotConfigured() {
 
 func (s *AttestorSuite) TestAttestFailsWhenAttestedBefore() {
 	agentID := "spiffe://example.org/spire/agent/k8s_sat/FOO/UUID"
-	s.agentStore.SetAgentInfo(&agentstorev0.AgentInfo{
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
 		AgentId: agentID,
 	})
 
@@ -283,7 +283,7 @@ func (s *AttestorSuite) TestConfigure() {
 		var err error
 		plugintest.Load(s.T(), BuiltIn(), nil,
 			plugintest.CaptureConfigureError(&err),
-			plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+			plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 			plugintest.CoreConfig(coreConfig),
 			plugintest.Configure(config),
 		)
@@ -373,7 +373,7 @@ func (s *AttestorSuite) TestServiceAccountKeyFileAlternateEncodings() {
 	}), 0600))
 
 	plugintest.Load(s.T(), BuiltIn(), nil,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
@@ -419,7 +419,7 @@ func (s *AttestorSuite) loadPlugin() nodeattestor.NodeAttestor {
 	}
 	v1 := new(nodeattestor.V1)
 	plugintest.Load(s.T(), builtin(attestor), v1,
-		plugintest.HostServices(agentstorev0.AgentStoreServiceServer(s.agentStore)),
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(s.agentStore)),
 		plugintest.CoreConfig(catalog.CoreConfig{
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spiffe/spire/pkg/server/hostservice/identityprovider"
 	"github.com/spiffe/spire/pkg/server/registration"
 	"github.com/spiffe/spire/pkg/server/svid"
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
 	identityproviderv0 "github.com/spiffe/spire/proto/spire/hostservice/server/identityprovider/v0"
 	"google.golang.org/grpc"
 )
@@ -231,7 +230,7 @@ func (s *Server) setupProfiling(ctx context.Context) (stop func()) {
 	}
 }
 
-func (s *Server) loadCatalog(ctx context.Context, metrics telemetry.Metrics, identityProvider identityproviderv0.IdentityProviderServer, agentStore agentstorev0.AgentStoreServer,
+func (s *Server) loadCatalog(ctx context.Context, metrics telemetry.Metrics, identityProvider identityproviderv0.IdentityProviderServer, agentStore *agentstore.AgentStore,
 	healthChecker health.Checker) (*catalog.Repository, error) {
 	return catalog.Load(ctx, catalog.Config{
 		Log:              s.config.Log.WithField(telemetry.SubsystemName, telemetry.Catalog),

--- a/test/fakes/fakeagentstore/agentstore.go
+++ b/test/fakes/fakeagentstore/agentstore.go
@@ -4,31 +4,31 @@ import (
 	"context"
 	"sync"
 
-	agentstorev0 "github.com/spiffe/spire/proto/spire/hostservice/server/agentstore/v0"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 type AgentStore struct {
-	agentstorev0.UnsafeAgentStoreServer
+	agentstorev1.UnsafeAgentStoreServer
 
 	mu    sync.RWMutex
-	nodes map[string]*agentstorev0.AgentInfo
+	nodes map[string]*agentstorev1.AgentInfo
 }
 
 func New() *AgentStore {
 	return &AgentStore{
-		nodes: make(map[string]*agentstorev0.AgentInfo),
+		nodes: make(map[string]*agentstorev1.AgentInfo),
 	}
 }
 
-func (s *AgentStore) SetAgentInfo(info *agentstorev0.AgentInfo) {
+func (s *AgentStore) SetAgentInfo(info *agentstorev1.AgentInfo) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.nodes[info.AgentId] = info
 }
 
-func (s *AgentStore) GetAgentInfo(ctx context.Context, req *agentstorev0.GetAgentInfoRequest) (*agentstorev0.GetAgentInfoResponse, error) {
+func (s *AgentStore) GetAgentInfo(ctx context.Context, req *agentstorev1.GetAgentInfoRequest) (*agentstorev1.GetAgentInfoResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -36,7 +36,7 @@ func (s *AgentStore) GetAgentInfo(ctx context.Context, req *agentstorev0.GetAgen
 	if !ok {
 		return nil, status.Error(codes.NotFound, "no such node")
 	}
-	return &agentstorev0.GetAgentInfoResponse{
+	return &agentstorev1.GetAgentInfoResponse{
 		Info: info,
 	}, nil
 }


### PR DESCRIPTION
This changes the server to host a V1 AgentStore service server for plugins. The v0 metrics legacy service is still hosted until we deprecate the v0 interfaces.