### PR TITLE
SDS v3 endpoints support SPIFFE validator

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -404,7 +404,7 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 	ac.DefaultBundleName = c.Agent.SDS.DefaultBundleName
 	ac.DefaultAllBundlesName = c.Agent.SDS.DefaultAllBundlesName
 	if ac.DefaultAllBundlesName == ac.DefaultBundleName {
-		logger.Warn(`"default_bundle_name" and "default_all_bundles_name" has the same value, "default_bundle_name" will be used. In future versions this misconfiguration will cause agent to not start.`)
+		logger.Warn(`The "default_bundle_name" and "default_all_bundles_name" configurables have the same value. "default_all_bundles_name" will be ignored. Please configure distinct values or use the defaults. This will be a configuration error in a future release.`)
 	}
 
 	err = setupTrustBundle(ac, c)

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -37,10 +37,11 @@ const (
 	defaultConfigPath = "conf/agent/agent.conf"
 
 	// TODO: Make my defaults sane
-	defaultDataDir           = "."
-	defaultLogLevel          = "INFO"
-	defaultDefaultSVIDName   = "default"
-	defaultDefaultBundleName = "ROOTCA"
+	defaultDataDir               = "."
+	defaultLogLevel              = "INFO"
+	defaultDefaultSVIDName       = "default"
+	defaultDefaultBundleName     = "ROOTCA"
+	defaultDefaultAllBundlesName = "ALL"
 )
 
 // Config contains all available configurables, arranged by section
