### PR TITLE
Fix ghostunnel-federation integration test

### DIFF
--- a/test/integration/suites/ghostunnel-federation/Dockerfile
+++ b/test/integration/suites/ghostunnel-federation/Dockerfile
@@ -1,10 +1,10 @@
 FROM spire-agent:latest-local as spire-agent
 
-FROM alpine/socat:latest AS socat-latest
+FROM ghostunnel/ghostunnel:latest AS ghostunnel-latest
 
-FROM ghostunnel/ghostunnel:latest AS socat-ghostunnel-agent-mashup
+FROM alpine/socat:latest AS socat-ghostunnel-agent-mashup
 COPY --from=spire-agent /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent
-COPY --from=socat-latest /usr/bin/socat /usr/bin/socat
+COPY --from=ghostunnel-latest /usr/bin/ghostunnel /usr/bin/ghostunnel
 RUN apk --no-cache add dumb-init
 RUN apk --no-cache add supervisor
 ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration", "/opt/supervisord/supervisord.conf"]


### PR DESCRIPTION
There is a misalignment in the libs available in the socat image v.s.
the ghostunnel image (namely openssl). This is causing a breakage since
the mashup image (using the ghostunnel image as a base) does not have
these libs anymore. Since ghostunnel has no dependencies (outside of
musl) and socat has many, it makes more sense to use the socat image as
the base for the mashup image.

This change updates the Dockerfile to use the socat image as the base.

