### PR TITLE
Only support v0 interfaces with legacy plugins

### DIFF
--- a/pkg/agent/catalog/nodeattestor.go
+++ b/pkg/agent/catalog/nodeattestor.go
@@ -28,8 +28,6 @@ func (repo *nodeAttestorRepository) Constraints() catalog.Constraints {
 func (repo *nodeAttestorRepository) Versions() []catalog.Version {
 	return []catalog.Version{
 		nodeAttestorV1{},
-		// TODO: remove v0 once all of the built-ins have been migrated to v1
-		nodeAttestorV0{},
 	}
 }
 

--- a/pkg/common/catalog/plugin.go
+++ b/pkg/common/catalog/plugin.go
@@ -103,6 +103,7 @@ func (p *pluginImpl) bindRepos(pluginRepo bindablePluginRepo, serviceRepos []bin
 	var impl interface{}
 	if p.isLegacy() {
 		if legacyVersion, ok := pluginRepo.LegacyVersion(); ok {
+			p.log.Warn("Legacy plugins are deprecated and will be unsupported in a future release. Please migrate the plugin to use the Plugin SDK.")
 			impl = p.bindFacade(pluginRepo, legacyVersion.New())
 		} else {
 			return nil, fmt.Errorf("no legacy version available for plugin type %q", p.info.Type())

--- a/pkg/server/catalog/nodeattestor.go
+++ b/pkg/server/catalog/nodeattestor.go
@@ -28,8 +28,6 @@ func (repo *nodeAttestorRepository) Constraints() catalog.Constraints {
 func (repo *nodeAttestorRepository) Versions() []catalog.Version {
 	return []catalog.Version{
 		nodeAttestorV1{},
-		// TODO: remove v0 once all of the built-ins have been migrated to v1
-		nodeAttestorV0{},
 	}
 }
 

--- a/pkg/server/catalog/notifier.go
+++ b/pkg/server/catalog/notifier.go
@@ -22,8 +22,6 @@ func (repo *notifierRepository) Constraints() catalog.Constraints {
 func (repo *notifierRepository) Versions() []catalog.Version {
 	return []catalog.Version{
 		notifierV1{},
-		// TODO: remove v0 once all of the built-ins have been migrated to v1
-		notifierV0{},
 	}
 }
 

--- a/pkg/server/catalog/upstreamauthority.go
+++ b/pkg/server/catalog/upstreamauthority.go
@@ -27,8 +27,6 @@ func (repo *upstreamAuthorityRepository) Constraints() catalog.Constraints {
 func (repo *upstreamAuthorityRepository) Versions() []catalog.Version {
 	return []catalog.Version{
 		upstreamAuthorityV1{},
-		// TODO: remove v0 once all of the built-ins have been migrated to v1
-		upstreamAuthorityV0{},
 	}
 }
 


### PR DESCRIPTION
Now that all of the built-ins have migrated to v1, we can remove support for v0 interfaces except when loading legacy plugins.

A few of the plugin types had already done this where all built-ins for that type were ported at the time the v1 interface was introduced.