### PR TITLE
Add Dynamic TrustDomainConfig sources

### DIFF
--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -57,22 +57,6 @@ func (p HTTPSSPIFFEProfile) Name() string {
 	return "https_spiffe"
 }
 
-type TrustDomainConfigSource interface {
-	GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
-}
-
-type TrustDomainConfigSourceFunc func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
-
-func (fn TrustDomainConfigSourceFunc) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
-	return fn(ctx)
-}
-
-type TrustDomainConfigMap map[spiffeid.TrustDomain]TrustDomainConfig
-
-func (m TrustDomainConfigMap) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
-	return m, nil
-}
-
 type ManagerConfig struct {
 	Log       logrus.FieldLogger
 	Metrics   telemetry.Metrics

--- a/pkg/server/bundle/client/sources.go
+++ b/pkg/server/bundle/client/sources.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/datastore"
+)
+
+type TrustDomainConfigSource interface {
+	GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
+}
+
+type TrustDomainConfigSourceFunc func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error)
+
+func (fn TrustDomainConfigSourceFunc) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+	return fn(ctx)
+}
+
+type TrustDomainConfigMap map[spiffeid.TrustDomain]TrustDomainConfig
+
+func (m TrustDomainConfigMap) GetTrustDomainConfigs(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+	return m, nil
+}
+
+func MergeTrustDomainConfigSources(sources ...TrustDomainConfigSource) TrustDomainConfigSource {
+	return TrustDomainConfigSourceFunc(func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+		merged := make(map[spiffeid.TrustDomain]TrustDomainConfig)
+		// merge in reverse order
+		for i := len(sources) - 1; i >= 0; i-- {
+			configs, err := sources[i].GetTrustDomainConfigs(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for td, config := range configs {
+				merged[td] = config
+			}
+		}
+		return merged, nil
+	})
+}
+
+func DataStoreTrustDomainConfigSource(log logrus.FieldLogger, ds datastore.DataStore) TrustDomainConfigSource {
+	return TrustDomainConfigSourceFunc(func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
+		resp, err := ds.ListFederationRelationships(ctx, &datastore.ListFederationRelationshipsRequest{})
+		if err != nil {
+			return nil, err
+		}
+
+		configs := make(map[spiffeid.TrustDomain]TrustDomainConfig)
+		for _, fr := range resp.FederationRelationships {
+			config := TrustDomainConfig{
+				EndpointURL: fr.BundleEndpointURL.String(),
+			}
+			switch fr.BundleEndpointProfile {
+			case datastore.BundleEndpointSPIFFE:
+				config.EndpointProfile = HTTPSSPIFFEProfile{
+					EndpointSPIFFEID: fr.EndpointSPIFFEID,
+				}
+			case datastore.BundleEndpointWeb:
+				config.EndpointProfile = HTTPSWebProfile{}
+			default:
+				log.WithFields(logrus.Fields{
+					telemetry.TrustDomain:           fr.TrustDomain,
+					telemetry.BundleEndpointProfile: fr.BundleEndpointProfile,
+				}).Warn("Ignoring federation relationship with unknown profile type")
+				continue
+			}
+			configs[fr.TrustDomain] = config
+		}
+		return configs, nil
+	})
+}

