### PR TITLE
Fail agent path template execution if key missing

### DIFF
--- a/pkg/common/agentpathtemplate/template.go
+++ b/pkg/common/agentpathtemplate/template.go
@@ -1,0 +1,49 @@
+package agentpathtemplate
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// Parse parses an agent path template. It changes the behavior for missing
+// keys to return an error instead of the default behavior, which renders a
+// value that requires percent-encoding to include in a URI, which is against
+// the SPIFFE specification.
+func Parse(text string) (*Template, error) {
+	tmpl, err := template.New("agent-path").Option("missingkey=error").Parse(text)
+	if err != nil {
+		return nil, err
+	}
+	return &Template{tmpl: tmpl}, nil
+}
+
+// MustParse parses an agent path template. It changes the behavior for missing
+// keys to return an error instead of the default behavior, which renders a
+// value that requires percent-encoding to include in a URI, which is against
+// the SPIFFE specification. If parsing fails, the function panics.
+func MustParse(text string) *Template {
+	tmpl, err := Parse(text)
+	if err != nil {
+		panic(err)
+	}
+	return tmpl
+}
+
+type Template struct {
+	tmpl *template.Template
+}
+
+func (t *Template) Execute(args interface{}) (string, error) {
+	buf := new(bytes.Buffer)
+	if err := t.tmpl.Execute(buf, args); err != nil {
+		return "", err
+	}
+	return ensureLeadingSlash(buf.String()), nil
+}
+
+func ensureLeadingSlash(s string) string {
+	if len(s) > 0 && s[0] != '/' {
+		s = "/" + s
+	}
+	return s
+}

