### PR TITLE
Fix image pushing script

### DIFF
--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -9,6 +9,6 @@ fi
 
 for img in spire-server spire-agent k8s-workload-registrar oidc-discovery-provider; do
     gcrimg=gcr.io/spiffe-io/"$img":"${IMAGETAG}"
-    docker tag "$img" "$gcrimg"
+    docker tag "$img":latest-local "$gcrimg"
     docker push "$gcrimg"
 done


### PR DESCRIPTION
It was tagging and pushing `latest` (by default) but the images are built and tagged against latest-local. This script worked as is with the nightly build since it does the image building and pushing in one job.