### PR TITLE
Fix oidc discovery provider scheme on openid-configuration urls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/docker/docker v1.4.2-0.20191008235115-448db5a783a0
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad
+	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-sql-driver/mysql v1.5.0
@@ -39,6 +40,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-tpm v0.3.2
 	github.com/google/go-tpm-tools v0.2.1
+	github.com/gorilla/handlers v1.5.1
 	github.com/hashicorp/go-hclog v0.15.0
 	github.com/hashicorp/go-plugin v1.4.0
 	github.com/hashicorp/golang-lru v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,9 @@ github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -390,6 +393,8 @@ github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1a
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -34,6 +34,7 @@ The configuration file is **required** by the provider. It contains
 | -------------------- | --------| ----------- | -------------------------------------------------------- | -------- |
 | `acme`               | section | required[1] | Provides the ACME configuration.                         |          |
 | `domain`             | string  | required    | The domain the provider is being served from.            |          |
+| `insecure_addr`      | string  | required[1] | Exposes the service on http.                             |          |
 | `listen_socket_path` | string  | required[1] | Path on disk to listen with a Unix Domain Socket.        |          |
 | `log_format`         | string  | optional    | Format of the logs (either `"TEXT"` or `"JSON"`)         | `""`     |
 | `log_level`          | string  | required    | Log level (one of `"error"`,`"warn"`,`"info"`,`"debug"`) | `"info"` |

