### PR TITLE
Update outdated config example in DevID attestor

### DIFF
--- a/doc/plugin_server_nodeattestor_tpm_devid.md
+++ b/doc/plugin_server_nodeattestor_tpm_devid.md
@@ -40,8 +40,8 @@ A sample configuration:
 ```
 	NodeAttestor "tpm_devid" {
 		plugin_data {
-			devid_bundle_path = "/opt/spire/conf/server/devid-cacert.pem"
-			endorsement_bundle_path = "/opt/spire/conf/server/endorsement-cacert.pem"
+			devid_ca_path = "/opt/spire/conf/server/devid-cacert.pem"
+			endorsement_ca_path = "/opt/spire/conf/server/endorsement-cacert.pem"
 		}
 	}
 ```


### PR DESCRIPTION
Signed-off-by: Marcos Yedro <marcosyedro@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
DevID node attestor (documentation only)

**Description of change**
<!-- Please provide a description of the change -->
During the DevID node attestor review process we rename some configurables. This change was not fully reflected in the server configuration example. This PR updates the docs to match the actual configurable name.


