### PR TITLE
Fix TAG name extraction bug

### DIFF
--- a/.github/workflows/scripts/build_artifacts.sh
+++ b/.github/workflows/scripts/build_artifacts.sh
@@ -3,11 +3,11 @@
 set -e
 
 export TAG=
-if [[ "$GITHUB_REF" =~ ^/refs/tags/v[0-9.]+$ ]]; then
+if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9.]+$ ]]; then
         # Strip off the leading "v" from the release tag. Release artifacts are
         # named just with the version number (e.g. v0.9.3 tag produces
         # spire-0.9.3-linux-x64.tar.gz).
-        TAG="${GITHUB_REF##/refs/tags/v}"
+        TAG="${GITHUB_REF##refs/tags/v}"
 fi
 
 # Make references the $TAG environment variable set above


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

CI/CD script

**Description of change**
<!-- Please provide a description of the change -->

If expand the artifact of v1.0.0,  I get the directory as follow.
```
tar zxvf spire-1.0.0-linux-x86_64-glibc.tar.gz
./
spire-858d04b/
```

This PR fixes the directory name of the artifact generated at release  is now correct.

cf. https://docs.github.com/en/actions/reference/environment-variables

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

