### PR TITLE
Bump deps for 1.1.2 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,8 +137,8 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.0.0-beta.8
-	github.com/spiffe/spire-api-sdk v1.1.1
-	github.com/spiffe/spire-plugin-sdk v1.1.1
+	github.com/spiffe/spire-api-sdk v1.1.2
+	github.com/spiffe/spire-plugin-sdk v1.1.2
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.3.4 // indirect
 	github.com/tklauser/numcpus v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -868,10 +868,10 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.8 h1:ou8ywBGFdYdG4BXjB/EBk2ND3OhtAwiMxLEbYcUS+ts=
 github.com/spiffe/go-spiffe/v2 v2.0.0-beta.8/go.mod h1:TEfgrEcyFhuSuvqohJt6IxENUNeHfndWCCV1EX7UaVk=
-github.com/spiffe/spire-api-sdk v1.1.1 h1:h3bZQVSaW4+LnggZqLvUAuVbyMMmvn/Eo452xK+GJHg=
-github.com/spiffe/spire-api-sdk v1.1.1/go.mod h1:UylWypx+g3HPJeelhKiKykUvcTJFw5VKIKaSaCYgpFw=
-github.com/spiffe/spire-plugin-sdk v1.1.1 h1:19zNeDHHMEmJjXSByTNf9pV1mxCn0cb5Pt8KlBbBY88=
-github.com/spiffe/spire-plugin-sdk v1.1.1/go.mod h1:fzNSP83Z848jZtPQYeZ9qPWZkbSPwmd/JFNux1gxsbM=
+github.com/spiffe/spire-api-sdk v1.1.2 h1:wbHEDRFpSWI7G5Ifd5r/cYzr5nWIEXL2rzls18XJPec=
+github.com/spiffe/spire-api-sdk v1.1.2/go.mod h1:UylWypx+g3HPJeelhKiKykUvcTJFw5VKIKaSaCYgpFw=
+github.com/spiffe/spire-plugin-sdk v1.1.2 h1:jk3vuoSf5WAWzVZ8jK+A3qdyMUpcsIsNdrNhhhUmb6E=
+github.com/spiffe/spire-plugin-sdk v1.1.2/go.mod h1:fzNSP83Z848jZtPQYeZ9qPWZkbSPwmd/JFNux1gxsbM=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=


### PR DESCRIPTION
This commit bumps the deps for SPIRE API and Plugin interfaces such that
they depend on the release versions.

Signed-off-by: Evan Gilman <egilman@vmware.com>