### PR TITLE
[tpmdevid node attestor plugin] Add support for new selector issuer:cn

### DIFF
--- a/doc/plugin_server_nodeattestor_tpm_devid.md
+++ b/doc/plugin_server_nodeattestor_tpm_devid.md
@@ -51,4 +51,5 @@ A sample configuration:
 | Selector                  	| Example								| Description				|
 | ---------------------------- 	| -----------------------------------------------------------------	| ---------------------------------	|
 | Subject common name		|`tpm_devid:subject:cn:example.org`					| The subject's common name.		|
+| Issuer common name		|`tpm_devid:issuer:cn:authority.org`					| The issuer's common name.		|
 | SHA1 fingerprint		|`tpm_devid:fingerprint:9ba51e2643bea24e91d24bdec3a1aaf8e967b6e5`	| The SHA1 fingerprint as a hex string for each cert in the PoP chain, excluding the leaf.|

--- a/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -545,6 +545,10 @@ func TestAttestSucceeds(t *testing.T) {
 				},
 				{
 					Type:  "tpm_devid",
+					Value: "issuer:cn:intermediate",
+				},
+				{
+					Type:  "tpm_devid",
 					Value: "ca:fingerprint:" + tpmdevid.Fingerprint(devIDRSA.Intermediates[0]),
 				},
 				{
@@ -565,6 +569,10 @@ func TestAttestSucceeds(t *testing.T) {
 				},
 				{
 					Type:  "tpm_devid",
+					Value: "issuer:cn:intermediate",
+				},
+				{
+					Type:  "tpm_devid",
 					Value: "ca:fingerprint:" + tpmdevid.Fingerprint(devIDECC.Intermediates[0]),
 				},
 				{
@@ -582,6 +590,10 @@ func TestAttestSucceeds(t *testing.T) {
 				{
 					Type:  "tpm_devid",
 					Value: "subject:cn:devid-leaf",
+				},
+				{
+					Type:  "tpm_devid",
+					Value: "issuer:cn:root",
 				},
 				{
 					Type:  "tpm_devid",

--- a/pkg/server/plugin/nodeattestor/tpmdevid/selectors.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/selectors.go
@@ -13,6 +13,10 @@ func buildSelectorValues(leaf *x509.Certificate, chains [][]*x509.Certificate) [
 		selectorValues = append(selectorValues, "subject:cn:"+leaf.Subject.CommonName)
 	}
 
+	if leaf.Issuer.CommonName != "" {
+		selectorValues = append(selectorValues, "issuer:cn:"+leaf.Issuer.CommonName)
+	}
+
 	// Used to avoid duplicating selectors.
 	fingerprints := map[string]*x509.Certificate{}
 	for _, chain := range chains {


### PR DESCRIPTION
Signed-off-by: André Lima <alima@hpe.com>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Adding a new selector (issuer´s common name) to tpmdevid node attestor plugin. 

**Description of change**
With the new selector the issuer´s common name is returned as a default selector.

**Which issue this PR fixes**
There is no open issue but today with the current selectors there is no shared information between nodes attested by tpmdevid node attestor to easly create a node alias.

**Tests**
SPIRE server successfully built (`make bin/spire-server`) and unit tests successfully executed and passed (`.../spire/pkg/server/plugin/nodeattestor/tpmdevid` folder).