### PR TITLE
Configure Dependabot to not raise PRs for AWS SDK v1 patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,6 @@ updates:
   # go-sqlite3 v2 is not the latest release. See the repo for more information.
   - dependency-name: "github.com/mattn/go-sqlite3"
     versions: ["2.x"]
+  - dependency-name: "github.com/aws/aws-sdk-go"
+    update-types: ["version-update:semver-patch"]
   open-pull-requests-limit: 5


### PR DESCRIPTION
The AWS SDK has near daily releases, and most releases do not affect our usage. Tell dependabot to chill a bit and only care about minor and major versions.