### PR TITLE
Add authorizers for clientset for psat attestor

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,7 @@ github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsC
 github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/psat/psat.go
@@ -15,6 +15,9 @@ import (
 	"github.com/spiffe/spire/pkg/common/plugin/k8s/apiserver"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	// Add auth providers to authenticate to clusters to verify tokens
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Auth providers were removed by default in the golang clientset by default in kubernetes/kubernetes#41532, similar to this issue in https://github.com/helm/helm/issues/3806#issuecomment-378072159, authorizers need to be imported explicitly in order to be used. This is crucial for the`k8s_psat` attestor because it relies on authenticating via `KUBECONFIG` files.

**Description of change**
<!-- Please provide a description of the change -->
Import golang k8s clientset authorizers so that auth can be done properly with different type of kubeconfig files, this is done by importing the authorizers packages.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
NA
