### PR TITLE
Opportunistically reload bundle configuration

### DIFF
--- a/pkg/server/api/trustdomain/v1/service_test.go
+++ b/pkg/server/api/trustdomain/v1/service_test.go
@@ -1022,6 +1022,14 @@ func TestBatchCreateFederationRelationship(t *testing.T) {
 			spiretest.AssertProtoEqual(t, &trustdomainv1.BatchCreateFederationRelationshipResponse{
 				Results: tt.expectResults,
 			}, resp)
+
+			var expectReloadCount int
+			for _, result := range tt.expectResults {
+				if result.Status.Code == 0 {
+					expectReloadCount = 1
+				}
+			}
+			assert.Equal(t, expectReloadCount, test.br.ReloadCount(), "unexpected reload count")
 		})
 	}
 }
@@ -1302,6 +1310,14 @@ func TestBatchDeleteFederationRelationship(t *testing.T) {
 			spiretest.AssertProtoEqual(t, &trustdomainv1.BatchDeleteFederationRelationshipResponse{
 				Results: tt.expectResults,
 			}, resp)
+
+			var expectReloadCount int
+			for _, result := range tt.expectResults {
+				if result.Status.Code == 0 {
+					expectReloadCount = 1
+				}
+			}
+			assert.Equal(t, expectReloadCount, test.br.ReloadCount(), "unexpected reload count")
 
 			// Validate DS contains expected federation relationships
 			listResp, err := ds.ListFederationRelationships(ctx, &datastore.ListFederationRelationshipsRequest{})
@@ -1973,6 +1989,14 @@ func TestBatchUpdateFederationRelationship(t *testing.T) {
 				Results: tt.expectResults,
 			}, resp)
 
