### PR TITLE
Update the `k8s_sat` node attestor to work with projected tokens also

### DIFF
--- a/pkg/common/plugin/k8s/utils.go
+++ b/pkg/common/plugin/k8s/utils.go
@@ -36,7 +36,6 @@ type SATClaims struct {
 		Namespace      string `json:"namespace"`
 		ServiceAccount struct {
 			Name string `json:"name"`
-			UID  string `json:"uid"`
 		} `json:"serviceaccount"`
 	} `json:"kubernetes.io"`
 }

--- a/pkg/common/plugin/k8s/utils.go
+++ b/pkg/common/plugin/k8s/utils.go
@@ -29,6 +29,16 @@ type SATClaims struct {
 	jwt.Claims
 	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
 	ServiceAccountName string `json:"kubernetes.io/serviceaccount/service-account.name"`
+
+	// This struct is included in case that a projected service account token is
+	// parsed as a regular service account token
+	K8s struct {
+		Namespace      string `json:"namespace"`
+		ServiceAccount struct {
+			Name string `json:"name"`
+			UID  string `json:"uid"`
+		} `json:"serviceaccount"`
+	} `json:"kubernetes.io"`
 }
 
 // PSATClaims represents claims in a projected service account token, for example:

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
@@ -197,8 +197,7 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer)
 		}
 		if !claims.Expiry.Time().IsZero() {
 			// This is an indication that this may be a projected service account token
-			p.log.Warn(`The service account token has an expiration time, which is an indication that may be a projected service account token.
-			If your cluster supports Service Account Token Volume Projection you should instead consider using the "k8s_psat" attestor. Please look at https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_k8s_sat.md#security-considerations for details about security considerations when using the "k8s_sat" attestor.`)
+			p.log.Warn("The service account token has an expiration time, which is an indication that may be a projected service account token. If your cluster supports Service Account Token Volume Projection you should instead consider using the `k8s_psat` attestor. Please look at https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_k8s_sat.md#security-considerations for details about security considerations when using the `k8s_sat` attestor.")
 
 			// Validate the time with leeway
 			if err := claims.ValidateWithLeeway(jwt.Expected{
@@ -243,7 +242,7 @@ func (p *AttestorPlugin) getNamesFromClaims(claims *k8s.SATClaims) (namespace st
 		namespace = claims.K8s.Namespace
 	} else {
 		if claims.K8s.Namespace != "" {
-			return "", "", errors.New("malformed token: namespace found in two places")
+			return "", "", errors.New("malformed token: namespace found in two claims")
 		}
 		namespace = claims.Namespace
 	}
@@ -255,7 +254,7 @@ func (p *AttestorPlugin) getNamesFromClaims(claims *k8s.SATClaims) (namespace st
 		serviceAccountName = claims.K8s.ServiceAccount.Name
 	} else {
 		if claims.K8s.ServiceAccount.Name != "" {
-			return "", "", errors.New("malformed token: service account name found in two places")
+			return "", "", errors.New("malformed token: service account name found in two claims")
 		}
 		serviceAccountName = claims.ServiceAccountName
 	}

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
@@ -8,9 +8,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/gofrs/uuid"
 	hclog "github.com/hashicorp/go-hclog"
@@ -28,6 +30,10 @@ import (
 
 const (
 	pluginName = "k8s_sat"
+
+	// If there are clock differences between the agent and server then token
+	// validation may fail unless we give a little leeway.
+	tokenLeeway = time.Minute * 5
 )
 
 func BuiltIn() catalog.BuiltIn {
@@ -90,6 +96,7 @@ type AttestorPlugin struct {
 
 	hooks struct {
 		newUUID func() (string, error)
+		now     func() time.Time
 	}
 }
 
@@ -102,6 +109,7 @@ func New() *AttestorPlugin {
 		}
 		return u.String(), nil
 	}
+	p.hooks.now = time.Now
 	return p
 }
 
@@ -187,24 +195,23 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer)
 		if err != nil {
 			return err
 		}
+		if !claims.Expiry.Time().IsZero() {
+			// This is an indication that this may be a projected service account token
+			p.log.Warn(`The service account token has an expiration time, which is an indication that may be a projected service account token.
+			If your cluster supports Service Account Token Volume Projection you should instead consider using the "k8s_psat" attestor. Please look at https://github.com/spiffe/spire/blob/main/doc/plugin_server_nodeattestor_k8s_sat.md#security-considerations for details about security considerations when using the "k8s_sat" attestor.`)
 
-		// TODO: service account tokens don't currently expire.... when they do, validate the time (with leeway)
-		if err := claims.Validate(jwt.Expected{
-			Issuer: "kubernetes/serviceaccount",
-		}); err != nil {
-			return status.Errorf(codes.InvalidArgument, "unable to validate token claims: %v", err)
+			// Validate the time with leeway
+			if err := claims.ValidateWithLeeway(jwt.Expected{
+				Time: p.hooks.now(),
+			}, tokenLeeway); err != nil {
+				return status.Errorf(codes.InvalidArgument, "unable to validate token claims: %v", err)
+			}
 		}
 
-		if claims.Namespace == "" {
-			return status.Error(codes.InvalidArgument, "token missing namespace claim")
+		namespace, serviceAccountName, err = p.getNamesFromClaims(claims)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "error parsing token claims: %v", err)
 		}
-
-		if claims.ServiceAccountName == "" {
-			return status.Error(codes.InvalidArgument, "token missing service account name claim")
-		}
-
-		namespace = claims.Namespace
-		serviceAccountName = claims.ServiceAccountName
 	}
 
 	fullServiceAccountName := fmt.Sprintf("%v:%v", namespace, serviceAccountName)
@@ -224,6 +231,36 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer)
 			},
 		},
 	})
