### PR TITLE
Fix default k8s secrets path

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -159,8 +159,8 @@ plugins {
             # cluster = ""
 
             # token_path: Path to the service account token on disk.
-            # Default: /run/secrets/kubernetes.io/serviceaccount/token.
-            # token_path = "/run/secrets/kubernetes.io/serviceaccount/token"
+            # Default: /var/run/secrets/kubernetes.io/serviceaccount/token.
+            # token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         }
     }
 
@@ -277,16 +277,16 @@ plugins {
             # kubelet_ca_path: The path on disk to a file containing CA certificates
             # used to verify the kubelet certificate. Required unless
             # skip_kubelet_verification is set. Defaults to the cluster CA
-            # bundle /run/secrets/kubernetes.io/serviceaccount/ca.crt.
-            # kubelet_ca_path = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            # bundle /var/run/secrets/kubernetes.io/serviceaccount/ca.crt.
+            # kubelet_ca_path = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
             # skip_kubelet_verification: If true, kubelet certificate verification
             # is skipped.
             # skip_kubelet_verification = false
 
             # token_path: The path on disk to the bearer token used for kubelet
-            # authentication. Defaults to the service account token /run/secrets/kubernetes.io/serviceaccount/token.
-            # token_path = "/run/secrets/kubernetes.io/serviceaccount/token"
+            # authentication. Defaults to the service account token /var/run/secrets/kubernetes.io/serviceaccount/token.
+            # token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
             # certificate_path: The path on disk to client certificate used for
             # kubelet authentication.

--- a/doc/plugin_agent_nodeattestor_k8s_sat.md
+++ b/doc/plugin_agent_nodeattestor_k8s_sat.md
@@ -19,7 +19,7 @@ The main configuration accepts the following values:
 | Configuration   | Description | Default                 |
 | --------------- | ----------- | ----------------------- |
 | `cluster`       | Name of the cluster. It must correspond to a cluster configured in the server plugin. |
-| `token_path`      | Path to the service account token on disk | "/run/secrets/kubernetes.io/serviceaccount/token" |
+| `token_path`      | Path to the service account token on disk | "/var/run/secrets/kubernetes.io/serviceaccount/token" |
 
 The token path defaults to the default location kubernetes uses to place the token and should not need to be overriden in most cases.
 

--- a/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/agent/plugin/nodeattestor/k8s/sat/sat.go
@@ -19,7 +19,7 @@ import (
 const (
 	pluginName = "k8s_sat"
 
-	defaultTokenPath = "/run/secrets/kubernetes.io/serviceaccount/token" //nolint: gosec // false positive
+	defaultTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint: gosec // false positive
 )
 
 func BuiltIn() catalog.BuiltIn {

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -37,8 +37,8 @@ const (
 	defaultMaxPollAttempts   = 60
 	defaultPollRetryInterval = time.Millisecond * 500
 	defaultSecureKubeletPort = 10250
-	defaultKubeletCAPath     = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	defaultTokenPath         = "/run/secrets/kubernetes.io/serviceaccount/token" //nolint: gosec // false positive
+	defaultKubeletCAPath     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	defaultTokenPath         = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint: gosec // false positive
 	defaultNodeNameEnv       = "MY_NODE_NAME"
 	defaultReloadInterval    = time.Minute
 )

--- a/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s-scratch/conf/agent/spire-agent.yaml
@@ -73,7 +73,6 @@ data:
           # Minikube does not have a cert in the cluster CA bundle that
           # can authenticate the kubelet cert, so skip validation.
           skip_kubelet_verification = true
-          token_path = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         }
       }
     }


### PR DESCRIPTION
The official path to these files is under /var/run/ not /run. We've only managed to get by using /run because the two are symlink'd in many distros. However, there is no such symlink in scratch environments. We should be using the official path anyway.

I surmise the risk here is low, except maybe in some one off test environments. The official paths should be available in any production K8s system.