### PR TITLE
Improve SDS unauthorized identity diagnostics

### DIFF
--- a/pkg/agent/endpoints/sdsv2/handler.go
+++ b/pkg/agent/endpoints/sdsv2/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"sort"
 	"strconv"
 
 	api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -297,7 +298,7 @@ func (h *Handler) buildResponse(versionInfo string, req *api_v2.DiscoveryRequest
 	}
 
 	if len(names) > 0 {
-		return nil, errs.New("unable to retrieve all requested identities, missing %v", names)
+		return nil, errs.New("workload is not authorized for the requested identities %q", sortedNames(names))
 	}
 
 	return resp, nil
@@ -368,4 +369,13 @@ func nextNonce() (string, error) {
 		return "", errs.Wrap(err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+func sortedNames(names map[string]bool) []string {
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -322,7 +322,7 @@ func (h *Handler) buildResponse(versionInfo string, req *discovery_v3.DiscoveryR
 	}
 
 	if len(names) > 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "unable to retrieve all requested identities, missing %v", names)
+		return nil, status.Errorf(codes.InvalidArgument, "workload is not authorized for the requested identities %q", sortedNames(names))
 	}
 
 	return resp, nil
@@ -538,4 +538,13 @@ func nextNonce() (string, error) {
 		return "", errs.Wrap(err)
 	}
 	return hex.EncodeToString(b), nil
+}
+
+func sortedNames(names map[string]bool) []string {
+	out := make([]string, 0, len(names))
+	for name := range names {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -406,7 +406,7 @@ func TestStreamSecrets(t *testing.T) {
 				},
 			},
 			expectCode: codes.InvalidArgument,
-			expectMsg:  "unable to retrieve all requested identities, missing map[spiffe://domain.test/WHATEVER:true]",
+			expectMsg:  `workload is not authorized for the requested identities ["spiffe://domain.test/WHATEVER"]`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -740,7 +740,7 @@ func TestFetchSecrets(t *testing.T) {
 				},
 			},
 			expectCode: codes.InvalidArgument,
-			expectMsg:  `unable to retrieve all requested identities, missing map[spiffe://domain.test/other:true]`,
+			expectMsg:  `workload is not authorized for the requested identities ["spiffe://domain.test/other"]`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The current message contains a string version of a golang map[string]bool, which confuses consumers. Changing to a sorted list of resource names.