### PR TITLE
plugins/gcp_cas: Update to v1 of the privatecas api

### DIFF
--- a/doc/plugin_server_upstreamauthority_gcp_cas.md
+++ b/doc/plugin_server_upstreamauthority_gcp_cas.md
@@ -3,9 +3,6 @@
 The `gcp_cas` plugin uses the Certificate Authority from Google Cloud Platform, known as "Certificate Authority Service" (CAS),
  to generate intermediate signing certificates for SPIRE Server.
 
-# Considerations
-**This plugin relies on GCP Certificate Authority Service which is currently in Beta and hence is not recommended to run in production environments**.
-
 # Configuration
 The plugin has a mandatory root_cert_spec section. It is used to specify which CAs are used for signing
  intermediate CAs as well as being part of the trusted root bundle. If it matches multiple CAs,
@@ -17,6 +14,7 @@ The plugin has a mandatory root_cert_spec section. It is used to specify which C
 | ----------------------------- | ----------------------------------------------------------------- |
 | project_name   | Project in GCP that has the root CA certificate                   |
 | region_name    | The name of the region within GCP                                 |
+| ca_pool        | The name of the CA Pool that has the root CA certificate          |
 | label_key      | Label key - value pair is used to filter and select the relevant certificate  |
 | label_value    | Label key - value pair is used to filter and select the relevant certificate  |
 
@@ -28,6 +26,7 @@ UpstreamAuthority "gcp_cas" {
         root_cert_spec {
             project_name = "MyProject"
             region_name = "us-central1"
+            ca_pool = "mypool"
             label_key = "myapp-identity-root"
             label_value = "true"
         }


### PR DESCRIPTION


<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Affects the server/upstreamauthority/gcp_cas plugin.  Adds new config field which will require intervention from users of the plugin.

**Description of change**
Google's CAS service entered general availability and in doing so v1 of
the API was published.  When this happened requests to the v1beta1
seemingly stopped returning data.

* Adds `ca_pool` to the plugin config. CAs now live within CA Pools in
  CAS, so we need to know which pool to search in for CA.
* `ReusableConfigs` were removed from the `CreateCertificate` API call.
  The request now expects the `X509Config` argument to be provided,
  which details the Key Usage and other X509 options for the certificate
  to be created.

Signed-off-by: Mikhail Swift <mswift@mswift.dev>

**Which issue this PR fixes**
fixes #2567

