### PR TITLE
Fix race in TestEndpoints test

### DIFF
--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -224,18 +223,10 @@ func TestEndpoints(t *testing.T) {
 				assert.NoError(t, <-errCh)
 			}()
 			waitForListening(t, endpoints, errCh)
-			// Dial the endpoints server with custom connect params that reduce the
-			// base backoff delay. Otherwise, if the dial happens before the endpoint
-			// is being served, the test can wait for a second before retrying.
-			connectParams := grpc.ConnectParams{
-				Backoff: backoff.DefaultConfig,
-			}
-			connectParams.Backoff.BaseDelay = 5 * time.Millisecond
 			target, err := util.GetTargetName(endpoints.addr)
 			require.NoError(t, err)
 			conn, err := grpc.DialContext(ctx, target,
 				grpc.WithReturnConnectionError(),
-				grpc.WithConnectParams(connectParams),
 				grpc.WithTransportCredentials(insecure.NewCredentials()))
 			require.NoError(t, err)
 			defer conn.Close()


### PR DESCRIPTION
The TestEndpoints test has defined parameters for the grpc connection. This was introduced to handle the situation when the dial happens before the endpoint is being served.
The parameters didn't specify the MinConnectTimeout duration property, that's the minimum time to give a connection to complete. Since that was not specified, the default value of 20 seconds (https://github.com/grpc/grpc-go/blob/master/clientconn.go#L56) was not in use, and instead it had a value of 0, which ends up meaning that will be based on the backoff config (https://github.com/grpc/grpc-go/blob/master/clientconn.go#L1182). In this case, that meant that if the connection took more than 5 milliseconds in the first try, it could fail.
Occasional failures are seen on Windows tests, but by artificially delaying the time that takes accepting a connection (in the Accept function) the same kind of failure can be seen in the posix tests also.

Since recently we have introduced and call in this test a function that waits until the endpoints are listening and serving, the use of the parameters are not needed anymore. Hence, this PR removes them from the test and fixes the race condition observed.

Fixes #2870.