### PR TITLE
Preserve "ensure leading slash" behavior

### DIFF
--- a/pkg/common/agentpathtemplate/template.go
+++ b/pkg/common/agentpathtemplate/template.go
@@ -63,7 +63,7 @@ func (t *Template) Execute(args interface{}) (string, error) {
 
 // SetEnsureLeadingSlashLog sets the logger used to report "ensure leading slash"
 // related deprecation warnings. Called by server/server.go. This is a hack.
-// Deprecate: remove in SPIRE 1.3
+// Deprecated: remove in SPIRE 1.3
 func SetEnsureLeadingSlashLog(log logrus.FieldLogger) {
 	ensureLeadingSlashLog = log
 }

--- a/pkg/common/agentpathtemplate/template.go
+++ b/pkg/common/agentpathtemplate/template.go
@@ -51,7 +51,7 @@ func (t *Template) Execute(args interface{}) (string, error) {
 	}
 	path := buf.String()
 
-	// Deprecate: remove in SPIRE 1.3
+	// Deprecated: remove in SPIRE 1.3
 	ensuredPath, modified := idutil.EnsureLeadingSlashForBackcompat(path)
 	if modified && ensureLeadingSlashLog != nil && ensureLeadingSlashLogLimiter.Allow() {
 		ensureLeadingSlashLog.WithField(telemetry.Path, path).

--- a/pkg/common/agentpathtemplate/template.go
+++ b/pkg/common/agentpathtemplate/template.go
@@ -3,6 +3,17 @@ package agentpathtemplate
 import (
 	"bytes"
 	"text/template"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"golang.org/x/time/rate"
+)
+
+var (
+	ensureLeadingSlashLog        logrus.FieldLogger
+	ensureLeadingSlashLogLimiter = rate.NewLimiter(rate.Every(time.Minute), 1)
 )
 
 // Parse parses an agent path template. It changes the behavior for missing
@@ -38,12 +49,21 @@ func (t *Template) Execute(args interface{}) (string, error) {
 	if err := t.tmpl.Execute(buf, args); err != nil {
 		return "", err
 	}
-	return ensureLeadingSlash(buf.String()), nil
+	path := buf.String()
+
+	// Deprecate: remove in SPIRE 1.3
+	ensuredPath, modified := idutil.EnsureLeadingSlashForBackcompat(path)
+	if modified && ensureLeadingSlashLog != nil && ensureLeadingSlashLogLimiter.Allow() {
+		ensureLeadingSlashLog.WithField(telemetry.Path, path).
+			Warn("Support for agent path templates which produce paths without leading slashes are deprecated and will be removed in a future release")
+	}
+
+	return ensuredPath, nil
 }
 
-func ensureLeadingSlash(s string) string {
-	if len(s) > 0 && s[0] != '/' {
-		s = "/" + s
-	}
-	return s
+// SetEnsureLeadingSlashLog sets the logger used to report "ensure leading slash"
+// related deprecation warnings. Called by server/server.go. This is a hack.
+// Deprecate: remove in SPIRE 1.3
+func SetEnsureLeadingSlashLog(log logrus.FieldLogger) {
+	ensureLeadingSlashLog = log
 }

--- a/pkg/common/agentpathtemplate/template_test.go
+++ b/pkg/common/agentpathtemplate/template_test.go
@@ -3,11 +3,14 @@ package agentpathtemplate_test
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
-func TextExecute(t *testing.T) {
+func TestExecute(t *testing.T) {
 	tmpl, err := agentpathtemplate.Parse("{{ .key }}")
 	require.NoError(t, err)
 
@@ -24,12 +27,23 @@ func TextExecute(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("ensure leading slash", func(t *testing.T) {
+	t.Run("ensure leading slash warns", func(t *testing.T) {
+		log, logHook := test.NewNullLogger()
+		agentpathtemplate.SetEnsureLeadingSlashLog(log)
 		path, err := tmpl.Execute(map[string]string{
 			"key": "value",
 		})
 		require.NoError(t, err)
 		require.Equal(t, "/value", path)
+		spiretest.AssertLogs(t, logHook.AllEntries(), []spiretest.LogEntry{
+			{
+				Level:   logrus.WarnLevel,
+				Message: "Support for agent path templates which produce paths without leading slashes are deprecated and will be removed in a future release",
+				Data: logrus.Fields{
+					"path": "value",
+				},
+			},
+		})
 	})
 }
 

--- a/pkg/common/api/ratelimit.go
+++ b/pkg/common/api/ratelimit.go
@@ -1,0 +1,13 @@
+package api
+
+import "context"
+
+type RateLimiter interface {
+	RateLimit(ctx context.Context, count int) error
+}
+
+type RateLimiterFunc func(ctx context.Context, count int) error
+
+func (fn RateLimiterFunc) RateLimit(ctx context.Context, count int) error {
+	return fn(ctx, count)
+}

--- a/pkg/common/idutil/safety.go
+++ b/pkg/common/idutil/safety.go
@@ -74,3 +74,13 @@ func IDFromProto(id *types.SPIFFEID) (spiffeid.ID, error) {
 	}
 	return spiffeid.FromPath(td, id.Path)
 }
+
+// EnsureLeadingSlashForBackcompat is for backcompat only. It adds a leading
+// slash to a path, if necessary. It is not expected to receive more callers.
+// Deprecated: remove in SPIRE 1.3
+func EnsureLeadingSlashForBackcompat(path string) (string, bool) {
+	if len(path) != 0 && path[0] != '/' {
+		return "/" + path, true
+	}
+	return path, false
+}

--- a/pkg/common/plugin/sshpop/handshake_test.go
+++ b/pkg/common/plugin/sshpop/handshake_test.go
@@ -97,7 +97,7 @@ func TestHandshake(t *testing.T) {
 
 func TestServerSpiffeID(t *testing.T) {
 	tt := newTest(t, principal("ec2abcdef-uswest1"))
-	agentPathTemplate := agentpathtemplate.MustParse("static/{{ index .ValidPrincipals 0 }}")
+	agentPathTemplate := agentpathtemplate.MustParse("/static/{{ index .ValidPrincipals 0 }}")
 
 	s := &ServerHandshake{
 		s: &Server{

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -143,13 +143,13 @@ func TestMakeAgentID(t *testing.T) {
 		},
 		{
 			desc:     "custom template with subject identifiers",
-			template: agentpathtemplate.MustParse("foo/{{ .Subject.CommonName }}"),
+			template: agentpathtemplate.MustParse("/foo/{{ .Subject.CommonName }}"),
 			expectID: "spiffe://example.org/spire/agent/foo/test-cert",
 		},
 		{
 			desc:      "custom template with nonexistant fields",
-			template:  agentpathtemplate.MustParse("{{ .Foo }}"),
-			expectErr: `template: agent-path:1:3: executing "agent-path" at <.Foo>: can't evaluate field Foo in type x509pop.agentPathTemplateData`,
+			template:  agentpathtemplate.MustParse("/{{ .Foo }}"),
+			expectErr: `template: agent-path:1:4: executing "agent-path" at <.Foo>: can't evaluate field Foo in type x509pop.agentPathTemplateData`,
 		},
 	}
 

--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -155,7 +155,7 @@ func (s *Service) ListAgents(ctx context.Context, req *agentv1.ListAgentsRequest
 func (s *Service) GetAgent(ctx context.Context, req *agentv1.GetAgentRequest) (*types.Agent, error) {
 	log := rpccontext.Logger(ctx)
 
-	agentID, err := api.TrustDomainAgentIDFromProto(s.td, req.Id)
+	agentID, err := api.TrustDomainAgentIDFromProto(ctx, s.td, req.Id)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.InvalidArgument, "invalid agent ID", err)
 	}
@@ -190,7 +190,7 @@ func (s *Service) GetAgent(ctx context.Context, req *agentv1.GetAgentRequest) (*
 func (s *Service) DeleteAgent(ctx context.Context, req *agentv1.DeleteAgentRequest) (*emptypb.Empty, error) {
 	log := rpccontext.Logger(ctx)
 
-	id, err := api.TrustDomainAgentIDFromProto(s.td, req.Id)
+	id, err := api.TrustDomainAgentIDFromProto(ctx, s.td, req.Id)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.InvalidArgument, "invalid agent ID", err)
 	}
@@ -215,7 +215,7 @@ func (s *Service) DeleteAgent(ctx context.Context, req *agentv1.DeleteAgentReque
 func (s *Service) BanAgent(ctx context.Context, req *agentv1.BanAgentRequest) (*emptypb.Empty, error) {
 	log := rpccontext.Logger(ctx)
 
-	id, err := api.TrustDomainAgentIDFromProto(s.td, req.Id)
+	id, err := api.TrustDomainAgentIDFromProto(ctx, s.td, req.Id)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.InvalidArgument, "invalid agent ID", err)
 	}
@@ -436,7 +436,7 @@ func (s *Service) CreateJoinToken(ctx context.Context, req *agentv1.CreateJoinTo
 	var agentID spiffeid.ID
 	var err error
 	if req.AgentId != nil {
-		agentID, err = api.TrustDomainWorkloadIDFromProto(s.td, req.AgentId)
+		agentID, err = api.TrustDomainWorkloadIDFromProto(ctx, s.td, req.AgentId)
 		if err != nil {
 			return nil, api.MakeErr(log, codes.InvalidArgument, "invalid agent ID", err)
 		}

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -1218,7 +1218,7 @@ func TestDeleteAgent(t *testing.T) {
 			req: &agentv1.DeleteAgentRequest{
 				Id: &types.SPIFFEID{
 					TrustDomain: "",
-					Path:        "spiffe://examples.org/spire/agent/node1",
+					Path:        "/spire/agent/node1",
 				},
 			},
 		},
@@ -1260,7 +1260,7 @@ func TestDeleteAgent(t *testing.T) {
 					Level:   logrus.ErrorLevel,
 					Message: "Invalid argument: invalid agent ID",
 					Data: logrus.Fields{
-						logrus.ErrorKey: "path must have a leading slash",
+						logrus.ErrorKey: "\"spiffe://example.org/host\" is not an agent in trust domain \"example.org\"; path is not in the agent namespace",
 					},
 				},
 				{
@@ -1270,16 +1270,16 @@ func TestDeleteAgent(t *testing.T) {
 						telemetry.Status:        "error",
 						telemetry.Type:          "audit",
 						telemetry.StatusCode:    "InvalidArgument",
-						telemetry.StatusMessage: "invalid agent ID: path must have a leading slash",
+						telemetry.StatusMessage: "invalid agent ID: \"spiffe://example.org/host\" is not an agent in trust domain \"example.org\"; path is not in the agent namespace",
 					},
 				},
 			},
 			code: codes.InvalidArgument,
-			err:  "invalid agent ID: path must have a leading slash",
+			err:  "invalid agent ID: \"spiffe://example.org/host\" is not an agent in trust domain \"example.org\"; path is not in the agent namespace",
 			req: &agentv1.DeleteAgentRequest{
 				Id: &types.SPIFFEID{
 					TrustDomain: "example.org",
-					Path:        "host",
+					Path:        "/host",
 				},
 			},
 		},

--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -70,8 +71,8 @@ func RegistrationEntryToProto(e *common.RegistrationEntry) (*types.Entry, error)
 }
 
 // ProtoToRegistrationEntry converts and validate entry into common registration entry
-func ProtoToRegistrationEntry(td spiffeid.TrustDomain, e *types.Entry) (*common.RegistrationEntry, error) {
-	return ProtoToRegistrationEntryWithMask(td, e, nil)
+func ProtoToRegistrationEntry(ctx context.Context, td spiffeid.TrustDomain, e *types.Entry) (*common.RegistrationEntry, error) {
+	return ProtoToRegistrationEntryWithMask(ctx, td, e, nil)
 }
 
 // ProtoToRegistrationEntryWithMask converts and validate entry into common registration entry,
@@ -79,7 +80,7 @@ func ProtoToRegistrationEntry(td spiffeid.TrustDomain, e *types.Entry) (*common.
 // in the mask are false.
 // This allows the user to not specify these fields while updating using a mask.
 // All other fields are allowed to be empty (with or without a mask).
-func ProtoToRegistrationEntryWithMask(td spiffeid.TrustDomain, e *types.Entry, mask *types.EntryMask) (*common.RegistrationEntry, error) {
+func ProtoToRegistrationEntryWithMask(ctx context.Context, td spiffeid.TrustDomain, e *types.Entry, mask *types.EntryMask) (*common.RegistrationEntry, error) {
 	if e == nil {
 		return nil, errors.New("missing entry")
 	}
@@ -90,7 +91,7 @@ func ProtoToRegistrationEntryWithMask(td spiffeid.TrustDomain, e *types.Entry, m
 
 	var parentIDString string
 	if mask.ParentId {
-		parentID, err := TrustDomainMemberIDFromProto(td, e.ParentId)
+		parentID, err := TrustDomainMemberIDFromProto(ctx, td, e.ParentId)
 		if err != nil {
 			return nil, fmt.Errorf("invalid parent ID: %w", err)
 		}
@@ -102,7 +103,7 @@ func ProtoToRegistrationEntryWithMask(td spiffeid.TrustDomain, e *types.Entry, m
 
 	var spiffeIDString string
 	if mask.SpiffeId {
-		spiffeID, err := TrustDomainWorkloadIDFromProto(td, e.SpiffeId)
+		spiffeID, err := TrustDomainWorkloadIDFromProto(ctx, td, e.SpiffeId)
 		if err != nil {
 			return nil, fmt.Errorf("invalid spiffe ID: %w", err)
 		}

--- a/pkg/server/api/entry_test.go
+++ b/pkg/server/api/entry_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -181,7 +182,7 @@ func TestProtoToRegistrationEntryWithMask(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			entry, err := api.ProtoToRegistrationEntryWithMask(td, tt.entry, tt.mask)
+			entry, err := api.ProtoToRegistrationEntryWithMask(context.Background(), td, tt.entry, tt.mask)
 			if tt.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.err)
@@ -348,7 +349,7 @@ func TestProtoToRegistrationEntry(t *testing.T) {
 	} {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			entry, err := api.ProtoToRegistrationEntry(td, tt.entry)
+			entry, err := api.ProtoToRegistrationEntry(context.Background(), td, tt.entry)
 			if tt.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.err)

--- a/pkg/server/api/id.go
+++ b/pkg/server/api/id.go
@@ -1,16 +1,25 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/api/rpccontext"
+	"golang.org/x/time/rate"
 )
 
-func TrustDomainMemberIDFromProto(td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
-	id, err := idFromProto(protoID)
+var (
+	ensureLeadingSlashLogLimiter = rate.NewLimiter(rate.Every(time.Minute), 1)
+)
+
+func TrustDomainMemberIDFromProto(ctx context.Context, td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
+	id, err := idFromProto(ctx, protoID)
 	if err != nil {
 		return spiffeid.ID{}, err
 	}
@@ -30,8 +39,8 @@ func VerifyTrustDomainMemberID(td spiffeid.TrustDomain, id spiffeid.ID) error {
 	return nil
 }
 
-func TrustDomainAgentIDFromProto(td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
-	id, err := idFromProto(protoID)
+func TrustDomainAgentIDFromProto(ctx context.Context, td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
+	id, err := idFromProto(ctx, protoID)
 	if err != nil {
 		return spiffeid.ID{}, err
 	}
@@ -54,8 +63,8 @@ func VerifyTrustDomainAgentID(td spiffeid.TrustDomain, id spiffeid.ID) error {
 	return nil
 }
 
-func TrustDomainWorkloadIDFromProto(td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
-	id, err := idFromProto(protoID)
+func TrustDomainWorkloadIDFromProto(ctx context.Context, td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error) {
+	id, err := idFromProto(ctx, protoID)
 	if err != nil {
 		return spiffeid.ID{}, err
 	}
@@ -87,9 +96,24 @@ func ProtoFromID(id spiffeid.ID) *types.SPIFFEID {
 	}
 }
 
-func idFromProto(protoID *types.SPIFFEID) (spiffeid.ID, error) {
+// RemoveEnsureLeadingSlashLogLimit is a test hook to reset the limit for logs
+// related to "ensure leading slash" conversions.
+// Deprecated: remove in SPIRE 1.3
+func RemoveEnsureLeadingSlashLogLimit() {
+	ensureLeadingSlashLogLimiter.SetLimit(rate.Inf)
+}
+
+func idFromProto(ctx context.Context, protoID *types.SPIFFEID) (spiffeid.ID, error) {
 	if protoID == nil {
 		return spiffeid.ID{}, errors.New("request must specify SPIFFE ID")
 	}
+	path, modified := idutil.EnsureLeadingSlashForBackcompat(protoID.Path)
+	if modified && ensureLeadingSlashLogLimiter.Allow() {
+		// Deprecated: remove in SPIRE 1.3
+		if log := rpccontext.Logger(ctx); log != nil {
+			log.WithField(telemetry.Path, protoID.Path).Warn("API support for paths without leading slashes in SPIFFEID messages is deprecated and will be removed in a future release")
+		}
+	}
+	protoID.Path = path
 	return idutil.IDFromProto(protoID)
 }

--- a/pkg/server/api/ratelimit.go
+++ b/pkg/server/api/ratelimit.go
@@ -1,13 +1,6 @@
 package api
 
-import "context"
+import "github.com/spiffe/spire/pkg/common/api"
 
-type RateLimiter interface {
-	RateLimit(ctx context.Context, count int) error
-}
-
-type RateLimiterFunc func(ctx context.Context, count int) error
-
-func (fn RateLimiterFunc) RateLimit(ctx context.Context, count int) error {
-	return fn(ctx, count)
-}
+type RateLimiter = api.RateLimiter
+type RateLimiterFunc = api.RateLimiterFunc

--- a/pkg/server/api/rpccontext/ratelimit.go
+++ b/pkg/server/api/rpccontext/ratelimit.go
@@ -3,7 +3,7 @@ package rpccontext
 import (
 	"context"
 
-	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/common/api"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -566,7 +566,7 @@ func TestServiceMintX509SVID(t *testing.T) {
 			require.NotEmpty(t, certChain)
 			svid := certChain[0]
 
-			id, err := api.TrustDomainWorkloadIDFromProto(td, resp.Svid.Id)
+			id, err := api.TrustDomainWorkloadIDFromProto(context.Background(), td, resp.Svid.Id)
 			require.NoError(t, err)
 
 			require.Equal(t, workloadID, id)
@@ -2094,7 +2094,7 @@ func verifyJWTSVIDResponse(t *testing.T, jwtsvid *types.JWTSVID, id spiffeid.ID,
 	err = token.UnsafeClaimsWithoutVerification(&claims)
 	require.NoError(t, err)
 
-	jwtsvidID, err := api.TrustDomainWorkloadIDFromProto(td, jwtsvid.Id)
+	jwtsvidID, err := api.TrustDomainWorkloadIDFromProto(context.Background(), td, jwtsvid.Id)
 	require.NoError(t, err)
 	require.Equal(t, id, jwtsvidID)
 	require.Equal(t, id.String(), claims.Subject)

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -480,7 +480,7 @@ func BenchmarkBuildSQL(b *testing.B) {
 	ds := newSQLPlugin(b)
 
 	for _, entry := range allEntries {
-		e, _ := api.ProtoToRegistrationEntry(td, entry)
+		e, _ := api.ProtoToRegistrationEntry(context.Background(), td, entry)
 		createRegistrationEntry(ctx, b, ds, e)
 	}
 

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -215,7 +215,7 @@ func TestAttest(t *testing.T) {
 		},
 		{
 			name:     "success with agent_path_template",
-			config:   `agent_path_template = "{{ .PluginName }}/custom/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"`,
+			config:   `agent_path_template = "/{{ .PluginName }}/custom/{{ .AccountID }}/{{ .Region }}/{{ .InstanceID }}"`,
 			expectID: "spiffe://example.org/spire/agent/aws_iid/custom/test-account/test-region/test-instance",
 		},
 		{
@@ -228,15 +228,15 @@ func TestAttest(t *testing.T) {
 					},
 				}
 			},
-			config:          `agent_path_template = "{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
+			config:          `agent_path_template = "/{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
 			expectID:        "spiffe://example.org/spire/agent/aws_iid/zone1/host1",
 			expectSelectors: []*common.Selector{{Type: "aws_iid", Value: "tag:Hostname:host1"}},
 		},
 		{
 			name:            "fails with missing tags in template",
-			config:          `agent_path_template = "{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
+			config:          `agent_path_template = "/{{ .PluginName }}/zone1/{{ .Tags.Hostname }}"`,
 			expectCode:      codes.Internal,
-			expectMsgPrefix: `nodeattestor(aws_iid): failed to create spiffe ID: template: agent-path:1:32: executing "agent-path" at <.Tags.Hostname>: map has no entry for key "Hostname"`,
+			expectMsgPrefix: `nodeattestor(aws_iid): failed to create spiffe ID: template: agent-path:1:33: executing "agent-path" at <.Tags.Hostname>: map has no entry for key "Hostname"`,
 		},
 		{
 			name: "success with all the selectors",
@@ -421,7 +421,7 @@ func TestConfigure(t *testing.T) {
 
 	t.Run("bad agent template", func(t *testing.T) {
 		err := doConfig(t, coreConfig, `
-		agent_path_template = "{{ .InstanceID "
+		agent_path_template = "/{{ .InstanceID "
 		`)
 		spiretest.RequireGRPCStatusContains(t, err, codes.InvalidArgument, "failed to parse agent svid template")
 	})

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -245,7 +245,7 @@ func (s *IITAttestorSuite) TestAttestFailureDueToMissingInstanceMetadata() {
 func (s *IITAttestorSuite) TestAttestSuccessWithCustomSPIFFEIDTemplate() {
 	attestor := s.loadPluginWithConfig(`
 projectid_allow_list = ["test-project"]
-agent_path_template = "{{ .InstanceID }}"
+agent_path_template = "/{{ .InstanceID }}"
 `)
 
 	expectSVID := "spiffe://example.org/spire/agent/test-instance-id"
@@ -293,7 +293,7 @@ projectid_allow_list = ["bar"]
 	s.T().Run("bad SVID template", func(t *testing.T) {
 		err := doConfig(t, coreConfig, `
 projectid_allow_list = ["test-project"]
-agent_path_template = "{{ .InstanceID "
+agent_path_template = "/{{ .InstanceID "
 `)
 		spiretest.AssertGRPCStatusContains(t, err, codes.InvalidArgument, "failed to parse agent path template")
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
 	server_util "github.com/spiffe/spire/cmd/spire-server/util"
+	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/profiling"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -61,6 +62,9 @@ func (s *Server) Run(ctx context.Context) error {
 }
 
 func (s *Server) run(ctx context.Context) (err error) {
+	// Deprecated: remove in SPIRE 1.3
+	agentpathtemplate.SetEnsureLeadingSlashLog(s.config.Log)
+
 	// Log configuration values that are useful for debugging
 	s.config.Log.WithFields(logrus.Fields{
 		telemetry.AdminIDs: s.config.AdminIDs,


### PR DESCRIPTION
This change restores "ensure leading slash" behavior to the API layer when processing SPIFFEID messages. It further adds deprecation warnings so that we can deprecate this unwanted behavior in SPIRE 1.3.

Unfortunately, threading a logger into the right spots caused some more code churn that would otherwise be warranted for this kind of change. This includes some shuffling of types to resolve import cycles.

Most of the grossness involved with this change will be removed for SPIRE 1.3.