### PR TITLE
Federation Management API: Implement DataStore support for ListFederationRelationships

### DIFF
--- a/pkg/common/telemetry/server/datastore/federation_relationship.go
+++ b/pkg/common/telemetry/server/datastore/federation_relationship.go
@@ -16,3 +16,9 @@ func StartCreateFederationRelationshipCall(m telemetry.Metrics) *telemetry.CallC
 func StartFetchFederationRelationshipCall(m telemetry.Metrics) *telemetry.CallCounter {
 	return telemetry.StartCall(m, telemetry.Datastore, telemetry.FederationRelationship, telemetry.Fetch)
 }
+
+// StartListFederationRelationshipsCall return metric
+// for server's datastore, on listing federation relationships.
+func StartListFederationRelationshipsCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Datastore, telemetry.FederationRelationship, telemetry.List)
+}

--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -64,6 +64,12 @@ func (w metricsWrapper) CreateFederationRelationship(ctx context.Context, fr *da
 	return w.ds.CreateFederationRelationship(ctx, fr)
 }
 
+func (w metricsWrapper) ListFederationRelationships(ctx context.Context, req *datastore.ListFederationRelationshipsRequest) (_ *datastore.ListFederationRelationshipsResponse, err error) {
+	callCounter := StartListFederationRelationshipsCall(w.m)
+	defer callCounter.Done(&err)
+	return w.ds.ListFederationRelationships(ctx, req)
+}
+
 func (w metricsWrapper) DeleteAttestedNode(ctx context.Context, spiffeID string) (_ *common.AttestedNode, err error) {
 	callCounter := StartDeleteNodeCall(w.m)
 	defer callCounter.Done(&err)

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -133,6 +133,10 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "ListRegistrationEntries",
 		},
 		{
+			key:        "datastore.federation_relationship.list",
+			methodName: "ListFederationRelationships",
+		},
+		{
 			key:        "datastore.bundle.prune",
 			methodName: "PruneBundle",
 		},
