### PR TITLE
Update usage of AWS SDK in aws_pca UpstreamAuthority plugin to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.11.0
 )
 
+require github.com/aws/aws-sdk-go-v2/service/acmpca v1.14.0
+
 require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0 h1:3ADoioDMOtF4uiK59vC
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0/go.mod h1:BsCSJHx5DnDXIrOcqB8KN1/B+hXLG/bi4Y6Vjcx/x9E=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.5 h1:ixotxbfTCFpqbuwFv/RcZwyzhkxPSYDYEMcj4niB5Uk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.5/go.mod h1:R3sWUqPcfXSiF/LSFJhjyJmpg9uV6yP2yv3YZZjldVI=
+github.com/aws/aws-sdk-go-v2/service/acmpca v1.14.0 h1:sSD2N0B3VDQFG99UdQ0mFrMXFrYATQmabRL9PmxQ2Xw=
+github.com/aws/aws-sdk-go-v2/service/acmpca v1.14.0/go.mod h1:ofh63tUw372aK3DEX1TRnZY8OYateQQiLO+SgRHpFag=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.7.0 h1:4QAOB3KrvI1ApJK14sliGr3Ie2pjyvNypn/lfzDHfUw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.7.0/go.mod h1:K/qPe6AP2TGYv4l6n7c88zh9jWBDf6nHhvg1fx/EWfU=
 github.com/aws/aws-sdk-go-v2/service/kms v1.14.0 h1:A8FMqkP+OlnSiVY+2QakwqW0fAGnE18TqPig/T7aJU0=

--- a/pkg/server/plugin/upstreamauthority/awspca/pca.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"github.com/andres-erbsen/clock"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
+	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
 	upstreamauthorityv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/upstreamauthority/v1"
@@ -31,7 +32,12 @@ const (
 	// The default CA signing template to use.
 	// The SPIRE server intermediate CA can sign end-entity SVIDs only.
 	defaultCASigningTemplateArn = "arn:aws:acm-pca:::template/SubordinateCACertificate_PathLen0/V1"
+	// Max certificate issuance wait duration
+	maxCertIssuanceWaitDur = 3 * time.Minute
 )
