### PR TITLE
Fix agent cache getSelectorIndex concurrent-map-read-and-write bug

### DIFF
--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -687,6 +687,8 @@ func (c *Cache) getRecordsForSelectors(set selectorSet) (recordSet, func()) {
 func (c *Cache) getSelectorIndex(s selector) *selectorIndex {
 	index, ok := c.selectors[s]
 	if !ok {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
 		index = newSelectorIndex()
 		c.selectors[s] = index
 	}

--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -107,6 +107,8 @@ type Cache struct {
 
 	mu sync.RWMutex
 
+	mux sync.Mutex
+
 	// records holds the records for registration entries, keyed by registration entry ID
 	records map[string]*cacheRecord
 
@@ -695,8 +697,8 @@ func (c *Cache) getSelectorIndex(s selector) *selectorIndex {
 
 // setSelectorIndex sets the selector index for the selector.
 func (c *Cache) setSelectorIndex(s selector, index *selectorIndex) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mux.Lock()
+	defer c.mux.Unlock()
 	c.selectors[s] = index
 }
 

--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -685,8 +685,6 @@ func (c *Cache) getRecordsForSelectors(set selectorSet) (recordSet, func()) {
 // getSelectorIndex gets the selector index for the selector. If one doesn't
 // exist, it is created.
 func (c *Cache) getSelectorIndex(s selector) *selectorIndex {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
 	index, ok := c.selectors[s]
 	if !ok {
 		index = newSelectorIndex()

--- a/pkg/agent/manager/cache/cache.go
+++ b/pkg/agent/manager/cache/cache.go
@@ -685,14 +685,21 @@ func (c *Cache) getRecordsForSelectors(set selectorSet) (recordSet, func()) {
 // getSelectorIndex gets the selector index for the selector. If one doesn't
 // exist, it is created.
 func (c *Cache) getSelectorIndex(s selector) *selectorIndex {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	index, ok := c.selectors[s]
 	if !ok {
-		c.mu.RLock()
-		defer c.mu.RUnlock()
 		index = newSelectorIndex()
-		c.selectors[s] = index
+		c.setSelectorIndex(s, index)
 	}
 	return index
+}
+
+// setSelectorIndex sets the selector index for the selector.
+func (c *Cache) setSelectorIndex(s selector, index *selectorIndex) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.selectors[s] = index
 }
 
 type cacheRecord struct {


### PR DESCRIPTION
Signed-off-by: Yuhan Li [liyuhan.loveyana@bytedance.com](mailto:liyuhan.loveyana@bytedance.com)

**Pull Request check list**

* [x]  Commit conforms to CONTRIBUTING.md?
* [ ]  Proper tests/regressions included?
* [ ]  Documentation updated?

**Affected functionality**

Agent workload attest

**Description of change**

When doing workload attest to the spire agent, because the getSelectorIndex function is not locked, multiple goroutine call the getSelectorIndex function at the same time, triggering the read and write of the c.selectors map at the same time

Panic the process of spire agent, and the error message is `fatal error: concurrent map reading and map writing`

**Reproduction method**

Start multiple identical workload processes concurrently, and each process will call the getSelectorIndex function when GRPC connects to Agent, causing panic.

**Repair**

I created a setSelectorIndex method separately, and when the specified key does not exist passed the index and selector key obtained by newSelectorIndex into the method, using `c.mu.Lock` to ensure concurrency security for writing

**Which issue this PR fixes**

