### PR TITLE
Revert "Don't run CI for PRs that contain only doc changes (#2434)"

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,9 +1,6 @@
 name: PR Build
 on:
-  pull_request:
-    paths-ignore:
-      - 'doc/**'
-      - '*.md'
+  pull_request: {}
   workflow_dispatch: {}
 env:
   GO_VERSION: 1.16.5


### PR DESCRIPTION
The change wasn't compatible with how we have GitHub actions configured in the repository