+			var expectReloadCount int
+			for _, result := range tt.expectResults {
+				if result.Status.Code == 0 {
+					expectReloadCount = 1
+				}
+			}
+			assert.Equal(t, expectReloadCount, test.br.ReloadCount(), "unexpected reload count")
+
 			// Check datastore
 			// Unable to use Equal because it contains PROTO + regular structs
 			for _, eachFR := range tt.expectDSFR {
@@ -2144,6 +2168,7 @@ func assertFederationRelationshipWithMask(t *testing.T, expected, actual *types.
 type serviceTest struct {
 	client  trustdomainv1.TrustDomainClient
 	ds      datastore.DataStore
+	br      *fakeBundleRefresher
 	logHook *test.Hook
 	done    func()
 }
@@ -2153,10 +2178,11 @@ func (s *serviceTest) Cleanup() {
 }
 
 func setupServiceTest(t *testing.T, ds datastore.DataStore) *serviceTest {
+	br := &fakeBundleRefresher{}
 	service := trustdomain.New(trustdomain.Config{
 		DataStore:       ds,
 		TrustDomain:     td,
-		BundleRefresher: fakeBundleRefresher{},
+		BundleRefresher: br,
 	})
 
 	log, logHook := test.NewNullLogger()
@@ -2167,6 +2193,7 @@ func setupServiceTest(t *testing.T, ds datastore.DataStore) *serviceTest {
 
 	test := &serviceTest{
 		ds:      ds,
+		br:      br,
 		logHook: logHook,
 	}
 
@@ -2222,9 +2249,19 @@ func (d *fakeDS) UpdateFederationRelationship(c context.Context, fr *datastore.F
 	return d.DataStore.UpdateFederationRelationship(ctx, fr, mask)
 }
 
-type fakeBundleRefresher struct{}
+type fakeBundleRefresher struct {
+	reloads int
+}
 
-func (fakeBundleRefresher) RefreshBundleFor(ctx context.Context, td spiffeid.TrustDomain) (bool, error) {
+func (r *fakeBundleRefresher) TriggerReload() {
+	r.reloads++
+}
+
+func (r *fakeBundleRefresher) ReloadCount() int {
+	return r.reloads
+}
+
+func (r *fakeBundleRefresher) RefreshBundleFor(ctx context.Context, td spiffeid.TrustDomain) (bool, error) {
 	switch {
 	case td == spiffeid.RequireTrustDomainFromString("good.test"):
 		return true, nil

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -82,6 +82,7 @@ type Manager struct {
 	clock            clock.Clock
 	ds               datastore.DataStore
 	source           TrustDomainConfigSource
+	configRefreshCh  chan struct{}
 	configRefreshMtx sync.Mutex
 	updatersMtx      sync.RWMutex
 	updaters         map[spiffeid.TrustDomain]*managedBundleUpdater
@@ -120,6 +121,7 @@ func NewManager(config ManagerConfig) *Manager {
 		ds:                config.DataStore,
 		source:            config.Source,
 		newBundleUpdater:  config.newBundleUpdater,
+		configRefreshCh:   make(chan struct{}),
 		configRefreshedCh: config.configRefreshedCh,
 		bundleRefreshedCh: config.bundleRefreshedCh,
 		updaters:          make(map[spiffeid.TrustDomain]*managedBundleUpdater),
@@ -140,12 +142,22 @@ func (m *Manager) Run(ctx context.Context) error {
 		timer.Reset(configRefreshInterval)
 		m.notifyConfigRefreshed(ctx, configRefreshInterval)
 		select {
+		case <-m.configRefreshCh:
 		case <-timer.C:
 		case <-ctx.Done():
 			m.log.Info("Shutting down")
 			return ctx.Err()
 		}
 	}
+}
+
+// TriggerConfigReload triggers the manager to reload the configuration
+func (m *Manager) TriggerConfigReload() {
+	select {
+	case <-m.configRefreshCh:
+	default:
+	}
+	m.configRefreshCh <- struct{}{}
 }
 
 // RefreshBundleFor refreshes the trust domain bundle for the given trust

--- a/pkg/server/endpoints/config.go
+++ b/pkg/server/endpoints/config.go
@@ -114,7 +114,6 @@ func (c *Config) maybeMakeBundleEndpointServer() Server {
 func (c *Config) makeAPIServers(entryFetcher api.AuthorizedEntryFetcher) APIServers {
 	ds := c.Catalog.GetDataStore()
 	upstreamPublisher := UpstreamPublisher(c.Manager)
-	bundleRefresher := BundleRefresher(c.BundleManager)
 
 	return APIServers{
 		AgentServer: agentv1.New(agentv1.Config{
@@ -154,7 +153,7 @@ func (c *Config) makeAPIServers(entryFetcher api.AuthorizedEntryFetcher) APIServ
 		TrustDomainServer: trustdomainv1.New(trustdomainv1.Config{
 			TrustDomain:     c.TrustDomain,
 			DataStore:       ds,
-			BundleRefresher: bundleRefresher,
+			BundleRefresher: c.BundleManager,
 		}),
 	}
 }

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -12,9 +12,7 @@ import (
 	"github.com/spiffe/spire/pkg/server/api/limits"
 	"github.com/spiffe/spire/pkg/server/api/middleware"
 	"github.com/spiffe/spire/pkg/server/api/rpccontext"
-	"github.com/spiffe/spire/pkg/server/api/trustdomain/v1"
 	"github.com/spiffe/spire/pkg/server/authpolicy"
-	bundle_client "github.com/spiffe/spire/pkg/server/bundle/client"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/datastore"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -56,10 +54,6 @@ func EntryFetcher(ds datastore.DataStore) middleware.EntryFetcher {
 
 func UpstreamPublisher(manager *ca.Manager) bundle.UpstreamPublisher {
 	return bundle.UpstreamPublisherFunc(manager.PublishJWTKey)
-}
-
-func BundleRefresher(manager *bundle_client.Manager) trustdomain.BundleRefresher {
-	return trustdomain.BundleRefresherFunc(manager.RefreshBundleFor)
 }
 
 func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.Clock) middleware.AgentAuthorizer {


### PR DESCRIPTION
This introduces a mechanism for the TrustDomain API handler to trigger
the bundle manager to opportunistically reload its configuration when
changes have been made to federation relationships.