### PR TITLE
Remove deprecated "noop" plugin shim

### DIFF
--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -101,12 +101,6 @@ func Load(ctx context.Context, config Config) (_ *Repository, err error) {
 		return nil, err
 	}
 
-	if noopConfig, ok := config.PluginConfig[nodeResolverType]["noop"]; ok && noopConfig.PluginCmd == "" {
-		// TODO: remove in 1.1.0
-		delete(config.PluginConfig[nodeResolverType], "noop")
-		config.Log.Warn(`The "noop" NodeResolver is not required, is deprecated, and will be removed from a future release`)
-	}
-
 	pluginConfigs, err := catalog.PluginConfigsFromHCL(config.PluginConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Noop plugin has been unneeded for quite some time and was finally removed in 1.0. A compatability shim was added so that old configurations would not break.
This PR removes that shim for 1.1.