### PR TITLE
Update non self-serving validations

### DIFF
--- a/pkg/server/api/trustdomain.go
+++ b/pkg/server/api/trustdomain.go
@@ -129,7 +129,7 @@ func FederationRelationshipToProto(f *datastore.FederationRelationship, mask *ty
 				},
 			}
 			// Only self-serving endpoints has a bundle
-			if f.EndpointSPIFFEID.TrustDomain().Compare(f.TrustDomain) == 0 {
+			if f.EndpointSPIFFEID.TrustDomain() == f.TrustDomain {
 				bundle, err := BundleToProto(f.Bundle)
 				if err != nil {
 					return nil, err

--- a/pkg/server/api/trustdomain/v1/service_test.go
+++ b/pkg/server/api/trustdomain/v1/service_test.go
@@ -795,10 +795,10 @@ func TestBatchCreateFederationRelationship(t *testing.T) {
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.WarnLevel,
-					Message: "bundle not found for endpoint SPIFFE ID trustdomain",
+					Message: "bundle not found for the endpoint SPIFFE ID trust domain",
 					Data: logrus.Fields{
 						telemetry.TrustDomainID:    "domain.test",
-						telemetry.EndpointSpiffeID: "federated-td-web.org",
+						telemetry.EndpointSpiffeID: "spiffe://federated-td-web.org/endpoint",
 					},
 				},
 				{
@@ -1888,9 +1888,9 @@ func TestBatchUpdateFederationRelationship(t *testing.T) {
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.WarnLevel,
-					Message: "bundle not found for endpoint SPIFFE ID trustdomain",
+					Message: "bundle not found for the endpoint SPIFFE ID trust domain",
 					Data: logrus.Fields{
-						telemetry.EndpointSpiffeID: "not.found",
+						telemetry.EndpointSpiffeID: "spiffe://not.found/endpoint",
 						telemetry.TrustDomainID:    "foo.test",
 					},
 				},


### PR DESCRIPTION
Update federation relationships validations to allow the use of non self-serving endpoints, 
change: 

- don't validate if bundle exists
- return bundle if endpoint_spiffe_id has the same trust domain as the relationship
- add warning when creating/updating federation relationships, where endpoints trust domain does not have a bundle

