### PR TITLE
Windows support: do not panic if system procedures are not found

### DIFF
--- a/pkg/common/peertracker/npipe_windows.go
+++ b/pkg/common/peertracker/npipe_windows.go
@@ -17,8 +17,10 @@ var (
 	kernelbase = windows.NewLazyDLL("kernelbase.dll")
 	kernel32   = windows.NewLazyDLL("kernel32.dll")
 
-	procCompareObjectHandles        = kernelbase.NewProc("CompareObjectHandles")
-	procGetNamedPipeClientProcessID = kernel32.NewProc("GetNamedPipeClientProcessId")
+	procCompareObjectHandles           = kernelbase.NewProc("CompareObjectHandles")
+	procCompareObjectHandlesErr        = procCompareObjectHandles.Find()
+	procGetNamedPipeClientProcessID    = kernel32.NewProc("GetNamedPipeClientProcessId")
+	procGetNamedPipeClientProcessIDErr = procGetNamedPipeClientProcessID.Find()
 )
 
 func getCallerInfoFromNamedPipeConn(conn net.Conn) (CallerInfo, error) {
@@ -47,6 +49,9 @@ func getCallerInfoFromNamedPipeConn(conn net.Conn) (CallerInfo, error) {
 // getNamedPipeClientProcessID retrieves the client process identifier
 // for the specified handle representing a named pipe.
 func getNamedPipeClientProcessID(pipe windows.Handle, clientProcessID *int32) (err error) {
+	if procGetNamedPipeClientProcessIDErr != nil {
+		return procGetNamedPipeClientProcessIDErr
+	}
 	r1, _, e1 := syscall.SyscallN(procGetNamedPipeClientProcessID.Addr(), uintptr(pipe), uintptr(unsafe.Pointer(clientProcessID)))
 	if r1 == 0 {
 		return e1
@@ -57,6 +62,9 @@ func getNamedPipeClientProcessID(pipe windows.Handle, clientProcessID *int32) (e
 // compareObjectHandles compares two object handles to determine if they
 // refer to the same underlying kernel object
 func compareObjectHandles(firstHandle, secondHandle windows.Handle) error {
+	if procCompareObjectHandlesErr != nil {
+		return procCompareObjectHandlesErr
+	}
 	r1, _, e1 := syscall.SyscallN(procCompareObjectHandles.Addr(), uintptr(firstHandle), uintptr(secondHandle))
 	if r1 == 0 {
 		return e1


### PR DESCRIPTION
SPIRE should not panic if a system procedures is not found.
This PR updates agent code to check the existence of the procedures before calling them.