### PR TITLE
Federation configuration: have a better check to enforce HTTPS in endpoint URL

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -671,7 +671,7 @@ func validateConfig(c *Config) error {
 				}
 			case tdConfig.BundleEndpointURL == "":
 				return fmt.Errorf("federation.federates_with[\"%s\"].bundle_endpoint_url must be configured", td)
-			case !strings.HasPrefix(strings.ToLower(tdConfig.BundleEndpointURL), "https"):
+			case !strings.HasPrefix(strings.ToLower(tdConfig.BundleEndpointURL), "https://"):
 				return fmt.Errorf("federation.federates_with[\"%s\"].bundle_endpoint_url must use the HTTPS protocol; URL found: %q", td, tdConfig.BundleEndpointURL)
 			}
 		}


### PR DESCRIPTION
Check for the prefix "https://" instead of just "https" in the bundle endpoint URL.