### PR TITLE
Don't render nil plugin_data

### DIFF
--- a/pkg/common/catalog/config.go
+++ b/pkg/common/catalog/config.go
@@ -68,8 +68,10 @@ func PluginConfigsFromHCL(hclPlugins HCLPluginConfigMap) ([]PluginConfig, error)
 
 func PluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig HCLPluginConfig) (PluginConfig, error) {
 	var data bytes.Buffer
-	if err := printer.DefaultConfig.Fprint(&data, hclPluginConfig.PluginData); err != nil {
-		return PluginConfig{}, err
+	if hclPluginConfig.PluginData != nil {
+		if err := printer.DefaultConfig.Fprint(&data, hclPluginConfig.PluginData); err != nil {
+			return PluginConfig{}, err
+		}
 	}
 
 	return PluginConfig{

--- a/pkg/common/catalog/config_test.go
+++ b/pkg/common/catalog/config_test.go
@@ -29,6 +29,8 @@ func TestParsePluginConfigsFromHCLSuccess(t *testing.T) {
 		plugin_data = "DATA3"
 		enabled = false
 	}
+	TYPE4 "NAME4" {
+	}
 `)
 	require.NoError(t, err)
 
@@ -55,6 +57,10 @@ func TestParsePluginConfigsFromHCLSuccess(t *testing.T) {
 			Type:     "TYPE3",
 			Data:     `"DATA3"`,
 			Disabled: true,
+		},
+		{
+			Name: "NAME4",
+			Type: "TYPE4",
 		},
 	}, config)
 }


### PR DESCRIPTION
This causes some diagnostics text to be written to stderr by the hcl
library, and can disrupt structured log parsing.

Fixes #2914