### PR TITLE
Bump SPIRE SDKs deps in preparation for 1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,8 @@ require (
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spiffe/go-spiffe/v2 v2.0.0-beta.6
-	github.com/spiffe/spire-api-sdk v1.0.2-0.20210816212232-782cd5a6b660
-	github.com/spiffe/spire-plugin-sdk v1.0.0
+	github.com/spiffe/spire-api-sdk v1.0.2
+	github.com/spiffe/spire-plugin-sdk v1.0.2
 	github.com/stretchr/testify v1.7.0
 	github.com/uber-go/tally v3.3.12+incompatible
 	github.com/zeebo/errs v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -700,10 +700,10 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.6 h1:3DOMziVxNur7Gq7JkfJg5sLZbbtfkBi13SlDfByV9YI=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.6/go.mod h1:TEfgrEcyFhuSuvqohJt6IxENUNeHfndWCCV1EX7UaVk=
-github.com/spiffe/spire-api-sdk v1.0.2-0.20210816212232-782cd5a6b660 h1:/QgMFt0sZRzYoa07t6vmvlTShI46p2ZCe64VnM3yD3Q=
-github.com/spiffe/spire-api-sdk v1.0.2-0.20210816212232-782cd5a6b660/go.mod h1:2wSTZ6oEnKqI3uBST05Mmm751+yoHEvgxomYKYOQ6Ko=
-github.com/spiffe/spire-plugin-sdk v1.0.0 h1:Y5oWPvWS2S+BT9pIKP6fjPXIFLFfARqbIcxp0gjyYls=
-github.com/spiffe/spire-plugin-sdk v1.0.0/go.mod h1:fzNSP83Z848jZtPQYeZ9qPWZkbSPwmd/JFNux1gxsbM=
+github.com/spiffe/spire-api-sdk v1.0.2 h1:wzzzv5rosTEFvz/RDEzYrD799W+EYb2WPaLuSVBmlRA=
+github.com/spiffe/spire-api-sdk v1.0.2/go.mod h1:2wSTZ6oEnKqI3uBST05Mmm751+yoHEvgxomYKYOQ6Ko=
+github.com/spiffe/spire-plugin-sdk v1.0.2 h1:2cXV/rAFeff96cnZucENd9ctZjXVV2BSzyVOXJiu3zY=
+github.com/spiffe/spire-plugin-sdk v1.0.2/go.mod h1:fzNSP83Z848jZtPQYeZ9qPWZkbSPwmd/JFNux1gxsbM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=


### PR DESCRIPTION
Bump SPIRE SDKs deps in preparation for 1.0.2.

Fixes #2471.
