### PR TITLE
Invoke run subcommand from scratch image entrypoint

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -14,7 +14,7 @@ FROM scratch AS spire-server-scratch
 COPY --from=builder /spire/bin/spire-server-static /opt/spire/bin/spire-server
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /opt/spire
-ENTRYPOINT ["/opt/spire/bin/spire-server"]
+ENTRYPOINT ["/opt/spire/bin/spire-server", "run"]
 CMD []
 
 FROM scratch  AS spire-agent-scratch
@@ -22,7 +22,7 @@ COPY --from=builder /spire/bin/spire-agent-static /opt/spire/bin/spire-agent
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /opt/spire
 EXPOSE 8080 8443
-ENTRYPOINT ["/opt/spire/bin/spire-agent"]
+ENTRYPOINT ["/opt/spire/bin/spire-agent", "run"]
 CMD []
 
 # K8S Workload Registrar

--- a/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
@@ -123,7 +123,7 @@ spec:
         - name: spire-agent
           image: spire-agent-scratch:latest-local
           imagePullPolicy: Never
-          args: ["run", "-config", "/run/spire/config/agent.conf"]
+          args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config

--- a/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-scratch/conf/server/spire-server.yaml
@@ -238,7 +238,7 @@ spec:
         - name: spire-server
           image: spire-server-scratch:latest-local
           imagePullPolicy: Never
-          args: ["run", "-config", "/run/spire/config/server.conf"]
+          args: ["-config", "/run/spire/config/server.conf"]
           ports:
             - containerPort: 8081
           volumeMounts:


### PR DESCRIPTION
This makes them differ from the non-scratch images and adds undue friction when switching over.