### PR TITLE
Fix release workflow publish images dependencies

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -279,7 +279,7 @@ jobs:
 
   publish-images:
     runs-on: ubuntu-18.04
-    needs: [lint, unit-test, artifacts, integration]
+    needs: [lint, unit-test, unit-test-race-detector, artifacts, integration]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Job was missing the dependency on the race detector unit tests. This
means that the images get published even if the job fails.

This change adds the job dependency.
