### PR TITLE
Fix nil pointer dereference when allow_unsafe_ids is configured (#2476)

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -356,13 +356,6 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		return nil, err
 	}
 
-	// This is a terrible hack but is just a short-term band-aid.
-	// TODO: Deprecated and should be removed in 1.1
-	if c.Server.AllowUnsafeIDs != nil {
-		sc.Log.Warn("The insecure allow_unsafe_ids configurable is deprecated and will be removed in a future release.")
-		idutil.SetAllowUnsafeIDs(*c.Server.AllowUnsafeIDs)
-	}
-
 	logOptions = append(logOptions,
 		log.WithLevel(c.Server.LogLevel),
 		log.WithFormat(c.Server.LogFormat),
@@ -373,6 +366,13 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		return nil, fmt.Errorf("could not start logger: %w", err)
 	}
 	sc.Log = logger
+
+	// This is a terrible hack but is just a short-term band-aid.
+	// TODO: Deprecated and should be removed in 1.1
+	if c.Server.AllowUnsafeIDs != nil {
+		sc.Log.Warn("The insecure allow_unsafe_ids configurable is deprecated and will be removed in a future release.")
+		idutil.SetAllowUnsafeIDs(*c.Server.AllowUnsafeIDs)
+	}
 
 	ip := net.ParseIP(c.Server.BindAddress)
 	if ip == nil {


### PR DESCRIPTION
Change-Id: I9200600b251e2f51be7277104112222f92964265
Signed-off-by: Marc Yang <marc.yang@bytedance.com>

fixes #2476 