### PR TITLE
Windows support: enable agent Admin APIs

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -96,8 +96,9 @@ type sdsConfig struct {
 }
 
 type experimentalConfig struct {
-	SyncInterval  string `hcl:"sync_interval"`
-	NamedPipeName string `hcl:"named_pipe_name"`
+	SyncInterval       string `hcl:"sync_interval"`
+	NamedPipeName      string `hcl:"named_pipe_name"`
+	AdminNamedPipeName string `hcl:"admin_named_pipe_name"`
 
 	Flags fflag.RawConfig `hcl:"feature_flags"`
 
@@ -446,7 +447,7 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 	}
 	ac.BindAddress = addr
 
-	if c.Agent.AdminSocketPath != "" {
+	if c.Agent.hasAdminAddr() {
 		adminAddr, err := c.Agent.getAdminAddr()
 		if err != nil {
 			return nil, err

--- a/cmd/spire-agent/cli/run/run_posix.go
+++ b/cmd/spire-agent/cli/run/run_posix.go
@@ -27,7 +27,7 @@ func (c *agentConfig) getAddr() (net.Addr, error) {
 	return util.GetUnixAddrWithAbsPath(c.SocketPath)
 }
 
-func (c *agentConfig) getAdminAddr() (*net.UnixAddr, error) {
+func (c *agentConfig) getAdminAddr() (net.Addr, error) {
 	socketPathAbs, err := filepath.Abs(c.SocketPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get absolute path for socket_path: %w", err)
@@ -47,10 +47,17 @@ func (c *agentConfig) getAdminAddr() (*net.UnixAddr, error) {
 	}, nil
 }
 
+func (c *agentConfig) hasAdminAddr() bool {
+	return c.AdminSocketPath != ""
+}
+
 // validateOS performs posix specific validations of the agent config
 func (c *agentConfig) validateOS() error {
 	if c.Experimental.NamedPipeName != "" {
 		return errors.New("invalid configuration: named_pipe_name is not supported in this platform; please use socket_path instead")
+	}
+	if c.Experimental.AdminNamedPipeName != "" {
+		return errors.New("invalid configuration: admin_named_pipe_name is not supported in this platform; please use admin_socket_path instead")
 	}
 	return nil
 }

--- a/cmd/spire-agent/cli/run/run_posix_test.go
+++ b/cmd/spire-agent/cli/run/run_posix_test.go
@@ -127,6 +127,16 @@ func mergeInputCasesOS() []mergeInputCase {
 				require.Equal(t, "bar", c.Agent.SocketPath)
 			},
 		},
+		{
+			msg: "admin_socket_path should be configurable by file",
+			fileInput: func(c *Config) {
+				c.Agent.AdminSocketPath = "/tmp/admin.sock"
+			},
+			cliInput: func(c *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, "/tmp/admin.sock", c.Agent.AdminSocketPath)
+			},
+		},
 	}
 }
 
@@ -148,8 +158,8 @@ func newAgentConfigCasesOS() []newAgentConfigCase {
 				c.Agent.AdminSocketPath = "/foo"
 			},
 			test: func(t *testing.T, c *agent.Config) {
-				require.Equal(t, "/foo", c.AdminBindAddress.Name)
-				require.Equal(t, "unix", c.AdminBindAddress.Net)
+				require.Equal(t, "/foo", c.AdminBindAddress.String())
+				require.Equal(t, "unix", c.AdminBindAddress.Network())
 			},
 		},
 		{
@@ -159,8 +169,8 @@ func newAgentConfigCasesOS() []newAgentConfigCase {
 				c.Agent.AdminSocketPath = "/tmp/workload-admin/admin.sock"
 			},
 			test: func(t *testing.T, c *agent.Config) {
-				require.Equal(t, "/tmp/workload-admin/admin.sock", c.AdminBindAddress.Name)
-				require.Equal(t, "unix", c.AdminBindAddress.Net)
+				require.Equal(t, "/tmp/workload-admin/admin.sock", c.AdminBindAddress.String())
+				require.Equal(t, "unix", c.AdminBindAddress.Network())
 			},
 		},
 		{
@@ -172,8 +182,8 @@ func newAgentConfigCasesOS() []newAgentConfigCase {
 			test: func(t *testing.T, c *agent.Config) {
 				require.Equal(t, "/tmp/workload/workload.sock", c.BindAddress.String())
 				require.Equal(t, "unix", c.BindAddress.Network())
-				require.Equal(t, "/tmp/admin.sock", c.AdminBindAddress.Name)
-				require.Equal(t, "unix", c.AdminBindAddress.Net)
+				require.Equal(t, "/tmp/admin.sock", c.AdminBindAddress.String())
+				require.Equal(t, "unix", c.AdminBindAddress.Network())
 			},
 		},
 		{
@@ -207,6 +217,15 @@ func newAgentConfigCasesOS() []newAgentConfigCase {
 			},
 			test: func(t *testing.T, c *agent.Config) {
 				require.Nil(t, c)
+			},
+		},
+		{
+			msg: "admin_socket_path not provided",
+			input: func(c *Config) {
+				c.Agent.AdminSocketPath = ""
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.Nil(t, c.AdminBindAddress)
 			},
 		},
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -502,16 +502,6 @@ func TestMergeInput(t *testing.T) {
 				require.Equal(t, "bar", c.Agent.TrustDomain)
 			},
 		},
