### PR TITLE
Windows support: update Docker Workload Attestor

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -2,9 +2,7 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"regexp"
 	"sync"
 
 	"github.com/docker/docker/api/types"
@@ -14,8 +12,6 @@ import (
 	"github.com/hashicorp/hcl"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
-	"github.com/spiffe/spire/pkg/agent/common/cgroups"
-	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/cgroup"
 	"github.com/spiffe/spire/pkg/common/catalog"
 )
 
@@ -47,45 +43,43 @@ type Plugin struct {
 	configv1.UnsafeConfigServer
 
 	log     hclog.Logger
-	fs      cgroups.FileSystem
 	retryer *retryer
 
-	mtx               sync.RWMutex
-	containerIDFinder cgroup.ContainerIDFinder
-	docker            Docker
+	mtx    sync.RWMutex
+	docker Docker
+	c      *containerHelper
 }
 
 func New() *Plugin {
 	return &Plugin{
-		fs:      cgroups.OSFileSystem{},
 		retryer: newRetryer(),
 	}
 }
 
 type dockerPluginConfig struct {
-	// DockerSocketPath is the location of the docker daemon socket (default: "unix:///var/run/docker.sock" on unix).
+	// DockerSocketPath is the location of the docker daemon socket, this config can be used only on unix environments (default: "unix:///var/run/docker.sock").
 	DockerSocketPath string `hcl:"docker_socket_path"`
 	// DockerVersion is the API version of the docker daemon. If not specified, the version is negotiated by the client.
 	DockerVersion string `hcl:"docker_version"`
 	// ContainerIDCGroupMatchers is a list of patterns used to discover container IDs from cgroup entries.
-	// See the documentation for cgroup.NewContainerIDFinder in the cgroup subpackage for more information.
+	// See the documentation for cgroup.NewContainerIDFinder in the cgroup subpackage for more information. (Unix)
 	ContainerIDCGroupMatchers []string `hcl:"container_id_cgroup_matchers"`
+	// DockerHost is the host URI used to connect Docker API (default: "npipe:////./pipe/docker_engine").
+	DockerHost string `hcl:"docker_host"`
 }
 
 func (p *Plugin) SetLogger(log hclog.Logger) {
 	p.log = log
+	if p.c != nil {
+		p.c.log = log
+	}
 }
 
 func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
 	p.mtx.RLock()
 	defer p.mtx.RUnlock()
 
-	cgroupList, err := cgroups.GetCgroups(req.Pid, p.fs)
-	if err != nil {
-		return nil, err
-	}
-
-	containerID, err := getContainerIDFromCGroups(p.containerIDFinder, cgroupList)
+	containerID, err := p.c.getContainerID(req.Pid)
 	switch {
 	case err != nil:
 		return nil, err
@@ -132,9 +126,19 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		return nil, err
 	}
 
+	if err := validateOS(config); err != nil {
+		return nil, err
+	}
+
+	containerHelper, err := createHelper(config, p.log)
+	if err != nil {
+		return nil, err
+	}
+
 	var opts []dockerclient.Opt
