### PR TITLE
Adding additional CA logic to cert-manager plugin

### DIFF
--- a/doc/plugin_server_upstreamauthority_cert_manager.md
+++ b/doc/plugin_server_upstreamauthority_cert_manager.md
@@ -35,6 +35,7 @@ This plugin requests certificates from the configured
 | issuer_name               | The name of the issuer to reference in CertificateRequests.       |
 | issuer_kind               | (Optional) The kind of the issuer to reference in CertificateRequests. Defaults to "Issuer" if empty. |
 | issuer_group              | (Optional) The group of the issuer to reference in CertificateRequests. Defaults to "cert-manager.io" if empty. |
+| bundle_file_path          | (Optional) A bundle of additional certificate authorities to trust. This has security implications. |
 
 
 ```hcl
@@ -48,3 +49,11 @@ UpstreamAuthority "cert-manager" {
     }
 }
 ```
+
+Adding additonal certificate authorities to the trust bundle that Spire provides allows those authorities
+to be able to mint their own SPIFFE Identities. This means that an SVID could be generated without going
+through SPIRE's attestion process if a certificate is able to be requested with it's URI SAN set from
+the added certificate authorities. 
+
+Care should be taken when using this configuration value, and the added certificate authorities should
+be tightly controlled to avoid this. 

--- a/pkg/server/plugin/upstreamauthority/certmanager/certmanager_test.go
+++ b/pkg/server/plugin/upstreamauthority/certmanager/certmanager_test.go
@@ -40,11 +40,12 @@ func testingCAPEM(t *testing.T) (*x509.Certificate, []byte) {
 
 func Test_MintX509CA(t *testing.T) {
 	var (
-		trustDomain = spiffeid.RequireTrustDomainFromString("example.com")
-		issuerName  = "test-issuer"
-		issuerKind  = "Issuer"
-		issuerGroup = "example.cert-manager.io"
-		namespace   = "spire"
+		trustDomain    = spiffeid.RequireTrustDomainFromString("example.com")
+		issuerName     = "test-issuer"
+		issuerKind     = "Issuer"
+		issuerGroup    = "example.cert-manager.io"
+		namespace      = "spire"
+		bundleFilePath = ""
 	)
 
 	csr, _, err := util.NewCSRTemplate(trustDomain.IDString())
@@ -145,10 +146,11 @@ func Test_MintX509CA(t *testing.T) {
 				},
 			}
 			config := &Config{
-				IssuerName:  issuerName,
-				IssuerKind:  issuerKind,
-				IssuerGroup: issuerGroup,
-				Namespace:   namespace,
+				IssuerName:     issuerName,
+				IssuerKind:     issuerKind,
+				IssuerGroup:    issuerGroup,
+				Namespace:      namespace,
+				BundleFilePath: bundleFilePath,
 			}
 			ua := new(upstreamauthority.V1)
 			plugintest.Load(t, builtin(p), ua,
@@ -246,6 +248,7 @@ func Test_Configure(t *testing.T) {
 		issuer_group = "my-group"
 		namespace = "my-namespace"
 		kube_config_file = "/path/to/config"
+		bundle_file_path = "/path/to/bundle"
 		`,
 			expectConfig: &Config{
 				IssuerName:         "my-issuer",
@@ -253,6 +256,7 @@ func Test_Configure(t *testing.T) {
 				IssuerGroup:        "my-group",
 				Namespace:          "my-namespace",
 				KubeConfigFilePath: "/path/to/config",
+				BundleFilePath:     "/path/to/bundle",
 			},
 			expectConfigFile: "/path/to/config",
 		},
@@ -268,6 +272,7 @@ func Test_Configure(t *testing.T) {
 				IssuerGroup:        "cert-manager.io",
 				Namespace:          "my-namespace",
 				KubeConfigFilePath: "/path/to/config",
+				BundleFilePath:     "",
 			},
 			expectConfigFile: "/path/to/config",
 		},


### PR DESCRIPTION
Signed-off-by: Liam Decker <ldecker@indeed.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Impacts the configuration and certificate minting process of the UpstreamAuthority: cert-manager plugin.

**Description of change**
Adds a configuration value to the UpstreamAuthority: cert-manager plugin which allows the user to configure additional certificates to add to the cabundle. 

**Which issue this PR fixes**
fixes #2797 

