### PR TITLE
Push container images to GHCR

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -20,3 +20,11 @@ jobs:
           password: ${{ secrets.GCR_JSON_KEY }}
       - name: Push images
         run: ./.github/workflows/scripts/push-images.sh nightly
+      - name: Log in to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push images
+        run: ./.github/workflows/scripts/push-scratch-images.sh nightly

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -269,8 +269,15 @@ jobs:
         with:
           name: images
           path: .
+      - name: Download archived scratch images
+        uses: actions/download-artifact@v2
+        with:
+          name: scratch-images
+          path: .
       - name: Load archived images
         run: zcat images.tar.gz | docker load
+      - name: Load archived scratch images
+        run: zcat scratch-images.tar.gz | docker load
       - name: Log in to GCR
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -280,3 +280,12 @@ jobs:
       # Push the images to GCR using the version number (without the "v" prefix).
       - name: Push images
         run: ./.github/workflows/scripts/push-images.sh "${GITHUB_REF#refs/tags/v}"
+      - name: Log in to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Push the images to GHCR using the version number (without the "v" prefix).
+      - name: Push images
+        run: ./.github/workflows/scripts/push-scratch-images.sh "${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -17,8 +17,8 @@ echo "Pushing images tagged as $IMAGETAG..."
 
 for img in spire-server spire-agent; do
     ghcrimg=ghcr.io/"$ORGNAME"/"$img":"${IMAGETAG}"
-    echo "Executing: docker tag $img:latest-local $ghcrimg"
-    docker tag "$img":latest-local "$ghcrimg"
+    echo "Executing: docker tag $img-scratch:latest-local $ghcrimg"
+    docker tag "$img"-scratch:latest-local "$ghcrimg"
     echo "Executing: docker push $ghcrimg"
     docker push "$ghcrimg"
 done

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -11,7 +11,7 @@ fi
 
 # Extracting org name rather than hardcoding allows this
 # action to be portable across forks
-ORGNAME=`echo $GITHUB_REPOSITORY | tr '/' "\n" | head -1 | tr -d "\n"`
+ORGNAME=$(echo $GITHUB_REPOSITORY | tr '/' "\n" | head -1 | tr -d "\n")
 
 echo "Pushing images tagged as $IMAGETAG..."
 

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+IMAGETAG="$1"
+if [ -z "$IMAGETAG" ]; then
+    echo "IMAGETAG not provided!" 1>&2
+    echo "Usage: push-images.sh IMAGETAG" 1>&2
+    exit 1
+fi
+
+# Extracting org name rather than hardcoding allows this
+# action to be portable across forks
+ORGNAME=`echo $GITHUB_REPOSITORY | tr '/' "\n" | head -1 | tr -d "\n"`
+
+echo "Pushing images tagged as $IMAGETAG..."
+
+for img in spire-server spire-agent; do
+    ghcrimg=ghcr.io/"$ORGNAME"/"$img":"${IMAGETAG}"
+    echo "Executing: docker tag $img:latest-local $ghcrimg"
+    docker tag "$img":latest-local "$ghcrimg"
+    echo "Executing: docker push $ghcrimg"
+    docker push "$ghcrimg"
+done

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -15,8 +15,16 @@ ORGNAME=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
 
 echo "Pushing images tagged as $IMAGETAG..."
 
-for img in spire-server spire-agent; do
-    ghcrimg=ghcr.io/"$ORGNAME"/"$img":"${IMAGETAG}"
+for img in spire-server spire-agent oidc-discovery-provider; do
+    ghcrimg="ghcr.io/${ORGNAME}/${img}:${IMAGETAG}"
+
+    # Detect the oidc image and give it a different name for GHCR
+    # TODO: Remove this hack and fully rename the image once we move
+    # off of GCR.
+    if [ "$img" == "oidc-discovery-provider" ]; then
+            ghcrimg="ghcr.io/${ORGNAME}/spire-oidc-provider:${IMAGETAG}"
+    fi
+
     echo "Executing: docker tag $img-scratch:latest-local $ghcrimg"
     docker tag "$img"-scratch:latest-local "$ghcrimg"
     echo "Executing: docker push $ghcrimg"

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -11,7 +11,7 @@ fi
 
 # Extracting org name rather than hardcoding allows this
 # action to be portable across forks
-ORGNAME=$(echo $GITHUB_REPOSITORY | tr '/' "\n" | head -1 | tr -d "\n")
+ORGNAME=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
 
 echo "Pushing images tagged as $IMAGETAG..."
 

--- a/Makefile
+++ b/Makefile
@@ -251,15 +251,8 @@ bin/:
 
 build-static: tidy bin/spire-server-static bin/spire-agent-static bin/k8s-workload-registrar-static bin/oidc-discovery-provider-static
 
-define binary_rule_static
-.PHONY: $1
-$1: | go-check bin/
-	@echo Building $1...
-	$(E)$(go_path) CGO_ENABLED=0 go build $$(go_flags) -ldflags $$(go_ldflags) -o $1 $2
-
-endef
 # https://7thzero.com/blog/golang-w-sqlite3-docker-scratch-image
-define binary_rule_external_static
+define binary_rule_static
 .PHONY: $1
 $1: | go-check bin/
 	@echo Building $1...
@@ -268,7 +261,7 @@ $1: | go-check bin/
 endef
 
 # static builds
-$(eval $(call binary_rule_external_static,bin/spire-server-static,./cmd/spire-server))
+$(eval $(call binary_rule_static,bin/spire-server-static,./cmd/spire-server))
 $(eval $(call binary_rule_static,bin/spire-agent-static,./cmd/spire-agent))
 $(eval $(call binary_rule_static,bin/k8s-workload-registrar-static,./support/k8s/k8s-workload-registrar))
 $(eval $(call binary_rule_static,bin/oidc-discovery-provider-static,./support/oidc-discovery-provider))


### PR DESCRIPTION
This commit updates our GitHub workflows to push container images to
GHCR in addition to GCR. Assuming all goes well, we will deprecate
GCR-based images in a futur release.

One major change here is that this commit ships scratch images to GHCR
instead of alpine-based images. Switching base images has been something
we've discussed for a while now, and now seems like the right time to do
it. GCR will still receive alpine images.

Signed-off-by: Evan Gilman <egilman@vmware.com>