+
+type newACMPCAClientFunc func(context.Context, *Configuration) (PCAClient, error)
+type newCertificateIssuedWaiterFunc func(acmpca.GetCertificateAPIClient, ...func(*acmpca.CertificateIssuedWaiterOptions)) certificateIssuedWaiter
 
 func BuiltIn() catalog.BuiltIn {
 	return builtin(New())
@@ -67,8 +73,9 @@ type PCAPlugin struct {
 	config    *configuration
 
 	hooks struct {
-		clock     clock.Clock
-		newClient func(config *Configuration) (PCAClient, error)
+		clock                      clock.Clock
+		newClient                  newACMPCAClientFunc
+		newCertificateIssuedWaiter newCertificateIssuedWaiterFunc
 	}
 }
 
@@ -81,13 +88,14 @@ type configuration struct {
 
 // New returns an instantiated plugin
 func New() *PCAPlugin {
-	return newPlugin(newPCAClient)
+	return newPlugin(newPCAClient, newCertificateIssuedWaiter)
 }
 
-func newPlugin(newClient func(config *Configuration) (PCAClient, error)) *PCAPlugin {
+func newPlugin(newClient newACMPCAClientFunc, newWaiter newCertificateIssuedWaiterFunc) *PCAPlugin {
 	p := &PCAPlugin{}
 	p.hooks.clock = clock.New()
 	p.hooks.newClient = newClient
+	p.hooks.newCertificateIssuedWaiter = newWaiter
 	return p
 }
 
@@ -112,14 +120,14 @@ func (p *PCAPlugin) Configure(ctx context.Context, req *configv1.ConfigureReques
 	}
 
 	// Create the client
-	pcaClient, err := p.hooks.newClient(config)
+	pcaClient, err := p.hooks.newClient(ctx, config)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client: %v", err)
 	}
 
 	// Perform a check for the presence of the CA
 	p.log.Info("Looking up certificate authority from ACM", "certificate_authority_arn", config.CertificateAuthorityARN)
-	describeResponse, err := pcaClient.DescribeCertificateAuthorityWithContext(ctx, &acmpca.DescribeCertificateAuthorityInput{
+	describeResponse, err := pcaClient.DescribeCertificateAuthority(ctx, &acmpca.DescribeCertificateAuthorityInput{
 		CertificateAuthorityArn: aws.String(config.CertificateAuthorityARN),
 	})
 	if err != nil {
@@ -127,7 +135,7 @@ func (p *PCAPlugin) Configure(ctx context.Context, req *configv1.ConfigureReques
 	}
 
 	// Ensure the CA is set to ACTIVE
-	caStatus := aws.StringValue(describeResponse.CertificateAuthority.Status)
+	caStatus := describeResponse.CertificateAuthority.Status
 	if caStatus != "ACTIVE" {
 		p.log.Warn("Certificate is in an invalid state for issuance",
 			"certificate_authority_arn", config.CertificateAuthorityARN,
@@ -138,7 +146,7 @@ func (p *PCAPlugin) Configure(ctx context.Context, req *configv1.ConfigureReques
 	// Otherwise, fall back to the pre-configured value on the CA
 	signingAlgorithm := config.SigningAlgorithm
 	if signingAlgorithm == "" {
-		signingAlgorithm = aws.StringValue(describeResponse.CertificateAuthority.CertificateAuthorityConfiguration.SigningAlgorithm)
+		signingAlgorithm = string(describeResponse.CertificateAuthority.CertificateAuthorityConfiguration.SigningAlgorithm)
 		p.log.Info("No signing algorithm specified, using the CA default", "signing_algorithm", signingAlgorithm)
 	}
 
@@ -186,13 +194,13 @@ func (p *PCAPlugin) MintX509CAAndSubscribe(request *upstreamauthorityv1.MintX509
 	p.log.Info("Submitting CSR to ACM", "signing_algorithm", config.signingAlgorithm)
 	validityPeriod := time.Second * time.Duration(request.PreferredTtl)
 
-	issueResponse, err := p.pcaClient.IssueCertificateWithContext(ctx, &acmpca.IssueCertificateInput{
+	issueResponse, err := p.pcaClient.IssueCertificate(ctx, &acmpca.IssueCertificateInput{
 		CertificateAuthorityArn: aws.String(config.certificateAuthorityArn),
-		SigningAlgorithm:        aws.String(config.signingAlgorithm),
+		SigningAlgorithm:        acmpcatypes.SigningAlgorithm(config.signingAlgorithm),
 		Csr:                     csrBuf.Bytes(),
 		TemplateArn:             aws.String(config.caSigningTemplateArn),
-		Validity: &acmpca.Validity{
-			Type:  aws.String(acmpca.ValidityPeriodTypeAbsolute),
+		Validity: &acmpcatypes.Validity{
+			Type:  acmpcatypes.ValidityPeriodTypeAbsolute,
 			Value: aws.Int64(p.hooks.clock.Now().Add(validityPeriod).Unix()),
 		},
 	})
@@ -204,36 +212,36 @@ func (p *PCAPlugin) MintX509CAAndSubscribe(request *upstreamauthorityv1.MintX509
 	// the certificate has been issued
 	certificateArn := issueResponse.CertificateArn
 
-	p.log.Info("Waiting for issuance from ACM", "certificate_arn", aws.StringValue(certificateArn))
+	p.log.Info("Waiting for issuance from ACM", "certificate_arn", aws.ToString(certificateArn))
 	getCertificateInput := &acmpca.GetCertificateInput{
 		CertificateAuthorityArn: aws.String(config.certificateAuthorityArn),
 		CertificateArn:          certificateArn,
 	}
-	err = p.pcaClient.WaitUntilCertificateIssuedWithContext(ctx, getCertificateInput)
-	if err != nil {
+	waiter := p.hooks.newCertificateIssuedWaiter(p.pcaClient)
+	if err := waiter.Wait(ctx, getCertificateInput, maxCertIssuanceWaitDur); err != nil {
 		return status.Errorf(codes.Internal, "failed waiting for issuance: %v", err)
 	}
-	p.log.Info("Certificate issued", "certificate_arn", aws.StringValue(certificateArn))
+	p.log.Info("Certificate issued", "certificate_arn", aws.ToString(certificateArn))
 
 	// Finally get the certificate contents
-	p.log.Info("Retrieving certificate and chain from ACM", "certificate_arn", aws.StringValue(certificateArn))
-	getResponse, err := p.pcaClient.GetCertificateWithContext(ctx, getCertificateInput)
+	p.log.Info("Retrieving certificate and chain from ACM", "certificate_arn", aws.ToString(certificateArn))
+	getResponse, err := p.pcaClient.GetCertificate(ctx, getCertificateInput)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to get cerficates: %v", err)
 	}
 
 	// Parse the cert from the response
-	cert, err := pemutil.ParseCertificate([]byte(aws.StringValue(getResponse.Certificate)))
+	cert, err := pemutil.ParseCertificate([]byte(aws.ToString(getResponse.Certificate)))
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to parse certificate from response: %v", err)
 	}
 
 	// Parse the chain from the response
-	certChain, err := pemutil.ParseCertificates([]byte(aws.StringValue(getResponse.CertificateChain)))
+	certChain, err := pemutil.ParseCertificates([]byte(aws.ToString(getResponse.CertificateChain)))
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to parse certificate chain from response: %v", err)
 	}
-	p.log.Info("Certificate and chain received", "certificate_arn", aws.StringValue(certificateArn))
+	p.log.Info("Certificate and chain received", "certificate_arn", aws.ToString(certificateArn))
 
 	// ACM's API outputs the certificate chain from a GetCertificate call in the following
 	// order: A (signed by B) -> B (signed by ROOT) -> ROOT.

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_client.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_client.go
@@ -1,49 +1,67 @@
 package awspca
 
 import (
+	"context"
+	"fmt"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/acmpca"
-	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // PCAClient provides an interface which can be mocked to test
 // the functionality of the plugin.
 type PCAClient interface {
-	DescribeCertificateAuthorityWithContext(aws.Context, *acmpca.DescribeCertificateAuthorityInput, ...request.Option) (*acmpca.DescribeCertificateAuthorityOutput, error)
-	IssueCertificateWithContext(aws.Context, *acmpca.IssueCertificateInput, ...request.Option) (*acmpca.IssueCertificateOutput, error)
-	WaitUntilCertificateIssuedWithContext(aws.Context, *acmpca.GetCertificateInput, ...request.WaiterOption) error
-	GetCertificateWithContext(aws.Context, *acmpca.GetCertificateInput, ...request.Option) (*acmpca.GetCertificateOutput, error)
+	DescribeCertificateAuthority(context.Context, *acmpca.DescribeCertificateAuthorityInput, ...func(*acmpca.Options)) (*acmpca.DescribeCertificateAuthorityOutput, error)
+	IssueCertificate(context.Context, *acmpca.IssueCertificateInput, ...func(*acmpca.Options)) (*acmpca.IssueCertificateOutput, error)
+	GetCertificate(context.Context, *acmpca.GetCertificateInput, ...func(*acmpca.Options)) (*acmpca.GetCertificateOutput, error)
 }
 
-func newPCAClient(config *Configuration) (PCAClient, error) {
-	awsConfig := &aws.Config{
-		Region:   aws.String(config.Region),
-		Endpoint: aws.String(config.Endpoint),
-	}
+type certificateIssuedWaiter interface {
+	Wait(context.Context, *acmpca.GetCertificateInput, time.Duration, ...func(*acmpca.CertificateIssuedWaiterOptions)) error
+	WaitForOutput(context.Context, *acmpca.GetCertificateInput, time.Duration, ...func(*acmpca.CertificateIssuedWaiterOptions)) (*acmpca.GetCertificateOutput, error)
+}
 
-	// Optional: Assuming role
-	if config.AssumeRoleARN != "" {
-		staticsess, err := session.NewSession(&aws.Config{Credentials: awsConfig.Credentials})
-		if err != nil {
-			return nil, err
-		}
-		awsConfig.Credentials = credentials.NewCredentials(&stscreds.AssumeRoleProvider{
-			Client:   sts.New(staticsess),
-			RoleARN:  config.AssumeRoleARN,
-			Duration: 15 * time.Minute,
+func newPCAClient(ctx context.Context, cfg *Configuration) (PCAClient, error) {
+	var endpointResolver aws.EndpointResolverWithOptions
+	if cfg.Endpoint != "" {
+		endpointResolver = aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			if service == acmpca.ServiceID && region == cfg.Region {
+				return aws.Endpoint{
+					PartitionID:   "aws",
+					URL:           cfg.Endpoint,
+					SigningRegion: region,
+				}, nil
+			}
+
+			return aws.Endpoint{}, fmt.Errorf("unknown endpoint requested")
 		})
 	}
 
-	awsSession, err := session.NewSession(awsConfig)
-	if err != nil {
-		return nil, err
+	var credsProvider aws.CredentialsProvider
+	switch {
+	case cfg.AssumeRoleARN != "":
+		stsClient := sts.NewFromConfig(aws.Config{})
+		credsProvider = stscreds.NewAssumeRoleProvider(stsClient, cfg.AssumeRoleARN)
+	default:
+		awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.Region), config.WithEndpointResolverWithOptions(endpointResolver))
+		if err != nil {
+			return nil, err
+		}
+
+		credsProvider = awsCfg.Credentials
 	}
 
-	return acmpca.New(awsSession), nil
+	return acmpca.NewFromConfig(aws.Config{
+		Region:                      cfg.Region,
+		EndpointResolverWithOptions: endpointResolver,
+		Credentials:                 credsProvider,
+	}), nil
+}
+
+func newCertificateIssuedWaiter(client acmpca.GetCertificateAPIClient, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) certificateIssuedWaiter {
+	return acmpca.NewCertificateIssuedWaiter(client, optFns...)
 }

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_client_fake.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_client_fake.go
@@ -1,11 +1,11 @@
 package awspca
 
 import (
+	"context"
 	"testing"
+	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,7 +27,7 @@ type pcaClientFake struct {
 	waitUntilCertificateIssuedErr error
 }
 
-func (f *pcaClientFake) DescribeCertificateAuthorityWithContext(ctx aws.Context, input *acmpca.DescribeCertificateAuthorityInput, option ...request.Option) (*acmpca.DescribeCertificateAuthorityOutput, error) {
+func (f *pcaClientFake) DescribeCertificateAuthority(ctx context.Context, input *acmpca.DescribeCertificateAuthorityInput, optFns ...func(*acmpca.Options)) (*acmpca.DescribeCertificateAuthorityOutput, error) {
 	require.Equal(f.t, f.expectedDescribeInput, input)
 	if f.describeCertificateErr != nil {
 		return nil, f.describeCertificateErr
@@ -35,7 +35,7 @@ func (f *pcaClientFake) DescribeCertificateAuthorityWithContext(ctx aws.Context,
 	return f.describeCertificateOutput, nil
 }
 
-func (f *pcaClientFake) IssueCertificateWithContext(ctx aws.Context, input *acmpca.IssueCertificateInput, option ...request.Option) (*acmpca.IssueCertificateOutput, error) {
+func (f *pcaClientFake) IssueCertificate(ctx context.Context, input *acmpca.IssueCertificateInput, optFns ...func(*acmpca.Options)) (*acmpca.IssueCertificateOutput, error) {
 	require.Equal(f.t, f.expectedIssueInput, input)
 	if f.issueCertifcateErr != nil {
 		return nil, f.issueCertifcateErr
@@ -43,16 +43,29 @@ func (f *pcaClientFake) IssueCertificateWithContext(ctx aws.Context, input *acmp
 	return f.issueCertificateOutput, nil
 }
 
-func (f *pcaClientFake) WaitUntilCertificateIssuedWithContext(ctx aws.Context, input *acmpca.GetCertificateInput, option ...request.WaiterOption) error {
-	require.Equal(f.t, f.expectedGetCertificateInput, input)
-
-	return f.waitUntilCertificateIssuedErr
-}
-
-func (f *pcaClientFake) GetCertificateWithContext(ctx aws.Context, input *acmpca.GetCertificateInput, option ...request.Option) (*acmpca.GetCertificateOutput, error) {
+func (f *pcaClientFake) GetCertificate(ctx context.Context, input *acmpca.GetCertificateInput, optFns ...func(*acmpca.Options)) (*acmpca.GetCertificateOutput, error) {
 	require.Equal(f.t, f.expectedGetCertificateInput, input)
 	if f.getCertificateErr != nil {
 		return nil, f.getCertificateErr
 	}
 	return f.getCertificateOutput, nil
+}
+
+type fakeCertificateIssuedWaiter struct {
+	t                             testing.TB
+	expectedGetCertificateInput   *acmpca.GetCertificateInput
+	waitUntilCertificateIssuedErr error
+	getCertificateOutput          *acmpca.GetCertificateOutput
+}
+
+func (f *fakeCertificateIssuedWaiter) Wait(ctx context.Context, input *acmpca.GetCertificateInput, maxWaitDur time.Duration, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) error {
+	require.Equal(f.t, f.expectedGetCertificateInput, input)
+
+	return f.waitUntilCertificateIssuedErr
+}
+
+func (f *fakeCertificateIssuedWaiter) WaitForOutput(ctx context.Context, input *acmpca.GetCertificateInput, maxWaitDur time.Duration, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) (*acmpca.GetCertificateOutput, error) {
+	require.Equal(f.t, f.expectedGetCertificateInput, input)
+	return f.getCertificateOutput, f.waitUntilCertificateIssuedErr
+
 }

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
@@ -6,14 +6,15 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/andres-erbsen/clock"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/acmpca"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/acmpca"
+	acmpcatypes "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/server/plugin/upstreamauthority"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -120,7 +121,7 @@ func TestConfigure(t *testing.T) {
 		},
 		{
 			test:                    "Describe certificate fails",
-			expectDescribeErr:       awserr.New("Internal", "some error", errors.New("oh no")),
+			expectDescribeErr:       awsErr("Internal", "some error", errors.New("oh no")),
 			region:                  validRegion,
 			certificateAuthorityARN: validCertificateAuthorityARN,
 			caSigningTemplateARN:    validCASigningTemplateARN,
@@ -174,7 +175,7 @@ badjson
 		},
 		{
 			test:                    "Fail to create client",
-			newClientErr:            aws.ErrMissingEndpoint,
+			newClientErr:            awsErr("MissingEndpoint", "'Endpoint' configuration is required for this service", nil),
 			region:                  validRegion,
 			certificateAuthorityARN: validCertificateAuthorityARN,
 			caSigningTemplateARN:    validCASigningTemplateARN,
@@ -212,12 +213,16 @@ badjson
 
 			p := new(PCAPlugin)
 			p.hooks.clock = clock
-			p.hooks.newClient = func(config *Configuration) (PCAClient, error) {
+			p.hooks.newClient = newACMPCAClientFunc(func(ctx context.Context, config *Configuration) (PCAClient, error) {
 				if tt.newClientErr != nil {
 					return nil, tt.newClientErr
 				}
 				return client, nil
-			}
+			})
+			p.hooks.newCertificateIssuedWaiter = newCertificateIssuedWaiterFunc(func(client acmpca.GetCertificateAPIClient, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) certificateIssuedWaiter {
+				return &fakeCertificateIssuedWaiter{}
+			})
+
 			setupDescribeCertificateAuthority(client, tt.expectedDescribeStatus, tt.expectDescribeErr)
 
 			plugintest.Load(t, builtin(p), nil, options...)
@@ -293,7 +298,7 @@ func TestMintX509CA(t *testing.T) {
 		expectTTL               time.Duration
 	}{
 		{
-			test:                    "Succesull mint",
+			test:                    "Successful mint",
 			config:                  successConfig,
 			csr:                     makeCSR("spiffe://example.com/foo"),
 			preferredTTL:            300 * time.Second,
@@ -324,16 +329,16 @@ func TestMintX509CA(t *testing.T) {
 			config:          successConfig,
 			csr:             makeCSR("spiffe://example.com/foo"),
 			preferredTTL:    300 * time.Second,
-			issuedCertErr:   awserr.New("Internal", "some error", errors.New("oh no")),
+			issuedCertErr:   awsErr("Internal", "some error", errors.New("oh no")),
 			expectCode:      codes.Internal,
 			expectMsgPrefix: "upstreamauthority(aws_pca): failed submitting CSR: Internal: some error\ncaused by: oh no",
 		},
 		{
-			test:            "Issueance wait fails",
+			test:            "Issuance wait fails",
 			config:          successConfig,
 			csr:             makeCSR("spiffe://example.com/foo"),
 			preferredTTL:    300 * time.Second,
-			waitCertErr:     awserr.New("Internal", "some error", errors.New("oh no")),
+			waitCertErr:     awsErr("Internal", "some error", errors.New("oh no")),
 			expectCode:      codes.Internal,
 			expectMsgPrefix: "upstreamauthority(aws_pca): failed waiting for issuance: Internal: some error\ncaused by: oh no",
 		},
@@ -342,12 +347,12 @@ func TestMintX509CA(t *testing.T) {
 			config:            successConfig,
 			csr:               makeCSR("spiffe://example.com/foo"),
 			preferredTTL:      300 * time.Second,
-			getCertificateErr: awserr.New("Internal", "some error", errors.New("oh no")),
+			getCertificateErr: awsErr("Internal", "some error", errors.New("oh no")),
 			expectCode:        codes.Internal,
 			expectMsgPrefix:   "upstreamauthority(aws_pca): failed to get cerficates: Internal: some error\ncaused by: oh no",
 		},
 		{
-			test:                    "Fails to parce certificate from GetCertificate",
+			test:                    "Fails to parse certificate from GetCertificate",
 			config:                  successConfig,
 			csr:                     makeCSR("spiffe://example.com/foo"),
 			preferredTTL:            300 * time.Second,
@@ -357,7 +362,7 @@ func TestMintX509CA(t *testing.T) {
 			expectMsgPrefix:         "upstreamauthority(aws_pca): failed to parse certificate from response: no PEM blocks",
 		},
 		{
-			test:                    "Fails to parce certificate chain from GetCertificate",
+			test:                    "Fails to parse certificate chain from GetCertificate",
 			config:                  successConfig,
 			csr:                     makeCSR("spiffe://example.com/foo"),
 			preferredTTL:            300 * time.Second,
@@ -370,14 +375,18 @@ func TestMintX509CA(t *testing.T) {
 		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			client := &pcaClientFake{t: t}
+			certIssuedWaiter := &fakeCertificateIssuedWaiter{t: t}
 			clk := clock.NewMock()
 
 			// Configure plugin
 			setupDescribeCertificateAuthority(client, "ACTIVE", nil)
 			p := New()
-			p.hooks.newClient = func(config *Configuration) (PCAClient, error) {
+			p.hooks.newClient = func(ctx context.Context, config *Configuration) (PCAClient, error) {
 				return client, nil
 			}
+			p.hooks.newCertificateIssuedWaiter = newCertificateIssuedWaiterFunc(func(client acmpca.GetCertificateAPIClient, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) certificateIssuedWaiter {
+				return certIssuedWaiter
+			})
 			p.hooks.clock = clk
 
 			ua := new(upstreamauthority.V1)
@@ -392,7 +401,7 @@ func TestMintX509CA(t *testing.T) {
 
 			// Setup expected responses and verify parameters to AWS client
 			setupIssueCertificate(client, clk, expectPem, tt.issuedCertErr)
-			setupWaitUntilCertificateIssued(client, tt.waitCertErr)
+			setupWaitUntilCertificateIssued(certIssuedWaiter, tt.waitCertErr)
 			setupGetCertificate(client, tt.getCertificateCert, tt.getCertificateCertChain, tt.getCertificateErr)
 
 			x509CA, x509Authorities, stream, err := ua.MintX509CA(context.Background(), tt.csr, tt.preferredTTL)
@@ -421,9 +430,12 @@ func TestPublishJWTKey(t *testing.T) {
 	// Configure plugin
 	setupDescribeCertificateAuthority(client, "ACTIVE", nil)
 	p := New()
-	p.hooks.newClient = func(config *Configuration) (PCAClient, error) {
+	p.hooks.newClient = func(ctx context.Context, config *Configuration) (PCAClient, error) {
 		return client, nil
 	}
+	p.hooks.newCertificateIssuedWaiter = newCertificateIssuedWaiterFunc(func(client acmpca.GetCertificateAPIClient, optFns ...func(*acmpca.CertificateIssuedWaiterOptions)) certificateIssuedWaiter {
+		return &fakeCertificateIssuedWaiter{}
+	})
 
 	ua := new(upstreamauthority.V1)
 	var err error
@@ -456,13 +468,13 @@ func setupDescribeCertificateAuthority(client *pcaClientFake, status string, err
 	client.describeCertificateErr = err
 
 	client.describeCertificateOutput = &acmpca.DescribeCertificateAuthorityOutput{
-		CertificateAuthority: &acmpca.CertificateAuthority{
-			CertificateAuthorityConfiguration: &acmpca.CertificateAuthorityConfiguration{
-				SigningAlgorithm: aws.String("defaultSigningAlgorithm"),
+		CertificateAuthority: &acmpcatypes.CertificateAuthority{
+			CertificateAuthorityConfiguration: &acmpcatypes.CertificateAuthorityConfiguration{
+				SigningAlgorithm: acmpcatypes.SigningAlgorithm("defaultSigningAlgorithm"),
 			},
 			// For all possible statuses, see:
 			// https://docs.aws.amazon.com/cli/latest/reference/acm-pca/describe-certificate-authority.html
-			Status: aws.String(status),
+			Status: acmpcatypes.CertificateAuthorityStatus(status),
 		},
 	}
 }
@@ -470,11 +482,11 @@ func setupDescribeCertificateAuthority(client *pcaClientFake, status string, err
 func setupIssueCertificate(client *pcaClientFake, clk clock.Clock, csr []byte, err error) {
 	client.expectedIssueInput = &acmpca.IssueCertificateInput{
 		CertificateAuthorityArn: aws.String(validCertificateAuthorityARN),
-		SigningAlgorithm:        aws.String(validSigningAlgorithm),
+		SigningAlgorithm:        acmpcatypes.SigningAlgorithm(validSigningAlgorithm),
 		Csr:                     csr,
 		TemplateArn:             aws.String(validCASigningTemplateARN),
-		Validity: &acmpca.Validity{
-			Type:  aws.String(acmpca.ValidityPeriodTypeAbsolute),
+		Validity: &acmpcatypes.Validity{
+			Type:  acmpcatypes.ValidityPeriodType(acmpcatypes.ValidityPeriodTypeAbsolute),
 			Value: aws.Int64(clk.Now().Add(time.Second * testTTL).Unix()),
 		},
 	}
@@ -484,7 +496,7 @@ func setupIssueCertificate(client *pcaClientFake, clk clock.Clock, csr []byte, e
 	}
 }
 
-func setupWaitUntilCertificateIssued(client *pcaClientFake, err error) {
+func setupWaitUntilCertificateIssued(client *fakeCertificateIssuedWaiter, err error) {
 	client.expectedGetCertificateInput = &acmpca.GetCertificateInput{
 		CertificateAuthorityArn: aws.String(validCertificateAuthorityARN),
 		CertificateArn:          aws.String("certificateArn"),
@@ -527,4 +539,8 @@ func svidFixture(t *testing.T) (*x509.Certificate, *bytes.Buffer) {
 	})
 	require.NoError(t, err)
 	return cert, encodedCert
+}
+
+func awsErr(code, status string, err error) error {
+	return fmt.Errorf("%s: %s\ncaused by: %s", code, status, err)
 }


### PR DESCRIPTION
This is primarily motivated by trying to consolidate to a single AWS SDK dependency in SPIRE.

The max wait time for certificate issuance introduced in this change matches the default behavior used in the v1 SDK.