### PR TITLE
Adapt bundle manager to manage dynamic relationships

### DIFF
--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -442,8 +442,8 @@ const (
 	// Type tags a type
 	Type = "type"
 
-	// TrustDomainName tags the name of some trust domain
-	TrustDomainName = "trust_domain_id"
+	// TrustDomain tags the name of some trust domain
+	TrustDomain = "trust_domain"
 
 	// TrustDomainID tags the ID of some trust domain
 	TrustDomainID = "trust_domain_id"

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -136,6 +136,12 @@ const (
 	// Audience tags some audience for a token
 	Audience = "audience"
 
+	// BundleEndpointProfile is the name of the bundle endpoint profile
+	BundleEndpointProfile = "bundle_endpoint_profile"
+
+	// BundleEndpointURL is the URL of the bundle endpoint
+	BundleEndpointURL = "bundle_endpoint_url"
+
 	// ByBanned tags filtering by banned agents
 	ByBanned = "by_banned"
 
@@ -436,7 +442,10 @@ const (
 	// Type tags a type
 	Type = "type"
 
-	// TrustDomainID tags some trust domain ID
+	// TrustDomainName tags the name of some trust domain
+	TrustDomainName = "trust_domain_id"
+
+	// TrustDomainID tags the ID of some trust domain
 	TrustDomainID = "trust_domain_id"
 
 	// Unknown tags some unknown caller, entity, or status

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/andres-erbsen/clock"
@@ -10,7 +11,6 @@ import (
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
-	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/pkg/server/datastore"
 )
 
@@ -20,6 +20,11 @@ const (
 	// bundle. It is important to try more than once within a refresh hint
 	// period so we can be resilient to temporary downtime or failures.
 	attemptsPerRefreshHint = 4
+
+	// configRefreshInterval is how often the manager reloads trust domain
+	// configs from the source and reconciles it against the current bundle
+	// updaters.
+	configRefreshInterval = time.Second * 10
 )
 
 type TrustDomainConfig struct {
@@ -39,27 +44,81 @@ type EndpointProfileInfo interface {
 
 type HTTPSWebProfile struct{}
 
+func (p HTTPSWebProfile) Name() string {
+	return "https_web"
+}
+
 type HTTPSSPIFFEProfile struct {
 	// EndpointSPIFFEID is the expected SPIFFE ID of the bundle endpoint server.
 	EndpointSPIFFEID spiffeid.ID
 }
 
+func (p HTTPSSPIFFEProfile) Name() string {
+	return "https_spiffe"
+}
+
+type TrustDomainConfigSource interface {
+	GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
+}
+
+type TrustDomainConfigSourceFunc func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
+
+func (fn TrustDomainConfigSourceFunc) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+	return fn(ctx)
+}
+
+type TrustDomainConfigMap map[spiffeid.TrustDomain]TrustDomainConfig
+
+func (m TrustDomainConfigMap) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+	return m, nil
+}
+
 type ManagerConfig struct {
-	Log          logrus.FieldLogger
-	Metrics      telemetry.Metrics
-	DataStore    datastore.DataStore
-	Clock        clock.Clock
-	TrustDomains map[spiffeid.TrustDomain]TrustDomainConfig
+	Log       logrus.FieldLogger
+	Metrics   telemetry.Metrics
+	DataStore datastore.DataStore
+	Clock     clock.Clock
+	Source    TrustDomainConfigSource
 
 	// newBundleUpdater is a test hook to inject updater behavior
 	newBundleUpdater func(BundleUpdaterConfig) BundleUpdater
+
+	// configRefreshedCh is a test hook to learn when the trust domain config
+	// has been refreshed and be apprised of the next scheduled refresh.
+	configRefreshedCh chan time.Duration
+
+	// bundleRefreshedCh is a test hook to learn when a bundle has been
+	// refreshed and be apprised of the next scheduled refresh.
+	bundleRefreshedCh chan time.Duration
 }
 
 type Manager struct {
-	log      logrus.FieldLogger
-	metrics  telemetry.Metrics
-	clock    clock.Clock
-	updaters map[spiffeid.TrustDomain]BundleUpdater
+	log              logrus.FieldLogger
+	metrics          telemetry.Metrics
+	clock            clock.Clock
+	ds               datastore.DataStore
+	source           TrustDomainConfigSource
+	configRefreshMtx sync.Mutex
+	updatersMtx      sync.RWMutex
+	updaters         map[spiffeid.TrustDomain]*managedBundleUpdater
+
+	// test hooks
+	newBundleUpdater  func(BundleUpdaterConfig) BundleUpdater
+	configRefreshedCh chan time.Duration
+	bundleRefreshedCh chan time.Duration
+}
+
+type managedBundleUpdater struct {
+	BundleUpdater
+
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+	runCh  chan chan error
+}
+
+func (m *managedBundleUpdater) Stop() {
+	m.cancel()
+	m.wg.Wait()
 }
 
 func NewManager(config ManagerConfig) *Manager {
@@ -70,41 +129,144 @@ func NewManager(config ManagerConfig) *Manager {
 		config.newBundleUpdater = NewBundleUpdater
 	}
 
-	updaters := make(map[spiffeid.TrustDomain]BundleUpdater)
-	for trustDomain, trustDomainConfig := range config.TrustDomains {
-		updaters[trustDomain] = config.newBundleUpdater(BundleUpdaterConfig{
-			TrustDomainConfig: trustDomainConfig,
-			TrustDomain:       trustDomain,
-			DataStore:         config.DataStore,
-		})
-	}
-
 	return &Manager{
-		log:      config.Log,
-		metrics:  config.Metrics,
-		clock:    config.Clock,
-		updaters: updaters,
+		log:               config.Log,
+		metrics:           config.Metrics,
+		clock:             config.Clock,
+		ds:                config.DataStore,
+		source:            config.Source,
+		newBundleUpdater:  config.newBundleUpdater,
+		configRefreshedCh: config.configRefreshedCh,
+		bundleRefreshedCh: config.bundleRefreshedCh,
+		updaters:          make(map[spiffeid.TrustDomain]*managedBundleUpdater),
 	}
 }
 
 func (m *Manager) Run(ctx context.Context) error {
-	var tasks []func(context.Context) error
-	for trustDomain, updater := range m.updaters {
-		// alias the loop variables that are used by the closure
-		trustDomain := trustDomain
-		updater := updater
-		tasks = append(tasks, func(ctx context.Context) error {
-			return m.runUpdater(ctx, trustDomain, updater)
-		})
-	}
+	// Initialize the timer that will reload the configs. The initial duration
+	// isn't very important since we'll reset it after the reload has
+	// completed.
+	timer := m.clock.Timer(configRefreshInterval)
+	defer timer.Stop()
 
-	return util.RunTasks(ctx, tasks...)
+	for {
+		if err := m.refreshConfigs(ctx); err != nil {
+			m.log.WithError(err).Error("Failed to reload configs")
+		}
+		timer.Reset(configRefreshInterval)
+		m.notifyConfigRefreshed(ctx, configRefreshInterval)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			m.log.Info("Shutting down")
+			return ctx.Err()
+		}
+	}
 }
 
-func (m *Manager) runUpdater(ctx context.Context, trustDomain spiffeid.TrustDomain, updater BundleUpdater) error {
+// RefreshBundleFor refreshes the trust domain bundle for the given trust
+// domain. If the trust domain is not managed by the manager, false is returned.
+func (m *Manager) RefreshBundleFor(ctx context.Context, td spiffeid.TrustDomain) (bool, error) {
+	if err := m.refreshConfigs(ctx); err != nil {
+		m.log.WithError(err).Error("Failed to reload configs")
+	}
+
+	m.updatersMtx.RLock()
+	updater, ok := m.updaters[td]
+	m.updatersMtx.RUnlock()
+
+	if !ok {
+		return false, nil
+	}
+
+	_, _, err := updater.UpdateBundle(ctx)
+	return true, err
+}
+
+func (m *Manager) refreshConfigs(ctx context.Context) error {
+	m.configRefreshMtx.Lock()
+	defer m.configRefreshMtx.Unlock()
+
+	configs, err := m.source.GetTrustDomainConfigs(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Duplicate the configs map since we're going to mutate it while figuring
+	// out what needs to be started/updated/stopped.
+	configs = cloneTrustDomainConfigs(configs)
+
+	var toStop []func()
+	defer func() {
+		if len(toStop) > 0 {
+			m.log.Debug("Stopping stale updaters")
+			for _, stop := range toStop {
+				stop()
+			}
+			m.log.Debug("Done stopping stale updaters")
+		}
+	}()
+
+	m.updatersMtx.Lock()
+	defer m.updatersMtx.Unlock()
+
+	for td, updater := range m.updaters {
+		tdLog := m.log.WithField(telemetry.Entry, td)
+		if config, ok := configs[td]; ok {
+			// Updater still needed. Update the configuration and remove it
+			// from the configs list since so a new updater isn't started for
+			// this trust domain.
+			if updater.SetTrustDomainConfig(config) {
+				tdLog.WithFields(logrus.Fields{
+					telemetry.BundleEndpointURL:     config.EndpointURL,
+					telemetry.BundleEndpointProfile: config.EndpointProfile.Name(),
+				}).Info("Updated configuration for managed trust domain")
+			}
+			delete(configs, td)
+		} else {
+			// Updater no longer needed. Stage it to be stopped and remove it
+			// from the updaters list.
+			tdLog.Info("Trust domain no longer managed")
+			toStop = append(toStop, updater.Stop)
+			delete(m.updaters, td)
+		}
+	}
+
+	// The remaining configs are for newly managed trust domains. Create and
+	// start up an updater for it.
+	for td, config := range configs {
+		m.log.WithFields(logrus.Fields{
+			telemetry.BundleEndpointURL:     config.EndpointURL,
+			telemetry.BundleEndpointProfile: config.EndpointProfile.Name(),
+			telemetry.TrustDomainName:       td,
+		}).Info("Trust domain is now managed")
+		ctx, cancel := context.WithCancel(ctx)
+		updater := &managedBundleUpdater{
+			BundleUpdater: m.newBundleUpdater(BundleUpdaterConfig{
+				TrustDomainConfig: config,
+				TrustDomain:       td,
+				DataStore:         m.ds,
+			}),
+			cancel: cancel,
+			runCh:  make(chan chan error),
+		}
+		m.updaters[td] = updater
+		updater.wg.Add(1)
+		go func(td spiffeid.TrustDomain) {
+			defer updater.wg.Done()
+			m.runUpdater(ctx, td, updater)
+		}(td)
+	}
+	return nil
+}
+
+func (m *Manager) runUpdater(ctx context.Context, trustDomain spiffeid.TrustDomain, updater BundleUpdater) {
+	// Initialize the timer. The initial duration does not matter since it will
+	// be reset with the actual refresh interval before first use.
+	timer := m.clock.Timer(time.Hour)
+	defer timer.Stop()
+
 	log := m.log.WithField("trust_domain", trustDomain)
-	log = log.WithField("bundle_endpoint_url", updater.TrustDomainConfig().EndpointURL)
-	log = log.WithField("bundle_endpoint_profile", updater.TrustDomainConfig().EndpointProfile.Name())
 	for {
 		var nextRefresh time.Duration
 		log.Debug("Polling for bundle update")
@@ -134,12 +296,34 @@ func (m *Manager) runUpdater(ctx context.Context, trustDomain spiffeid.TrustDoma
 			"at": m.clock.Now().Add(nextRefresh).UTC().Format(time.RFC3339),
 		}).Debug("Scheduling next bundle refresh")
 
-		timer := m.clock.Timer(nextRefresh)
+		// Notify the test hook
+		timer.Reset(nextRefresh)
+
+		m.notifyBundleRefreshed(ctx, nextRefresh)
+
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
+			log.Info("No longer polling for updates")
+			return
+		}
+	}
+}
+
+func (m *Manager) notifyConfigRefreshed(ctx context.Context, nextRefresh time.Duration) {
+	if m.configRefreshedCh != nil {
+		select {
+		case m.configRefreshedCh <- nextRefresh:
+		case <-ctx.Done():
+		}
+	}
+}
+
+func (m *Manager) notifyBundleRefreshed(ctx context.Context, nextRefresh time.Duration) {
+	if m.bundleRefreshedCh != nil {
+		select {
+		case m.bundleRefreshedCh <- nextRefresh:
+		case <-ctx.Done():
 		}
 	}
 }
@@ -148,10 +332,10 @@ func calculateNextUpdate(b *bundleutil.Bundle) time.Duration {
 	return bundleutil.CalculateRefreshHint(b) / attemptsPerRefreshHint
 }
 
-func (p HTTPSWebProfile) Name() string {
-	return "https_web"
-}
-
-func (p HTTPSSPIFFEProfile) Name() string {
-	return "https_spiffe"
+func cloneTrustDomainConfigs(configs map[spiffeid.TrustDomain]TrustDomainConfig) map[spiffeid.TrustDomain]TrustDomainConfig {
+	clone := make(map[spiffeid.TrustDomain]TrustDomainConfig, len(configs))
+	for k, v := range configs {
+		clone[k] = v
+	}
+	return clone
 }

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -238,7 +238,7 @@ func (m *Manager) refreshConfigs(ctx context.Context) error {
 		m.log.WithFields(logrus.Fields{
 			telemetry.BundleEndpointURL:     config.EndpointURL,
 			telemetry.BundleEndpointProfile: config.EndpointProfile.Name(),
-			telemetry.TrustDomainName:       td,
+			telemetry.TrustDomain:           td,
 		}).Info("Trust domain is now managed")
 		ctx, cancel := context.WithCancel(ctx)
 		updater := &managedBundleUpdater{

--- a/pkg/server/bundle/client/updater.go
+++ b/pkg/server/bundle/client/updater.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
@@ -12,13 +13,13 @@ import (
 )
 
 type BundleUpdaterConfig struct {
-	TrustDomainConfig
-
 	TrustDomain spiffeid.TrustDomain
 	DataStore   datastore.DataStore
 
-	// newClient is a test hook for injecting client behavior
-	newClient func(ClientConfig) (Client, error)
+	TrustDomainConfig TrustDomainConfig
+
+	// newClientHook is a test hook for injecting client behavior
+	newClientHook func(ClientConfig) (Client, error)
 }
 
 type BundleUpdater interface {
@@ -32,31 +33,43 @@ type BundleUpdater interface {
 	// local bundle, and is successfully stored.
 	UpdateBundle(ctx context.Context) (*bundleutil.Bundle, *bundleutil.Bundle, error)
 
-	// TrustDomainConfig returns the configuration for the updater
-	TrustDomainConfig() TrustDomainConfig
+	// GetTrustDomainConfig returns the configuration for the updater
+	GetTrustDomainConfig() TrustDomainConfig
+
+	// SetTrustDomainConfig sets the configuration for the updater
+	SetTrustDomainConfig(TrustDomainConfig) bool
 }
 
 type bundleUpdater struct {
-	c BundleUpdaterConfig
+	td            spiffeid.TrustDomain
+	ds            datastore.DataStore
+	newClientHook func(ClientConfig) (Client, error)
+
+	trustDomainConfigMtx sync.Mutex
+	trustDomainConfig    TrustDomainConfig
 }
 
 func NewBundleUpdater(config BundleUpdaterConfig) BundleUpdater {
-	if config.newClient == nil {
-		config.newClient = NewClient
+	if config.newClientHook == nil {
+		config.newClientHook = NewClient
 	}
-
 	return &bundleUpdater{
-		c: config,
+		td:                config.TrustDomain,
+		ds:                config.DataStore,
+		newClientHook:     config.newClientHook,
+		trustDomainConfig: config.TrustDomainConfig,
 	}
 }
 
 func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*bundleutil.Bundle, *bundleutil.Bundle, error) {
-	client, err := u.newClient(ctx)
+	trustDomainConfig := u.GetTrustDomainConfig()
+
+	client, err := u.newClient(ctx, trustDomainConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	localFederatedBundleOrNil, err := fetchBundleIfExists(ctx, u.c.DataStore, u.c.TrustDomain)
+	localFederatedBundleOrNil, err := fetchBundleIfExists(ctx, u.ds, u.td)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to fetch local federated bundle: %w", err)
 	}
@@ -70,7 +83,7 @@ func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*bundleutil.Bundle, *
 		return localFederatedBundleOrNil, nil, nil
 	}
 
-	_, err = u.c.DataStore.SetBundle(ctx, fetchedFederatedBundle.Proto())
+	_, err = u.ds.SetBundle(ctx, fetchedFederatedBundle.Proto())
 	if err != nil {
 		return localFederatedBundleOrNil, nil, fmt.Errorf("failed to store fetched federated bundle: %w", err)
 	}
@@ -78,19 +91,32 @@ func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*bundleutil.Bundle, *
 	return localFederatedBundleOrNil, fetchedFederatedBundle, nil
 }
 
-func (u *bundleUpdater) TrustDomainConfig() TrustDomainConfig {
-	return u.c.TrustDomainConfig
+func (u *bundleUpdater) GetTrustDomainConfig() TrustDomainConfig {
+	u.trustDomainConfigMtx.Lock()
+	trustDomainConfig := u.trustDomainConfig
+	u.trustDomainConfigMtx.Unlock()
+	return trustDomainConfig
 }
 
-func (u *bundleUpdater) newClient(ctx context.Context) (Client, error) {
-	config := ClientConfig{
-		TrustDomain: u.c.TrustDomain,
-		EndpointURL: u.c.EndpointURL,
+func (u *bundleUpdater) SetTrustDomainConfig(trustDomainConfig TrustDomainConfig) bool {
+	u.trustDomainConfigMtx.Lock()
+	defer u.trustDomainConfigMtx.Unlock()
+	if u.trustDomainConfig != trustDomainConfig {
+		u.trustDomainConfig = trustDomainConfig
+		return true
+	}
+	return false
+}
+
+func (u *bundleUpdater) newClient(ctx context.Context, trustDomainConfig TrustDomainConfig) (Client, error) {
+	clientConfig := ClientConfig{
+		TrustDomain: u.td,
+		EndpointURL: trustDomainConfig.EndpointURL,
 	}
 
-	if spiffeAuth, ok := u.c.EndpointProfile.(HTTPSSPIFFEProfile); ok {
+	if spiffeAuth, ok := trustDomainConfig.EndpointProfile.(HTTPSSPIFFEProfile); ok {
 		trustDomain := spiffeAuth.EndpointSPIFFEID.TrustDomain()
-		localEndpointBundle, err := fetchBundleIfExists(ctx, u.c.DataStore, trustDomain)
+		localEndpointBundle, err := fetchBundleIfExists(ctx, u.ds, trustDomain)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch local copy of bundle for %q: %w", trustDomain, err)
 		}
@@ -98,12 +124,12 @@ func (u *bundleUpdater) newClient(ctx context.Context) (Client, error) {
 		if localEndpointBundle == nil {
 			return nil, errors.New("can't perform SPIFFE Authentication: local copy of bundle not found")
 		}
-		config.SPIFFEAuth = &SPIFFEAuthConfig{
+		clientConfig.SPIFFEAuth = &SPIFFEAuthConfig{
 			EndpointSpiffeID: spiffeAuth.EndpointSPIFFEID,
 			RootCAs:          localEndpointBundle.RootCAs(),
 		}
 	}
-	return u.c.newClient(config)
+	return u.newClientHook(clientConfig)
 }
 
 func fetchBundleIfExists(ctx context.Context, ds datastore.DataStore, trustDomain spiffeid.TrustDomain) (*bundleutil.Bundle, error) {

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -96,7 +96,7 @@ func TestBundleUpdater(t *testing.T) {
 						EndpointSPIFFEID: trustDomain.ID(),
 					},
 				},
-				newClient: func(client ClientConfig) (Client, error) {
+				newClientHook: func(client ClientConfig) (Client, error) {
 					return testCase.client, nil
 				},
 			})

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -13,12 +13,11 @@ import (
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBundleUpdater(t *testing.T) {
-	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
-
+func TestBundleUpdaterUpdateBundle(t *testing.T) {
 	bundle1 := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "bundle1"))
 	bundle2 := bundleutil.BundleFromRootCA(trustDomain, createCACertificate(t, "bundle2"))
 	bundle2.SetRefreshHint(time.Minute)
@@ -130,6 +129,38 @@ func TestBundleUpdater(t *testing.T) {
 				require.Nil(t, bundle)
 			}
 		})
+	}
+}
+
+func TestBundleUpdaterConfiguration(t *testing.T) {
+	configs := []TrustDomainConfig{
+		{
+			EndpointURL:     "https://some-domain.test/webA",
+			EndpointProfile: HTTPSWebProfile{},
+		},
+		{
+			EndpointURL:     "https://some-domain.test/webB",
+			EndpointProfile: HTTPSWebProfile{},
+		},
+		{
+			EndpointURL: "https://some-domain.test/spiffeA",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: spiffeid.RequireFromString("spiffe://some-domain.test/spiffeA"),
+			},
+		},
+		{
+			EndpointURL: "https://some-domain.test/spiffeB",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: spiffeid.RequireFromString("spiffe://some-domain.test/spiffeB"),
+			},
+		},
+	}
+
+	updater := NewBundleUpdater(BundleUpdaterConfig{})
+
+	for _, config := range configs {
+		assert.True(t, updater.SetTrustDomainConfig(config), "config should have changed")
+		assert.False(t, updater.SetTrustDomainConfig(config), "config should not have changed")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -330,10 +330,10 @@ func (s *Server) newEndpointsServer(ctx context.Context, catalog catalog.Catalog
 
 func (s *Server) newBundleManager(cat catalog.Catalog, metrics telemetry.Metrics) *bundle_client.Manager {
 	return bundle_client.NewManager(bundle_client.ManagerConfig{
-		Log:          s.config.Log.WithField(telemetry.SubsystemName, "bundle_client"),
-		Metrics:      metrics,
-		DataStore:    cat.GetDataStore(),
-		TrustDomains: s.config.Federation.FederatesWith,
+		Log:       s.config.Log.WithField(telemetry.SubsystemName, "bundle_client"),
+		Metrics:   metrics,
+		DataStore: cat.GetDataStore(),
+		Source:    bundle_client.TrustDomainConfigMap(s.config.Federation.FederatesWith),
 	})
 }
 


### PR DESCRIPTION
- Run now reloads configuration from source on a 10 second interval
- A new RefreshBundle call is added (satisfying the interface from #2513) that refreshes the bundle for the given trust domain. It reloads the configuration beforehand.

Fixes: #2514