### PR TITLE
Federation Management API: Add documentation

### DIFF
--- a/cmd/spire-server/cli/federation/create.go
+++ b/cmd/spire-server/cli/federation/create.go
@@ -37,7 +37,7 @@ func (*createCommand) Name() string {
 }
 
 func (*createCommand) Synopsis() string {
-	return "Creates a federation relationship to a foreign trust domain"
+	return "Creates a dynamic federation relationship with a foreign trust domain"
 }
 
 func (c *createCommand) AppendFlags(f *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/create_test.go
+++ b/cmd/spire-server/cli/federation/create_test.go
@@ -40,7 +40,7 @@ func TestCreatetHelp(t *testing.T) {
 
 func TestCreateSynopsis(t *testing.T) {
 	test := setupTest(t, newCreateCommand)
-	require.Equal(t, "Creates a federation relationship to a foreign trust domain", test.client.Synopsis())
+	require.Equal(t, "Creates a dynamic federation relationship with a foreign trust domain", test.client.Synopsis())
 }
 
 func TestCreate(t *testing.T) {

--- a/cmd/spire-server/cli/federation/delete.go
+++ b/cmd/spire-server/cli/federation/delete.go
@@ -32,7 +32,7 @@ func (c *deleteCommand) Name() string {
 }
 
 func (c *deleteCommand) Synopsis() string {
-	return "Deletes federation relationship"
+	return "Deletes a dynamic federation relationship"
 }
 
 func (c *deleteCommand) AppendFlags(fs *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/delete_test.go
+++ b/cmd/spire-server/cli/federation/delete_test.go
@@ -24,7 +24,7 @@ func TestDeleteHelp(t *testing.T) {
 
 func TestDeleteSynopsis(t *testing.T) {
 	test := setupTest(t, newDeleteCommand)
-	require.Equal(t, "Deletes federation relationship", test.client.Synopsis())
+	require.Equal(t, "Deletes a dynamic federation relationship", test.client.Synopsis())
 }
 
 func TestDelete(t *testing.T) {

--- a/cmd/spire-server/cli/federation/list.go
+++ b/cmd/spire-server/cli/federation/list.go
@@ -27,7 +27,7 @@ func (c *listCommand) Name() string {
 }
 
 func (c *listCommand) Synopsis() string {
-	return "List federation relationships"
+	return "Lists all dynamic federation relationships"
 }
 
 func (c *listCommand) AppendFlags(fs *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/list_test.go
+++ b/cmd/spire-server/cli/federation/list_test.go
@@ -22,7 +22,7 @@ func TestListHelp(t *testing.T) {
 
 func TestListSynopsis(t *testing.T) {
 	test := setupTest(t, newListCommand)
-	require.Equal(t, "List federation relationships", test.client.Synopsis())
+	require.Equal(t, "Lists all dynamic federation relationships", test.client.Synopsis())
 }
 
 func TestList(t *testing.T) {

--- a/cmd/spire-server/cli/federation/refresh.go
+++ b/cmd/spire-server/cli/federation/refresh.go
@@ -32,7 +32,7 @@ func (c *refreshCommand) Name() string {
 }
 
 func (c *refreshCommand) Synopsis() string {
-	return "Refresh bundle"
+	return "Refreshes the bundle from the specified federated trust domain"
 }
 
 func (c *refreshCommand) AppendFlags(fs *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/refresh_test.go
+++ b/cmd/spire-server/cli/federation/refresh_test.go
@@ -24,7 +24,7 @@ func TestRefreshHelp(t *testing.T) {
 
 func TestRefreshSynopsis(t *testing.T) {
 	test := setupTest(t, newRefreshCommand)
-	require.Equal(t, "Refresh bundle", test.client.Synopsis())
+	require.Equal(t, "Refreshes the bundle from the specified federated trust domain", test.client.Synopsis())
 }
 
 func TestRefresh(t *testing.T) {

--- a/cmd/spire-server/cli/federation/show.go
+++ b/cmd/spire-server/cli/federation/show.go
@@ -30,7 +30,7 @@ func (c *showCommand) Name() string {
 }
 
 func (c *showCommand) Synopsis() string {
-	return "Show a federation relationship"
+	return "Shows a dynamic federation relationship"
 }
 
 func (c *showCommand) AppendFlags(f *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/show_test.go
+++ b/cmd/spire-server/cli/federation/show_test.go
@@ -24,7 +24,7 @@ func TestShowHelp(t *testing.T) {
 
 func TestShowSynopsis(t *testing.T) {
 	test := setupTest(t, newShowCommand)
-	require.Equal(t, "Show a federation relationship", test.client.Synopsis())
+	require.Equal(t, "Shows a dynamic federation relationship", test.client.Synopsis())
 }
 
 func TestShow(t *testing.T) {

--- a/cmd/spire-server/cli/federation/update.go
+++ b/cmd/spire-server/cli/federation/update.go
@@ -32,7 +32,7 @@ func (*updateCommand) Name() string {
 }
 
 func (*updateCommand) Synopsis() string {
-	return "Updates a federation relationship to a foreign trust domain"
+	return "Updates a dynamic federation relationship with a foreign trust domain"
 }
 
 func (c *updateCommand) AppendFlags(f *flag.FlagSet) {

--- a/cmd/spire-server/cli/federation/update_test.go
+++ b/cmd/spire-server/cli/federation/update_test.go
@@ -40,7 +40,7 @@ func TestUpdateHelp(t *testing.T) {
 
 func TestUpdateSynopsis(t *testing.T) {
 	test := setupTest(t, newUpdateCommand)
-	require.Equal(t, "Updates a federation relationship to a foreign trust domain", test.client.Synopsis())
+	require.Equal(t, "Updates a dynamic federation relationship with a foreign trust domain", test.client.Synopsis())
 }
 
 func TestUpdate(t *testing.T) {

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -358,6 +358,72 @@ Deletes bundle data for a trust domain. This command cannot be used to delete th
 | `-mode`       | One of: `restrict`, `dissociate`, `delete`. `restrict` prevents the bundle from being deleted if it is associated to registration entries (i.e. federated with). `dissociate` allows the bundle to be deleted and removes the association from registration entries. `delete` deletes the bundle as well as associated registration entries. | `restrict` |
 | `-socketPath` | Path to the SPIRE Server API socket | /tmp/spire-server/private/api.sock |
 
+### `spire-server federation create`
+
+Creates a federation relationship with a foreign trust domain.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-bundleEndpointProfile` | Endpoint profile type. Eeither `https_web` or `https_spiffe`. | |
+| `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
+| `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
+| `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+| `-trustDomain` | Name of the trust domain to federate with (e.g., example.org) | |
+| `-trustDomainBundleFormat` | The format of the bundle data (optional). Either `pem` or `spiffe`. | pem |
+| `-trustDomainBundlePath` | Path to the trust domain bundle data (optional). | |
+
+### `spire-server federation delete`
+
+Deletes a federation relationship.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id` | SPIFFE ID of the trust domain of the relationship. | |
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+
+### `spire-server federation list`
+
+Lists all the federation relationships.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id` | SPIFFE ID of the trust domain of the relationship | |
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+
+### `spire-server refresh`
+
+Refreshes the bundle from the specified federated trust domain.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-id` | SPIFFE ID of the trust domain of the relationship | |
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+
+### `spire-server show`
+
+Shows a federation relationship.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+| `-trustDomain` | The trust domain name of the federation relationship to show (e.g., example.org) | |
+
+### `spire-server federation update`
+
+Updates a federation relationship with a foreign trust domain.
+
+| Command       | Action                                                             | Default        |
+|:--------------|:-------------------------------------------------------------------|:---------------|
+| `-bundleEndpointProfile` | Endpoint profile type. Eeither `https_web` or `https_spiffe`. | |
+| `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
+| `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
+| `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |
+| `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
+| `-trustDomain` | Name of the trust domain to federate with (e.g., example.org) | |
+| `-trustDomainBundleFormat` | The format of the bundle data (optional). Either `pem` or `spiffe`. | pem |
+| `-trustDomainBundlePath` | Path to the trust domain bundle data (optional). | |
+
 ### `spire-server agent ban`
 
 Ban attested node given its spiffeID. A banned attested node is not able to re-attest.

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -126,7 +126,7 @@ Please see the [built-in plugins](#built-in-plugins) section below for informati
 
 SPIRE Server can be configured to federate with others SPIRE Servers living in different trust domains. SPIRE supports configuring federation relationships in the SPIRE Server configuration file (static relationships) and through the [Trust Domain API](https://github.com/spiffe/spire-api-sdk/blob/main/proto/spire/api/server/trustdomain/v1/trustdomain.proto) (dynamic relationships). This section describes how to configure statically defined relationships in the configuration file.
 
-_Note: static relationships override dynamic relationships. If you need to configure dynamic relationships, see the [`federation`](#spire-server-federation-create) command. Static relationships are not relflected in the `federation` command._
+_Note: static relationships override dynamic relationships. If you need to configure dynamic relationships, see the [`federation`](#spire-server-federation-create) command. Static relationships are not reflected in the `federation` command._
 
 Configuring a federated trust domain allows a trust domain to authenticate identities issued by other SPIFFE authorities, allowing workloads in one trust domain to securely autenticate workloads in a foreign trust domain.
 A key element to achieve federation is the use of SPIFFE bundle endpoints, these are resources (represented by URLs) that serve a copy of a trust bundle for a trust domain.
@@ -252,7 +252,7 @@ Creates registration entries.
 | Command          | Action                                                                 | Default        |
 |:-----------------|:-----------------------------------------------------------------------|:---------------|
 | `-admin`         | If set, the SPIFFE ID in this entry will be granted access to the Server APIs | |
-| `-data`          | Path to a file containing registration data in JSON format (optional). If set to '-', read the JSON from stdin. |                |
+| `-data`          | Path to a file containing registration data in JSON format (optional, if specified, other flags related with entry information must be omitted). If set to '-', read the JSON from stdin. |                |
 | `-dns`           | A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once | |
 | `-downstream`    | A boolean value that, when set, indicates that the entry describes a downstream SPIRE server | |
 | `-entryExpiry`   | An expiry, from epoch in seconds, for the resulting registration entry to be pruned from the datastore. Please note that this is a data management feature and not a security feature (optional).| |
@@ -271,7 +271,7 @@ Updates registration entries.
 | Command          | Action                                                                 | Default        |
 |:-----------------|:-----------------------------------------------------------------------|:---------------|
 | `-admin`         | If true, the SPIFFE ID in this entry will be granted access to the Server APIs | |
-| `-data`          | Path to a file containing registration data in JSON format (optional). If set to '-', read the JSON from stdin. |                |
+| `-data`          | Path to a file containing registration data in JSON format (optional, if specified, other flags related with entry information must be omitted). If set to '-', read the JSON from stdin. |                |
 | `-dns`           | A DNS name that will be included in SVIDs issued based on this entry, where appropriate. Can be used more than once | |
 | `-downstream`    | A boolean value that, when set, indicates that the entry describes a downstream SPIRE server | |
 | `-entryExpiry`   | An expiry, from epoch in seconds, for the resulting registration entry to be pruned | |
@@ -370,7 +370,7 @@ Creates a dynamic federation relationship with a foreign trust domain.
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-bundleEndpointProfile` | Endpoint profile type. Either `https_web` or `https_spiffe`. | |
 | `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
-| `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
+| `-data` | Path to a file containing federation relationships in JSON format (optional, if specified, other flags related with federation relationship information must be omitted). If set to '-', read the JSON from stdin. | |
 | `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |
 | `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
 | `-trustDomain` | Name of the trust domain to federate with (e.g., example.org) | |
@@ -421,7 +421,7 @@ Updates a dynamic federation relationship with a foreign trust domain.
 |:--------------|:-------------------------------------------------------------------|:---------------|
 | `-bundleEndpointProfile` | Endpoint profile type. Either `https_web` or `https_spiffe`. | |
 | `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
-| `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
+| `-data` | Path to a file containing federation relationships in JSON format (optional, if specified, other flags related with federation relationship information must be omitted). If set to '-', read the JSON from stdin. | |
 | `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |
 | `-socketPath` | Path to the SPIRE Server API socket. | /tmp/spire-server/private/api.sock |
 | `-trustDomain` | Name of the trust domain to federate with (e.g., example.org) | |

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -124,7 +124,11 @@ Please see the [built-in plugins](#built-in-plugins) section below for informati
 
 ## Federation configuration
 
-SPIRE Server can be configured to federate with others SPIRE Servers living in different trust domains. This allows a trust domain to authenticate identities issued by other SPIFFE authorities, allowing workloads in one trust domain to securely autenticate workloads in a foreign trust domain.
+SPIRE Server can be configured to federate with others SPIRE Servers living in different trust domains. SPIRE supports configuring federation relationships in the SPIRE Server configuration file (static relationships) and through the [Trust Domain API](https://github.com/spiffe/spire-api-sdk/blob/main/proto/spire/api/server/trustdomain/v1/trustdomain.proto) (dynamic relationships). This section describes how to configure statically defined relationships in the configuration file.
+
+_Note: static relationships override dynamic relationships. If you need to configure dynamic relationships, see the [`federation`](#spire-server-federation-create) command. Static relationships are not relflected in the `federation` command._
+
+Configuring a federated trust domain allows a trust domain to authenticate identities issued by other SPIFFE authorities, allowing workloads in one trust domain to securely autenticate workloads in a foreign trust domain.
 A key element to achieve federation is the use of SPIFFE bundle endpoints, these are resources (represented by URLs) that serve a copy of a trust bundle for a trust domain.
 Using the `federation` section you will be able to set up SPIRE as a SPIFFE bundle endpoint server and also configure the federated trust domains that this SPIRE Server will fetch bundles from.
 ```hcl
@@ -360,7 +364,7 @@ Deletes bundle data for a trust domain. This command cannot be used to delete th
 
 ### `spire-server federation create`
 
-Creates a federation relationship with a foreign trust domain.
+Creates a dynamic federation relationship with a foreign trust domain.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
@@ -375,7 +379,7 @@ Creates a federation relationship with a foreign trust domain.
 
 ### `spire-server federation delete`
 
-Deletes a federation relationship.
+Deletes a dynamic federation relationship.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
@@ -384,7 +388,7 @@ Deletes a federation relationship.
 
 ### `spire-server federation list`
 
-Lists all the federation relationships.
+Lists all the dynamic federation relationships.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
@@ -402,7 +406,7 @@ Refreshes the bundle from the specified federated trust domain.
 
 ### `spire-server show`
 
-Shows a federation relationship.
+Shows a dynamic federation relationship.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
@@ -411,7 +415,7 @@ Shows a federation relationship.
 
 ### `spire-server federation update`
 
-Updates a federation relationship with a foreign trust domain.
+Updates a dynamic federation relationship with a foreign trust domain.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -364,7 +364,7 @@ Creates a federation relationship with a foreign trust domain.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-bundleEndpointProfile` | Endpoint profile type. Eeither `https_web` or `https_spiffe`. | |
+| `-bundleEndpointProfile` | Endpoint profile type. Either `https_web` or `https_spiffe`. | |
 | `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
 | `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
 | `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |
@@ -415,7 +415,7 @@ Updates a federation relationship with a foreign trust domain.
 
 | Command       | Action                                                             | Default        |
 |:--------------|:-------------------------------------------------------------------|:---------------|
-| `-bundleEndpointProfile` | Endpoint profile type. Eeither `https_web` or `https_spiffe`. | |
+| `-bundleEndpointProfile` | Endpoint profile type. Either `https_web` or `https_spiffe`. | |
 | `-bundleEndpointURL` | URL of the SPIFFE bundle endpoint that provides the trust bundle (must use the HTTPS protocol). | |
 | `-data` | Path to a file containing federation relationships in JSON format (optional). If set to '-', read the JSON from stdin. | |
 | `-endpointSpiffeID` | SPIFFE ID of the SPIFFE bundle endpoint server. Only used for `https_spiffe` profile. | |


### PR DESCRIPTION
- Updates documentation to describe `federation` subcommands.
- Updates synopsis of `federation` subcommands.
- Introduce the notion of static vs dynamic relationships.