### PR TITLE
Really fix upgrade integration test

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -148,10 +148,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # The "upgrade" integration test needs a little more history to ensure
+          # The "upgrade" integration test needs the history to ensure
           # that the version number in the source code has been bumped as
-          # expected.
-          fetch-depth: 100
+          # expected. This action does not fetch tags unless we supply a
+          # fetch depth of zero.
+          fetch-depth: 0
       - name: Setup go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -149,10 +149,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          # The "upgrade" integration test needs a little more history to ensure
+          # The "upgrade" integration test needs the history to ensure
           # that the version number in the source code has been bumped as
-          # expected.
-          fetch-depth: 100
+          # expected. This action does not fetch tags unless we supply a
+          # fetch depth of zero.
+          fetch-depth: 0
       - name: Setup go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Turns out the github checkout action will not fetch any tag information unless you specify a fetch-depth of 0, meaning "full history". Updating our CI/CD integration test checkout action to fetch depth 0 to fix the upgrade integration test, which relies on tag information to assert that the repository has bumped the in-code version appropriately.