### PR TITLE
Fix Kubernetes-based integration test failures

### DIFF
--- a/test/integration/suites/k8s-reconcile/00-setup
+++ b/test/integration/suites/k8s-reconcile/00-setup
@@ -5,31 +5,37 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.10.0
+KINDVERSION=v0.11.1
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
-KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTLVERSION=v1.21.1
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
 
-# Ensure kubectl is available
+# Create a temporary path that will be added to the PATH to avoid picking up
+# binaries from the environment that aren't a version match.
 mkdir -p ./bin
-if [ -n "${KUBECTLPATH}" ]; then
+
+download_bin() {
+    local bin_path=$1
+    local bin_url=$2
+    if [ ! -f "${bin_path}" ] ; then
+        log-info "downloading $(basename ${bin_path}) from ${bin_url}..."
+        curl -# -f -Lo "${bin_path}" "${bin_url}"
+        chmod +x "${bin_path}"
+    fi
+}
+
+# Ensure kind exists at the expected version
+if [ -x "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
+    ln -s "${KINDPATH}" ./bin/kind
+else
+    download_bin ./bin/kind "${KINDURL}"
+fi
+
+# Ensure kubectl exists at the expected version
+if [ -x "${KUBECTLPATH}" ] && "${KUBECTLPATH}" version --short --client=true | grep -q "${KUBECTLVERSION}"; then
     ln -s "${KUBECTLPATH}" ./bin/kubectl
 else
-    log-info "downloading kubectl from ${KUBECTLURL}..."
-    curl -# -f -Lo ./bin/kubectl "${KUBECTLURL}"
-    chmod +x ./bin/kubectl
-fi
-
-# Ensure kind is available and at the expected version
-mkdir -p ./bin
-if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
-    ln -s "${KINDPATH}" ./bin/kind
-fi
-
-if [ ! -f ./bin/kind ]; then
-    log-info "downloading kind from ${KINDURL}..."
-    curl -# -f -Lo ./bin/kind "${KINDURL}"
-    chmod +x ./bin/kind
+    download_bin ./bin/kubectl "${KUBECTLURL}"
 fi
 
 # We must supply an absolute path to the configuration directory. Replace the
@@ -45,3 +51,6 @@ log-info "loading container images..."
 ./bin/kind load docker-image --name k8stest spire-server:latest-local
 ./bin/kind load docker-image --name k8stest spire-agent:latest-local
 ./bin/kind load docker-image --name k8stest k8s-workload-registrar:latest-local
+
+log-info "setting kubectl cluster context..."
+./bin/kubectl cluster-info --context kind-k8stest

--- a/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/kind-config.yaml
@@ -14,6 +14,7 @@ kubeadmConfigPatches:
         "admission-control-config-file": "/etc/kubernetes/pki/admctrl/admission-control.yaml"
 nodes:
 - role: control-plane
+  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl

--- a/test/integration/suites/k8s-scratch/00-setup
+++ b/test/integration/suites/k8s-scratch/00-setup
@@ -5,31 +5,37 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.10.0
+KINDVERSION=v0.11.1
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
-KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTLVERSION=v1.21.1
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
 
-# Ensure kubectl is available
+# Create a temporary path that will be added to the PATH to avoid picking up
+# binaries from the environment that aren't a version match.
 mkdir -p ./bin
-if [ -n "${KUBECTLPATH}" ]; then
+
+download_bin() {
+    local bin_path=$1
+    local bin_url=$2
+    if [ ! -f "${bin_path}" ] ; then
+        log-info "downloading $(basename ${bin_path}) from ${bin_url}..."
+        curl -# -f -Lo "${bin_path}" "${bin_url}"
+        chmod +x "${bin_path}"
+    fi
+}
+
+# Ensure kind exists at the expected version
+if [ -x "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
+    ln -s "${KINDPATH}" ./bin/kind
+else
+    download_bin ./bin/kind "${KINDURL}"
+fi
+
+# Ensure kubectl exists at the expected version
+if [ -x "${KUBECTLPATH}" ] && "${KUBECTLPATH}" version --short --client=true | grep -q "${KUBECTLVERSION}"; then
     ln -s "${KUBECTLPATH}" ./bin/kubectl
 else
-    log-info "downloading kubectl from ${KUBECTLURL}..."
-    curl -# -f -Lo ./bin/kubectl "${KUBECTLURL}"
-    chmod +x ./bin/kubectl
-fi
-
-# Ensure kind is available and at the expected version
-mkdir -p ./bin
-if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
-    ln -s "${KINDPATH}" ./bin/kind
-fi
-
-if [ ! -f ./bin/kind ]; then
-    log-info "downloading kind from ${KINDURL}..."
-    curl -# -f -Lo ./bin/kind "${KINDURL}"
-    chmod +x ./bin/kind
+    download_bin ./bin/kubectl "${KUBECTLURL}"
 fi
 
 # We must supply an absolute path to the configuration directory. Replace the
@@ -45,3 +51,6 @@ log-info "loading container images..."
 ./bin/kind load docker-image --name k8stest spire-server-scratch:latest-local
 ./bin/kind load docker-image --name k8stest spire-agent-scratch:latest-local
 ./bin/kind load docker-image --name k8stest k8s-workload-registrar-scratch:latest-local
+
+log-info "setting kubectl cluster context..."
+./bin/kubectl cluster-info --context kind-k8stest

--- a/test/integration/suites/k8s-scratch/conf/kind-config.yaml
+++ b/test/integration/suites/k8s-scratch/conf/kind-config.yaml
@@ -14,6 +14,7 @@ kubeadmConfigPatches:
         "admission-control-config-file": "/etc/kubernetes/pki/admctrl/admission-control.yaml"
 nodes:
 - role: control-plane
+  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl

--- a/test/integration/suites/k8s/00-setup
+++ b/test/integration/suites/k8s/00-setup
@@ -5,31 +5,37 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.10.0
+KINDVERSION=v0.11.1
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
-KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTLVERSION=v1.21.1
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
 
-# Ensure kubectl is available
+# Create a temporary path that will be added to the PATH to avoid picking up
+# binaries from the environment that aren't a version match.
 mkdir -p ./bin
-if [ -n "${KUBECTLPATH}" ]; then
+
+download_bin() {
+    local bin_path=$1
+    local bin_url=$2
+    if [ ! -f "${bin_path}" ] ; then
+        log-info "downloading $(basename ${bin_path}) from ${bin_url}..."
+        curl -# -f -Lo "${bin_path}" "${bin_url}"
+        chmod +x "${bin_path}"
+    fi
+}
+
+# Ensure kind exists at the expected version
+if [ -x "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
+    ln -s "${KINDPATH}" ./bin/kind
+else
+    download_bin ./bin/kind "${KINDURL}"
+fi
+
+# Ensure kubectl exists at the expected version
+if [ -x "${KUBECTLPATH}" ] && "${KUBECTLPATH}" version --short --client=true | grep -q "${KUBECTLVERSION}"; then
     ln -s "${KUBECTLPATH}" ./bin/kubectl
 else
-    log-info "downloading kubectl from ${KUBECTLURL}..."
-    curl -# -f -Lo ./bin/kubectl "${KUBECTLURL}"
-    chmod +x ./bin/kubectl
-fi
-
-# Ensure kind is available and at the expected version
-mkdir -p ./bin
-if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
-    ln -s "${KINDPATH}" ./bin/kind
-fi
-
-if [ ! -f ./bin/kind ]; then
-    log-info "downloading kind from ${KINDURL}..."
-    curl -# -f -Lo ./bin/kind "${KINDURL}"
-    chmod +x ./bin/kind
+    download_bin ./bin/kubectl "${KUBECTLURL}"
 fi
 
 # We must supply an absolute path to the configuration directory. Replace the
@@ -45,3 +51,6 @@ log-info "loading container images..."
 ./bin/kind load docker-image --name k8stest spire-server:latest-local
 ./bin/kind load docker-image --name k8stest spire-agent:latest-local
 ./bin/kind load docker-image --name k8stest k8s-workload-registrar:latest-local
+
+log-info "setting kubectl cluster context..."
+./bin/kubectl cluster-info --context kind-k8stest

--- a/test/integration/suites/k8s/conf/kind-config.yaml
+++ b/test/integration/suites/k8s/conf/kind-config.yaml
@@ -14,6 +14,7 @@ kubeadmConfigPatches:
         "admission-control-config-file": "/etc/kubernetes/pki/admctrl/admission-control.yaml"
 nodes:
 - role: control-plane
+  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
   extraMounts:
   - containerPath: /etc/kubernetes/pki/admctrl
     hostPath: CONFDIR/admctrl

--- a/test/integration/suites/upstream-authority-cert-manager/00-setup-kind
+++ b/test/integration/suites/upstream-authority-cert-manager/00-setup-kind
@@ -5,35 +5,45 @@ KINDPATH=$(command -v kind || echo)
 
 UNAME=$(uname | awk '{print tolower($0)}')
 
-KINDVERSION=v0.10.0
+KINDVERSION=v0.11.1
 KINDURL="https://github.com/kubernetes-sigs/kind/releases/download/$KINDVERSION/kind-$UNAME-amd64"
-KUBECTLVERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KUBECTLVERSION=v1.21.1
 KUBECTLURL="https://storage.googleapis.com/kubernetes-release/release/$KUBECTLVERSION/bin/$UNAME/amd64/kubectl"
 
-# Ensure kubectl is available
+# Create a temporary path that will be added to the PATH to avoid picking up
+# binaries from the environment that aren't a version match.
 mkdir -p ./bin
-if [ -n "${KUBECTLPATH}" ]; then
+
+download_bin() {
+    local bin_path=$1
+    local bin_url=$2
+    if [ ! -f "${bin_path}" ] ; then
+        log-info "downloading $(basename ${bin_path}) from ${bin_url}..."
+        curl -# -f -Lo "${bin_path}" "${bin_url}"
+        chmod +x "${bin_path}"
+    fi
+}
+
+# Ensure kind exists at the expected version
+if [ -x "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
+    ln -s "${KINDPATH}" ./bin/kind
+else
+    download_bin ./bin/kind "${KINDURL}"
+fi
+
+# Ensure kubectl exists at the expected version
+if [ -x "${KUBECTLPATH}" ] && "${KUBECTLPATH}" version --short --client=true | grep -q "${KUBECTLVERSION}"; then
     ln -s "${KUBECTLPATH}" ./bin/kubectl
 else
-    log-info "downloading kubectl from ${KUBECTLURL}..."
-    curl -# -f -Lo ./bin/kubectl "${KUBECTLURL}"
-    chmod +x ./bin/kubectl
+    download_bin ./bin/kubectl "${KUBECTLURL}"
 fi
 
-# Ensure kind is available and at the expected version
-mkdir -p ./bin
-if [ -n "${KINDPATH}" ] && "${KINDPATH}" version | grep -q "${KINDVERSION}"; then
-    ln -s "${KINDPATH}" ./bin/kind
-fi
-
-if [ ! -f ./bin/kind ]; then
-    log-info "downloading kind from ${KINDURL}..."
-    curl -# -f -Lo ./bin/kind "${KINDURL}"
-    chmod +x ./bin/kind
-fi
 
 log-info "starting cluster..."
-./bin/kind create cluster --name cert-manager-test || fail-now "unable to create cluster"
+./bin/kind create cluster --name cert-manager-test --config conf/kind-config.yaml || fail-now "unable to create cluster"
 
 log-info "loading container images..."
 ./bin/kind load docker-image --name cert-manager-test spire-server:latest-local
+
+log-info "setting kubectl cluster context..."
+./bin/kubectl cluster-info --context kind-cert-manager-test

--- a/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
+++ b/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
@@ -1,0 +1,5 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9


### PR DESCRIPTION
Kind 0.10 started failing on linux for some reason. I dug for a while
but couldn't figure it out. The node would not enter a ready state. This
started failing at roughly the same time for me, both locally and on
CI/CD.

In any case, 0.11.1 works fine, so I've migrated to integration tests to
use it. I've pinned the node version to Kubernetes v1.20 to maintain the
same version that was being used with Kind 0.10.

I've also updated the tooling to use a pinned version of kubectl instead
of grabbing the latest.

Since this is contributing to a CI/CD failure that we need sorted
somewhat quickly, I didn't take the time to refactor some of these
Kubernetes cluster setup bits that have been copy/pasted into multiple
integration tests now, but that would be an excellent contribution at a
later date.