### PR TITLE
Give stable ordering of federates-with field

### DIFF
--- a/pkg/agent/api/delegatedidentity/v1/service.go
+++ b/pkg/agent/api/delegatedidentity/v1/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"sort"
 
 	"github.com/sirupsen/logrus"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
@@ -155,6 +156,10 @@ func composeX509SVIDBySelectors(update *cache.WorkloadUpdate) (*delegatedidentit
 	for td := range update.FederatedBundles {
 		resp.FederatesWith = append(resp.FederatesWith, td.IDString())
 	}
+
+	// Sort list to give a stable response instead of one dependent on the map
+	// iteration order above.
+	sort.Strings(resp.FederatesWith)
 
 	for _, identity := range update.Identities {
 		// Do not send admin nor downstream SVIDs to the caller


### PR DESCRIPTION
The delegated identity API response populates a string slice from a set of map keys. This leads to inconsistent ordering in the response. This probably shouldn't matter to consumers, but it does impact the tests, which are asserting the response contents. While sorting the fields in the test could also work, it doesn't seem like a heavy lift to just sort these fields when crafting the response. It may help minimize false positives on downstream consumers who may be doing naive response
equivalence to detect if something has changed, for example.