@@ -84,8 +85,9 @@ type agentConfig struct {
 }
 
 type sdsConfig struct {
-	DefaultSVIDName   string `hcl:"default_svid_name"`
-	DefaultBundleName string `hcl:"default_bundle_name"`
+	DefaultSVIDName       string `hcl:"default_svid_name"`
+	DefaultBundleName     string `hcl:"default_bundle_name"`
+	DefaultAllBundlesName string `hcl:"default_all_bundles_name"`
 }
 
 type experimentalConfig struct {
@@ -400,6 +402,10 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 	ac.DataDir = c.Agent.DataDir
 	ac.DefaultSVIDName = c.Agent.SDS.DefaultSVIDName
 	ac.DefaultBundleName = c.Agent.SDS.DefaultBundleName
+	ac.DefaultAllBundlesName = c.Agent.SDS.DefaultAllBundlesName
+	if ac.DefaultAllBundlesName == ac.DefaultBundleName {
+		logger.Warn(`"default_bundle_name" and "default_all_bundles_name" has the same value, "default_bundle_name" will be used. In future versions this misconfiguration will cause agent to not start.`)
+	}
 
 	err = setupTrustBundle(ac, c)
 	if err != nil {
@@ -539,8 +545,9 @@ func defaultConfig() *Config {
 			LogFormat:  log.DefaultFormat,
 			SocketPath: common.DefaultSocketPath,
 			SDS: sdsConfig{
-				DefaultBundleName: defaultDefaultBundleName,
-				DefaultSVIDName:   defaultDefaultSVIDName,
+				DefaultBundleName:     defaultDefaultBundleName,
+				DefaultSVIDName:       defaultDefaultSVIDName,
+				DefaultAllBundlesName: defaultDefaultAllBundlesName,
 			},
 		},
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -237,6 +237,26 @@ func TestMergeInput(t *testing.T) {
 			},
 		},
 		{
+			msg:       "default_all_bundles_name should default value of ALL",
+			fileInput: func(c *Config) {},
+			cliInput:  func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, "ALL", c.Agent.SDS.DefaultAllBundlesName)
+			},
+		},
+		{
+			msg: "default_all_bundles_name should be configurable by file",
+			fileInput: func(c *Config) {
+				c.Agent.SDS = sdsConfig{
+					DefaultAllBundlesName: "foo",
+				}
+			},
+			cliInput: func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, "foo", c.Agent.SDS.DefaultAllBundlesName)
+			},
+		},
+		{
 			msg: "insecure_bootstrap should be configurable by file",
 			fileInput: func(c *Config) {
 				c.Agent.InsecureBootstrap = true

--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -49,6 +49,10 @@ agent {
     #     # default_bundle_name: The Validation Context resource name to use for the
     #     # default X.509 bundle with Envoy SDS. Default: ROOTCA.
     #     # default_bundle_name = "ROOTCA"
+    #
+    #     # default_all_bundles_name: The Validation Context resource name to use for when 
+    #     # fetching X.509 bundle togehter with federated bundles with Envoy SDS
+    #     # default_all_bundles_name = "ALL"
     # }
     
     # allowed_foreign_jwt_claims: set a list of trusted claims to be returned when validating foreign JWTSVIDs

--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -50,8 +50,9 @@ agent {
     #     # default X.509 bundle with Envoy SDS. Default: ROOTCA.
     #     # default_bundle_name = "ROOTCA"
     #
-    #     # default_all_bundles_name: The Validation Context resource name to use for when 
-    #     # fetching X.509 bundle togehter with federated bundles with Envoy SDS
+    #     # default_all_bundles_name: The Validation Context resource name to use to fetch 
+    #     # all bundles (including federated bundles) with Envoy SDS. Cannot be used with
+    #     # Envoy releases prior to 1.18.
     #     # default_all_bundles_name = "ALL"
     # }
     

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -67,11 +67,11 @@ Only one of these three options may be set at a time.
 
 ### SDS Configuration
 
-| Configuration              | Description                                                                             | Default              |
-| -------------------------- | --------------------------------------------------------------------------------------- | -------------------- |
-| `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS       | default              |
-| `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS | ROOTCA               |
-| `default_all_bundles_name` | The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS | ALL               |
+| Configuration              | Description                                                                                      | Default           |
+| -------------------------- | ------------------------------------------------------------------------------------------------ | ----------------- |
+| `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS                | default           |
+| `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS          | ROOTCA            |
+| `default_all_bundles_name` | The Validation Context resource name to use for all bundles (including federated) with Envoy SDS | ALL               |
 
 
 ## Plugin configuration
@@ -269,13 +269,18 @@ containing the default X509-SVID for the workload (i.e. Envoy) is fetched.
 The default name is configurable (see `default_svid_name` under [SDS Configuration](#sds-configuration)).
 
 [`auth.CertificateValidationContext`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/auth/cert.proto#auth-certificatevalidationcontext)
-resources containing trusted CA certificates can be fetched using the SPIFFE ID of the desired trust domain as the
-resource name (e.g. `spiffe://example.org`). Alternatively, if the default name "ROOTCA" is requested, the
-`auth.CertificateValidationContext` containing the trusted CA certificates for the agent's trust domain is fetched.
-The default name is configurable (see `default_bundle_name` under [SDS Configuration](#sds-configuration)).
-
-Another option is to request for `ALL` that creates a [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) that contains TrustDomain together with all Federated Bundles. This feature is supported starting with Envoy v1.18.0.
-The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration)
+resources containing trusted CA certificates can be fetched using the SPIFFE ID
+of the desired trust domain as the resource name (e.g. `spiffe://example.org`).
+In addition, two other special resource names are available. The first, which
+defaults to "ROOTCA", provides the CA certificates for the trust domain the
+agent belongs to. The second, which defaults to "ALL", returns the trusted CA
+certificates for both the trust domain the agent belongs to as well as any
+federated trust domains applicable to the Envoy workload.  The default names
+for these resource names are configurable via the `default_bundle_name` and
+`default_all_bundles_name`, respectively. The "ALL" resource name requires
+support for the [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto)
+extension, which is only available starting with Envoy 1.18.
+The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration).
 
 ## OpenShift Support
 

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -71,7 +71,7 @@ Only one of these three options may be set at a time.
 | -------------------------- | --------------------------------------------------------------------------------------- | -------------------- |
 | `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS       | default              |
 | `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS | ROOTCA               |
-| `default_all_bundle_sname` | The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS | ALL               |
+| `default_all_bundles_name` | The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS | ALL               |
 
 
 ## Plugin configuration
@@ -274,7 +274,7 @@ resource name (e.g. `spiffe://example.org`). Alternatively, if the default name 
 `auth.CertificateValidationContext` containing the trusted CA certificates for the agent's trust domain is fetched.
 The default name is configurable (see `default_bundle_name` under [SDS Configuration](#sds-configuration)).
 
-Another option is to request for `ALL` that creates a [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) that contains TrustDomain together with all Federated Bundles. This feature is supported from Envoy v1.18.0.
+Another option is to request for `ALL` that creates a [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) that contains TrustDomain together with all Federated Bundles. This feature is supported starting with Envoy v1.18.0.
 The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration)
 
 ## OpenShift Support

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -67,10 +67,11 @@ Only one of these three options may be set at a time.
 
 ### SDS Configuration
 
-| Configuration         | Description                                                                             | Default              |
-| --------------------- | --------------------------------------------------------------------------------------- | -------------------- |
-| `default_svid_name`   | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS       | default              |
-| `default_bundle_name` | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS | ROOTCA               |
+| Configuration              | Description                                                                             | Default              |
+| -------------------------- | --------------------------------------------------------------------------------------- | -------------------- |
+| `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS       | default              |
+| `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS | ROOTCA               |
+| `default_all_bundle_sname` | The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS | ALL               |
 
 
 ## Plugin configuration
@@ -272,6 +273,9 @@ resources containing trusted CA certificates can be fetched using the SPIFFE ID 
 resource name (e.g. `spiffe://example.org`). Alternatively, if the default name "ROOTCA" is requested, the
 `auth.CertificateValidationContext` containing the trusted CA certificates for the agent's trust domain is fetched.
 The default name is configurable (see `default_bundle_name` under [SDS Configuration](#sds-configuration)).
+
+Another option is to request for `ALL` that creates a [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) that contains TrustDomain together with all Federated Bundles. This feature is supported from Envoy v1.18.0.
+The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration)
 
 ## OpenShift Support
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/cenkalti/backoff/v3 v3.0.0
 	github.com/docker/docker v1.4.2-0.20200319182547-c7ad2b866182
-	github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210521033809-0cbd29f7d4f8
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-ole/go-ole v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
 github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
@@ -161,8 +162,9 @@ github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 h1:cqQfy1jclcSy/FwLjemeg3SR1yaINm74aQyupQ0Bl8M=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed h1:OZmjad4L3H8ncOIR8rnb5MREYqG8ixi5+WbeUsquF0c=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -224,8 +226,9 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
-github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad h1:EmNYJhPYy0pOFjCx2PrgtaBXmee0iUX9hLlxE1xHOJE=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210521033809-0cbd29f7d4f8 h1:iZy8+SuvO5p9mwWULLg45oJc1BWh80f5kFzZiPuxafg=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210521033809-0cbd29f7d4f8/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
@@ -427,6 +430,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -658,6 +662,7 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -744,6 +749,7 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
@@ -1087,6 +1093,7 @@ google.golang.org/genproto v0.0.0-20200312145019-da6875a35672/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200430143042-b979b6f78d84/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200511104702-f5ebc3bea380/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
@@ -1124,6 +1131,7 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
@@ -1171,6 +1179,7 @@ gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -217,6 +217,7 @@ func (a *Agent) newEndpoints(cat catalog.Catalog, metrics telemetry.Metrics, mgr
 		Metrics:                       metrics,
 		DefaultSVIDName:               a.c.DefaultSVIDName,
 		DefaultBundleName:             a.c.DefaultBundleName,
+		DefaultAllBundlesName:         a.c.DefaultAllBundlesName,
 		AllowUnauthenticatedVerifiers: a.c.AllowUnauthenticatedVerifiers,
 		AllowedForeignJWTClaims:       a.c.AllowedForeignJWTClaims,
 		TrustDomain:                   a.c.TrustDomain,

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Directory to bind the admin api to
 	AdminBindAddress *net.UnixAddr
 
+	// The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS
+	DefaultAllBundlesName string
+
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 

--- a/pkg/agent/endpoints/config.go
+++ b/pkg/agent/endpoints/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS
 	DefaultSVIDName string
 
+	// The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS
+	DefaultAllBundlesName string
+
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 

--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -81,10 +81,11 @@ func New(c Config) *Endpoints {
 	})
 
 	sdsv3Server := c.newSDSv3Server(sdsv3.Config{
-		Attestor:          attestor,
-		Manager:           c.Manager,
-		DefaultSVIDName:   c.DefaultSVIDName,
-		DefaultBundleName: c.DefaultBundleName,
+		Attestor:              attestor,
+		Manager:               c.Manager,
+		DefaultSVIDName:       c.DefaultSVIDName,
+		DefaultBundleName:     c.DefaultBundleName,
+		DefaultAllBundlesName: c.DefaultAllBundlesName,
 	})
 
 	healthServer := c.newHealthServer(healthv1.Config{

--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -172,6 +172,7 @@ func TestEndpoints(t *testing.T) {
 				Manager:                 FakeManager{},
 				DefaultSVIDName:         "DefaultSVIDName",
 				DefaultBundleName:       "DefaultBundleName",
+				DefaultAllBundlesName:   "DefaultAllBundlesName",
 				AllowedForeignJWTClaims: tt.allowedClaims,
 
 				// Assert the provided config and return a fake Workload API server
@@ -204,6 +205,7 @@ func TestEndpoints(t *testing.T) {
 					assert.Equal(t, FakeManager{}, c.Manager)
 					assert.Equal(t, "DefaultSVIDName", c.DefaultSVIDName)
 					assert.Equal(t, "DefaultBundleName", c.DefaultBundleName)
+					assert.Equal(t, "DefaultAllBundlesName", c.DefaultAllBundlesName)
 					return FakeSDSv3Server{Attestor: attestor}
 				},
 

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -13,6 +13,7 @@ import (
 	tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
@@ -22,15 +23,30 @@ import (
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 var (
 	tdBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("domain.test"), &x509.Certificate{
 		Raw: []byte("BUNDLE"),
+	})
+	tdCustomValidationConfig, _ = anypb.New(&tls_v3.SPIFFECertValidatorConfig{
+		TrustDomains: []*tls_v3.SPIFFECertValidatorConfig_TrustDomain{
+			{
+				Name: "domain.test",
+				TrustBundle: &core_v3.DataSource{
+					Specifier: &core_v3.DataSource_InlineBytes{
+						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nQlVORExF\n-----END CERTIFICATE-----\n"),
+					},
+				},
+			},
+		},
 	})
 	tdValidationContext = &tls_v3.Secret{
 		Name: "spiffe://domain.test",
@@ -40,6 +56,17 @@ var (
 					Specifier: &core_v3.DataSource_InlineBytes{
 						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nQlVORExF\n-----END CERTIFICATE-----\n"),
 					},
+				},
+			},
+		},
+	}
+	tdValidationContextSpiffeValidator = &tls_v3.Secret{
+		Name: "spiffe://domain.test",
+		Type: &tls_v3.Secret_ValidationContext{
+			ValidationContext: &tls_v3.CertificateValidationContext{
+				CustomValidatorConfig: &core_v3.TypedExtensionConfig{
+					Name:        "envoy.tls.cert_validator.spiffe",
+					TypedConfig: tdCustomValidationConfig,
 				},
 			},
 		},
@@ -57,9 +84,32 @@ var (
 			},
 		},
 	}
+	tdValidationContext2SpiffeValidator = &tls_v3.Secret{
+		Name: "ROOTCA",
+		Type: &tls_v3.Secret_ValidationContext{
+			ValidationContext: &tls_v3.CertificateValidationContext{
+				CustomValidatorConfig: &core_v3.TypedExtensionConfig{
+					Name:        "envoy.tls.cert_validator.spiffe",
+					TypedConfig: tdCustomValidationConfig,
+				},
+			},
+		},
+	}
 
 	fedBundle = bundleutil.BundleFromRootCA(spiffeid.RequireTrustDomainFromString("otherdomain.test"), &x509.Certificate{
 		Raw: []byte("FEDBUNDLE"),
+	})
+	fedCustomValidationConfig, _ = anypb.New(&tls_v3.SPIFFECertValidatorConfig{
+		TrustDomains: []*tls_v3.SPIFFECertValidatorConfig_TrustDomain{
+			{
+				Name: "otherdomain.test",
+				TrustBundle: &core_v3.DataSource{
+					Specifier: &core_v3.DataSource_InlineBytes{
+						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nRkVEQlVORExF\n-----END CERTIFICATE-----\n"),
+					},
+				},
+			},
+		},
 	})
 	fedValidationContext = &tls_v3.Secret{
 		Name: "spiffe://otherdomain.test",
@@ -73,7 +123,49 @@ var (
 			},
 		},
 	}
+	fedValidationContextSpiffeValidator = &tls_v3.Secret{
+		Name: "spiffe://otherdomain.test",
+		Type: &tls_v3.Secret_ValidationContext{
+			ValidationContext: &tls_v3.CertificateValidationContext{
+				CustomValidatorConfig: &core_v3.TypedExtensionConfig{
+					Name:        "envoy.tls.cert_validator.spiffe",
+					TypedConfig: fedCustomValidationConfig,
+				},
+			},
+		},
+	}
 
+	allBundlesCustomValidationConfig, _ = anypb.New(&tls_v3.SPIFFECertValidatorConfig{
+		TrustDomains: []*tls_v3.SPIFFECertValidatorConfig_TrustDomain{
+			{
+				Name: "domain.test",
+				TrustBundle: &core_v3.DataSource{
+					Specifier: &core_v3.DataSource_InlineBytes{
+						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nQlVORExF\n-----END CERTIFICATE-----\n"),
+					},
+				},
+			},
+			{
+				Name: "otherdomain.test",
+				TrustBundle: &core_v3.DataSource{
+					Specifier: &core_v3.DataSource_InlineBytes{
+						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nRkVEQlVORExF\n-----END CERTIFICATE-----\n"),
+					},
+				},
+			},
+		},
+	})
+	allBundlesValidationContext = &tls_v3.Secret{
+		Name: "ALL",
+		Type: &tls_v3.Secret_ValidationContext{
+			ValidationContext: &tls_v3.CertificateValidationContext{
+				CustomValidatorConfig: &core_v3.TypedExtensionConfig{
+					Name:        "envoy.tls.cert_validator.spiffe",
+					TypedConfig: allBundlesCustomValidationConfig,
+				},
+			},
+		},
+	}
 	workloadKeyPEM = []byte(`-----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgN2PdPEglb3JjF1Fg
 cqyEiRJHqtqzSUBnIeWCixn4hH2hRANCAARW+TsDRr0b0wJqg2kY5JvjX7UfAV3m
@@ -139,39 +231,566 @@ MC2hK9d8Z5ENZc9lFW48vObdcHcHdHvAaA8z2GM02pDkTt5pgUvRHlsf
 	}
 
 	workloadSelectors = cache.Selectors{{Type: "TYPE", Value: "VALUE"}}
+
+	userAgentVersionTypeV17 = &core_v3.Node_UserAgentBuildVersion{
+		UserAgentBuildVersion: &core_v3.BuildVersion{
+			Version: &envoy_type_v3.SemanticVersion{
+				MajorNumber: 1,
+				MinorNumber: 17,
+			},
+		},
+	}
+
+	userAgentVersionTypeV18 = &core_v3.Node_UserAgentBuildVersion{
+		UserAgentBuildVersion: &core_v3.BuildVersion{
+			Version: &envoy_type_v3.SemanticVersion{
+				MajorNumber: 1,
+				MinorNumber: 18,
+			},
+		},
+	}
 )
 
-func TestHandler(t *testing.T) {
-	spiretest.Run(t, new(HandlerSuite))
+func TestStreamSecrets(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		req           *discovery_v3.DiscoveryRequest
+		expectSecrets []*tls_v3.Secret
+		expectCode    codes.Code
+		expectMsg     string
+	}{
+		{
+			name: "All Secrets: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{
+				tdValidationContext,
+				fedValidationContext,
+				workloadTLSCertificate1,
+			},
+		},
+		{
+			name: "All Secrets: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{
+				tdValidationContextSpiffeValidator,
+				fedValidationContextSpiffeValidator,
+				workloadTLSCertificate1,
+			},
+		},
+		{
+			name: "TrustDomain bundle: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext},
+		},
+		{
+			name: "TrustDomain bundle: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
+		},
+		{
+			name: "Default TrustDomain bundle: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ROOTCA"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext2},
+		},
+		{
+			name: "Default TrustDomain bundle: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ROOTCA"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext2SpiffeValidator},
+		},
+		{
+			name: "Federated TrustDomain bundle: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://otherdomain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{fedValidationContext},
+		},
+		{
+			name: "Federated TrustDomain bundle: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://otherdomain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{fedValidationContextSpiffeValidator},
+		},
+		{
+			name: "TLS certificates only: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test/workload"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate1},
+		},
+		{
+			name: "TLS certificates only: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test/workload"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate1},
+		},
+		{
+			name: "Default All bundles: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectCode: codes.Internal,
+			expectMsg:  `unable to use "SPIFFE validator" on envoy below 1.17`,
+		},
+		{
+			name: "Default All bundles: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{allBundlesValidationContext},
+		},
+		{
+			name: "Default TLS certificate",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Unknown resource",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test/WHATEVER"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectCode: codes.InvalidArgument,
+			expectMsg:  "unable to retrieve all requested identities, missing map[spiffe://domain.test/WHATEVER:true]",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupTest(t)
+			defer test.cleanup()
+
+			stream, err := test.handler.StreamSecrets(context.Background())
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, stream.CloseSend())
+			}()
+
+			test.sendAndWait(stream, tt.req)
+
+			resp, err := stream.Recv()
+			spiretest.AssertGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			if tt.expectCode != codes.OK {
+				require.Nil(t, resp)
+				return
+			}
+
+			requireSecrets(t, resp, tt.expectSecrets...)
+		})
+	}
 }
 
-type HandlerSuite struct {
-	spiretest.Suite
-	manager  *FakeManager
-	server   *grpc.Server
-	handler  secret_v3.SecretDiscoveryServiceClient
-	received chan struct{}
+func TestStreamSecretsStreaming(t *testing.T) {
+	test := setupTest(t)
+	defer test.server.Stop()
+
+	stream, err := test.handler.StreamSecrets(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stream.CloseSend())
+	}()
+
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.VersionInfo)
+	require.NotEmpty(t, resp.Nonce)
+	requireSecrets(t, resp, workloadTLSCertificate1)
+
+	test.setWorkloadUpdate(workloadCert2)
+
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate2)
 }
 
-func (s *HandlerSuite) SetupTest() {
-	s.manager = NewFakeManager(s.T())
-	handler := New(Config{
-		Attestor:          FakeAttestor(workloadSelectors),
-		Manager:           s.manager,
-		DefaultSVIDName:   "default",
-		DefaultBundleName: "ROOTCA",
+func TestStreamSecretsApplicationDoesNotSpin(t *testing.T) {
+	test := setupTest(t)
+	defer test.server.Stop()
+
+	stream, err := test.handler.StreamSecrets(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stream.CloseSend())
+	}()
+
+	// Subscribe to some updates
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
 	})
 
-	s.received = make(chan struct{})
-	handler.hooks.received = s.received
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate1)
+
+	// Reject the update
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResponseNonce: resp.Nonce,
+		VersionInfo:   "OHNO",
+		ErrorDetail:   &status.Status{Message: "OHNO!"},
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+
+	test.setWorkloadUpdate(workloadCert2)
+
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate2)
+}
+
+func TestStreamSecretsRequestReceivedBeforeWorkloadUpdate(t *testing.T) {
+	test := setupTest(t)
+	defer test.server.Stop()
+
+	test.setWorkloadUpdate(nil)
+
+	stream, err := test.handler.StreamSecrets(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stream.CloseSend())
+	}()
+
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+
+	test.setWorkloadUpdate(workloadCert2)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate2)
+}
+
+func TestStreamSecretsSubChanged(t *testing.T) {
+	test := setupTest(t)
+	defer test.server.Stop()
+
+	stream, err := test.handler.StreamSecrets(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stream.CloseSend())
+	}()
+
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate1)
+
+	// Ack the response
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResponseNonce: resp.Nonce,
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+		VersionInfo:   resp.VersionInfo,
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+	})
+
+	// Send another request for different resources.
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResponseNonce: resp.Nonce,
+		VersionInfo:   resp.VersionInfo,
+		ResourceNames: []string{"spiffe://domain.test"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, tdValidationContext)
+}
+
+func TestStreamSecretsBadNonce(t *testing.T) {
+	test := setupTest(t)
+	defer test.server.Stop()
+
+	stream, err := test.handler.StreamSecrets(context.Background())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stream.CloseSend())
+	}()
+
+	// The first request should be good
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate1)
+
+	// Now update the workload SVID
+	test.setWorkloadUpdate(workloadCert2)
+
+	// The third request should be ignored because the nonce isn't set to
+	// the value returned in the response.
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResponseNonce: "FOO",
+		VersionInfo:   resp.VersionInfo,
+		ResourceNames: []string{"spiffe://domain.test"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+
+	// The fourth request should be good since the nonce matches that sent with
+	// the last response.
+	test.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
+		ResponseNonce: resp.Nonce,
+		VersionInfo:   resp.VersionInfo,
+		ResourceNames: []string{"spiffe://domain.test/workload"},
+		Node: &core_v3.Node{
+			UserAgentVersionType: userAgentVersionTypeV17,
+		},
+	})
+	resp, err = stream.Recv()
+	require.NoError(t, err)
+	requireSecrets(t, resp, workloadTLSCertificate2)
+}
+
+func TestFetchSecrets(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		req           *discovery_v3.DiscoveryRequest
+		expectSecrets []*tls_v3.Secret
+		expectCode    codes.Code
+		expectMsg     string
+	}{
+		{
+			name: "Fetch all secrets: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				TypeUrl: "TYPEURL",
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{
+				tdValidationContext,
+				fedValidationContext,
+				workloadTLSCertificate1,
+			},
+		},
+		{
+			name: "Fetch all secrets: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				TypeUrl: "TYPEURL",
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{
+				tdValidationContextSpiffeValidator,
+				fedValidationContextSpiffeValidator,
+				workloadTLSCertificate1,
+			},
+		},
+		{
+			name: "TrustDomain bundle: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext},
+		},
+		{
+			name: "TrustDomain bundle: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
+		},
+		{
+			name: "Federated bundle: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://otherdomain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{fedValidationContext},
+		},
+		{
+			name: "Federated bundle: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://otherdomain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{fedValidationContextSpiffeValidator},
+		},
+		{
+			name: "Default All bundles: RootCA",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectCode: codes.Internal,
+			expectMsg:  `unable to use "SPIFFE validator" on envoy below 1.17`,
+		},
+		{
+			name: "Default all bundles: SPIFFE",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{allBundlesValidationContext},
+		},
+		{
+			name: "TLS Certificate",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test/workload"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate1},
+		},
+		{
+			name: "Non-existent resource",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test/other"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV17,
+				},
+			},
+			expectCode: codes.InvalidArgument,
+			expectMsg:  `unable to retrieve all requested identities, missing map[spiffe://domain.test/other:true]`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupTest(t)
+			defer test.server.Stop()
+
+			resp, err := test.handler.FetchSecrets(context.Background(), tt.req)
+
+			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
+			if tt.expectCode != codes.OK {
+				require.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Empty(t, resp.VersionInfo)
+			require.Empty(t, resp.Nonce)
+			require.Equal(t, tt.req.TypeUrl, resp.TypeUrl)
+			requireSecrets(t, resp, tt.expectSecrets...)
+		})
+	}
+}
+
+func DeltaSecretsTest(t *testing.T) {
+	test := setupTest(t)
+	defer test.cleanup()
+
+	resp, err := test.handler.DeltaSecrets(context.Background())
+	spiretest.RequireGRPCStatus(t, err, codes.Unimplemented, "Method is not implemented")
+	require.Nil(t, resp)
+}
+
+func setupTest(t *testing.T) *handlerTest {
+	manager := NewFakeManager(t)
+	handler := New(Config{
+		Attestor:              FakeAttestor(workloadSelectors),
+		Manager:               manager,
+		DefaultSVIDName:       "default",
+		DefaultBundleName:     "ROOTCA",
+		DefaultAllBundlesName: "ALL",
+	})
+
+	received := make(chan struct{})
+	handler.hooks.received = received
 
 	listener, err := net.Listen("tcp", "localhost:0")
-	s.Require().NoError(err)
+	require.NoError(t, err)
 
 	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithInsecure())
-	s.Require().NoError(err)
-	s.handler = secret_v3.NewSecretDiscoveryServiceClient(conn)
-
+	require.NoError(t, err)
 	log, _ := test.NewNullLogger()
 	unaryInterceptor, streamInterceptor := middleware.Interceptors(middleware.WithLogger(log))
 	server := grpc.NewServer(grpc.Creds(FakeCreds{}),
@@ -180,312 +799,34 @@ func (s *HandlerSuite) SetupTest() {
 	)
 	secret_v3.RegisterSecretDiscoveryServiceServer(server, handler)
 	go func() { _ = server.Serve(listener) }()
-	s.server = server
 
-	s.setWorkloadUpdate(workloadCert1)
+	test := &handlerTest{
+		t:        t,
+		manager:  manager,
+		server:   server,
+		handler:  secret_v3.NewSecretDiscoveryServiceClient(conn),
+		received: received,
+	}
+
+	test.setWorkloadUpdate(workloadCert1)
+
+	return test
 }
 
-func (s *HandlerSuite) TearDownTest() {
-	s.server.Stop()
+type handlerTest struct {
+	t *testing.T
+
+	manager  *FakeManager
+	server   *grpc.Server
+	handler  secret_v3.SecretDiscoveryServiceClient
+	received chan struct{}
 }
 
-func (s *HandlerSuite) TestStreamSecretsStreamAllSecrets() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{})
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, tdValidationContext, fedValidationContext, workloadTLSCertificate1)
+func (h *handlerTest) cleanup() {
+	h.server.Stop()
 }
 
-func (s *HandlerSuite) TestStreamSecretsStreamTrustDomainBundleOnly() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, tdValidationContext)
-}
-
-func (s *HandlerSuite) TestStreamSecretsStreamDefaultTrustDomainBundleOnly() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"ROOTCA"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, tdValidationContext2)
-}
-
-func (s *HandlerSuite) TestStreamSecretsStreamFederatedTrustDomainBundleOnly() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://otherdomain.test"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, fedValidationContext)
-}
-
-func (s *HandlerSuite) TestStreamSecretsStreamTLSCertificateOnly() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-}
-
-func (s *HandlerSuite) TestStreamSecretsStreamDefaultTLSCertificateOnly() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"default"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate3)
-}
-
-func (s *HandlerSuite) TestStreamSecretsUnknownResource() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/WHATEVER"},
-	})
-	_, err = stream.Recv()
-	s.Require().Error(err)
-}
-
-func (s *HandlerSuite) TestStreamSecretsStreaming() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.Require().NotEmpty(resp.VersionInfo)
-	s.Require().NotEmpty(resp.Nonce)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-
-	s.setWorkloadUpdate(workloadCert2)
-
-	resp, err = stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate2)
-}
-
-func (s *HandlerSuite) TestStreamSecretsApplicationDoesNotSpin() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	// Subscribe to some updates
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-
-	// Reject the update
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResponseNonce: resp.Nonce,
-		VersionInfo:   "OHNO",
-		ErrorDetail:   &status.Status{Message: "OHNO!"},
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-
-	s.setWorkloadUpdate(workloadCert2)
-
-	resp, err = stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate2)
-}
-
-func (s *HandlerSuite) TestStreamSecretsRequestReceivedBeforeWorkloadUpdate() {
-	s.setWorkloadUpdate(nil)
-
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-
-	s.setWorkloadUpdate(workloadCert2)
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate2)
-}
-
-func (s *HandlerSuite) TestStreamSecretsSubChanged() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-
-	// Ack the response
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResponseNonce: resp.Nonce,
-		VersionInfo:   resp.VersionInfo,
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-
-	// Send another request for different resources.
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResponseNonce: resp.Nonce,
-		VersionInfo:   resp.VersionInfo,
-		ResourceNames: []string{"spiffe://domain.test"},
-	})
-
-	resp, err = stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, tdValidationContext)
-}
-
-func (s *HandlerSuite) TestStreamSecretsBadNonce() {
-	stream, err := s.handler.StreamSecrets(context.Background())
-	s.Require().NoError(err)
-	defer func() {
-		s.Require().NoError(stream.CloseSend())
-	}()
-
-	// The first request should be good
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-	resp, err := stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-
-	// Now update the workload SVID
-	s.setWorkloadUpdate(workloadCert2)
-
-	// The third request should be ignored because the nonce isn't set to
-	// the value returned in the response.
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResponseNonce: "FOO",
-		VersionInfo:   resp.VersionInfo,
-		ResourceNames: []string{"spiffe://domain.test"},
-	})
-
-	// The fourth request should be good since the nonce matches that sent with
-	// the last response.
-	s.sendAndWait(stream, &discovery_v3.DiscoveryRequest{
-		ResponseNonce: resp.Nonce,
-		VersionInfo:   resp.VersionInfo,
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-	resp, err = stream.Recv()
-	s.Require().NoError(err)
-	s.requireSecrets(resp, workloadTLSCertificate2)
-}
-
-func (s *HandlerSuite) TestFetchSecrets() {
-	// Fetch all secrets
-	resp, err := s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{TypeUrl: "TYPEURL"})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.Require().Equal("TYPEURL", resp.TypeUrl)
-	s.requireSecrets(resp, tdValidationContext, fedValidationContext, workloadTLSCertificate1)
-
-	// Fetch trust domain validation context only
-	resp, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test"},
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.requireSecrets(resp, tdValidationContext)
-
-	// Fetch federated validation context only
-	resp, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://otherdomain.test"},
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.requireSecrets(resp, fedValidationContext)
-
-	// Fetch tls certificate only
-	resp, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/workload"},
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(resp)
-	s.Require().Empty(resp.VersionInfo)
-	s.Require().Empty(resp.Nonce)
-	s.requireSecrets(resp, workloadTLSCertificate1)
-
-	// Fetch non-existent resource
-	_, err = s.handler.FetchSecrets(context.Background(), &discovery_v3.DiscoveryRequest{
-		ResourceNames: []string{"spiffe://domain.test/other"},
-	})
-	s.Require().Error(err)
-}
-
-func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {
+func (h *handlerTest) setWorkloadUpdate(workloadCert *x509.Certificate) {
 	var workloadUpdate *cache.WorkloadUpdate
 	if workloadCert != nil {
 		workloadUpdate = &cache.WorkloadUpdate{
@@ -504,29 +845,18 @@ func (s *HandlerSuite) setWorkloadUpdate(workloadCert *x509.Certificate) {
 			},
 		}
 	}
-	s.manager.SetWorkloadUpdate(workloadUpdate)
+	h.manager.SetWorkloadUpdate(workloadUpdate)
 }
 
-func (s *HandlerSuite) sendAndWait(stream secret_v3.SecretDiscoveryService_StreamSecretsClient, req *discovery_v3.DiscoveryRequest) {
-	s.Require().NoError(stream.Send(req))
+func (h *handlerTest) sendAndWait(stream secret_v3.SecretDiscoveryService_StreamSecretsClient, req *discovery_v3.DiscoveryRequest) {
+	require.NoError(h.t, stream.Send(req))
 	timer := time.NewTimer(time.Second)
 	defer timer.Stop()
 	select {
-	case <-s.received:
+	case <-h.received:
 	case <-timer.C:
-		s.Fail("timed out waiting for request to be received")
+		assert.Fail(h.t, "timed out waiting for request to be received")
 	}
-}
-
-func (s *HandlerSuite) requireSecrets(resp *discovery_v3.DiscoveryResponse, expectedSecrets ...*tls_v3.Secret) {
-	var actualSecrets []*tls_v3.Secret
-	for _, resource := range resp.Resources {
-		secret := new(tls_v3.Secret)
-		s.Require().NoError(resource.UnmarshalTo(secret)) //nolint: scopelint // pointer to resource isn't held
-		actualSecrets = append(actualSecrets, secret)
-	}
-
-	s.RequireProtoListEqual(expectedSecrets, actualSecrets)
 }
 
 type FakeAttestor []*common.Selector
@@ -644,3 +974,14 @@ func (w FakeWatcher) Close() {}
 func (w FakeWatcher) IsAlive() error { return nil }
 
 func (w FakeWatcher) PID() int32 { return 123 }
+
+func requireSecrets(t *testing.T, resp *discovery_v3.DiscoveryResponse, expectedSecrets ...*tls_v3.Secret) {
+	var actualSecrets []*tls_v3.Secret
+	for _, resource := range resp.Resources {
+		secret := new(tls_v3.Secret)
+		require.NoError(t, resource.UnmarshalTo(secret)) //nolint: scopelint // pointer to resource isn't held
+		actualSecrets = append(actualSecrets, secret)
+	}
+
+	spiretest.RequireProtoListEqual(t, expectedSecrets, actualSecrets)
+}

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -374,7 +374,7 @@ func TestStreamSecrets(t *testing.T) {
 				},
 			},
 			expectCode: codes.Internal,
-			expectMsg:  `unable to use "SPIFFE validator" on envoy below 1.17`,
+			expectMsg:  `unable to use "SPIFFE validator" on Envoy below 1.17`,
 		},
 		{
 			name: "Default All bundles: SPIFFE",
@@ -708,7 +708,7 @@ func TestFetchSecrets(t *testing.T) {
 				},
 			},
 			expectCode: codes.Internal,
-			expectMsg:  `unable to use "SPIFFE validator" on envoy below 1.17`,
+			expectMsg:  `unable to use "SPIFFE validator" on Envoy below 1.17`,
 		},
 		{
 			name: "Default all bundles: SPIFFE",


### PR DESCRIPTION
Update SDS v3 endpoints to use "SPIFFE Certificate Validator", it is used as default for Envoys from v1.18.0.
Add a new configurable to set `default_all_bundles_name` that i used to configure a validator config that contains Bundle together with all Federated Bundles.



**Which issue this PR fixes**
fixes #2420 
