### PR TITLE
Introduce Marcos Yacob as a CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 # VMware, Inc
 # @azdagron
 
-# Marcos Jacob
+# Marcos Yacob
 # Hewlett-Packard Enterprise
 # @MarcosDY
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @evan2645 @amartinezfayo @azdagron @APTy @rturner3
+* @evan2645 @amartinezfayo @azdagron @MarcosDY @rturner3
 
 ##########################################
 # Maintainers
@@ -16,14 +16,13 @@
 # VMware, Inc
 # @azdagron
 
-# Tyler Julian
-# fast.co
-# @APTy
+# Marcos Jacob
+# Hewlett-Packard Enterprise
+# @MarcosDY
 
 # Ryan Turner
 # Uber Technologies, Inc
 # @rturner3
-
 
 ##########################################
 # Community Chair


### PR DESCRIPTION
Marcos Yacob (@MarcosDY) has been involved in the SPIRE project for many years and has been shadowing the SPIRE maintainers since late 2021. He has demonstrated his willingness to dive in and tackle large development chores, do research on new features and capabilities, provide valuable feedback on reviews and issues, present talks, and otherwise serve the SPIRE community. The maintainers have come to consensus, and I now propose, that Marcos Yacob be added as a maintainer to the SPIRE project.

Marcos will replace Tyler Julian. Tyler is no longer in a position to actively contribute and has stepped down from SPIRE maintainer-ship. I'd like to thank Tyler for his long time support of the project and his excellent and varied contributions over the years.