--- a/support/oidc-discovery-provider/handler_test.go
+++ b/support/oidc-discovery-provider/handler_test.go
@@ -12,7 +12,227 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-func TestHandler(t *testing.T) {
+func TestHandlerHTTPS(t *testing.T) {
+	testCases := []struct {
+		name    string
+		method  string
+		path    string
+		jwks    *jose.JSONWebKeySet
+		modTime time.Time
+		code    int
+		body    string
+	}{
+		{
+			name:   "GET well-known",
+			method: "GET",
+			path:   "/.well-known/openid-configuration",
+			code:   http.StatusOK,
+			body: `{
+  "issuer": "https://domain.test",
+  "jwks_uri": "https://domain.test/keys",
+  "authorization_endpoint": "",
+  "response_types_supported": [
+    "id_token"
+  ],
+  "subject_types_supported": [],
+  "id_token_signing_alg_values_supported": [
+    "RS256",
+    "ES256",
+    "ES384"
+  ]
+}`,
+		},
+		{
+			name:   "PUT well-known",
+			method: "PUT",
+			path:   "/.well-known/openid-configuration",
+			code:   http.StatusMethodNotAllowed,
+			body:   "method not allowed\n",
+		},
+		{
+			name:   "GET keys with no key set",
+			method: "GET",
+			path:   "/keys",
+			code:   http.StatusInternalServerError,
+			body:   "document not available\n",
+		},
+		{
+			name:   "GET keys with empty key set",
+			method: "GET",
+			path:   "/keys",
+			jwks:   new(jose.JSONWebKeySet),
+			code:   http.StatusOK,
+			body: `{
+  "keys": null
+}`,
+		},
+		{
+			name:   "GET keys with key in set",
+			method: "GET",
+			path:   "/keys",
+			jwks: &jose.JSONWebKeySet{
+				Keys: []jose.JSONWebKey{
+					{
+						Key:       ec256Pubkey,
+						KeyID:     "KEYID",
+						Algorithm: "ES256",
+					},
+				},
+			},
+			code: http.StatusOK,
+			body: `{
+  "keys": [
+    {
+      "kty": "EC",
+      "kid": "KEYID",
+      "crv": "P-256",
+      "alg": "ES256",
+      "x": "iSt7S4ih6QLodw9wf-zdPV8bmAlDJBCRRy24_UAZY70",
+      "y": "Gb4gkQCeHj7HCbZzdctcAx9dxoDgC9sudsSG7ZLIWJs"
+    }
+  ]
+}`,
+		},
+		{
+			name:   "PUT keys",
+			method: "PUT",
+			path:   "/keys",
+			code:   http.StatusMethodNotAllowed,
+			body:   "method not allowed\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			source := new(FakeKeySetSource)
+			source.SetKeySet(testCase.jwks, testCase.modTime)
+
+			r, err := http.NewRequest(testCase.method, "https://localhost"+testCase.path, nil)
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+
+			h := NewHandler("domain.test", source)
+			h.ServeHTTP(w, r)
+
+			t.Logf("HEADERS: %q", w.Header())
+			assert.Equal(t, testCase.code, w.Code)
+			assert.Equal(t, testCase.body, w.Body.String())
+		})
+	}
+}
+
+func TestHandlerHTTP(t *testing.T) {
+	testCases := []struct {
+		name    string
+		method  string
+		path    string
+		jwks    *jose.JSONWebKeySet
+		modTime time.Time
+		code    int
+		body    string
+	}{
+		{
+			name:   "GET well-known",
+			method: "GET",
+			path:   "/.well-known/openid-configuration",
+			code:   http.StatusOK,
+			body: `{
+  "issuer": "http://domain.test",
+  "jwks_uri": "http://domain.test/keys",
+  "authorization_endpoint": "",
+  "response_types_supported": [
+    "id_token"
+  ],
+  "subject_types_supported": [],
+  "id_token_signing_alg_values_supported": [
+    "RS256",
+    "ES256",
+    "ES384"
+  ]
+}`,
+		},
+		{
+			name:   "PUT well-known",
+			method: "PUT",
+			path:   "/.well-known/openid-configuration",
+			code:   http.StatusMethodNotAllowed,
+			body:   "method not allowed\n",
+		},
+		{
+			name:   "GET keys with no key set",
+			method: "GET",
+			path:   "/keys",
+			code:   http.StatusInternalServerError,
+			body:   "document not available\n",
+		},
+		{
+			name:   "GET keys with empty key set",
+			method: "GET",
+			path:   "/keys",
+			jwks:   new(jose.JSONWebKeySet),
+			code:   http.StatusOK,
+			body: `{
+  "keys": null
+}`,
+		},
+		{
+			name:   "GET keys with key in set",
+			method: "GET",
+			path:   "/keys",
+			jwks: &jose.JSONWebKeySet{
+				Keys: []jose.JSONWebKey{
+					{
+						Key:       ec256Pubkey,
+						KeyID:     "KEYID",
+						Algorithm: "ES256",
+					},
+				},
+			},
+			code: http.StatusOK,
+			body: `{
+  "keys": [
+    {
+      "kty": "EC",
+      "kid": "KEYID",
+      "crv": "P-256",
+      "alg": "ES256",
+      "x": "iSt7S4ih6QLodw9wf-zdPV8bmAlDJBCRRy24_UAZY70",
+      "y": "Gb4gkQCeHj7HCbZzdctcAx9dxoDgC9sudsSG7ZLIWJs"
+    }
+  ]
+}`,
+		},
+		{
+			name:   "PUT keys",
+			method: "PUT",
+			path:   "/keys",
+			code:   http.StatusMethodNotAllowed,
+			body:   "method not allowed\n",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			source := new(FakeKeySetSource)
+			source.SetKeySet(testCase.jwks, testCase.modTime)
+
+			r, err := http.NewRequest(testCase.method, "http://localhost"+testCase.path, nil)
+			require.NoError(t, err)
+			w := httptest.NewRecorder()
+
+			h := NewHandler("domain.test", source)
+			h.ServeHTTP(w, r)
+
+			t.Logf("HEADERS: %q", w.Header())
+			assert.Equal(t, testCase.code, w.Code)
+			assert.Equal(t, testCase.body, w.Body.String())
+		})
+	}
+}
+
+func TestHandlerProxied(t *testing.T) {
 	testCases := []struct {
 		name    string
 		method  string
@@ -110,6 +330,7 @@ func TestHandler(t *testing.T) {
 
 			r, err := http.NewRequest(testCase.method, "http://localhost"+testCase.path, nil)
 			require.NoError(t, err)
+			r.Header.Add("X-Forwarded-Scheme", "https")
 			w := httptest.NewRecorder()
 
 			h := NewHandler("domain.test", source)


### PR DESCRIPTION
This allows to deploy the oidc-discovery-provider on http, https, or behind a proxy with ssl offloading. This is a shortcoming I stumbled on when trying to embed this service in a [Helm chart](https://github.com/philips-labs/helm-charts/pull/24). The idea here is that we can make another component / helm-chart responsible for doing the ACME parts or SSL certificates.

Also updated the README for an undocumented config option. 

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

URLs in `/.well-known/openid-configuration`.

**Description of change**

The URLs match the scheme the oidc discovery provider is hosted on. Also when running behind a reverse proxy like Nginx HAProxy Traefik.

**Which issue this PR fixes**

N.A.

**Related to**:

https://github.com/philips-labs/helm-charts/pull/24

