### PR TITLE
1152/reopen log file

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -14,6 +14,25 @@ agent {
     # join_token = ""
 
     # log_file: File to write logs to.
+    #
+    # If set, spire-agent will spawn a handler to reopen the file upon receipt
+    # of SIGUSR2 to support log rotation. To use logrotate without lossy
+    # copytruncate option, users MUST add a postrotate script to the logrotate
+    # configuration to send the SIGUSR2 signal to the spire-agent process.
+    #
+    # Example logrotate.conf:
+    #
+    # /path/to/spire-agent.log {
+    #     compress
+    #     delaycompress
+    #     maxsize 100M
+    #     missingok
+    #     rotate 7
+    #     postrotate
+    #         killall -USR2 spire-agent
+    #     endscript
+    # }
+    #
     # log_file = ""
 
     # log_format: Format of logs, <text|json>. Default: text.

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -100,6 +100,25 @@ server {
     # jwt_issuer = ""
 
     # log_file: File to write logs to
+    #
+    # If set, spire-server will spawn a handler to reopen the file upon receipt
+    # of SIGUSR2 to support log rotation. To use logrotate without lossy
+    # copytruncate option, users MUST add a postrotate script to the logrotate
+    # configuration to send the SIGUSR2 signal to the spire-server process.
+    #
+    # Example logrotate.conf:
+    #
+    # /path/to/spire-server.log {
+    #     compress
+    #     delaycompress
+    #     maxsize 100M
+    #     missingok
+    #     rotate 7
+    #     postrotate
+    #         killall -USR2 spire-server
+    #     endscript
+    # }
+    #
     # log_file = ""
 
     # log_level: Sets the logging level <DEBUG|INFO|WARN|ERROR>. Default: INFO.

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/health"
+	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 )
 
@@ -41,6 +42,9 @@ type Config struct {
 	PluginConfigs catalog.HCLPluginConfigMap
 
 	Log logrus.FieldLogger
+
+	// LogReopener facilitates handling a signal to rotate log file.
+	LogReopener log.ReopenableWriteCloser
 
 	// Address of SPIRE server
 	ServerAddress string

--- a/pkg/common/log/reopen.go
+++ b/pkg/common/log/reopen.go
@@ -1,0 +1,95 @@
+package log
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+const _reopenSignal = syscall.SIGUSR2
+
+var _ ReopenableWriteCloser = (*ReopenableFile)(nil)
+
+// Reopener inspired by https://github.com/client9/reopen
+type Reopener interface {
+	Reopen() error
+}
+
+type ReopenableWriteCloser interface {
+	Reopener
+	io.WriteCloser
+}
+
+type ReopenableFile struct {
+	name string
+	f    *os.File
+	mu   sync.Mutex
+}
+
+func NewReopenableFile(name string) (*ReopenableFile, error) {
+	file, err := os.OpenFile(name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		return nil, err
+	}
+	return &ReopenableFile{
+		name: name,
+		f:    file,
+	}, nil
+}
+
+func (r *ReopenableFile) Reopen() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.f != nil {
+		if err := r.f.Close(); err != nil {
+			return err
+		}
+		r.f = nil
+	}
+	newFile, err := os.OpenFile(r.name, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0640)
+	if err != nil {
+		r.f = nil
+		return err
+	}
+	r.f = newFile
+	return nil
+}
+
+func (r *ReopenableFile) Write(p []byte) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.f.Write(p)
+}
+
+func (r *ReopenableFile) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.f.Close()
+}
+
+func ReopenOnSignal(ctx context.Context, rwc ReopenableWriteCloser) {
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, _reopenSignal)
+	reopenOnSignal(ctx, rwc, signalCh)
+}
+
+func reopenOnSignal(
+	ctx context.Context,
+	rwc ReopenableWriteCloser,
+	signalCh chan os.Signal,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-signalCh:
+			rwc.Reopen()
+		}
+	}
+}

--- a/pkg/common/log/reopen_test.go
+++ b/pkg/common/log/reopen_test.go
@@ -1,0 +1,74 @@
+package log
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReopenOnSignal(t *testing.T) {
+	const (
+		_tempDir         = "spirelogrotatetest"
+		_testLogFileName = "test.log"
+		_rotatedSuffix   = "rotated"
+		_firstMsg        = "a message"
+		_secondMsg       = "another message"
+	)
+	dir, err := os.MkdirTemp("", _tempDir)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	logFileName := filepath.Join(dir, _testLogFileName)
+	rotatedLogFileName := logFileName + "." + _rotatedSuffix
+	rf, err := NewReopenableFile(logFileName)
+	require.NoError(t, err)
+
+	fsInfo, err := rf.f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fsInfo.Size(), "%s should be empty", fsInfo.Name())
+
+	logger, err := NewLogger(WithReopenableOutputFile(rf))
+	require.NoError(t, err)
+
+	logger.Warning(_firstMsg)
+
+	fsInfo, err = rf.f.Stat()
+	require.NoError(t, err)
+	initialLogSize := fsInfo.Size()
+	assert.NotEqual(t, int64(0), fsInfo.Size(), "%s should not be empty", fsInfo.Name())
+
+	signalCh := make(chan os.Signal, 1)
+	// prevent test from hanging until test runner timeout when failing
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	renamedCh := make(chan struct{})
+	go func() {
+		// emulate logrotate
+		os.Rename(logFileName, rotatedLogFileName)
+		signalCh <- _reopenSignal
+		close(renamedCh)
+	}()
+	reopenOnSignal(ctx, rf, signalCh)
+	<-renamedCh
+	fsInfo, err = rf.f.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fsInfo.Size(), "%s should be empty again", fsInfo.Name())
+
+	rotatedLog, err := os.Open(rotatedLogFileName)
+	require.NoError(t, err)
+	fsInfo, err = rotatedLog.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, initialLogSize, fsInfo.Size(), "%s should be same size as before rename", fsInfo.Name())
+
+	logger.Warning(_secondMsg)
+	fsInfo, err = rf.f.Stat()
+	require.NoError(t, err)
+	assert.NotEqual(t, int64(0), fsInfo.Size(), "%s should not be empty", fsInfo.Name())
+	assert.NotEqual(t, initialLogSize, fsInfo.Size(), "%s should not be same size as initial file", fsInfo.Name())
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	common "github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/health"
+	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/authpolicy"
 	bundle_client "github.com/spiffe/spire/pkg/server/bundle/client"
@@ -22,6 +23,9 @@ type Config struct {
 	PluginConfigs common.HCLPluginConfigMap
 
 	Log logrus.FieldLogger
+
+	// LogReopener facilitates handling a signal to rotate log file.
+	LogReopener log.ReopenableWriteCloser
 
 	// If true enables audit logs
 	AuditLogEnabled bool


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md
- [x] Proper tests/regressions included
- [x] Documentation updated

**Affected functionality**
Support logrotate without lossy copytruncate directive.

**Description of change**
Add capability to reopen log_file upon receipt of SIGUSR2 so logrotate can trigger it via postrotate script.

Fixes #1152.

