### PR TITLE
TD-API: Add the DeleteFederationRelationship method to the datastore

### DIFF
--- a/pkg/common/telemetry/server/datastore/federation_relationship.go
+++ b/pkg/common/telemetry/server/datastore/federation_relationship.go
@@ -11,6 +11,12 @@ func StartCreateFederationRelationshipCall(m telemetry.Metrics) *telemetry.CallC
 	return telemetry.StartCall(m, telemetry.Datastore, telemetry.FederationRelationship, telemetry.Create)
 }
 
+// StartDeleteFederationRelationshipCall return metric
+// for server's datastore, on deleting a federation relationship.
+func StartDeleteFederationRelationshipCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.FederationRelationship, telemetry.Delete)
+}
+
 // StartFetchFederationRelationship return metric
 // for server's datastore, on fetching a federation relationship.
 func StartFetchFederationRelationshipCall(m telemetry.Metrics) *telemetry.CallCounter {

--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -76,6 +76,12 @@ func (w metricsWrapper) DeleteBundle(ctx context.Context, trustDomain string, mo
 	return w.ds.DeleteBundle(ctx, trustDomain, mode)
 }
 
+func (w metricsWrapper) DeleteFederationRelationship(ctx context.Context, trustDomain spiffeid.TrustDomain) (err error) {
+	callCounter := StartDeleteFederationRelationshipCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.DeleteFederationRelationship(ctx, trustDomain)
+}
+
 func (w metricsWrapper) DeleteJoinToken(ctx context.Context, token string) (err error) {
 	callCounter := StartDeleteJoinTokenCall(w.m)
 	defer callCounter.Done(&err)

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -85,6 +85,10 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "DeleteBundle",
 		},
 		{
+			key:        "datastore.federation_relationship.delete",
+			methodName: "DeleteFederationRelationship",
+		},
+		{
 			key:        "datastore.join_token.delete",
 			methodName: "DeleteJoinToken",
 		},
@@ -289,6 +293,10 @@ func (ds *fakeDataStore) DeleteAttestedNode(context.Context, string) (*common.At
 }
 
 func (ds *fakeDataStore) DeleteBundle(context.Context, string, datastore.DeleteMode) error {
+	return ds.err
+}
+
+func (ds *fakeDataStore) DeleteFederationRelationship(context.Context, spiffeid.TrustDomain) error {
 	return ds.err
 }
 

--- a/pkg/server/datastore/datastore.go
+++ b/pkg/server/datastore/datastore.go
@@ -54,6 +54,7 @@ type DataStore interface {
 	// Federation Relationships
 	CreateFederationRelationship(context.Context, *FederationRelationship) (*FederationRelationship, error)
 	FetchFederationRelationship(context.Context, spiffeid.TrustDomain) (*FederationRelationship, error)
+	DeleteFederationRelationship(context.Context, spiffeid.TrustDomain) error
 }
 
 // DataConsistency indicates the required data consistency for a read operation.

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -280,6 +280,13 @@ func (s *DataStore) CreateFederationRelationship(c context.Context, fr *datastor
 	return s.ds.CreateFederationRelationship(c, fr)
 }
 
+func (s *DataStore) DeleteFederationRelationship(c context.Context, trustDomain spiffeid.TrustDomain) error {
+	if err := s.getNextError(); err != nil {
+		return err
+	}
+	return s.ds.DeleteFederationRelationship(c, trustDomain)
+}
+
 func (s *DataStore) FetchFederationRelationship(c context.Context, trustDomain spiffeid.TrustDomain) (*datastore.FederationRelationship, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Marcos Yedro <marcosyedro@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Datastore

**Description of change**
<!-- Please provide a description of the change -->
Add the DeleteFederationRelationship() method to the datastore.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
Fixes #2507