-	if config.DockerSocketPath != "" {
-		opts = append(opts, dockerclient.WithHost(config.DockerSocketPath))
+	dockerHost := getDockerHost(config)
+	if dockerHost != "" {
+		opts = append(opts, dockerclient.WithHost(dockerHost))
 	}
 	switch {
 	case config.DockerVersion != "":
@@ -148,83 +152,9 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		return nil, err
 	}
 
-	var containerIDFinder cgroup.ContainerIDFinder = &defaultContainerIDFinder{}
-	if len(config.ContainerIDCGroupMatchers) > 0 {
-		containerIDFinder, err = cgroup.NewContainerIDFinder(config.ContainerIDCGroupMatchers)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
 	p.docker = docker
-	p.containerIDFinder = containerIDFinder
+	p.c = containerHelper
 	return &configv1.ConfigureResponse{}, nil
-}
-
-// getContainerIDFromCGroups returns the container ID from a set of cgroups
-// using the given finder. The container ID found on each cgroup path (if any)
-// must be consistent. If no container ID is found among the cgroups, i.e.,
-// this isn't a docker workload, the function returns an empty string. If more
-// than one container ID is found, or the "found" container ID is blank, the
-// function will fail.
-func getContainerIDFromCGroups(finder cgroup.ContainerIDFinder, cgroups []cgroups.Cgroup) (string, error) {
-	var hasDockerEntries bool
-	var containerID string
-	for _, cgroup := range cgroups {
-		candidate, ok := finder.FindContainerID(cgroup.GroupPath)
-		if !ok {
-			continue
-		}
-
-		hasDockerEntries = true
-
-		switch {
-		case containerID == "":
-			// This is the first container ID found so far.
-			containerID = candidate
-		case containerID != candidate:
-			// More than one container ID found in the cgroups.
-			return "", fmt.Errorf("workloadattestor/docker: multiple container IDs found in cgroups (%s, %s)",
-				containerID, candidate)
-		}
-	}
-
-	switch {
-	case !hasDockerEntries:
-		// Not a docker workload. Since it is expected that non-docker workloads will call the
-		// workload API, it is fine to return a response without any selectors.
-		return "", nil
-	case containerID == "":
-		// The "finder" found a container ID, but it was blank. This is a
-		// defensive measure against bad matcher patterns and shouldn't
-		// be possible with the default finder.
-		return "", errors.New("workloadattestor/docker: a pattern matched, but no container id was found")
-	default:
-		return containerID, nil
-	}
-}
-
-// dockerCGroupRE matches cgroup paths that have the following properties.
-// 1) `\bdocker\b` the whole word docker
-// 2) `.+` followed by one or more characters (which will start on a word boundary due to #1)
-// 3) `\b([[:xdigit:]][64])\b` followed by a 64 hex-character container id on word boundary
-//
-// The "docker" prefix and 64-hex character container id can be anywhere in the path. The only
-// requirement is that the docker prefix comes before the id.
-var dockerCGroupRE = regexp.MustCompile(`\bdocker\b.+\b([[:xdigit:]]{64})\b`)
-
-type defaultContainerIDFinder struct{}
-
-// FindContainerID returns the container ID in the given cgroup path. The cgroup
-// path must have the whole word "docker" at some point in the path followed
-// at some point by a 64 hex-character container ID. If the cgroup path does
-// not match the above description, the method returns false.
-func (f *defaultContainerIDFinder) FindContainerID(cgroupPath string) (string, bool) {
-	m := dockerCGroupRE.FindStringSubmatch(cgroupPath)
-	if m != nil {
-		return m[1], true
-	}
-	return "", false
 }

--- a/pkg/agent/plugin/workloadattestor/docker/docker_posix.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_posix.go
@@ -1,0 +1,126 @@
+//go:build !windows
+// +build !windows
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/spiffe/spire/pkg/agent/common/cgroups"
+	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/cgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func createHelper(c *dockerPluginConfig, log hclog.Logger) (*containerHelper, error) {
+	var containerIDFinder cgroup.ContainerIDFinder = &defaultContainerIDFinder{}
+	var err error
+	if len(c.ContainerIDCGroupMatchers) > 0 {
+		containerIDFinder, err = cgroup.NewContainerIDFinder(c.ContainerIDCGroupMatchers)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &containerHelper{
+		fs:                cgroups.OSFileSystem{},
+		containerIDFinder: containerIDFinder,
+		log:               log,
+	}, nil
+}
+
+type containerHelper struct {
+	containerIDFinder cgroup.ContainerIDFinder
+	fs                cgroups.FileSystem
+	log               hclog.Logger
+}
+
+func (h *containerHelper) getContainerID(pID int32) (string, error) {
+	cgroupList, err := cgroups.GetCgroups(pID, h.fs)
+	if err != nil {
+		return "", err
+	}
+
+	return getContainerIDFromCGroups(h.containerIDFinder, cgroupList)
+}
+
+func validateOS(c *dockerPluginConfig) error {
+	if c.DockerHost != "" {
+		return status.Error(codes.InvalidArgument, "invalid configuration: docker_host is not supported in this platform; please use docker_socket_path instead")
+	}
+
+	return nil
+}
+
+func getDockerHost(c *dockerPluginConfig) string {
+	return c.DockerSocketPath
+}
+
+// getContainerIDFromCGroups returns the container ID from a set of cgroups
+// using the given finder. The container ID found on each cgroup path (if any)
+// must be consistent. If no container ID is found among the cgroups, i.e.,
+// this isn't a docker workload, the function returns an empty string. If more
+// than one container ID is found, or the "found" container ID is blank, the
+// function will fail.
+func getContainerIDFromCGroups(finder cgroup.ContainerIDFinder, cgroups []cgroups.Cgroup) (string, error) {
+	var hasDockerEntries bool
+	var containerID string
+	for _, cgroup := range cgroups {
+		candidate, ok := finder.FindContainerID(cgroup.GroupPath)
+		if !ok {
+			continue
+		}
+
+		hasDockerEntries = true
+
+		switch {
+		case containerID == "":
+			// This is the first container ID found so far.
+			containerID = candidate
+		case containerID != candidate:
+			// More than one container ID found in the cgroups.
+			return "", fmt.Errorf("workloadattestor/docker: multiple container IDs found in cgroups (%s, %s)",
+				containerID, candidate)
+		}
+	}
+
+	switch {
+	case !hasDockerEntries:
+		// Not a docker workload. Since it is expected that non-docker workloads will call the
+		// workload API, it is fine to return a response without any selectors.
+		return "", nil
+	case containerID == "":
+		// The "finder" found a container ID, but it was blank. This is a
+		// defensive measure against bad matcher patterns and shouldn't
+		// be possible with the default finder.
+		return "", errors.New("workloadattestor/docker: a pattern matched, but no container id was found")
+	default:
+		return containerID, nil
+	}
+}
+
+type defaultContainerIDFinder struct{}
+
+// FindContainerID returns the container ID in the given cgroup path. The cgroup
+// path must have the whole word "docker" at some point in the path followed
+// at some point by a 64 hex-character container ID. If the cgroup path does
+// not match the above description, the method returns false.
+func (f *defaultContainerIDFinder) FindContainerID(cgroupPath string) (string, bool) {
+	m := dockerCGroupRE.FindStringSubmatch(cgroupPath)
+	if m != nil {
+		return m[1], true
+	}
+	return "", false
+}
+
+// dockerCGroupRE matches cgroup paths that have the following properties.
+// 1) `\bdocker\b` the whole word docker
+// 2) `.+` followed by one or more characters (which will start on a word boundary due to #1)
+// 3) `\b([[:xdigit:]][64])\b` followed by a 64 hex-character container id on word boundary
+//
+// The "docker" prefix and 64-hex character container id can be anywhere in the path. The only
+// requirement is that the docker prefix comes before the id.
+var dockerCGroupRE = regexp.MustCompile(`\bdocker\b.+\b([[:xdigit:]]{64})\b`)

--- a/pkg/agent/plugin/workloadattestor/docker/docker_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_test.go
@@ -279,7 +279,7 @@ container_id_cgroup_matchers = [
 		require.NotNil(t, p.docker)
 		require.Equal(t, "unix:///socket_path", p.docker.(*dockerclient.Client).DaemonHost())
 		require.Equal(t, "1.20", p.docker.(*dockerclient.Client).ClientVersion())
-		require.Equal(t, expectFinder, p.containerIDFinder)
+		require.Equal(t, expectFinder, p.c.containerIDFinder)
 	})
 	t.Run("bad matcher", func(t *testing.T) {
 		p := New()
@@ -309,7 +309,7 @@ func TestDockerConfigDefault(t *testing.T) {
 	require.NotNil(t, p.docker)
 	require.Equal(t, dockerclient.DefaultDockerHost, p.docker.(*dockerclient.Client).DaemonHost())
 	require.Equal(t, "1.41", p.docker.(*dockerclient.Client).ClientVersion())
-	require.Equal(t, &defaultContainerIDFinder{}, p.containerIDFinder)
+	require.Equal(t, &defaultContainerIDFinder{}, p.c.containerIDFinder)
 }
 
 func doAttest(t *testing.T, p *Plugin) ([]string, error) {
@@ -350,7 +350,7 @@ func withDocker(docker Docker) testPluginOpt {
 
 func withFileSystem(m cgroups.FileSystem) testPluginOpt {
 	return func(p *Plugin) {
-		p.fs = m
+		p.c.fs = m
 	}
 }
 

--- a/pkg/agent/plugin/workloadattestor/docker/docker_windows.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_windows.go
@@ -1,0 +1,271 @@
+//go:build windows
+// +build windows
+
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor/docker/winapi"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"golang.org/x/sys/windows"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func createHelper(c *dockerPluginConfig, log hclog.Logger) (*containerHelper, error) {
+	return &containerHelper{
+		wapi: winapi.CreateAPI(),
+		log:  log,
+	}, nil
+}
+
+type containerHelper struct {
+	wapi winapi.API
+	log  hclog.Logger
+}
+
+func (h *containerHelper) getContainerID(pID int32) (string, error) {
+	containerID, err := h.getContainerIDByProcess(pID)
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to get container ID: %v", err)
+	}
+	return containerID, nil
+}
+
+// GetContainerIDByProcess get container ID from provided process ID,
+// processes running in a docker containers are grouped by Job objects (https://docs.microsoft.com/en-us/windows/win32/procthread/job-objects),
+// those Jobs has the container ID as name, in the format `\Container_${CONTAINER_ID}`
+func (h *containerHelper) getContainerIDByProcess(pID int32) (string, error) {
+	// Search all processes that runs vmcompute.exe
+	vmComputeProcessIds, err := h.searchProcessByExeFile("vmcompute.exe")
+	if err != nil {
+		return "", fmt.Errorf("failed to search vmcompute process: %w", err)
+	}
+
+	// Get current process, current process handle is not required to be closed
+	currentProcess := h.wapi.CurrentProcess()
+
+	// Duplicate process handle we want to validate, with limited permissions
+	childProcessHandle, err := h.wapi.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pID))
+	if err != nil {
+		return "", fmt.Errorf("failed to open child process: %w", err)
+	}
+	defer func() {
+		if err := h.wapi.CloseHandle(childProcessHandle); err != nil {
+			h.log.Warn("Could not close child process handle", telemetry.Error, err)
+		}
+	}()
+
+	buffer, err := h.querySystemInformation()
+	if err != nil {
+		return "", err
+	}
+
+	handlesList := (*winapi.SystemExtendedHandleInformation)(unsafe.Pointer(&buffer[0]))
+	handles := make([]winapi.SystemHandleInformationExItem, int(handlesList.NumberOfHandles))
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&handles))
+	hdr.Data = uintptr(unsafe.Pointer(&handlesList.Handles[0]))
+
+	// Verify if process ID is a vmcompute process
+	isVmcomputeProcess := func(pID uint32) bool {
+		for _, vmID := range vmComputeProcessIds {
+			if pID == vmID {
+				return true
+			}
+		}
+		return false
+	}
+
+	var jobNames []string
+	for _, handle := range handles {
+		// Filter all handles related with vmcompute processes
+		if !isVmcomputeProcess(uint32(handle.UniqueProcessID)) {
+			continue
+		}
+
+		// Open handle process ID, with permissions to duplicateg handle
+		hProcess, err := h.wapi.OpenProcess(windows.PROCESS_DUP_HANDLE, false, uint32(handle.UniqueProcessID))
+		if err != nil {
+			// TODO: may I just continue?
+			// return "", fmt.Errorf("failed to open process: %v", err)
+			continue
+		}
+		defer func() {
+			if err := h.wapi.CloseHandle(hProcess); err != nil {
+				h.log.Warn("Could not close process handle", telemetry.Error, err)
+			}
+		}()
+
+		// Duplicate handle to get information
+		var dupHandle windows.Handle
+		if h.wapi.DuplicateHandle(hProcess, windows.Handle(handle.HandleValue), currentProcess, &dupHandle,
+			0, true, windows.DUPLICATE_SAME_ACCESS) != nil {
+			continue
+		}
+		defer func() {
+			if err := h.wapi.CloseHandle(dupHandle); err != nil {
+				h.log.Warn("Could not close duplicated process handle", telemetry.Error, err)
+			}
+		}()
+
+		typeName, err := h.getObjectType(dupHandle)
+		if err != nil {
+			return "", err
+		}
+
+		// Filter no Jobs handlers
+		if typeName != "Job" {
+			continue
+		}
+
+		isProcessInJob := false
+		if err := h.wapi.IsProcessInJob(childProcessHandle, dupHandle, &isProcessInJob); err != nil {
+			return "", err
+		}
+
+		if !isProcessInJob {
+			continue
+		}
+
+		objectName, err := h.getObjectName(dupHandle)
+		if err != nil {
+			return "", err
+		}
+
+		// Jobs created on windows environments start with "\Container_"
+		if !strings.HasPrefix(objectName, `\Container_`) {
+			continue
+		}
+
+		jobNames = append(jobNames, objectName)
+	}
+
+	if len(jobNames) > 1 {
+		return "", fmt.Errorf("process has multiple jobs: %v", jobNames)
+	}
+
+	return jobNames[0][11:], nil
+}
+
+// searchProcessByExeFile search all process with specified exe file
+func (h *containerHelper) searchProcessByExeFile(exeFile string) ([]uint32, error) {
+	snapshotHandle, err := h.wapi.CreateToolhelp32Snapshot(winapi.Th32csSnapProcess, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := h.wapi.CloseHandle(snapshotHandle); err != nil {
+			h.log.Warn("Could not close snapshot process handle", telemetry.Error, err)
+		}
+	}()
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := h.wapi.Process32First(snapshotHandle, &entry); err != nil {
+		return nil, err
+	}
+
+	var results []uint32
+
+	for {
+		entryExeFile := syscall.UTF16ToString(entry.ExeFile[:])
+		if entryExeFile == exeFile {
+			results = append(results, entry.ProcessID)
+		}
+
+		if err := h.wapi.Process32Next(snapshotHandle, &entry); err != nil {
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return nil, err
+		}
+	}
+
+	return results, nil
+}
+
+// querySystemInformation use NtQuerySystemInformation to get all handles runnig on system
+func (h *containerHelper) querySystemInformation() ([]byte, error) {
+	buffer := make([]byte, 1024)
+	var retLen uint32
+	var status windows.NTStatus
+
+	for {
+		status = h.wapi.NtQuerySystemInformation(
+			windows.SystemExtendedHandleInformation,
+			unsafe.Pointer(&buffer[0]),
+			uint32(len(buffer)),
+			&retLen,
+		)
+
+		if status == windows.STATUS_BUFFER_OVERFLOW ||
+			status == windows.STATUS_BUFFER_TOO_SMALL ||
+			status == windows.STATUS_INFO_LENGTH_MISMATCH {
+			if int(retLen) <= cap(buffer) {
+				(*reflect.SliceHeader)(unsafe.Pointer(&buffer)).Len = int(retLen)
+			} else {
+				buffer = make([]byte, int(retLen))
+			}
+			continue
+		} else {
+			// if no error
+			if status>>30 != 3 {
+				buffer = (buffer)[:int(retLen)]
+				return buffer, nil
+			}
+			return nil, status
+		}
+	}
+}
+
+// getObjectType get the handle type
+func (h *containerHelper) getObjectType(handle windows.Handle) (string, error) {
+	buffer := make([]byte, 1024*10)
+	length := uint32(0)
+
+	status := h.wapi.NtQueryObject(handle, winapi.ObjectTypeInformationClass,
+		&buffer[0], uint32(len(buffer)), &length)
+	if status != windows.STATUS_SUCCESS {
+		return "", status
+	}
+
+	return (*winapi.ObjectTypeInformation)(unsafe.Pointer(&buffer[0])).TypeName.String(), nil
+}
+
+// getObjectName get the handle name
+func (h *containerHelper) getObjectName(handle windows.Handle) (string, error) {
+	buffer := make([]byte, 1024*2)
+	var length uint32
+
+	status := h.wapi.NtQueryObject(handle, winapi.ObjectNameInformationClass,
+		&buffer[0], uint32(len(buffer)), &length)
+	if status != windows.STATUS_SUCCESS {
+		return "", status
+	}
+
+	return (*winapi.UnicodeString)(unsafe.Pointer(&buffer[0])).String(), nil
+}
+
+func validateOS(c *dockerPluginConfig) error {
+	if c.DockerSocketPath != "" {
+		return status.Error(codes.InvalidArgument, "invalid configuration: docker_socket_path is not supported in this platform; please use docker_host instead")
+	}
+
+	if len(c.ContainerIDCGroupMatchers) > 0 {
+		return status.Error(codes.InvalidArgument, "invalid configuration: container_id_cgroup_matchers is not supported in this platform")
+	}
+
+	return nil
+}
+
+func getDockerHost(c *dockerPluginConfig) string {
+	return c.DockerHost
+}


### PR DESCRIPTION
Implement changes on docker Workload Attestor to allow windows attesttion, 
It uses ObjectJob names in order to get container ID from caller process ID. 

**Which issue this PR fixes**
fixes #2935

