### PR TITLE
Move create entry "similarity" check inside of DataStore

### DIFF
--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -51,6 +51,12 @@ func (w metricsWrapper) CreateRegistrationEntry(ctx context.Context, entry *comm
 	return w.ds.CreateRegistrationEntry(ctx, entry)
 }
 
+func (w metricsWrapper) CreateOrReturnRegistrationEntry(ctx context.Context, entry *common.RegistrationEntry) (_ *common.RegistrationEntry, _ bool, err error) {
+	callCounter := StartCreateRegistrationCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.CreateOrReturnRegistrationEntry(ctx, entry)
+}
+
 func (w metricsWrapper) DeleteAttestedNode(ctx context.Context, spiffeID string) (_ *common.AttestedNode, err error) {
 	callCounter := StartDeleteNodeCall(w.m)
 	defer callCounter.Done(&err)

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -68,6 +68,10 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "CreateRegistrationEntry",
 		},
 		{
+			key:        "datastore.registration_entry.create",
+			methodName: "CreateOrReturnRegistrationEntry",
+		},
+		{
 			key:        "datastore.node.delete",
 			methodName: "DeleteAttestedNode",
 		},
@@ -261,6 +265,10 @@ func (ds *fakeDataStore) CreateJoinToken(context.Context, *datastore.JoinToken) 
 
 func (ds *fakeDataStore) CreateRegistrationEntry(context.Context, *common.RegistrationEntry) (*common.RegistrationEntry, error) {
 	return &common.RegistrationEntry{}, ds.err
+}
+
+func (ds *fakeDataStore) CreateOrReturnRegistrationEntry(context.Context, *common.RegistrationEntry) (*common.RegistrationEntry, bool, error) {
+	return &common.RegistrationEntry{}, true, ds.err
 }
 
 func (ds *fakeDataStore) DeleteAttestedNode(context.Context, string) (*common.AttestedNode, error) {

--- a/pkg/server/api/bundle/v1/service_test.go
+++ b/pkg/server/api/bundle/v1/service_test.go
@@ -781,9 +781,6 @@ func TestAppendBundle(t *testing.T) {
 }
 
 func TestBatchDeleteFederatedBundle(t *testing.T) {
-	test := setupServiceTest(t)
-	defer test.Cleanup()
-
 	td1 := spiffeid.RequireTrustDomainFromString("td1.org")
 	td2 := spiffeid.RequireTrustDomainFromString("td2.org")
 	td3 := spiffeid.RequireTrustDomainFromString("td3.org")
@@ -1108,7 +1105,8 @@ func TestBatchDeleteFederatedBundle(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			test.logHook.Reset()
+			test := setupServiceTest(t)
+			defer test.Cleanup()
 
 			// Create all test bundles
 			for _, td := range dsBundles {

--- a/pkg/server/api/entry/v1/service.go
+++ b/pkg/server/api/entry/v1/service.go
@@ -380,26 +380,6 @@ func applyMask(e *types.Entry, mask *types.EntryMask) {
 	}
 }
 
-func (s *Service) getExistingEntry(ctx context.Context, e *common.RegistrationEntry) (*common.RegistrationEntry, error) {
-	resp, err := s.ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{
-		BySpiffeID: e.SpiffeId,
-		ByParentID: e.ParentId,
-		BySelectors: &datastore.BySelectors{
-			Match:     datastore.Exact,
-			Selectors: e.Selectors,
-		},
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(resp.Entries) > 0 {
-		return resp.Entries[0], nil
-	}
-	return nil, nil
-}
-
 func (s *Service) updateEntry(ctx context.Context, e *types.Entry, inputMask *types.EntryMask, outputMask *types.EntryMask) *entryv1.BatchUpdateEntryResponse_Result {
 	log := rpccontext.Logger(ctx)
 	log = log.WithField(telemetry.RegistrationID, e.Id)

--- a/pkg/server/datastore/datastore.go
+++ b/pkg/server/datastore/datastore.go
@@ -23,6 +23,7 @@ type DataStore interface {
 	// Entries
 	CountRegistrationEntries(context.Context) (int32, error)
 	CreateRegistrationEntry(context.Context, *common.RegistrationEntry) (*common.RegistrationEntry, error)
+	CreateOrReturnRegistrationEntry(context.Context, *common.RegistrationEntry) (*common.RegistrationEntry, bool, error)
 	DeleteRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
 	FetchRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
 	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -197,6 +197,13 @@ func (s *DataStore) CreateRegistrationEntry(ctx context.Context, entry *common.R
 	return s.ds.CreateRegistrationEntry(ctx, entry)
 }
 
+func (s *DataStore) CreateOrReturnRegistrationEntry(ctx context.Context, entry *common.RegistrationEntry) (*common.RegistrationEntry, bool, error) {
+	if err := s.getNextError(); err != nil {
+		return nil, false, err
+	}
+	return s.ds.CreateOrReturnRegistrationEntry(ctx, entry)
+}
+
 func (s *DataStore) FetchRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err


### PR DESCRIPTION
The entry similarity check happens only on the API level, but not within the same transaction that the entry creation takes place in. This causes a small window where two concurrent requests for similar entries can result in both being created.

This PR moves the similarity check down to the SQL DataStore layer inside of the transaction that creates the entry. It also introduces a new DataStore function CreateOrReturnRegistrationEntry that returns the existing entry, that is useful for the API, but otherwise allows us to not have to update the existing CreateRegistrationEntry callers at this time. Both CreateRegistrationEntry and CreateOrReturnRegistrationEntry go through the same code paths and differ only in how they treat the case when a similar entry exists. CreateRegistrationEntry fails with AlreadyExists, while CreateOrReturnRegistrationEntry returns the existing entry along with a bool indicating that it is an existing entry.

This PR does NOT address the issue that UpdateRegistrationEntry can end up creating two "similar" entries.