-		{
-			msg: "admin_socket_path should be configurable by file",
-			fileInput: func(c *Config) {
-				c.Agent.AdminSocketPath = "/tmp/admin.sock"
-			},
-			cliInput: func(c *agentConfig) {},
-			test: func(t *testing.T, c *Config) {
-				require.Equal(t, "/tmp/admin.sock", c.Agent.AdminSocketPath)
-			},
-		},
 	}
 	cases = append(cases, mergeInputCasesOS()...)
 
@@ -687,15 +677,6 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 			test: func(t *testing.T, c *agent.Config) {
 				require.Nil(t, c)
-			},
-		},
-		{
-			msg: "admin_socket_path not provided",
-			input: func(c *Config) {
-				c.Agent.AdminSocketPath = ""
-			},
-			test: func(t *testing.T, c *agent.Config) {
-				require.Nil(t, c.AdminBindAddress)
 			},
 		},
 		{

--- a/cmd/spire-agent/cli/run/run_windows.go
+++ b/cmd/spire-agent/cli/run/run_windows.go
@@ -24,14 +24,21 @@ func (c *agentConfig) getAddr() (net.Addr, error) {
 	return util.GetNamedPipeAddr(c.Experimental.NamedPipeName), nil
 }
 
-func (c *agentConfig) getAdminAddr() (*net.UnixAddr, error) {
-	return nil, errors.New("admin API: platform not supported")
+func (c *agentConfig) getAdminAddr() (net.Addr, error) {
+	return util.GetNamedPipeAddr(c.Experimental.AdminNamedPipeName), nil
+}
+
+func (c *agentConfig) hasAdminAddr() bool {
+	return c.Experimental.AdminNamedPipeName != ""
 }
 
 // validateOS performs windows specific validations of the agent config
 func (c *agentConfig) validateOS() error {
 	if c.SocketPath != "" {
 		return errors.New("invalid configuration: socket_path is not supported in this platform; please use named_pipe_name instead")
+	}
+	if c.AdminSocketPath != "" {
+		return errors.New("invalid configuration: admin_socket_path is not supported in this platform; please use admin_named_pipe_name instead")
 	}
 	return nil
 }

--- a/cmd/spire-agent/cli/run/run_windows_test.go
+++ b/cmd/spire-agent/cli/run/run_windows_test.go
@@ -128,6 +128,16 @@ func mergeInputCasesOS() []mergeInputCase {
 				require.Equal(t, "bar", c.Agent.Experimental.NamedPipeName)
 			},
 		},
+		{
+			msg: "admin_named_pipe_name should be configurable by file",
+			fileInput: func(c *Config) {
+				c.Agent.Experimental.AdminNamedPipeName = "\\spire-agent\\private\\api-test"
+			},
+			cliInput: func(c *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, "\\spire-agent\\private\\api-test", c.Agent.Experimental.AdminNamedPipeName)
+			},
+		},
 	}
 }
 
