### PR TITLE
Cull needless v0 Configure/GetPluginInfo impls

### DIFF
--- a/pkg/agent/plugin/keymanager/svidkeymanager_test.go
+++ b/pkg/agent/plugin/keymanager/svidkeymanager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	keymanagerv0 "github.com/spiffe/spire/proto/spire/plugin/agent/keymanager/v0"
 	"github.com/spiffe/spire/test/fakes/fakeagentkeymanager"
 	"github.com/spiffe/spire/test/plugintest"
@@ -127,7 +126,7 @@ func TestMultiSVIDKeyManager(t *testing.T) {
 }
 
 type fakeV0Plugin struct {
-	keymanagerv0.UnsafeKeyManagerServer
+	keymanagerv0.UnimplementedKeyManagerServer
 
 	key *ecdsa.PrivateKey
 	mtx sync.RWMutex
@@ -180,12 +179,4 @@ func (m *fakeV0Plugin) FetchPrivateKey(context.Context, *keymanagerv0.FetchPriva
 	}
 
 	return &keymanagerv0.FetchPrivateKeyResponse{PrivateKey: privateKey}, nil
-}
-
-func (m *fakeV0Plugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (m *fakeV0Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
 }

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid.go
@@ -16,7 +16,6 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	common_devid "github.com/spiffe/spire/pkg/common/plugin/tpmdevid"
 	"github.com/spiffe/spire/pkg/common/util"
-	"github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -227,10 +226,6 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	p.c.passwords.EndorsementHierarchy = extConf.EndorsementHierarchyPassword
 
 	return &configv1.ConfigureResponse{}, nil
-}
-
-func (p *Plugin) GetPluginInfo(ctx context.Context, req *plugin.GetPluginInfoRequest) (*plugin.GetPluginInfoResponse, error) {
-	return &plugin.GetPluginInfoResponse{}, nil
 }
 
 func (p *Plugin) SetLogger(log hclog.Logger) {

--- a/pkg/agent/plugin/nodeattestor/v0_test.go
+++ b/pkg/agent/plugin/nodeattestor/v0_test.go
@@ -10,7 +10,6 @@ import (
 	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/proto/spire/common"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	nodeattestorv0 "github.com/spiffe/spire/proto/spire/plugin/agent/nodeattestor/v0"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
@@ -186,14 +185,6 @@ func (plugin *fakeV0Plugin) FetchAttestationData(stream nodeattestorv0.NodeAttes
 	}
 
 	return nil
-}
-
-func (plugin *fakeV0Plugin) Configure(context.Context, *spi.ConfigureRequest) (*spi.ConfigureResponse, error) {
-	return &spi.ConfigureResponse{}, nil
-}
-
-func (plugin *fakeV0Plugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
 }
 
 func v0AttestationData(attestationData *nodeattestor.AttestationData) *common.AttestationData {

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -31,7 +31,6 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
-	spi "github.com/spiffe/spire/proto/spire/common/plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -274,11 +273,6 @@ func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *configv1.Configu
 	p.clients.configure(config.SessionConfig)
 
 	return &configv1.ConfigureResponse{}, nil
-}
-
-// GetPluginInfo returns the version and related metadata of the installed plugin.
-func (*IIDAttestorPlugin) GetPluginInfo(context.Context, *spi.GetPluginInfoRequest) (*spi.GetPluginInfoResponse, error) {
-	return &spi.GetPluginInfoResponse{}, nil
 }
 
 // SetLogger sets this plugin's logger


### PR DESCRIPTION
One instance was left over in a few plugins ported to V1, the rest were in tests but aren't required.

