### PR TITLE
Support paths in AWS instance profiles for AWS IID node attestation

### DIFF
--- a/pkg/server/plugin/nodeattestor/aws/iid.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid.go
@@ -444,5 +444,7 @@ func instanceProfileNameFromArn(profileArn string) (string, error) {
 		return "", status.Errorf(codes.Internal, "arn is not for an instance profile")
 	}
 
-	return m[1], nil
+	name := strings.Split(m[1], "/")
+	// only the last element is the profile name
+	return name[len(name)-1], nil
 }

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	testInstanceProfileArn  = "arn:aws:iam::123412341234:instance-profile/nodes.test.k8s.local"
-	testInstanceProfileName = "nodes.test.k8s.local"
+	testInstanceProfileArn         = "arn:aws:iam::123412341234:instance-profile/nodes.test.k8s.local"
+	testInstanceProfileWithPathArn = "arn:aws:iam::123412341234:instance-profile/some/path/nodes.test.k8s.local"
+	testInstanceProfileName        = "nodes.test.k8s.local"
 )
 
 var (
@@ -454,6 +455,11 @@ func TestInstanceProfileArnParsing(t *testing.T) {
 
 	// success
 	name, err := instanceProfileNameFromArn(testInstanceProfileArn)
+	require.NoError(t, err)
+	require.Equal(t, testInstanceProfileName, name)
+
+	// check profiles with paths succeed (last part of arn is the profile name, path is ignored)
+	name, err = instanceProfileNameFromArn(testInstanceProfileWithPathArn)
 	require.NoError(t, err)
 	require.Equal(t, testInstanceProfileName, name)
 }


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?
  - Shouldn't require documentation update, but can add if requested

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Server AWS IID node attestor plugin

**Description of change**
<!-- Please provide a description of the change -->
Referencing issue #2796, when an instance profile has a path in the
ARN (say
`arn:aws:iam::123412341234:instance-profile/some/path/profile-name`)
the AWS IID node attestor attempts to get the instance profile
information from AWS passing in both the path and the
name (`some/path/profile-name`). AWS, however, considers only the
name (`profile-name`) to be relevant and returns a ValidationError if
the path is included as the forward slashes in the path are considered
invalid. AWS IAM documentation indicates that profile names are simply
EC2 specific versions of role names which are guaranteed to be unique
regardless of path. The fix for the node attestor is to pull out only
the name of the instance profile from the string that was previously
being passed in.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
Fixes #2796 