@@ -142,6 +152,15 @@ func newAgentConfigCasesOS() []newAgentConfigCase {
 				require.Equal(t, "\\\\.\\pipe\\foo", c.BindAddress.String())
 				require.Equal(t, "foo", c.BindAddress.(*util.NamedPipeAddr).PipeName())
 				require.Equal(t, "pipe", c.BindAddress.(*util.NamedPipeAddr).Network())
+			},
+		},
+		{
+			msg: "admin_named_pipe_name not provided",
+			input: func(c *Config) {
+				c.Agent.Experimental.AdminNamedPipeName = ""
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.Nil(t, c.AdminBindAddress)
 			},
 		},
 	}

--- a/pkg/agent/api/config.go
+++ b/pkg/agent/api/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 type Config struct {
-	BindAddr *net.UnixAddr
+	BindAddr net.Addr
 
 	Manager manager.Manager
 
@@ -31,7 +31,7 @@ type Config struct {
 func New(c *Config) *Endpoints {
 	return &Endpoints{
 		c: c,
-		unixListener: &peertracker.ListenerFactory{
+		listener: &peertracker.ListenerFactory{
 			Log: c.Log,
 		},
 	}

--- a/pkg/agent/api/endpoints_posix.go
+++ b/pkg/agent/api/endpoints_posix.go
@@ -7,22 +7,20 @@ import (
 	"fmt"
 	"net"
 	"os"
+
+	"github.com/spiffe/spire/pkg/common/util"
 )
 
-func (e *Endpoints) createUDSListener() (net.Listener, error) {
+func (e *Endpoints) createListener() (net.Listener, error) {
 	// Remove uds if already exists
 	os.Remove(e.c.BindAddr.String())
 
-	l, err := e.unixListener.ListenUnix(e.c.BindAddr.Network(), e.c.BindAddr)
+	l, err := e.listener.ListenUnix(e.c.BindAddr.Network(), util.GetUnixAddr(e.c.BindAddr.String()))
 	if err != nil {
-		return nil, fmt.Errorf("create UDS listener: %w", err)
+		return nil, fmt.Errorf("error creating UDS listener: %w", err)
 	}
 	if err := os.Chmod(e.c.BindAddr.String(), 0770); err != nil {
 		return nil, fmt.Errorf("unable to change UDS permissions: %w", err)
 	}
 	return l, nil
-}
-
-func (e *Endpoints) createListener() (net.Listener, error) {
-	return e.createUDSListener()
 }

--- a/pkg/agent/api/endpoints_windows.go
+++ b/pkg/agent/api/endpoints_windows.go
@@ -4,11 +4,17 @@
 package api
 
 import (
+	"fmt"
 	"net"
 
-	"github.com/spiffe/spire/pkg/common/peertracker"
+	"github.com/Microsoft/go-winio"
+	"github.com/spiffe/spire/pkg/common/util"
 )
 
 func (e *Endpoints) createListener() (net.Listener, error) {
-	return nil, peertracker.ErrUnsupportedPlatform
+	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+	if err != nil {
+		return nil, fmt.Errorf("error creating named pipe listener for admin APIs: %w", err)
+	}
+	return l, nil
 }

--- a/pkg/agent/api/endpoints_windows.go
+++ b/pkg/agent/api/endpoints_windows.go
@@ -14,7 +14,7 @@ import (
 func (e *Endpoints) createListener() (net.Listener, error) {
 	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
 	if err != nil {
-		return nil, fmt.Errorf("error creating named pipe listener for admin APIs: %w", err)
+		return nil, fmt.Errorf("error creating named pipe listener: %w", err)
 	}
 	return l, nil
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	DataDir string
 
 	// Directory to bind the admin api to
-	AdminBindAddress *net.UnixAddr
+	AdminBindAddress net.Addr
 
 	// The Validation Context resource name to use when fetching X.509 bundle together with federated bundles with Envoy SDS
 	DefaultAllBundlesName string


### PR DESCRIPTION
Enable support for the agent Admin APIs on Windows.

Fixes #2833.