### PR TITLE
added support for gcp_secretmanager user managed replication

### DIFF
--- a/doc/plugin_agent_svidstore_gcp_secretmanager.md
+++ b/doc/plugin_agent_svidstore_gcp_secretmanager.md
@@ -69,4 +69,5 @@ Selectors are used on `storable` entries to describre metadata that is needed by
 | `gcp_secretmanager:projectid` | `gcp_secretmanager:projectid:some-project` | x        | The Google Cloud project ID which the plugin will use Secret Manager |
 | `gcp_secretmanager:role`     | `gcp_secretmanager:role:roles/secretmanager.viewer` | -        | The Google Cloud role id for IAM policy (serviceaccount required when set) |
 | `gcp_secretmanager:serviceaccount` | `gcp_secretmanager:serviceaccount:test-secret@test-proj.iam.gserviceaccount.com` | -        | The Google Cloud Service account for IAM policy (role required when set) |
+| `gcp_secretmanager:location` | `gcp_secretmanager:location:europe-north1` | -        | The location into which you want to replicate the created secret if organizational policies prohibit 'global'. Can be specified multiple times. Available locations can be found at https://cloud.google.com/secret-manager/docs/locations |
 

--- a/pkg/agent/plugin/svidstore/awssecretsmanager/aws.go
+++ b/pkg/agent/plugin/svidstore/awssecretsmanager/aws.go
@@ -234,15 +234,42 @@ func (o *secretOptions) getSecretID() string {
 }
 
 func optionsFromSecretData(metadata []string) (*secretOptions, error) {
-	data, err := svidstore.ParseMetadata(metadata)
+	selectors, err := svidstore.ParseMetadata(pluginName, metadata)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse Metadata: %v", err)
 	}
 
+	var secretName string
+	_, err = svidstore.ExtractSelectorValue(selectors, "secretname", func(s string) {
+		secretName = s
+	})
+
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid metadata: %v", err)
+	}
+
+	var arn string
+	_, err = svidstore.ExtractSelectorValue(selectors, "arn", func(s string) {
+		arn = s
+	})
+
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid metadata: %v", err)
+	}
+
+	var kmsKeyID string
+	_, err = svidstore.ExtractSelectorValue(selectors, "kmskeyid", func(s string) {
+		kmsKeyID = s
+	})
+
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid metadata: %v", err)
+	}
+
 	opt := &secretOptions{
-		name:     data["secretname"],
-		arn:      data["arn"],
-		kmsKeyID: data["kmskeyid"],
+		name:     secretName,
+		arn:      arn,
+		kmsKeyID: kmsKeyID,
 	}
 
 	if opt.name == "" && opt.arn == "" {

--- a/pkg/agent/plugin/svidstore/utils_test.go
+++ b/pkg/agent/plugin/svidstore/utils_test.go
@@ -2,6 +2,7 @@ package svidstore_test
 
 import (
 	"crypto/x509"
+	"github.com/spiffe/spire/proto/spire/common"
 	"testing"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/svidstore"
@@ -64,7 +65,7 @@ dZglS5kKnYigmwDh+/U=
 func TestParseMetadata(t *testing.T) {
 	for _, tt := range []struct {
 		name       string
-		expect     map[string]string
+		expect     []*common.Selector
 		secretData []string
 		expectErr  string
 	}{
@@ -75,16 +76,25 @@ func TestParseMetadata(t *testing.T) {
 				"b:2",
 				"c:3",
 			},
-			expect: map[string]string{
-				"a": "1",
-				"b": "2",
-				"c": "3",
+			expect: []*common.Selector{
+				{
+					Type: "plugin_key",
+					Value: "a:1",
+				},
+				{
+					Type: "plugin_key",
+					Value: "b:2",
+				},
+				{
+					Type: "plugin_key",
+					Value: "c:3",
+				},
 			},
 		},
 		{
 			name:       "no data",
 			secretData: []string{},
-			expect:     map[string]string{},
+			expect:     []*common.Selector{},
 		},
 		{
 			name:       "invalid data",
@@ -94,7 +104,7 @@ func TestParseMetadata(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := svidstore.ParseMetadata(tt.secretData)
+			result, err := svidstore.ParseMetadata("plugin_key", tt.secretData)
 			if tt.expectErr != "" {
 				require.EqualError(t, err, tt.expectErr)
 				require.Nil(t, result)


### PR DESCRIPTION
Signed-off-by: Hampus Wingren <hampus.wingren@seb.se>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Added support for the gcp_secretmanager SVIDStore to use user managed replication for those cases where organizational policies prohibit data stored in arbitrary locations. 

**Description of change**
Added a selector (gcp_secretmanager:location) which can be specified multiple times. If specified at least one time, user managed replication will be used with the specified location(s) as replication targets

**Which issue this PR fixes**
None