@@ -270,6 +274,10 @@ func (ds *fakeDataStore) CreateBundle(context.Context, *common.Bundle) (*common.
 
 func (ds *fakeDataStore) CreateFederationRelationship(context.Context, *datastore.FederationRelationship) (*datastore.FederationRelationship, error) {
 	return &datastore.FederationRelationship{}, ds.err
+}
+
+func (ds *fakeDataStore) ListFederationRelationships(context.Context, *datastore.ListFederationRelationshipsRequest) (*datastore.ListFederationRelationshipsResponse, error) {
+	return &datastore.ListFederationRelationshipsResponse{}, ds.err
 }
 
 func (ds *fakeDataStore) CreateJoinToken(context.Context, *datastore.JoinToken) error {

--- a/pkg/server/datastore/datastore.go
+++ b/pkg/server/datastore/datastore.go
@@ -54,6 +54,7 @@ type DataStore interface {
 	// Federation Relationships
 	CreateFederationRelationship(context.Context, *FederationRelationship) (*FederationRelationship, error)
 	FetchFederationRelationship(context.Context, spiffeid.TrustDomain) (*FederationRelationship, error)
+	ListFederationRelationships(context.Context, *ListFederationRelationshipsRequest) (*ListFederationRelationshipsResponse, error)
 }
 
 // DataConsistency indicates the required data consistency for a read operation.
@@ -168,6 +169,15 @@ type ListRegistrationEntriesRequest struct {
 type ListRegistrationEntriesResponse struct {
 	Entries    []*common.RegistrationEntry
 	Pagination *Pagination
+}
+
+type ListFederationRelationshipsRequest struct {
+	Pagination *Pagination
+}
+
+type ListFederationRelationshipsResponse struct {
+	FederationRelationships []*FederationRelationship
+	Pagination              *Pagination
 }
 
 type BundleEndpointType string

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -487,7 +487,7 @@ func (ds *Plugin) FetchFederationRelationship(ctx context.Context, trustDomain s
 	return fr, nil
 }
 
-// ListFederationRelationships can be used to fetch all existing federation relationships.
+// ListFederationRelationships can be used to list all existing federation relationships
 func (ds *Plugin) ListFederationRelationships(ctx context.Context, req *datastore.ListFederationRelationshipsRequest) (resp *datastore.ListFederationRelationshipsResponse, err error) {
 	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
 		resp, err = listFederationRelationships(tx, req)

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -487,6 +487,17 @@ func (ds *Plugin) FetchFederationRelationship(ctx context.Context, trustDomain s
 	return fr, nil
 }
 
+// ListFederationRelationships can be used to fetch all existing federation relationships.
+func (ds *Plugin) ListFederationRelationships(ctx context.Context, req *datastore.ListFederationRelationshipsRequest) (resp *datastore.ListFederationRelationshipsResponse, err error) {
+	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
+		resp, err = listFederationRelationships(tx, req)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
 // Configure parses HCL config payload into config struct, and opens new DB based on the result
 func (ds *Plugin) Configure(hclConfiguration string) error {
 	config := &configuration{}
@@ -3294,13 +3305,68 @@ func fetchFederationRelationship(tx *gorm.DB, trustDomain spiffeid.TrustDomain) 
 		return nil, sqlError.Wrap(err)
 	}
 
+	return modelToFederationRelationship(tx, &model)
+}
+
+// listFederationRelationships can be used to fetch all existing federation relationshops.
+func listFederationRelationships(tx *gorm.DB, req *datastore.ListFederationRelationshipsRequest) (*datastore.ListFederationRelationshipsResponse, error) {
+	if req.Pagination != nil && req.Pagination.PageSize == 0 {
+		return nil, status.Error(codes.InvalidArgument, "cannot paginate with pagesize = 0")
+	}
+
+	p := req.Pagination
+	var err error
+	if p != nil {
+		tx, err = applyPagination(p, tx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var federationRelationships []FederatedTrustDomain
+	if err := tx.Find(&federationRelationships).Error; err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
+	if p != nil {
+		p.Token = ""
+		// Set token only if page size is the same than federationRelationships len
+		if len(federationRelationships) > 0 {
+			lastEntry := federationRelationships[len(federationRelationships)-1]
+			p.Token = fmt.Sprint(lastEntry.ID)
+		}
+	}
+
+	resp := &datastore.ListFederationRelationshipsResponse{
+		Pagination:              p,
+		FederationRelationships: []*datastore.FederationRelationship{},
+	}
+	for _, model := range federationRelationships {
+		model := model // alias the loop variable since we pass it by reference below
+		federationRelationship, err := modelToFederationRelationship(tx, &model)
+		if err != nil {
+			return nil, err
+		}
+
+		resp.FederationRelationships = append(resp.FederationRelationships, federationRelationship)
+	}
+
+	return resp, nil
+}
+
+func modelToFederationRelationship(tx *gorm.DB, model *FederatedTrustDomain) (*datastore.FederationRelationship, error) {
 	bundleEndpointURL, err := url.Parse(model.BundleEndpointURL)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse URL: %w", err)
 	}
 
+	td, err := spiffeid.TrustDomainFromString(model.TrustDomain)
+	if err != nil {
+		return nil, sqlError.Wrap(err)
+	}
+
 	fr := &datastore.FederationRelationship{
-		TrustDomain:           trustDomain,
+		TrustDomain:           td,
 		BundleEndpointURL:     bundleEndpointURL,
 		BundleEndpointProfile: datastore.BundleEndpointType(model.BundleEndpointProfile),
 	}
@@ -3314,7 +3380,7 @@ func fetchFederationRelationship(tx *gorm.DB, trustDomain spiffeid.TrustDomain) 
 		}
 		fr.EndpointSPIFFEID = endpointSPIFFEID
 
-		bundle, err := fetchBundle(tx, trustDomain.IDString())
+		bundle, err := fetchBundle(tx, td.IDString())
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch bundle: %w", err)
 		}

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -353,6 +353,51 @@ func (s *PluginSuite) TestListBundlesWithPagination() {
 		expectedErr        string
 	}{
 		{
+			name:         "no pagination",
+			expectedList: []*common.Bundle{bundle1, bundle2, bundle3, bundle4},
+		},
+		{
+			name: "page size bigger than items",
+			pagination: &datastore.Pagination{
+				PageSize: 5,
+			},
+			expectedList: []*common.Bundle{bundle1, bundle2, bundle3, bundle4},
+			expectedPagination: &datastore.Pagination{
+				Token:    "4",
+				PageSize: 5,
+			},
+		},
+		{
+			name: "pagination page size is zero",
+			pagination: &datastore.Pagination{
+				PageSize: 0,
+			},
+			expectedErr: "rpc error: code = InvalidArgument desc = cannot paginate with pagesize = 0",
+		},
+		{
+			name: "bundles first page",
+			pagination: &datastore.Pagination{
+				Token:    "0",
+				PageSize: 2,
+			},
+			expectedList: []*common.Bundle{bundle1, bundle2},
+			expectedPagination: &datastore.Pagination{Token: "2",
+				PageSize: 2,
+			},
+		},
+		{
+			name: "bundles second page",
+			pagination: &datastore.Pagination{
+				Token:    "2",
+				PageSize: 2,
+			},
+			expectedList: []*common.Bundle{bundle3, bundle4},
+			expectedPagination: &datastore.Pagination{
+				Token:    "4",
+				PageSize: 2,
+			},
+		},
+		{
 			name:         "bundles third page",
 			expectedList: []*common.Bundle{},
 			pagination: &datastore.Pagination{
@@ -361,6 +406,18 @@ func (s *PluginSuite) TestListBundlesWithPagination() {
 			},
 			expectedPagination: &datastore.Pagination{
 				Token:    "",
+				PageSize: 2,
+			},
+		},
+		{
+			name:         "invalid token",
+			expectedList: []*common.Bundle{},
+			expectedErr:  "rpc error: code = InvalidArgument desc = could not parse token 'invalid token'",
+			pagination: &datastore.Pagination{
+				Token:    "invalid token",
+				PageSize: 2,
+			},
+			expectedPagination: &datastore.Pagination{
 				PageSize: 2,
 			},
 		},

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -3407,17 +3407,19 @@ func (s *PluginSuite) TestListFederationRelationships() {
 	_, err := s.ds.CreateFederationRelationship(ctx, fr1)
 	s.Require().NoError(err)
 
+	s.createBundle("spiffe://example-2.org")
 	fr2 := &datastore.FederationRelationship{
 		TrustDomain:           spiffeid.RequireTrustDomainFromString("spiffe://example-2.org"),
-		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-1-web.org/bundleendpoint"),
-		BundleEndpointProfile: datastore.BundleEndpointWeb,
+		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-2-web.org/bundleendpoint"),
+		BundleEndpointProfile: datastore.BundleEndpointSPIFFE,
+		EndpointSPIFFEID:      spiffeid.RequireFromString("spiffe://example-2.org/test"),
 	}
 	_, err = s.ds.CreateFederationRelationship(ctx, fr2)
 	s.Require().NoError(err)
 
 	fr3 := &datastore.FederationRelationship{
 		TrustDomain:           spiffeid.RequireTrustDomainFromString("spiffe://example-3.org"),
-		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-1-web.org/bundleendpoint"),
+		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-3-web.org/bundleendpoint"),
 		BundleEndpointProfile: datastore.BundleEndpointWeb,
 	}
 	_, err = s.ds.CreateFederationRelationship(ctx, fr3)
@@ -3425,7 +3427,7 @@ func (s *PluginSuite) TestListFederationRelationships() {
 
 	fr4 := &datastore.FederationRelationship{
 		TrustDomain:           spiffeid.RequireTrustDomainFromString("spiffe://example-4.org"),
-		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-1-web.org/bundleendpoint"),
+		BundleEndpointURL:     requireURLFromString(s.T(), "https://example-4-web.org/bundleendpoint"),
 		BundleEndpointProfile: datastore.BundleEndpointWeb,
 	}
 	_, err = s.ds.CreateFederationRelationship(ctx, fr4)

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -287,6 +287,13 @@ func (s *DataStore) FetchFederationRelationship(c context.Context, trustDomain s
 	return s.ds.FetchFederationRelationship(c, trustDomain)
 }
 
+func (s *DataStore) ListFederationRelationships(ctx context.Context, req *datastore.ListFederationRelationshipsRequest) (*datastore.ListFederationRelationshipsResponse, error) {
+	if err := s.getNextError(); err != nil {
+		return nil, err
+	}
+	return s.ds.ListFederationRelationships(ctx, req)
+}
+
 func (s *DataStore) SetNextError(err error) {
 	s.errs = []error{err}
 }


### PR DESCRIPTION
This PR implements DataStore support for ListFederationRelationships.

Fixes #2503.