### PR TITLE
Replace usage of gotest.tools/assert with github.com/stretchr/testify/assert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.6.0
-	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v0.23.3
@@ -191,6 +190,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/apiextensions-apiserver v0.23.0 // indirect
 	k8s.io/component-base v0.23.3 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.6.0
-	gotest.tools v2.2.0+incompatible
+	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.23.3
 	k8s.io/apimachinery v0.23.3
 	k8s.io/client-go v0.23.3

--- a/pkg/common/cli/umask_test.go
+++ b/pkg/common/cli/umask_test.go
@@ -3,8 +3,9 @@ package cli
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus/hooks/test"
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUmask(t *testing.T) {
@@ -44,7 +45,7 @@ func TestUmask(t *testing.T) {
 		SetUmask(log)
 		actualUmask := setUmask(0022)
 		assert.Equal(t, testCase.Expected, actualUmask, "umask")
-		assert.DeepEqual(t, testCase.Logs, gatherLogs(hook))
+		assert.Empty(t, cmp.Diff(testCase.Logs, gatherLogs(hook)))
 	}
 }
 

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -32,13 +32,13 @@ import (
 	"github.com/spiffe/spire/test/fakes/fakeservernodeattestor"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/testkey"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"gotest.tools/assert"
 )
 
 const (

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/testkey"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"gotest.tools/assert"
 )
 
 const (

--- a/pkg/server/plugin/nodeattestor/v1_test.go
+++ b/pkg/server/plugin/nodeattestor/v1_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"gotest.tools/assert"
 )
 
 func TestV1(t *testing.T) {


### PR DESCRIPTION
The `gotest.tools/assert` package was accidentally pulled in. We use `github.com/stretchr/testify/assert` as the assert package. Consolidate to a single assert library dependency.