### PR TITLE
Update golangci-lint to v1.44.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ endif
 
 go_path := PATH="$(go_bin_dir):$(PATH)"
 
-golangci_lint_version = v1.39.0
+golangci_lint_version = v1.44.0
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 golangci_lint_cache = $(golangci_lint_dir)/cache

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -76,7 +76,8 @@ func TestShow(t *testing.T) {
 			},
 			}
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectedError != "" {
 				require.Equal(t, 1, rc)
@@ -341,7 +342,8 @@ func TestSet(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupTest(t, newSetCommand)
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			test.server.expectedSetBundle = tt.toSet
 			test.server.setResponse = tt.setResponse
 			test.server.err = tt.serverErr
@@ -444,7 +446,8 @@ func TestCount(t *testing.T) {
 			}
 
 			test.server.bundles = bundles[0:tt.count]
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectedStderr != "" {
 				require.Equal(t, tt.expectedStderr, test.stderr.String())
@@ -559,7 +562,8 @@ func TestList(t *testing.T) {
 				},
 			}
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectedStderr != "" {
 				require.Equal(t, tt.expectedStderr, test.stderr.String())
@@ -710,7 +714,8 @@ func TestDelete(t *testing.T) {
 			test.server.mode = tt.mode
 			test.server.toDelete = tt.toDelete
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectedStderr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/entry/count_test.go
+++ b/cmd/spire-server/cli/entry/count_test.go
@@ -69,7 +69,8 @@ func TestCount(t *testing.T) {
 			test := setupTest(t, NewCountCommandWithEnv)
 			test.server.err = tt.serverErr
 			test.server.countEntriesResp = tt.fakeCountResp
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 
 			rc := test.client.Run(args)
 			if tt.expErr != "" {

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -336,7 +336,8 @@ Error: failed to create one or more entries
 			test.server.expBatchCreateEntryReq = tt.expReq
 			test.server.batchCreateEntryResp = tt.fakeResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/entry/delete_test.go
+++ b/cmd/spire-server/cli/entry/delete_test.go
@@ -96,7 +96,8 @@ func TestDelete(t *testing.T) {
 			test.server.expBatchDeleteEntryReq = tt.expReq
 			test.server.batchDeleteEntryResp = tt.fakeResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/entry/show_test.go
+++ b/cmd/spire-server/cli/entry/show_test.go
@@ -356,7 +356,8 @@ func TestShow(t *testing.T) {
 			test.server.expGetEntryReq = tt.expGetReq
 			test.server.getEntryResp = tt.fakeGetResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -355,7 +355,8 @@ Error: failed to update one or more entries
 			test.server.expBatchUpdateEntryReq = tt.expReq
 			test.server.batchUpdateEntryResp = tt.fakeResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/create_test.go
+++ b/cmd/spire-server/cli/federation/create_test.go
@@ -345,7 +345,8 @@ Endpoint SPIFFE ID        : spiffe://td-3.org/bundle
 			test.server.expectCreateReq = tt.expReq
 			test.server.createResp = tt.fakeResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/delete_test.go
+++ b/cmd/spire-server/cli/federation/delete_test.go
@@ -93,7 +93,8 @@ func TestDelete(t *testing.T) {
 			test.server.expectDeleteReq = tt.expectReq
 			test.server.deleteResp = tt.deleteResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/list_test.go
+++ b/cmd/spire-server/cli/federation/list_test.go
@@ -122,7 +122,8 @@ Endpoint SPIFFE ID        : spiffe://baz.test/id
 			test.server.expectListReq = tt.expectListReq
 			test.server.listResp = tt.listResp
 
-			args := append(test.args, tt.arg...)
+			args := test.args
+			args = append(args, tt.arg...)
 			rc := test.client.Run(args)
 			if tt.expectErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/refresh_test.go
+++ b/cmd/spire-server/cli/federation/refresh_test.go
@@ -73,7 +73,8 @@ func TestRefresh(t *testing.T) {
 			test.server.expectRefreshReq = tt.expectReq
 			test.server.refreshResp = tt.refreshResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/show_test.go
+++ b/cmd/spire-server/cli/federation/show_test.go
@@ -102,7 +102,8 @@ Endpoint SPIFFE ID        : spiffe://endpoint.test/id
 			test.server.expectShowReq = tt.req
 			test.server.showResp = tt.resp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expectedStderr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/federation/update_test.go
+++ b/cmd/spire-server/cli/federation/update_test.go
@@ -345,7 +345,8 @@ Endpoint SPIFFE ID        : spiffe://td-3.org/bundle
 			test.server.expectUpdateReq = tt.expReq
 			test.server.updateResp = tt.fakeResp
 
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			rc := test.client.Run(args)
 			if tt.expErr != "" {
 				require.Equal(t, 1, rc)

--- a/cmd/spire-server/cli/token/generate_test.go
+++ b/cmd/spire-server/cli/token/generate_test.go
@@ -76,7 +76,8 @@ func TestCreateToken(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupTest(t)
-			args := append(test.args, tt.args...)
+			args := test.args
+			args = append(args, tt.args...)
 			test.server.token = tt.token
 			test.server.expectReq = tt.expectedReq
 			test.server.err = tt.serverErr

--- a/pkg/agent/attestor/workload/workload_test.go
+++ b/pkg/agent/attestor/workload/workload_test.go
@@ -80,7 +80,8 @@ func (s *WorkloadAttestorTestSuite) TestAttestWorkload() {
 	// both have selectors
 	selectors = s.attestor.Attest(ctx, 4)
 	util.SortSelectors(selectors)
-	combined := append(selectors1, selectors2...)
+	combined := selectors1
+	combined = append(combined, selectors2...)
 	util.SortSelectors(combined)
 	spiretest.AssertProtoListEqual(s.T(), combined, selectors)
 }

--- a/pkg/common/cli/umask_posix.go
+++ b/pkg/common/cli/umask_posix.go
@@ -1,4 +1,4 @@
-// +build !windows
+//go:build !windows
 
 package cli
 

--- a/pkg/common/peertracker/peertracker_test.go
+++ b/pkg/common/peertracker/peertracker_test.go
@@ -228,6 +228,7 @@ func (f *fakeUDSPeer) connectFromForkingChild(addr *net.UnixAddr, childPath stri
 	}
 
 	go func() {
+		// #nosec G204 test code
 		out, err := exec.Command(childPath, "-socketPath", addr.Name).Output()
 		if err != nil {
 			doneCh <- fmt.Errorf("child process failed: %w", err)

--- a/pkg/common/peertracker/tracker_linux.go
+++ b/pkg/common/peertracker/tracker_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package peertracker
 

--- a/pkg/common/peertracker/tracker_linux_test.go
+++ b/pkg/common/peertracker/tracker_linux_test.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package peertracker
 

--- a/pkg/common/peertracker/uds_linux.go
+++ b/pkg/common/peertracker/uds_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+//go:build linux
 
 package peertracker
 

--- a/pkg/server/bundle/client/client.go
+++ b/pkg/server/bundle/client/client.go
@@ -23,7 +23,7 @@ type SPIFFEAuthConfig struct {
 	RootCAs []*x509.Certificate
 }
 
-type ClientConfig struct { //nolint: golint // name stutter is intentional
+type Config struct { //nolint: golint // name stutter is intentional
 	// TrustDomain is the federated trust domain (i.e. domain.test)
 	TrustDomain spiffeid.TrustDomain
 
@@ -43,11 +43,11 @@ type Client interface {
 }
 
 type client struct {
-	c      ClientConfig
+	c      Config
 	client *http.Client
 }
 
-func NewClient(config ClientConfig) (Client, error) {
+func NewClient(config Config) (Client, error) {
 	httpClient := &http.Client{}
 	if config.SPIFFEAuth != nil {
 		endpointID := config.SPIFFEAuth.EndpointSpiffeID

--- a/pkg/server/bundle/client/client_test.go
+++ b/pkg/server/bundle/client/client_test.go
@@ -96,7 +96,7 @@ func TestClient(t *testing.T) {
 			server.StartTLS()
 			defer server.Close()
 
-			client, err := NewClient(ClientConfig{
+			client, err := NewClient(Config{
 				TrustDomain: trustDomain,
 				EndpointURL: server.URL,
 				SPIFFEAuth: &SPIFFEAuthConfig{

--- a/pkg/server/bundle/client/updater.go
+++ b/pkg/server/bundle/client/updater.go
@@ -19,7 +19,7 @@ type BundleUpdaterConfig struct {
 	TrustDomainConfig TrustDomainConfig
 
 	// newClientHook is a test hook for injecting client behavior
-	newClientHook func(ClientConfig) (Client, error)
+	newClientHook func(Config) (Client, error)
 }
 
 type BundleUpdater interface {
@@ -43,7 +43,7 @@ type BundleUpdater interface {
 type bundleUpdater struct {
 	td            spiffeid.TrustDomain
 	ds            datastore.DataStore
-	newClientHook func(ClientConfig) (Client, error)
+	newClientHook func(Config) (Client, error)
 
 	trustDomainConfigMtx sync.Mutex
 	trustDomainConfig    TrustDomainConfig
@@ -109,7 +109,7 @@ func (u *bundleUpdater) SetTrustDomainConfig(trustDomainConfig TrustDomainConfig
 }
 
 func (u *bundleUpdater) newClient(ctx context.Context, trustDomainConfig TrustDomainConfig) (Client, error) {
-	clientConfig := ClientConfig{
+	clientConfig := Config{
 		TrustDomain: u.td,
 		EndpointURL: trustDomainConfig.EndpointURL,
 	}

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -95,7 +95,7 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 						EndpointSPIFFEID: trustDomain.ID(),
 					},
 				},
-				newClientHook: func(client ClientConfig) (Client, error) {
+				newClientHook: func(client Config) (Client, error) {
 					return testCase.client, nil
 				},
 			})

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -1175,7 +1175,8 @@ func (s *PluginSuite) TestListNodeSelectors() {
 		}
 	}
 
-	allAttNodesToCreate := append(nonExpiredAttNodes, expiredAttNodes...)
+	allAttNodesToCreate := nonExpiredAttNodes
+	allAttNodesToCreate = append(allAttNodesToCreate, expiredAttNodes...)
 	selectorMap := make(map[string][]*common.Selector)
 	for i, n := range allAttNodesToCreate {
 		_, err := s.ds.CreateAttestedNode(ctx, n)

--- a/pkg/server/endpoints/middleware_test.go
+++ b/pkg/server/endpoints/middleware_test.go
@@ -42,7 +42,8 @@ func TestAuthorizedEntryFetcherWithFullCache(t *testing.T) {
 	e := createAuthorizedEntryTestData(t, ds)
 	expectedNodeAliasEntries := e.nodeAliasEntries
 	expectedWorkloadEntries := e.workloadEntries[:len(e.workloadEntries)-1]
-	expectedEntries := append(expectedNodeAliasEntries, expectedWorkloadEntries...)
+	expectedEntries := expectedNodeAliasEntries
+	expectedEntries = append(expectedEntries, expectedWorkloadEntries...)
 
 	buildCache := func(context.Context) (entrycache.Cache, error) {
 		entryMap := map[spiffeid.ID][]*types.Entry{


### PR DESCRIPTION
Also includes several linter fixes:
- `gocritic` appendAssign fixes where a new slice was declared and assigned the value of `append(anotherSlice1, anotherSlice2)` in the same statement
- `goimports` fixes related to a change in Go 1.17 where the `//+build` directives were deprecated in favor of `//go:build`
- Suppressing `gosec` linter error related to possible tainting of command execution using user-supplied input in test code location