--- a/pkg/common/agentpathtemplate/template_test.go
+++ b/pkg/common/agentpathtemplate/template_test.go
@@ -1,0 +1,48 @@
+package agentpathtemplate_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
+	"github.com/stretchr/testify/require"
+)
+
+func TextExecute(t *testing.T) {
+	tmpl, err := agentpathtemplate.Parse("{{ .key }}")
+	require.NoError(t, err)
+
+	t.Run("lookup ok", func(t *testing.T) {
+		path, err := tmpl.Execute(map[string]string{
+			"key": "/value",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "/value", path)
+	})
+
+	t.Run("lookup fails", func(t *testing.T) {
+		_, err := tmpl.Execute(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("ensure leading slash", func(t *testing.T) {
+		path, err := tmpl.Execute(map[string]string{
+			"key": "value",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "/value", path)
+	})
+}
+
+func TestMustParse(t *testing.T) {
+	t.Run("parse ok", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			tmpl := agentpathtemplate.MustParse("{{ .key }}")
+			require.NotNil(t, tmpl)
+		})
+	})
+	t.Run("parse fails", func(t *testing.T) {
+		require.Panics(t, func() {
+			agentpathtemplate.MustParse("{{ .key ")
+		})
+	})
+}

--- a/pkg/common/plugin/sshpop/handshake_test.go
+++ b/pkg/common/plugin/sshpop/handshake_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"text/template"
 
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
@@ -96,8 +96,7 @@ func TestHandshake(t *testing.T) {
 
 func TestServerSpiffeID(t *testing.T) {
 	tt := newTest(t, principal("ec2abcdef-uswest1"))
-	agentPathTemplate, err := template.New("agent-path").Parse("static/{{ index .ValidPrincipals 0 }}")
-	require.NoError(t, err)
+	agentPathTemplate := agentpathtemplate.MustParse("static/{{ index .ValidPrincipals 0 }}")
 
 	s := &ServerHandshake{
 		s: &Server{

--- a/pkg/common/plugin/sshpop/sshpop.go
+++ b/pkg/common/plugin/sshpop/sshpop.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"text/template"
 
 	"github.com/hashicorp/hcl"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -25,7 +25,7 @@ const (
 
 var (
 	// DefaultAgentPathTemplate is the default text/template.
-	DefaultAgentPathTemplate = template.Must(template.New("agent-path").Parse("{{ .PluginName}}/{{ .Fingerprint }}"))
+	DefaultAgentPathTemplate = agentpathtemplate.MustParse("{{ .PluginName}}/{{ .Fingerprint }}")
 )
 
 // agentPathTemplateData is used to hydrate the agent path template used in generating spiffe ids.
@@ -45,7 +45,7 @@ type Client struct {
 // Server is a factory for generating server handshake objects.
 type Server struct {
 	certChecker       *ssh.CertChecker
-	agentPathTemplate *template.Template
+	agentPathTemplate *agentpathtemplate.Template
 	trustDomain       string
 	canonicalDomain   string
 }
@@ -142,7 +142,7 @@ func NewServer(trustDomain, configString string) (*Server, error) {
 	}
 	agentPathTemplate := DefaultAgentPathTemplate
 	if len(config.AgentPathTemplate) > 0 {
-		tmpl, err := template.New("agent-path").Parse(config.AgentPathTemplate)
+		tmpl, err := agentpathtemplate.Parse(config.AgentPathTemplate)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse agent svid template: %q", config.AgentPathTemplate)
 		}

--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -1,7 +1,6 @@
 package x509pop
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -13,8 +12,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"text/template"
 
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/idutil"
 )
 
@@ -25,8 +24,8 @@ const (
 	PluginName = "x509pop"
 )
 
-// DefaultAgentPathTemplate is the default text/template
-var DefaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName }}/{{ .Fingerprint }}"))
+// DefaultAgentPathTemplate is the default template
+var DefaultAgentPathTemplate = agentpathtemplate.MustParse("{{ .PluginName }}/{{ .Fingerprint }}")
 
 type agentPathTemplateData struct {
 	*x509.Certificate
@@ -265,17 +264,16 @@ func Fingerprint(cert *x509.Certificate) string {
 }
 
 // MakeSpiffeID creates a SPIFFE ID from X.509 Certificate data.
-func MakeSpiffeID(trustDomain string, agentPathTemplate *template.Template, cert *x509.Certificate) (string, error) {
-	var agentPath bytes.Buffer
-	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
+func MakeSpiffeID(trustDomain string, agentPathTemplate *agentpathtemplate.Template, cert *x509.Certificate) (string, error) {
+	agentPath, err := agentPathTemplate.Execute(agentPathTemplateData{
 		Certificate: cert,
 		PluginName:  PluginName,
 		Fingerprint: Fingerprint(cert),
-	}); err != nil {
+	})
+	if err != nil {
 		return "", err
 	}
-
-	return idutil.AgentURI(trustDomain, agentPath.String()).String(), nil
+	return idutil.AgentURI(trustDomain, agentPath).String(), nil
 }
 
 func generateNonce() ([]byte, error) {

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -9,8 +9,8 @@ import (
 	"encoding/pem"
 	"math/big"
 	"testing"
-	"text/template"
 
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/stretchr/testify/require"
 )
 
@@ -131,7 +131,7 @@ func createBadCertificate(privateKey, publicKey interface{}) (*x509.Certificate,
 func TestMakeSPIFFEID(t *testing.T) {
 	tests := []struct {
 		desc         string
-		template     *template.Template
+		template     *agentpathtemplate.Template
 		expectSPIFFE string
 		expectErr    string
 	}{
@@ -142,13 +142,13 @@ func TestMakeSPIFFEID(t *testing.T) {
 		},
 		{
 			desc:         "custom template with subject identifiers",
-			template:     template.Must(template.New("test").Parse("foo/{{ .Subject.CommonName }}")),
+			template:     agentpathtemplate.MustParse("foo/{{ .Subject.CommonName }}"),
 			expectSPIFFE: "spiffe://example.org/spire/agent/foo/test-cert",
 		},
 		{
 			desc:      "custom template with nonexistant fields",
-			template:  template.Must(template.New("test").Parse("{{ .Foo }}")),
-			expectErr: `template: test:1:3: executing "test" at <.Foo>: can't evaluate field Foo in type x509pop.agentPathTemplateData`,
+			template:  agentpathtemplate.MustParse("{{ .Foo }}"),
+			expectErr: `template: agent-path:1:3: executing "agent-path" at <.Foo>: can't evaluate field Foo in type x509pop.agentPathTemplateData`,
 		},
 	}
 

--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -26,6 +25,7 @@ import (
 	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	caws "github.com/spiffe/spire/pkg/common/plugin/aws"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
@@ -93,7 +93,7 @@ type IIDAttestorConfig struct {
 	LocalValidAcctIDs               []string `hcl:"account_ids_for_local_validation"`
 	AgentPathTemplate               string   `hcl:"agent_path_template"`
 	AssumeRole                      string   `hcl:"assume_role"`
-	pathTemplate                    *template.Template
+	pathTemplate                    *agentpathtemplate.Template
 	trustDomain                     string
 	awsCAPublicKey                  *rsa.PublicKey
 }
@@ -237,7 +237,7 @@ func (p *IIDAttestorPlugin) Configure(ctx context.Context, req *configv1.Configu
 
 	config.pathTemplate = defaultAgentPathTemplate
 	if len(config.AgentPathTemplate) > 0 {
-		tmpl, err := template.New("agent-path").Parse(config.AgentPathTemplate)
+		tmpl, err := agentpathtemplate.Parse(config.AgentPathTemplate)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse agent svid template: %q", config.AgentPathTemplate)
 		}

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -233,9 +233,10 @@ func TestAttest(t *testing.T) {
 			expectSelectors: []*common.Selector{{Type: "aws_iid", Value: "tag:Hostname:host1"}},
 		},
 		{
-			name:     "success with missing tags in template",
-			config:   `agent_path_template = "{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
-			expectID: "spiffe://example.org/spire/agent/aws_iid/zone1/%3Cno%20value%3E",
+			name:            "fails with missing tags in template",
+			config:          `agent_path_template = "{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
+			expectCode:      codes.Internal,
+			expectMsgPrefix: `nodeattestor(aws_iid): failed to create spiffe ID: template: agent-path:1:32: executing "agent-path" at <.Tags.Hostname>: map has no entry for key "Hostname"`,
 		},
 		{
 			name: "success with all the selectors",

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid.go
@@ -1,16 +1,15 @@
 package aws
 
 import (
-	"bytes"
 	"net/url"
-	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/plugin/aws"
 )
 
-var defaultAgentPathTemplate = template.Must(template.New("agent-svid").Parse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"))
+var defaultAgentPathTemplate = agentpathtemplate.MustParse("{{ .PluginName}}/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}")
 
 type agentPathTemplateData struct {
 	InstanceID  string
@@ -24,17 +23,17 @@ type agentPathTemplateData struct {
 type instanceTags map[string]string
 
 // makeSpiffeID creates a spiffe ID from IID data
-func makeSpiffeID(trustDomain string, agentPathTemplate *template.Template, doc ec2metadata.EC2InstanceIdentityDocument, tags instanceTags) (*url.URL, error) {
-	var agentPath bytes.Buffer
-	if err := agentPathTemplate.Execute(&agentPath, agentPathTemplateData{
+func makeSpiffeID(trustDomain string, agentPathTemplate *agentpathtemplate.Template, doc ec2metadata.EC2InstanceIdentityDocument, tags instanceTags) (*url.URL, error) {
+	agentPath, err := agentPathTemplate.Execute(agentPathTemplateData{
 		InstanceID: doc.InstanceID,
 		AccountID:  doc.AccountID,
 		Region:     doc.Region,
 		PluginName: aws.PluginName,
 		Tags:       tags,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	return idutil.AgentURI(trustDomain, agentPath.String()), nil
+	return idutil.AgentURI(trustDomain, agentPath), nil
 }

--- a/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/spiffeid_test.go
@@ -2,19 +2,19 @@ package aws
 
 import (
 	"testing"
-	"text/template"
 
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/stretchr/testify/require"
 )
 
-var templateWithTags = template.Must(template.New("agent-svid").Parse("{{ .Tags.a }}/{{ .Tags.b }}"))
+var templateWithTags = agentpathtemplate.MustParse("{{ .Tags.a }}/{{ .Tags.b }}")
 
 func TestMakeSpiffeID(t *testing.T) {
 	tests := []struct {
 		name              string
 		trustDomain       string
-		agentPathTemplate *template.Template
+		agentPathTemplate *agentpathtemplate.Template
 		doc               ec2metadata.EC2InstanceIdentityDocument
 		tags              instanceTags
 		want              string

--- a/pkg/server/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/hashicorp/hcl"
@@ -13,6 +12,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/gcp"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
@@ -65,7 +65,7 @@ type IITAttestorPlugin struct {
 
 // IITAttestorConfig is the config for IITAttestorPlugin.
 type IITAttestorConfig struct {
-	idPathTemplate      *template.Template
+	idPathTemplate      *agentpathtemplate.Template
 	trustDomain         string
 	allowedLabelKeys    map[string]bool
 	allowedMetadataKeys map[string]bool
@@ -187,7 +187,7 @@ func (p *IITAttestorPlugin) Configure(ctx context.Context, req *configv1.Configu
 	tmpl := gcp.DefaultAgentPathTemplate
 	if len(hclConfig.AgentPathTemplate) > 0 {
 		var err error
-		tmpl, err = template.New("agent-path").Parse(hclConfig.AgentPathTemplate)
+		tmpl, err = agentpathtemplate.Parse(hclConfig.AgentPathTemplate)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse agent path template: %q", hclConfig.AgentPathTemplate)
 		}

--- a/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
@@ -5,11 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"sync"
-	"text/template"
 
 	"github.com/hashicorp/hcl"
 	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/x509pop"
 	"github.com/spiffe/spire/pkg/common/util"
@@ -35,7 +35,7 @@ func builtin(p *Plugin) catalog.BuiltIn {
 type configuration struct {
 	trustDomain  string
 	trustBundle  *x509.CertPool
-	pathTemplate *template.Template
+	pathTemplate *agentpathtemplate.Template
 }
 
 type Config struct {
@@ -175,7 +175,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	pathTemplate := x509pop.DefaultAgentPathTemplate
 	if len(hclConfig.AgentPathTemplate) > 0 {
-		tmpl, err := template.New("agent-path").Parse(hclConfig.AgentPathTemplate)
+		tmpl, err := agentpathtemplate.Parse(hclConfig.AgentPathTemplate)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "failed to parse agent svid template: %q", hclConfig.AgentPathTemplate)
 		}


### PR DESCRIPTION
The default behavior of the text/template library when a key is missing is to render `<no value>`. This is problematic for agent path templates, since the produced agent path would require percent encoding and would therefore not be conformant with the SPIFFE ID specification.

Previously this default behavior has been allowed. However, as of SPIRE 1.0, these types of agent would have been rejected when attempting to issue RPCs by the authorization layer, which rejects non-conformant agent IDs (unless the safety valve was activated).

The safety valve is being removed to a subsequent PR. Prior to that, this is a small change which:

- Unifies the path template parsing and execution
- Changes the missing key behavior to fail the execution
- Preserves "ensure leading slash" behavior on produced paths

Edit: these types of IDs would have actually been rejected during attestion, since the attestation code checks that the ID produced by the attestors is valid. So this change should have no change in behavior other than improved diagnostics (the error message will indicate which key was missing instead of just an error about an invalid ID).