### PR TITLE
Fix issue with socketPath handling

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -295,7 +295,7 @@ func parseFlags(name string, args []string, output io.Writer) (*serverConfig, er
 	flags.StringVar(&c.LogFile, "logFile", "", "File to write logs to")
 	flags.StringVar(&c.LogFormat, "logFormat", "", "'text' or 'json'")
 	flags.StringVar(&c.LogLevel, "logLevel", "", "'debug', 'info', 'warn', or 'error'")
-	flags.StringVar(&c.SocketPath, "socketPath", defaultSocketPath, "Path to bind the SPIRE Server API socket to")
+	flags.StringVar(&c.SocketPath, "socketPath", "", "Path to bind the SPIRE Server API socket to")
 	flags.StringVar(&c.TrustDomain, "trustDomain", "", "The trust domain that this server belongs to")
 	flags.BoolVar(&c.ExpandEnv, "expandEnv", false, "Expand environment variables in SPIRE config file")
 
@@ -363,8 +363,12 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		Port: c.Server.BindPort,
 	}
 
+	socketPath := defaultSocketPath
+	if c.Server.SocketPath != "" {
+		socketPath = c.Server.SocketPath
+	}
 	sc.BindUDSAddress = &net.UnixAddr{
-		Name: c.Server.SocketPath,
+		Name: socketPath,
 		Net:  "unix",
 	}
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -104,13 +104,13 @@ func TestMergeInput(t *testing.T) {
 	cases := []struct {
 		msg       string
 		fileInput func(*Config)
-		cliInput  func(*serverConfig)
+		cliFlags  []string
 		test      func(*testing.T, *Config)
 	}{
 		{
 			msg:       "bind_address should default to 0.0.0.0 if not set",
 			fileInput: func(c *Config) {},
-			cliInput:  func(c *serverConfig) {},
+			cliFlags:  []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "0.0.0.0", c.Server.BindAddress)
 			},
@@ -120,9 +120,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.BindAddress = "10.0.0.1"
 			},
-			cliInput: func(c *serverConfig) {
-				c.BindAddress = ""
-			},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "10.0.0.1", c.Server.BindAddress)
 			},
@@ -132,9 +130,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.BindAddress = ""
 			},
-			cliInput: func(c *serverConfig) {
-				c.BindAddress = "10.0.0.1"
-			},
+			cliFlags: []string{"-bindAddress=10.0.0.1"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "10.0.0.1", c.Server.BindAddress)
 			},
@@ -144,9 +140,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.BindAddress = "10.0.0.1"
 			},
-			cliInput: func(c *serverConfig) {
-				c.BindAddress = "10.0.0.2"
-			},
+			cliFlags: []string{"-bindAddress=10.0.0.2"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "10.0.0.2", c.Server.BindAddress)
 			},
@@ -154,7 +148,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "bind_port should default to 8081 if not set",
 			fileInput: func(c *Config) {},
-			cliInput:  func(c *serverConfig) {},
+			cliFlags:  []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, 8081, c.Server.BindPort)
 			},
@@ -164,7 +158,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.BindPort = 1337
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, 1337, c.Server.BindPort)
 			},
@@ -172,9 +166,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "bind_port should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.BindPort = 1337
-			},
+			cliFlags:  []string{"-serverPort=1337"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, 1337, c.Server.BindPort)
 			},
@@ -184,9 +176,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.BindPort = 1336
 			},
-			cliInput: func(c *serverConfig) {
-				c.BindPort = 1337
-			},
+			cliFlags: []string{"-serverPort=1337"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, 1337, c.Server.BindPort)
 			},
@@ -196,7 +186,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.CAKeyType = "rsa-2048"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "rsa-2048", c.Server.CAKeyType)
 			},
@@ -210,7 +200,7 @@ func TestMergeInput(t *testing.T) {
 					CommonName:   "test-cn",
 				}
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, []string{"test-country"}, c.Server.CASubject.Country)
 				require.Equal(t, []string{"test-org"}, c.Server.CASubject.Organization)
@@ -222,7 +212,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.CATTL = "1h"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "1h", c.Server.CATTL)
 			},
@@ -232,7 +222,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.DataDir = "foo"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.DataDir)
 			},
@@ -240,9 +230,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "data_dir should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.DataDir = "foo"
-			},
+			cliFlags:  []string{"-dataDir=foo"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.DataDir)
 			},
@@ -252,9 +240,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.DataDir = "foo"
 			},
-			cliInput: func(c *serverConfig) {
-				c.DataDir = "bar"
-			},
+			cliFlags: []string{"-dataDir=bar"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "bar", c.Server.DataDir)
 			},
@@ -264,7 +250,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.JWTIssuer = "ISSUER"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "ISSUER", c.Server.JWTIssuer)
 			},
@@ -274,7 +260,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogFile = "foo"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.LogFile)
 			},
@@ -282,9 +268,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "log_file should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.LogFile = "foo"
-			},
+			cliFlags:  []string{"-logFile=foo"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.LogFile)
 			},
@@ -294,9 +278,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogFile = "foo"
 			},
