### PR TITLE
CA manager should refuse to load CA certs that lack required x509 extensions

### DIFF
--- a/doc/plugin_server_upstreamauthority_disk.md
+++ b/doc/plugin_server_upstreamauthority_disk.md
@@ -20,6 +20,10 @@ The plugin accepts the following configuration options:
 | key_file_path   | Path to the "upstream" CA key file. Key files must contain a single PEM encoded key. The supported key types are EC (ASN.1 or PKCS8 encoded) or RSA (PKCS1 or PKCS8 encoded).|
 | bundle_file_path| If SPIRE is using a self-signed CA, `bundle_file_path` can be left unset. If not self-signed, then `bundle_file_path` should be the path to a file that must contain one or more certificates representing the upstream root certificates and the file at cert_file_path contains one or more certificates necessary to chain up the the root certificates in bundle_file_path (where the first certificate in cert_file_path is the upstream CA certificate). |
 
+> NOTE: The CA cert provided to SPIRE (whether self-signed or not) must have the following x509 extensions set:
+> CA:TRUE
+> KeyUsage: Certificate Sign
+
 The `disk` plugin is able to function as either a root CA, or join an existing PKI.
 
 When joining an existing PKI, the trust bundle for that PKI MUST be set explicitly

--- a/pkg/common/x509util/cert.go
+++ b/pkg/common/x509util/cert.go
@@ -1,6 +1,7 @@
 package x509util
 
 import (
+	"fmt"
 	"crypto"
 	"crypto/x509"
 
@@ -13,6 +14,17 @@ func CertificateMatchesPublicKey(certificate *x509.Certificate, publicKey crypto
 
 func CertificateMatchesPrivateKey(certificate *x509.Certificate, privateKey crypto.PrivateKey) (bool, error) {
 	return cryptoutil.KeyMatches(privateKey, certificate.PublicKey)
+}
+
+func CACertHasRequiredExtensionFlags(certificate *x509.Certificate) (error) {
+	if !certificate.IsCA {
+		return fmt.Errorf("Signing certificate must have CA flag set to true")
+	}
+	if certificate.KeyUsage&x509.KeyUsageCertSign == 0 {
+		return fmt.Errorf("Signing certificate must have 'keyCertSign' set as key usage")
+	}
+
+	return nil
 }
 
 func DedupeCertificates(bundles ...[]*x509.Certificate) []*x509.Certificate {

--- a/pkg/common/x509util/cert.go
+++ b/pkg/common/x509util/cert.go
@@ -16,7 +16,7 @@ func CertificateMatchesPrivateKey(certificate *x509.Certificate, privateKey cryp
 	return cryptoutil.KeyMatches(privateKey, certificate.PublicKey)
 }
 
-func CACertHasRequiredExtensionFlags(certificate *x509.Certificate) (error) {
+func CACertHasRequiredExtensionFlags(certificate *x509.Certificate) error {
 	if !certificate.IsCA {
 		return fmt.Errorf("Signing certificate must have CA flag set to true")
 	}

--- a/pkg/common/x509util/cert.go
+++ b/pkg/common/x509util/cert.go
@@ -1,9 +1,9 @@
 package x509util
 
 import (
-	"fmt"
 	"crypto"
 	"crypto/x509"
+	"fmt"
 
 	"github.com/spiffe/spire/pkg/common/cryptoutil"
 )

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -611,7 +611,7 @@ func (m *Manager) loadX509CASlotFromEntry(ctx context.Context, entry *X509CAEntr
 	// Validate CA cert has required x509 flags
 	err = x509util.CACertHasRequiredExtensionFlags(cert)
 	if err != nil {
-		return nil, "", errs.New("unable to load CA certificate: CA is missing required x509 extensions: %s", err)
+		return nil, "", errs.New("unable to load CA certificate: CA cert is missing required x509 extensions: %s", err)
 	}
 
 	var upstreamChain []*x509.Certificate

--- a/pkg/server/ca/manager.go
+++ b/pkg/server/ca/manager.go
@@ -608,6 +608,12 @@ func (m *Manager) loadX509CASlotFromEntry(ctx context.Context, entry *X509CAEntr
 		return nil, "", errs.New("unable to parse CA certificate: %v", err)
 	}
 
+	// Validate CA cert has required x509 flags
+	err = x509util.CACertHasRequiredExtensionFlags(cert)
+	if err != nil {
+		return nil, "", errs.New("unable to load CA certificate: CA is missing required x509 extensions: %s", err)
+	}
+
 	var upstreamChain []*x509.Certificate
 	for _, certDER := range entry.UpstreamChain {
 		cert, err := x509.ParseCertificate(certDER)

--- a/pkg/server/plugin/upstreamauthority/disk/disk.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk.go
@@ -202,11 +202,6 @@ func (p *Plugin) loadUpstreamCAAndCerts(config *Configuration) (*x509svid.Upstre
 	if !matched {
 		return nil, nil, status.Error(codes.InvalidArgument, "unable to load upstream CA: certificate and private key do not match")
 	}
-	// Validate cert has required x509 flags
-	err = x509util.CACertHasRequiredExtensionFlags(caCert)
-	if err != nil {
-		return nil, nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unable to load upstream CA: CA is missing required x509 extensions: %s", err))
-	}
 
 	intermediates := x509.NewCertPool()
 	roots := x509.NewCertPool()

--- a/pkg/server/plugin/upstreamauthority/disk/disk.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk.go
@@ -202,6 +202,11 @@ func (p *Plugin) loadUpstreamCAAndCerts(config *Configuration) (*x509svid.Upstre
 	if !matched {
 		return nil, nil, status.Error(codes.InvalidArgument, "unable to load upstream CA: certificate and private key do not match")
 	}
+	// Validate cert has required x509 flags
+	err = x509util.CACertHasRequiredExtensionFlags(caCert)
+	if err != nil {
+		return nil, nil, status.Error(codes.InvalidArgument, fmt.Sprintf("unable to load upstream CA: CA is missing required x509 extensions: %s", err))
+	}
 
 	intermediates := x509.NewCertPool()
 	roots := x509.NewCertPool()


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
If a provided CA cert does not have the correct x509 extension flags (namely `CA:TRUE` and `KeyUsage: Certificate Sign`), the SPIRE agent can malfunction, and downstream WorkloadAPI clients will be rendered unable to fetch workload certs.

**Description of change**
This modifies the ~UpstreamAuthority disk plugin~ SPIRE CA manager and documentation to validate that a provided external CA cert has all of the required x509 extensions that SPIRE and the SPIFFE spec mandate, and throws a server error describing the problem on startup during load of that CA cert if those extensions are missing.

This should make an implicit config requirements explicit, and prevent other people from hitting the same confusing state we did.

**Which issue this PR fixes**
See thread in SPIFFE Slack: https://spiffe.slack.com/archives/CBNCC2V17/p1635546587061500?thread_ts=1635373199.036300&cid=CBNCC2V17

