### PR TITLE
Use x509util to generate serial numbers for self-signed CAs

### DIFF
--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"math/big"
 	"net/url"
 	"path/filepath"
 	"sync"
@@ -24,6 +23,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
 	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/catalog"
 	"github.com/spiffe/spire/pkg/server/datastore"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
@@ -983,7 +983,12 @@ func GenerateServerCACSR(signer crypto.Signer, trustDomain spiffeid.TrustDomain,
 }
 
 func SelfSignX509CA(ctx context.Context, signer crypto.Signer, trustDomain spiffeid.TrustDomain, subject pkix.Name, notBefore, notAfter time.Time) (*X509CA, []*x509.Certificate, error) {
-	template, err := CreateServerCATemplate(trustDomain.ID(), signer.Public(), trustDomain, notBefore, notAfter, big.NewInt(0), subject)
+	serialNumber, err := x509util.NewSerialNumber()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	template, err := CreateServerCATemplate(trustDomain.ID(), signer.Public(), trustDomain, notBefore, notAfter, serialNumber, subject)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"sync"
@@ -142,6 +143,7 @@ func (s *ManagerSuite) TestSelfSigning() {
 		s.Equal(x509CA.Certificate.Subject, x509CA.Certificate.Issuer)
 	}
 	s.Empty(x509CA.UpstreamChain)
+	s.Require().Equal(1, x509CA.Certificate.SerialNumber.Cmp(big.NewInt(0)))
 }
 
 func (s *ManagerSuite) TestUpstreamSigned() {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request checklist**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated? (not needed?)

**Affected functionality**

Self-signed CA certificates now have the serial number compliant with RFC5280.

**Description of change**

We already have `x509util.NewSerialNumber()` to generate random serial numbers according to RFC5280. This commit adds the usage of this function in the `ca.manager.SelfSignX509CA` function.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
Fixes  #2484.