--- a/pkg/server/bundle/client/sources_test.go
+++ b/pkg/server/bundle/client/sources_test.go
@@ -1,0 +1,145 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/server/bundle/client"
+	"github.com/spiffe/spire/pkg/server/datastore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	domain1 = spiffeid.RequireTrustDomainFromString("domain1.test")
+	domain2 = spiffeid.RequireTrustDomainFromString("domain2.test")
+	domain3 = spiffeid.RequireTrustDomainFromString("domain3.test")
+)
+
+func TestMergedTrustDomainConfigSource(t *testing.T) {
+	sourceA := client.TrustDomainConfigMap{
+		domain1: client.TrustDomainConfig{EndpointURL: "A"},
+	}
+	sourceB := client.TrustDomainConfigMap{
+		domain1: client.TrustDomainConfig{EndpointURL: "B"},
+	}
+	sourceC := client.TrustDomainConfigMap{
+		domain2: client.TrustDomainConfig{EndpointURL: "A"},
+	}
+
+	t.Run("context is passed through and error returned", func(t *testing.T) {
+		expectedCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var actualCtx context.Context
+		source := client.MergeTrustDomainConfigSources(client.TrustDomainConfigSourceFunc(
+			func(ctx context.Context) (map[spiffeid.TrustDomain]client.TrustDomainConfig, error) {
+				actualCtx = ctx
+				return nil, errors.New("oh no")
+			},
+		))
+		configs, err := source.GetTrustDomainConfigs(expectedCtx)
+		assert.Nil(t, configs)
+		assert.Equal(t, expectedCtx, actualCtx)
+		assert.EqualError(t, err, "oh no")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		source := client.MergeTrustDomainConfigSources()
+		configs, err := source.GetTrustDomainConfigs(context.Background())
+		assert.Empty(t, configs)
+		assert.NoError(t, err)
+	})
+
+	t.Run("priority is in-order", func(t *testing.T) {
+		source := client.MergeTrustDomainConfigSources(sourceA, sourceB, sourceC)
+		configs, err := source.GetTrustDomainConfigs(context.Background())
+		require.NoError(t, err)
+
+		require.Equal(t, map[spiffeid.TrustDomain]client.TrustDomainConfig{
+			domain1: client.TrustDomainConfig{EndpointURL: "A"},
+			domain2: client.TrustDomainConfig{EndpointURL: "A"},
+		}, configs)
+	})
+}
+
+func TestDataStoreTrustDomainConfigSource(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		ds := &fakeDataStore{}
+		source := client.DataStoreTrustDomainConfigSource(log, ds)
+		configs, err := source.GetTrustDomainConfigs(context.Background())
+		assert.Empty(t, configs)
+		assert.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		ds := &fakeDataStore{err: errors.New("oh no")}
+		source := client.DataStoreTrustDomainConfigSource(log, ds)
+		configs, err := source.GetTrustDomainConfigs(context.Background())
+		assert.Nil(t, configs)
+		assert.EqualError(t, err, "oh no")
+	})
+
+	t.Run("drops unknown profiles", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		ds := &fakeDataStore{frs: []*datastore.FederationRelationship{
+			{
+				TrustDomain:           domain1,
+				BundleEndpointURL:     parseURL(t, "https://domain1.test/bundle"),
+				BundleEndpointProfile: datastore.BundleEndpointWeb,
+				EndpointSPIFFEID:      spiffeid.RequireFromString("spiffe://notused"),
+			},
+			{
+				TrustDomain:           domain2,
+				BundleEndpointURL:     parseURL(t, "https://domain2.test/bundle"),
+				BundleEndpointProfile: datastore.BundleEndpointType("UNKNOWN"),
+			},
+			{
+				TrustDomain:           domain3,
+				BundleEndpointURL:     parseURL(t, "https://domain3.test/bundle"),
+				BundleEndpointProfile: datastore.BundleEndpointSPIFFE,
+				EndpointSPIFFEID:      spiffeid.RequireFromString("spiffe://domain3.test/bundle-server"),
+			},
+		}}
+		source := client.DataStoreTrustDomainConfigSource(log, ds)
+		configs, err := source.GetTrustDomainConfigs(context.Background())
+		assert.Equal(t, map[spiffeid.TrustDomain]client.TrustDomainConfig{
+			domain1: {
+				EndpointURL:     "https://domain1.test/bundle",
+				EndpointProfile: client.HTTPSWebProfile{},
+			},
+			domain3: {
+				EndpointURL: "https://domain3.test/bundle",
+				EndpointProfile: client.HTTPSSPIFFEProfile{
+					EndpointSPIFFEID: spiffeid.RequireFromString("spiffe://domain3.test/bundle-server"),
+				},
+			},
+		}, configs)
+		assert.NoError(t, err)
+	})
+}
+
+type fakeDataStore struct {
+	datastore.DataStore
+	frs []*datastore.FederationRelationship
+	err error
+}
+
+func (ds fakeDataStore) ListFederationRelationships(context.Context, *datastore.ListFederationRelationshipsRequest) (*datastore.ListFederationRelationshipsResponse, error) {
+	if ds.err != nil {
+		return nil, ds.err
+	}
+	return &datastore.ListFederationRelationshipsResponse{FederationRelationships: ds.frs}, nil
+}
+
+func parseURL(t *testing.T, s string) *url.URL {
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+	return u
+}


### PR DESCRIPTION
Adds a source for the datastore and one that merges sources, with in-order priority (i.e. first source wins).