### PR TITLE
Set the correct value to log fields

### DIFF
--- a/pkg/server/api/middleware/authorization_opa.go
+++ b/pkg/server/api/middleware/authorization_opa.go
@@ -91,9 +91,9 @@ func (m *authorizationMiddleware) reconcileResult(ctx context.Context, res authp
 
 	if res.AllowIfAgent && !rpccontext.CallerIsLocal(ctx) {
 		if ctx, ok, err := isAgent(ctx, m.agentAuthorizer); err != nil {
-			ctx = setAuthorizationLogFields(ctx, "agent", "datastore")
 			return ctx, false, err
 		} else if ok {
+			ctx = setAuthorizationLogFields(ctx, "agent", "datastore")
 			return ctx, true, nil
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

Since v1.2.0, SPIRE Server writes authorization logs with additional new fields (`authorized_as`, `authorized_via`).
However, I found logs that do not have the correct value like below.

```
time="2022-02-15T02:37:50Z" level=info msg="Renewing agent SVID" authorized_as=nobody authorized_via= caller_addr="192.168.100.11:53514" caller_id="spiffe://example.com/spire/agent/...." method=RenewAgent request_id=f1a377c1-a122-47bb-974a-7a1d0da2992e service=agent.v1.Agent subsystem_name=api
```

After applied this PR, 

```
 time="2022-02-15T04:04:34Z" level=info msg="Renewing agent SVID" authorized_as=agent authorized_via=datastore caller_addr="192.168.100.11:41068" caller_id="spiffe://example.com/spire/agent/...." method=RenewAgent request_id=54633e3a-ef92-4353-888b-1c09dbce7e83 service=agent.v1.Agent subsystem_name=api
```

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

