### PR TITLE
Remove deprecated "domain" config

### DIFF
--- a/support/oidc-discovery-provider/config.go
+++ b/support/oidc-discovery-provider/config.go
@@ -23,12 +23,6 @@ type Config struct {
 	// LogRequests is a debug option that logs all incoming requests
 	LogRequests bool `hcl:"log_requests"`
 
-	// Domain is the domain this provider will be hosted under. It is used
-	// when obtaining certs via ACME (unless ListenSocketPath is specified).
-	// Deprecated. Domains should be used instead.
-	// Deprecated: remove in 1.2.0
-	Domain string `hcl:"domain"`
-
 	// Domains are the domains this provider will be hosted under. Incoming requests
 	// that are not received on (or proxied through) one of the domains specified by this list
 	// are rejected.
@@ -141,16 +135,10 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 		c.LogLevel = defaultLogLevel
 	}
 
-	switch {
-	case c.Domain == "" && len(c.Domains) == 0:
+	if len(c.Domains) == 0 {
 		return nil, errs.New("at least one domain must be configured")
-	case c.Domain != "" && len(c.Domains) == 0:
-		c.Domains = []string{c.Domain}
-	case c.Domain == "" && len(c.Domains) > 0:
-		c.Domains = dedupeList(c.Domains)
-	case c.Domain != "" && len(c.Domains) > 0:
-		return nil, errs.New("domain is deprecated and will be removed in a future release; please use domains instead")
 	}
+	c.Domains = dedupeList(c.Domains)
 
 	if c.ACME != nil {
 		c.ACME.CacheDir = defaultCacheDir

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -81,48 +81,6 @@ func TestParseConfig(t *testing.T) {
 			err: "at least one domain must be configured",
 		},
 		{
-			name: "using deprecated domain configuration",
-			in: `
-				domain = "domain.test"
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					address = "unix:///some/socket/path"
-				}
-			`,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domain:   "domain.test",
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:    "./.acme-cache",
-					Email:       "admin@domain.test",
-					ToSAccepted: true,
-				},
-				ServerAPI: &ServerAPIConfig{
-					Address:      "unix:///some/socket/path",
-					PollInterval: defaultPollInterval,
-				},
-			},
-		},
-		{
-			name: "using deprecated domain configuration and new configuration",
-			in: `
-				domain = "domain.test"
-				domains = ["domain.test", "domain2.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					socket_path = "/some/socket/path"
-				}
-			`,
-			err: "domain is deprecated and will be removed in a future release; please use domains instead",
-		},
-		{
 			name: "no ACME configuration",
 			in: `
 				domains = ["domain.test"]

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -48,12 +48,6 @@ func run(configPath string) error {
 	if err != nil {
 		return err
 	}
-	if config.Domain != "" {
-		log.Warn("The domain configurable is deprecated and will be removed in a future release; use domains instead.")
-		// Maintain backwards compatibility and allow requests over all domains
-		// if configured with the deprecated `domain` configurable.
-		domainPolicy = AllowAnyDomain()
-	}
 
 	var handler http.Handler = NewHandler(domainPolicy, source, config.AllowInsecureScheme, config.SetKeyUse)
 	if config.LogRequests {


### PR DESCRIPTION
This config was superseded and deprecated by the `domains` configurable in 1.0.2 and can be removed for the upcoming 1.2 release.