### PR TITLE
Build images and scratch images in parallel

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -127,18 +127,50 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tools-
       - name: Build images
-        run: make images scratch-images
+        run: make images
       - name: Export images
-        run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > images.tar.gz
+        run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local | gzip > images.tar.gz
       - name: Archive images
         uses: actions/upload-artifact@v2
         with:
           name: images
           path: images.tar.gz
 
+  scratch-images:
+    runs-on: ubuntu-18.04
+    needs: [cache-deps]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Load cached deps
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Load cached build tools
+        uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-tools-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
+      - name: Build scratch images
+        run: make scratch-images
+      - name: Export scratch images
+        run: docker save spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > scratch-images.tar.gz
+      - name: Archive scratch images
+        uses: actions/upload-artifact@v2
+        with:
+          name: scratch-images
+          path: scratch-images.tar.gz
+
   integration:
     runs-on: ubuntu-18.04
-    needs: [cache-deps, images]
+    needs: [cache-deps, images, scratch-images]
     strategy:
       fail-fast: false
       matrix:
@@ -174,8 +206,15 @@ jobs:
         with:
           name: images
           path: .
+      - name: Download archived scratch images
+        uses: actions/download-artifact@v2
+        with:
+          name: scratch-images
+          path: .
       - name: Load archived images
         run: zcat images.tar.gz | docker load
+      - name: Load archived scratch images
+        run: zcat scratch-images.tar.gz | docker load
       - name: Run integration tests
         env:
           NUM_RUNNERS: ${{ matrix.num_runners }}

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -128,18 +128,50 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tools-
       - name: Build images
-        run: make images scratch-images
+        run: make images
       - name: Export images
-        run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > images.tar.gz
+        run: docker save spire-server:latest-local spire-agent:latest-local k8s-workload-registrar:latest-local oidc-discovery-provider:latest-local | gzip > images.tar.gz
       - name: Archive images
         uses: actions/upload-artifact@v2
         with:
           name: images
           path: images.tar.gz
 
+  scratch-images:
+    runs-on: ubuntu-18.04
+    needs: [cache-deps]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Load cached deps
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Load cached build tools
+        uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-tools-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
+      - name: Build scratch images
+        run: make scratch-images
+      - name: Export scratch images
+        run: docker save spire-server-scratch:latest-local spire-agent-scratch:latest-local k8s-workload-registrar-scratch:latest-local oidc-discovery-provider-scratch:latest-local | gzip > scratch-images.tar.gz
+      - name: Archive scratch images
+        uses: actions/upload-artifact@v2
+        with:
+          name: scratch-images
+          path: scratch-images.tar.gz
+
   integration:
     runs-on: ubuntu-18.04
-    needs: [cache-deps, images]
+    needs: [cache-deps, images, scratch-images]
     strategy:
       fail-fast: false
       matrix:
@@ -184,8 +216,15 @@ jobs:
         with:
           name: images
           path: .
+      - name: Download archived scratch images
+        uses: actions/download-artifact@v2
+        with:
+          name: scratch-images
+          path: .
       - name: Load archived images
         run: zcat images.tar.gz | docker load
+      - name: Load archived scratch images
+        run: zcat scratch-images.tar.gz | docker load
       - name: Run integration tests
         env:
           NUM_RUNNERS: ${{ matrix.num_runners }}


### PR DESCRIPTION
This PR shortens the CI/CD pipeline running time by parallelizing the image and scratch image builds.