-			cliInput: func(c *serverConfig) {
-				c.LogFile = "bar"
-			},
+			cliFlags: []string{"-logFile=bar"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "bar", c.Server.LogFile)
 			},
@@ -304,7 +286,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "log_format should default to log.DefaultFormat if not set",
 			fileInput: func(c *Config) {},
-			cliInput:  func(c *serverConfig) {},
+			cliFlags:  []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, log.DefaultFormat, c.Server.LogFormat)
 			},
@@ -314,7 +296,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogFormat = "JSON"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "JSON", c.Server.LogFormat)
 			},
@@ -322,9 +304,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "log_format should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.LogFormat = "JSON"
-			},
+			cliFlags:  []string{"-logFormat=JSON"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "JSON", c.Server.LogFormat)
 			},
@@ -334,9 +314,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogFormat = "TEXT"
 			},
-			cliInput: func(c *serverConfig) {
-				c.LogFormat = "JSON"
-			},
+			cliFlags: []string{"-logFormat=JSON"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "JSON", c.Server.LogFormat)
 			},
@@ -344,7 +322,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "log_level should default to INFO if not set",
 			fileInput: func(c *Config) {},
-			cliInput:  func(c *serverConfig) {},
+			cliFlags:  []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "INFO", c.Server.LogLevel)
 			},
@@ -354,7 +332,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogLevel = "DEBUG"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "DEBUG", c.Server.LogLevel)
 			},
@@ -362,9 +340,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "log_level should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.LogLevel = "DEBUG"
-			},
+			cliFlags:  []string{"-logLevel=DEBUG"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "DEBUG", c.Server.LogLevel)
 			},
@@ -374,9 +350,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.LogLevel = "WARN"
 			},
-			cliInput: func(c *serverConfig) {
-				c.LogLevel = "DEBUG"
-			},
+			cliFlags: []string{"-logLevel=DEBUG"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "DEBUG", c.Server.LogLevel)
 			},
@@ -386,7 +360,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.SocketPath = "foo"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.SocketPath)
 			},
@@ -394,9 +368,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "socket_path should be configuable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.SocketPath = "foo"
-			},
+			cliFlags:  []string{"-socketPath=foo"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.SocketPath)
 			},
@@ -406,9 +378,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.SocketPath = "foo"
 			},
-			cliInput: func(c *serverConfig) {
-				c.SocketPath = "bar"
-			},
+			cliFlags: []string{"-socketPath=bar"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "bar", c.Server.SocketPath)
 			},
@@ -418,7 +388,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.DefaultSVIDTTL = "1h"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "1h", c.Server.DefaultSVIDTTL)
 			},
@@ -426,7 +396,7 @@ func TestMergeInput(t *testing.T) {
 		{
 			msg:       "trust_domain should not have a default value",
 			fileInput: func(c *Config) {},
-			cliInput:  func(c *serverConfig) {},
+			cliFlags:  []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "", c.Server.TrustDomain)
 			},
@@ -436,7 +406,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.TrustDomain = "foo"
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.TrustDomain)
 			},
@@ -445,9 +415,7 @@ func TestMergeInput(t *testing.T) {
 			// TODO: should it really?
 			msg:       "trust_domain should be configurable by CLI flag",
 			fileInput: func(c *Config) {},
-			cliInput: func(c *serverConfig) {
-				c.TrustDomain = "foo"
-			},
+			cliFlags:  []string{"-trustDomain=foo"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "foo", c.Server.TrustDomain)
 			},
@@ -457,9 +425,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.TrustDomain = "foo"
 			},
-			cliInput: func(c *serverConfig) {
-				c.TrustDomain = "bar"
-			},
+			cliFlags: []string{"-trustDomain=bar"},
 			test: func(t *testing.T, c *Config) {
 				require.Equal(t, "bar", c.Server.TrustDomain)
 			},
@@ -469,7 +435,7 @@ func TestMergeInput(t *testing.T) {
 			fileInput: func(c *Config) {
 				c.Server.AuditLogEnabled = true
 			},
-			cliInput: func(c *serverConfig) {},
+			cliFlags: []string{},
 			test: func(t *testing.T, c *Config) {
 				require.True(t, c.Server.AuditLogEnabled)
 			},
@@ -480,10 +446,10 @@ func TestMergeInput(t *testing.T) {
 		testCase := testCase
 
 		fileInput := &Config{Server: &serverConfig{}}
-		cliInput := &serverConfig{}
 
 		testCase.fileInput(fileInput)
-		testCase.cliInput(cliInput)
+		cliInput, err := parseFlags("run", testCase.cliFlags, os.Stderr)
+		require.NoError(t, err)
 
 		t.Run(testCase.msg, func(t *testing.T) {
 			i, err := mergeInput(fileInput, cliInput)


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included? 
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->
Bug fix, currently, `socketPath` is not respected in the server config file.

This is due to a bad interaction between https://github.com/spiffe/spire/blob/main/cmd/spire-server/cli/run/run.go#L298 and https://github.com/spiffe/spire/blob/main/cmd/spire-server/cli/run/run.go#L314

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

