### PR TITLE
Set KeyUsage properly for CA certs 

### DIFF
--- a/pkg/common/x509svid/upstreamca.go
+++ b/pkg/common/x509svid/upstreamca.go
@@ -82,8 +82,7 @@ func (ca *UpstreamCA) SignCSR(ctx context.Context, csrDER []byte, preferredTTL t
 		NotBefore:    notBefore,
 		NotAfter:     notAfter,
 		SubjectKeyId: keyID,
-		KeyUsage: x509.KeyUsageDigitalSignature |
-			x509.KeyUsageCertSign |
+		KeyUsage: x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/pkg/common/x509svid/upstreamca_test.go
+++ b/pkg/common/x509svid/upstreamca_test.go
@@ -82,8 +82,7 @@ func (s *UpstreamCASuite) TestSignCSRSuccess() {
 	s.Require().True(cert.IsCA)
 	s.Require().Equal("COMMONNAME", cert.Subject.CommonName)
 	s.Require().NotEmpty(cert.SubjectKeyId)
-	s.Require().Equal(x509.KeyUsageDigitalSignature|
-		x509.KeyUsageCertSign|
+	s.Require().Equal(x509.KeyUsageCertSign|
 		x509.KeyUsageCRLSign, cert.KeyUsage)
 }
 

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -323,7 +323,7 @@ func (s *CATestSuite) TestSignX509CASVID() {
 	s.False(svid.NotAfter.IsZero(), "NotAfter is not set")
 	s.NotEmpty(svid.SubjectKeyId, "SubjectKeyId is not set")
 	s.NotEmpty(svid.AuthorityKeyId, "AuthorityKeyId is not set")
-	s.Equal(x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign, svid.KeyUsage, "key usage does not match")
+	s.Equal(x509.KeyUsageCertSign|x509.KeyUsageCRLSign, svid.KeyUsage, "key usage does not match")
 	s.True(svid.IsCA, "CA bit is not set")
 	s.True(svid.BasicConstraintsValid, "Basic constraints are not valid")
 

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -146,6 +146,7 @@ func (s *ManagerSuite) TestSelfSigning() {
 	}
 	s.Empty(x509CA.UpstreamChain)
 	s.Require().Equal(1, x509CA.Certificate.SerialNumber.Cmp(big.NewInt(0)))
+	s.Require().Equal(x509.KeyUsageCertSign|x509.KeyUsageCRLSign, x509CA.Certificate.KeyUsage)
 
 	// Assert that the self-signed X.509 CA produces a valid certificate chain
 	validateSelfSignedX509CA(s.T(), x509CA.Certificate, x509CA.Signer)

--- a/pkg/server/ca/templates.go
+++ b/pkg/server/ca/templates.go
@@ -31,8 +31,7 @@ func CreateServerCATemplate(spiffeID spiffeid.ID, publicKey crypto.PublicKey, tr
 		NotBefore:    notBefore,
 		NotAfter:     notAfter,
 		SubjectKeyId: keyID,
-		KeyUsage: x509.KeyUsageDigitalSignature |
-			x509.KeyUsageCertSign |
+		KeyUsage: x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,

--- a/pkg/server/plugin/upstreamauthority/certmanager/api.go
+++ b/pkg/server/plugin/upstreamauthority/certmanager/api.go
@@ -58,9 +58,8 @@ func (p *Plugin) buildCertificateRequest(request *upstreamauthorityv1.MintX509CA
 			Request: csrBuf.Bytes(),
 			IsCA:    true,
 			Usages: []cmapi.KeyUsage{
-				cmapi.UsageDigitalSignature,
 				cmapi.UsageCertSign,
-				cmapi.UsageCertSign,
+				cmapi.UsageCRLSign,
 			},
 		},
 	}, nil

--- a/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
+++ b/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
@@ -297,9 +297,8 @@ func (p *Plugin) mintX509CA(ctx context.Context, csr []byte, preferredTTL int32)
 						KeyUsage: &privatecapb.KeyUsage{
 							// https://pkg.go.dev/google.golang.org/genproto/googleapis/cloud/security/privateca/v1#KeyUsage_KeyUsageOptions
 							BaseKeyUsage: &privatecapb.KeyUsage_KeyUsageOptions{
-								DigitalSignature: true,
-								CertSign:         true,
-								CrlSign:          true,
+								CertSign: true,
+								CrlSign:  true,
 							},
 						},
 					},

--- a/support/k8s/k8s-workload-registrar/generate-config.go
+++ b/support/k8s/k8s-workload-registrar/generate-config.go
@@ -178,8 +178,7 @@ func createCACert(caKey crypto.Signer) *x509.Certificate {
 		Subject: pkix.Name{
 			CommonName: "K8S WORKLOAD REGISTRAR CA",
 		},
-		KeyUsage: x509.KeyUsageDigitalSignature |
-			x509.KeyUsageCertSign |
+		KeyUsage: x509.KeyUsageCertSign |
 			x509.KeyUsageCRLSign,
 		BasicConstraintsValid: true,
 		IsCA:                  true,


### PR DESCRIPTION
Signed-off-by: Tomoya Usami <tousami@zlab.co.jp>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

SPIRE Server CA

**Description of change**
<!-- Please provide a description of the change -->

Set KeyUsage properly for CA certs. 
No longer set KeyUsage `DigitalSignature` for CA certs.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

fixes #2811 