### PR TITLE
Fix racy log assertions in awskms tests

### DIFF
--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -748,7 +748,11 @@ func TestGenerateKey(t *testing.T) {
 
 			select {
 			case <-deleteSignal:
-				spiretest.AssertLastLogs(t, ts.logHook.AllEntries(), tt.logs)
+				// The logs emitted by the deletion goroutine and those that
+				// enqueue deletion can be intermixed, so we cannot depend
+				// on the exact order of the logs, so we just assert that
+				// the expected log lines are present somewhere.
+				spiretest.AssertLogsContainEntries(t, ts.logHook.AllEntries(), tt.logs)
 			case <-time.After(testTimeout):
 				t.Fail()
 			}

--- a/test/spiretest/logs.go
+++ b/test/spiretest/logs.go
@@ -15,32 +15,14 @@ type LogEntry struct {
 }
 
 func AssertLogs(t *testing.T, entries []*logrus.Entry, expected []LogEntry) {
-	for _, entry := range entries {
-		for key, field := range entry.Data {
-			entry.Data[key] = fmt.Sprint(field)
-		}
-	}
-
 	assert.Equal(t, expected, convertLogEntries(entries), "unexpected logs")
 }
 
 func AssertLogsAnyOrder(t *testing.T, entries []*logrus.Entry, expected []LogEntry) {
-	for _, entry := range entries {
-		for key, field := range entry.Data {
-			entry.Data[key] = fmt.Sprint(field)
-		}
-	}
-
 	assert.ElementsMatch(t, expected, convertLogEntries(entries), "unexpected logs")
 }
 
 func AssertLastLogs(t *testing.T, entries []*logrus.Entry, expected []LogEntry) {
-	for _, entry := range entries {
-		for key, field := range entry.Data {
-			entry.Data[key] = fmt.Sprint(field)
-		}
-	}
-
 	removeLen := len(entries) - len(expected)
 	if removeLen > 0 {
 		assert.Equal(t, expected, convertLogEntries(entries[removeLen:]), "unexpected logs")
@@ -65,15 +47,18 @@ func convertLogEntries(entries []*logrus.Entry) (out []LogEntry) {
 		out = append(out, LogEntry{
 			Level:   entry.Level,
 			Message: entry.Message,
-			Data:    fieldsOrNil(entry.Data),
+			Data:    normalizeData(entry.Data),
 		})
 	}
 	return out
 }
 
-func fieldsOrNil(data logrus.Fields) logrus.Fields {
-	if len(data) > 0 {
-		return data
+func normalizeData(data logrus.Fields) logrus.Fields {
+	if len(data) == 0 {
+		return nil
 	}
-	return nil
+	for key, field := range data {
+		data[key] = fmt.Sprint(field)
+	}
+	return data
 }


### PR DESCRIPTION
Also fixes a bug in the AssertLogsContainEntries that did not normalize the log entry data fields.

Fixes: #2714