+}
+
+// getNamesFromClaims parses claims from a k8s.SATClaims struct
+// to extract the namespace and service account name
+func (p *AttestorPlugin) getNamesFromClaims(claims *k8s.SATClaims) (namespace string, serviceAccountName string, err error) {
+	if claims.Namespace == "" {
+		if claims.K8s.Namespace == "" {
+			return "", "", errors.New("token missing namespace claim")
+		}
+		namespace = claims.K8s.Namespace
+	} else {
+		if claims.K8s.Namespace != "" {
+			return "", "", errors.New("malformed token: namespace found in two places")
+		}
+		namespace = claims.Namespace
+	}
+
+	if claims.ServiceAccountName == "" {
+		if claims.K8s.ServiceAccount.Name == "" {
+			return "", "", errors.New("token missing service account name claim")
+		}
+		serviceAccountName = claims.K8s.ServiceAccount.Name
+	} else {
+		if claims.K8s.ServiceAccount.Name != "" {
+			return "", "", errors.New("malformed token: service account name found in two places")
+		}
+		serviceAccountName = claims.ServiceAccountName
+	}
+
+	return namespace, serviceAccountName, nil
 }
 
 func (p *AttestorPlugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -23,6 +23,7 @@ import (
 	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pemutil"
+	sat_common "github.com/spiffe/spire/pkg/common/plugin/k8s"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
@@ -77,6 +78,7 @@ type AttestorSuite struct {
 	bazSigner  jose.Signer
 	attestor   nodeattestor.NodeAttestor
 	agentStore *fakeagentstore.AgentStore
+	now        time.Time
 	mockCtrl   *gomock.Controller
 	mockClient *k8s_apiserver_mock.MockClient
 }
@@ -118,6 +120,7 @@ func (s *AttestorSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
 	s.agentStore = fakeagentstore.New()
 	s.attestor = s.loadPlugin()
+	s.now = time.Now()
 }
 
 func (s *AttestorSuite) TearDownTest() {
@@ -196,10 +199,26 @@ func (s *AttestorSuite) TestAttestFailsIfTokenReviewAPIFails() {
 		"unable to validate token with TokenReview API")
 }
 
-func (s *AttestorSuite) TestAttestFailsWithInvalidIssuer() {
-	token, err := jwt.Signed(s.fooSigner).CompactSerialize()
+func (s *AttestorSuite) TestAttestFailsWithMalformedToken() {
+	claims := sat_common.SATClaims{}
+	claims.Namespace = "ns1"
+	claims.K8s.Namespace = "ns2"
+
+	builder := jwt.Signed(s.fooSigner)
+	builder = builder.Claims(claims)
+	token, err := builder.CompactSerialize()
 	s.Require().NoError(err)
-	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "invalid issuer claim")
+	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: namespace found in two places")
+
+	// Clear the namespace from the SAT space but leave the duplicated service account name
+	claims.K8s.Namespace = ""
+	claims.ServiceAccountName = "sa1"
+	claims.K8s.ServiceAccount.Name = "sa2"
+
+	builder = builder.Claims(claims)
+	token, err = builder.CompactSerialize()
+	s.Require().NoError(err)
+	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: service account name found in two places")
 }
 
 func (s *AttestorSuite) TestAttestFailsIfTokenNotAuthenticated() {
@@ -394,18 +413,30 @@ func (s *AttestorSuite) TestServiceAccountKeyFileAlternateEncodings() {
 	)
 }
 
-func (s *AttestorSuite) signToken(signer jose.Signer, namespace, serviceAccountName string) string {
-	builder := jwt.Signed(signer)
+func (s *AttestorSuite) TestAttestTokenExpiration() {
+	token := s.signTokenWithExpiry(s.fooSigner, "NS1", "SA1")
 
-	// build up standard claims
-	claims := jwt.Claims{
-		Issuer: "kubernetes/serviceaccount",
-	}
-	builder = builder.Claims(claims)
-	builder = builder.Claims(map[string]interface{}{
-		"kubernetes.io/serviceaccount/namespace":            namespace,
-		"kubernetes.io/serviceaccount/service-account.name": serviceAccountName,
-	})
+	// within 5m leeway (token expires at 1m + 5m leeway = 6m)
+	s.adjustTime(4 * time.Minute)
+	result, err := s.attestor.Attest(context.Background(), makePayload("FOO", token), expectNoChallenge)
+	s.Require().NoError(err)
+	s.Require().NotNil(result)
+
+	// after 5m leeway
+	s.adjustTime(3 * time.Minute)
+	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "token is expired (exp)")
+}
+
+func (s *AttestorSuite) signToken(signer jose.Signer, namespace, serviceAccountName string) string {
+	builder := s.createBuilder(signer, namespace, serviceAccountName, jwt.NewNumericDate(time.Time{}))
+
+	token, err := builder.CompactSerialize()
+	s.Require().NoError(err)
+	return token
+}
+
+func (s *AttestorSuite) signTokenWithExpiry(signer jose.Signer, namespace, serviceAccountName string) string {
+	builder := s.createBuilder(signer, namespace, serviceAccountName, jwt.NewNumericDate(s.now.Add(time.Minute)))
 
 	token, err := builder.CompactSerialize()
 	s.Require().NoError(err)
@@ -416,6 +447,9 @@ func (s *AttestorSuite) loadPlugin() nodeattestor.NodeAttestor {
 	attestor := New()
 	attestor.hooks.newUUID = func() (string, error) {
 		return "UUID", nil
+	}
+	attestor.hooks.now = func() time.Time {
+		return s.now
 	}
 	v1 := new(nodeattestor.V1)
 	plugintest.Load(s.T(), builtin(attestor), v1,
@@ -456,6 +490,21 @@ func (s *AttestorSuite) fooCertPath() string {
 
 func (s *AttestorSuite) barCertPath() string {
 	return filepath.Join(s.dir, "bar.pem")
+}
+
+func (s *AttestorSuite) adjustTime(d time.Duration) {
+	s.now = s.now.Add(d)
+}
+
+func (s *AttestorSuite) createBuilder(signer jose.Signer, namespace, serviceAccountName string, numericDate *jwt.NumericDate) jwt.Builder {
+	claims := sat_common.SATClaims{}
+	claims.Namespace = namespace
+	claims.ServiceAccountName = serviceAccountName
+	claims.Expiry = numericDate
+
+	builder := jwt.Signed(signer)
+	builder = builder.Claims(claims)
+	return builder
 }
 
 func makePayload(cluster, token string) []byte {

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -208,7 +208,7 @@ func (s *AttestorSuite) TestAttestFailsWithMalformedToken() {
 	builder = builder.Claims(claims)
 	token, err := builder.CompactSerialize()
 	s.Require().NoError(err)
-	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: namespace found in two places")
+	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: namespace found in two claims")
 
 	// Clear the namespace from the SAT space but leave the duplicated service account name
 	claims.K8s.Namespace = ""
@@ -218,7 +218,7 @@ func (s *AttestorSuite) TestAttestFailsWithMalformedToken() {
 	builder = builder.Claims(claims)
 	token, err = builder.CompactSerialize()
 	s.Require().NoError(err)
-	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: service account name found in two places")
+	s.requireAttestError(makePayload("FOO", token), codes.InvalidArgument, "malformed token: service account name found in two claims")
 }
 
 func (s *AttestorSuite) TestAttestFailsIfTokenNotAuthenticated() {


### PR DESCRIPTION
Starting with Kubernetes 1.21, the [BoundServiceAccountTokenVolume](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) feature is enabled by default, which means that a projected service account token is used instead of a regular service account token.
This PR updates the `k8s_sat` node attestor to work with projected service account tokens also.

The current implementation validates the token issuer with a specific hardcoded issuer. This validation is not strictly needed by the attestation process and can be problematic in case that a non-default issuer has been defined in the cluster. This PR also updates the logic to remove that validation.

Fixes #2419.