### PR TITLE
Windows support: update the OIDC Discovery Provider to work on Windows

### DIFF
--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -35,9 +35,10 @@ The configuration file is **required** by the provider. It contains
 | `acme`                  | section | required[1]    | Provides the ACME configuration.                                             |          |
 | `allow_insecure_scheme` | string  | optional[3]    | Serves OIDC configuration response with HTTP url.                            | `false`  |
 | `domains`               | strings | required       | One or more domains the provider is being served from.                       |          |
+| `experimental`          | section | optional       | The experimental options that are subject to change or removal. | |
 | `insecure_addr`         | string  | optional[3]    | Exposes the service on http.                                                 |          |
 | `set_key_use`           | bool    | optional       | If true, the `use` parameter on JWKs will be set to `sig`.                   | `false`  |
-| `listen_socket_path`    | string  | required[1][3] | Path on disk to listen with a Unix Domain Socket.                            |          |
+| `listen_socket_path`    | string  | required[1][3] | Path on disk to listen with a Unix Domain Socket. Unix platforms only.                           |          |
 | `log_format`            | string  | optional       | Format of the logs (either `"TEXT"` or `"JSON"`)                             | `""`     |
 | `log_level`             | string  | required       | Log level (one of `"error"`,`"warn"`,`"info"`,`"debug"`)                     | `"info"` |
 | `log_path`              | string  | optional       | Path on disk to write the log.                                               |          |
@@ -45,11 +46,25 @@ The configuration file is **required** by the provider. It contains
 | `server_api`            | section | required[2]    | Provides SPIRE Server API details.                                           |          |
 | `workload_api`          | section | required[2]    | Provides Workload API details.                                               |          |
 
+| experimental             | Type   | Required?      | Description                                          | Default |
+| ------------------------ |--------|--------------- | -----------------------------------------------------| ------- |
+| `listen_named_pipe_name` | string | required[1][3] | Pipe name to listen with a named pipe. Windows only. |         |
+
+#### Considerations for Unix platforms
+
 [1]: One of `acme` or `listen_socket_path` must be defined.
 
-[2]: One of `server_api` or `workload_api` must be defined. The provider relies on one of these two APIs to obtain the public key material used to construct the JWKS document.
-
 [3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_socket_path`.
+
+#### Considerations for Windows platforms
+
+[1]: One of `acme` or `listen_named_pipe_name` must be defined.
+
+[3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
+
+#### Considerations for all platforms
+
+[2]: One of `server_api` or `workload_api` must be defined. The provider relies on one of these two APIs to obtain the public key material used to construct the JWKS document.
 
 The `domains` configurable contains the list of domains the provider is
 expected to be served from. If a request is received from a domain other than
@@ -71,26 +86,37 @@ will terminate if another domain is requested.
 
 | Key                | Type     | Required? | Description                              | Default |
 | ------------------ | -------- | --------- | ----------------------------------------- | ------- |
-| `address`          | string   | required  | SPIRE Server API gRPC target address. Only the unix name system is supported. See https://github.com/grpc/grpc/blob/master/doc/naming.md. | |
+| `address`          | string   | required  | SPIRE Server API gRPC target address. Only the unix name system is supported. See https://github.com/grpc/grpc/blob/master/doc/naming.md. Unix platforms only. | |
+| `experimental`     | section | optional  | The experimental options that are subject to change or removal. | |
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
+
+| experimental     | Type   | Required? | Description                                                | Default |
+|:--------------------------|-----------|------------------------------------------------------------| ------- |
+| `named_pipe_name`| string | required  |Pipe name of the SPIRE Server API named pipe. Windows only. |         |
 
 #### Workload API Section
 
 | Key                | Type     | Required? | Description                               | Default |
 | ------------------ | -------- | --------- | ----------------------------------------- | ------- |
-| `socket_path`      | string   | required  | Path on disk to the Workload API Unix Domain socket. | |
+| `experimental`     | section | optional  | The experimental options that are subject to change or removal. | |
+| `socket_path`      | string   | required  | Path on disk to the Workload API Unix Domain socket. Unix platforms only. | |
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
 | `trust_domain`     | string   | required  | Trust domain of the workload. This is used to pick the bundle out of the Workload API response. | |
 
-### Examples
+| experimental                | Description                    | Default        |
+|:----------------------------|--------------------------------|----------------|
+| `named_pipe_name`           | Pipe name of the Workload API named pipe. Windows only. | |
 
-#### Server API
+### Examples (Unix platforms)
+
+#### Server API 
 
 ```
 log_level = "debug"
 domains = ["mypublicdomain.test"]
 acme {
     cache_dir = "/some/path/on/disk/to/cache/creds"
+    email = "email@domain.test"
     tos_accepted = true
 }
 server_api {
@@ -105,6 +131,7 @@ log_level = "debug"
 domains = ["mypublicdomain.test"]
 acme {
     cache_dir = "/some/path/on/disk/to/cache/creds"
+    email = "email@domain.test"
     tos_accepted = true
 }
 workload_api {
@@ -149,4 +176,62 @@ daemon off;
      }
    }
  }
+```
+
+### Examples (Windows)
+
+#### Server API 
+
+```
+log_level = "debug"
+domains = ["mypublicdomain.test"]
+acme {
+    cache_dir = "c:\\some\\path\\on\\disk\\to\\cache\\creds"
+    email = "email@domain.test"
+    tos_accepted = true
+}
+server_api {
+    experimental {
+        named_pipe_name = "\\spire-server\\private\\api"
+    }
+}
+```
+
+#### Workload API
+
+```
+log_level = "debug"
+domains = ["mypublicdomain.test"]
+acme {
+    cache_dir = "c:\\some\\path\\on\\disk\\to\\cache\\creds"
+    email = "email@domain.test"
+    tos_accepted = true
+}
+workload_api {
+    experimental {
+        named_pipe_name = "\\spire-agent\\public\\api"
+    }
+    trust_domain = "domain.test"
+}
+```
+
+#### Listening on a Named Pipe
+
+The following configuration has the OIDC Discovery Provider listen for requests
+on the given named pipe.  This can be used in conjunction with a webserver that
+supports reverse proxying to a named pipe.
+
+```
+log_level = "debug"
+domains = ["mypublicdomain.test"]
+experimental {
+    listen_named_pipe_name = "oidc-discovery-provider"
+}
+
+workload_api {
+    experimental {
+        named_pipe_name = "\\spire-agent\\public\\api"
+    }
+    trust_domain = "domain.test"
+}
 ```

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -109,7 +109,7 @@ will terminate if another domain is requested.
 
 ### Examples (Unix platforms)
 
-#### Server API 
+#### Server API
 
 ```
 log_level = "debug"

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -87,18 +87,18 @@ will terminate if another domain is requested.
 | Key                | Type     | Required? | Description                              | Default |
 | ------------------ | -------- | --------- | ----------------------------------------- | ------- |
 | `address`          | string   | required  | SPIRE Server API gRPC target address. Only the unix name system is supported. See https://github.com/grpc/grpc/blob/master/doc/naming.md. Unix platforms only. | |
-| `experimental`     | section | optional  | The experimental options that are subject to change or removal. | |
+| `experimental`     | section  | optional  | The experimental options that are subject to change or removal. | |
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
 
-| experimental     | Type   | Required? | Description                                                | Default |
-|:--------------------------|-----------|------------------------------------------------------------| ------- |
-| `named_pipe_name`| string | required  |Pipe name of the SPIRE Server API named pipe. Windows only. |         |
+| experimental     | Type   | Required? | Description                                                 | Default |
+|:--------------------------|-----------|-------------------------------------------------------------| ------- |
+| `named_pipe_name`| string | required  | Pipe name of the SPIRE Server API named pipe. Windows only. |         |
 
 #### Workload API Section
 
 | Key                | Type     | Required? | Description                               | Default |
 | ------------------ | -------- | --------- | ----------------------------------------- | ------- |
-| `experimental`     | section | optional  | The experimental options that are subject to change or removal. | |
+| `experimental`     | section  | optional  | The experimental options that are subject to change or removal. | |
 | `socket_path`      | string   | required  | Path on disk to the Workload API Unix Domain socket. Unix platforms only. | |
 | `poll_interval`    | duration | optional  | How often to poll for changes to the public key material. | `"10s"` |
 | `trust_domain`     | string   | required  | Trust domain of the workload. This is used to pick the bundle out of the Workload API response. | |

--- a/support/oidc-discovery-provider/config.go
+++ b/support/oidc-discovery-provider/config.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/hcl"
@@ -60,6 +59,9 @@ type Config struct {
 	// Workload API is the configuration for using the SPIFFE Workload API
 	// as the source for the public keys. Only one source can be configured.
 	WorkloadAPI *WorkloadAPIConfig `hcl:"workload_api"`
+
+	// Experimental options that are subject to change or removal.
+	Experimental experimentalConfig `hcl:"experimental"`
 }
 
 type ACMEConfig struct {
@@ -97,6 +99,9 @@ type ServerAPIConfig struct {
 	// RawPollInterval holds the string version of the PollInterval. Consumers
 	// should use PollInterval instead.
 	RawPollInterval string `hcl:"poll_interval"`
+
+	// Experimental options that are subject to change or removal.
+	Experimental experimentalServerAPIConfig `hcl:"experimental"`
 }
 
 type WorkloadAPIConfig struct {
@@ -115,6 +120,26 @@ type WorkloadAPIConfig struct {
 	// RawPollInterval holds the string version of the PollInterval. Consumers
 	// should use PollInterval instead.
 	RawPollInterval string `hcl:"poll_interval"`
+
+	// Experimental options that are subject to change or removal.
+	Experimental experimentalWorkloadAPIConfig `hcl:"experimental"`
+}
+
+type experimentalConfig struct {
+	// ListenNamedPipeName specifies the pipe name of the named pipe
+	// to listen for plaintext HTTP on, for when deployed behind another
+	// webserver or sidecar.
+	ListenNamedPipeName string `hcl:"listen_named_pipe_name" json:"listen_named_pipe_name"`
+}
+
+type experimentalServerAPIConfig struct {
+	// Pipe name of the Server API named pipe.
+	NamedPipeName string `hcl:"named_pipe_name" json:"named_pipe_name"`
+}
+
+type experimentalWorkloadAPIConfig struct {
+	// Pipe name of the Workload API named pipe.
+	NamedPipeName string `hcl:"named_pipe_name" json:"named_pipe_name"`
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -148,32 +173,17 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 	}
 
 	switch {
-	case c.ACME == nil:
-		if c.InsecureAddr == "" && c.ListenSocketPath == "" {
-			return nil, errs.New("either acme or listen_socket_path must be configured")
-		}
-		if c.InsecureAddr != "" && c.ListenSocketPath != "" {
-			return nil, errs.New("insecure_addr and listen_socket_path are mutually exclusive")
-		}
-	case c.InsecureAddr != "":
+	case c.ACME != nil && c.InsecureAddr != "":
 		return nil, errs.New("insecure_addr and the acme section are mutually exclusive")
-	case c.ListenSocketPath != "":
-		return nil, errs.New("listen_socket_path and the acme section are mutually exclusive")
-	case !c.ACME.ToSAccepted:
+	case c.ACME != nil && !c.ACME.ToSAccepted:
 		return nil, errs.New("tos_accepted must be set to true in the acme configuration section")
-	case c.ACME.Email == "":
+	case c.ACME != nil && c.ACME.Email == "":
 		return nil, errs.New("email must be configured in the acme configuration section")
 	}
 
 	var methodCount int
 
 	if c.ServerAPI != nil {
-		if c.ServerAPI.Address == "" {
-			return nil, errs.New("address must be configured in the server_api configuration section")
-		}
-		if !strings.HasPrefix(c.ServerAPI.Address, "unix:") {
-			return nil, errs.New("address must use the unix name system in the server_api configuration section")
-		}
 		c.ServerAPI.PollInterval, err = parsePollInterval(c.ServerAPI.RawPollInterval)
 		if err != nil {
 			return nil, errs.New("invalid poll_interval in the server_api configuration section: %v", err)
@@ -182,9 +192,6 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 	}
 
 	if c.WorkloadAPI != nil {
-		if c.WorkloadAPI.SocketPath == "" {
-			return nil, errs.New("socket_path must be configured in the workload_api configuration section")
-		}
 		if c.WorkloadAPI.TrustDomain == "" {
 			return nil, errs.New("trust_domain must be configured in the workload_api configuration section")
 		}
@@ -193,6 +200,10 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 			return nil, errs.New("invalid poll_interval in the workload_api configuration section: %v", err)
 		}
 		methodCount++
+	}
+
+	if err := c.validateOS(); err != nil {
+		return nil, err
 	}
 
 	switch methodCount {

--- a/support/oidc-discovery-provider/config.go
+++ b/support/oidc-discovery-provider/config.go
@@ -170,15 +170,14 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 		if c.ACME.RawCacheDir != nil {
 			c.ACME.CacheDir = *c.ACME.RawCacheDir
 		}
-	}
-
-	switch {
-	case c.ACME != nil && c.InsecureAddr != "":
-		return nil, errs.New("insecure_addr and the acme section are mutually exclusive")
-	case c.ACME != nil && !c.ACME.ToSAccepted:
-		return nil, errs.New("tos_accepted must be set to true in the acme configuration section")
-	case c.ACME != nil && c.ACME.Email == "":
-		return nil, errs.New("email must be configured in the acme configuration section")
+		switch {
+		case c.InsecureAddr != "":
+			return nil, errs.New("insecure_addr and the acme section are mutually exclusive")
+		case !c.ACME.ToSAccepted:
+			return nil, errs.New("tos_accepted must be set to true in the acme configuration section")
+		case c.ACME.Email == "":
+			return nil, errs.New("email must be configured in the acme configuration section")
+		}
 	}
 
 	var methodCount int

--- a/support/oidc-discovery-provider/config_posix_test.go
+++ b/support/oidc-discovery-provider/config_posix_test.go
@@ -1,0 +1,392 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import "time"
+
+var (
+	minimalServerAPIConfig = `
+		domains = ["domain.test"]
+		acme {
+			email = "admin@domain.test"
+			tos_accepted = true
+		}
+		server_api {
+			address = "unix:///some/socket/path"
+		}
+`
+
+	serverAPIConfig = &ServerAPIConfig{
+		Address:      "unix:///some/socket/path",
+		PollInterval: defaultPollInterval,
+	}
+)
+
+func parseConfigCasesOS() []parseConfigCase {
+	return []parseConfigCase{
+		{
+			name: "no domain configured",
+			in: `
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "at least one domain must be configured",
+		},
+		{
+			name: "no ACME configuration",
+			in: `
+				domains = ["domain.test"]
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "either acme or listen_socket_path must be configured",
+		},
+		{
+			name: "ACME ToS not accepted",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "tos_accepted must be set to true in the acme configuration section",
+		},
+		{
+			name: "ACME email not configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					tos_accepted = true
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "email must be configured in the acme configuration section",
+		},
+		{
+			name: "ACME overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					tos_accepted = true
+					cache_dir = ""
+					directory_url = "https://directory.test"
+					email = "admin@domain.test"
+				}
+				server_api {
+					address = "unix:///some/socket/path"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:     "",
+					Email:        "admin@domain.test",
+					DirectoryURL: "https://directory.test",
+					RawCacheDir:  stringPtr(""),
+					ToSAccepted:  true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Address:      "unix:///some/socket/path",
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "both acme and insecure_addr configured",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "insecure_addr and the acme section are mutually exclusive",
+		},
+		{
+			name: "both acme and socket_listen_path configured",
+			in: `
+				domains = ["domain.test"]
+				listen_socket_path = "test"
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_socket_path and the acme section are mutually exclusive",
+		},
+		{
+			name: "both insecure_addr and socket_listen_path configured",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				listen_socket_path = "test"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "insecure_addr and listen_socket_path are mutually exclusive",
+		},
+		{
+			name: "with insecure addr and key use",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				server_api {
+					address = "unix:///some/socket/path"
+				}
+				set_key_use = true
+			`,
+			out: &Config{
+				LogLevel:     defaultLogLevel,
+				Domains:      []string{"domain.test"},
+				InsecureAddr: ":8080",
+				ServerAPI: &ServerAPIConfig{
+					Address:      "unix:///some/socket/path",
+					PollInterval: defaultPollInterval,
+				},
+				SetKeyUse: true,
+			},
+		},
+		{
+			name: "with listen_socket_path",
+			in: `
+				domains = ["domain.test"]
+				listen_socket_path = "/a/path/here"
+				server_api {
+					address = "unix:///some/socket/path"
+				}
+			`,
+			out: &Config{
+				LogLevel:         defaultLogLevel,
+				Domains:          []string{"domain.test"},
+				ListenSocketPath: "/a/path/here",
+				ServerAPI: &ServerAPIConfig{
+					Address:      "unix:///some/socket/path",
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "more than one source section configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api { address = "unix:///some/socket/path" }
+				workload_api { socket_path = "/some/socket/path" trust_domain="foo.test" }
+			`,
+			err: "the server_api and workload_api sections are mutually exclusive",
+		},
+		{
+			name: "minimal server API config",
+			in:   minimalServerAPIConfig,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Address:      "unix:///some/socket/path",
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "server API config overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					address = "unix:///other/socket/path"
+					poll_interval = "1h"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Address:         "unix:///other/socket/path",
+					PollInterval:    time.Hour,
+					RawPollInterval: "1h",
+				},
+			},
+		},
+		{
+			name: "server API config missing address",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+				}
+			`,
+			err: "address must be configured in the server_api configuration section",
+		},
+		{
+			name: "server API config invalid address",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					address = "localhost:8199"
+				}
+			`,
+			err: "address must use the unix name system in the server_api configuration section",
+		},
+		{
+			name: "server API config invalid poll interval",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					address = "unix:///some/socket/path"
+					poll_interval = "huh"
+				}
+			`,
+			err: "invalid poll_interval in the server_api configuration section: time: invalid duration \"huh\"",
+		},
+		{
+			name: "minimal workload API config",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					socket_path = "/some/socket/path"
+					trust_domain = "domain.test"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				WorkloadAPI: &WorkloadAPIConfig{
+					SocketPath:   "/some/socket/path",
+					PollInterval: defaultPollInterval,
+					TrustDomain:  "domain.test",
+				},
+			},
+		},
+		{
+			name: "workload API config overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					socket_path = "/other/socket/path"
+					poll_interval = "1h"
+					trust_domain = "foo.test"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				WorkloadAPI: &WorkloadAPIConfig{
+					SocketPath:      "/other/socket/path",
+					PollInterval:    time.Hour,
+					RawPollInterval: "1h",
+					TrustDomain:     "foo.test",
+				},
+			},
+		},
+		{
+			name: "workload API config missing socket path",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					trust_domain = "domain.test"
+				}
+			`,
+			err: "socket_path must be configured in the workload_api configuration section",
+		},
+		{
+			name: "workload API config invalid poll interval",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					socket_path = "/some/socket/path"
+					poll_interval = "huh"
+					trust_domain = "domain.test"
+				}
+			`,
+			err: "invalid poll_interval in the workload_api configuration section: time: invalid duration \"huh\"",
+		},
+		{
+			name: "workload API config missing trust domain",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					socket_path = "/some/socket/path"
+				}
+			`,
+			err: "trust_domain must be configured in the workload_api configuration section",
+		},
+	}
+}

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -4,24 +4,17 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	minimalServerAPIConfig = `
-		domains = ["domain.test"]
-		acme {
-			email = "admin@domain.test"
-			tos_accepted = true
-		}
-		server_api {
-			address = "unix:///some/socket/path"
-		}
-`
-)
+type parseConfigCase struct {
+	name string
+	in   string
+	out  *Config
+	err  string
+}
 
 func TestLoadConfig(t *testing.T) {
 	require := require.New(t)
@@ -48,185 +41,16 @@ func TestLoadConfig(t *testing.T) {
 			Email:       "admin@domain.test",
 			ToSAccepted: true,
 		},
-		ServerAPI: &ServerAPIConfig{
-			Address:      "unix:///some/socket/path",
-			PollInterval: defaultPollInterval,
-		},
+		ServerAPI: serverAPIConfig,
 	}, config)
 }
 
 func TestParseConfig(t *testing.T) {
-	testCases := []struct {
-		name string
-		in   string
-		out  *Config
-		err  string
-	}{
+	testCases := []parseConfigCase{
 		{
 			name: "malformed HCL",
 			in:   `BAD`,
 			err:  "unable to decode configuration",
-		},
-		{
-			name: "no domain configured",
-			in: `
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "at least one domain must be configured",
-		},
-		{
-			name: "no ACME configuration",
-			in: `
-				domains = ["domain.test"]
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "either acme or listen_socket_path must be configured",
-		},
-		{
-			name: "ACME ToS not accepted",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-				}
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "tos_accepted must be set to true in the acme configuration section",
-		},
-		{
-			name: "ACME email not configured",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					tos_accepted = true
-				}
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "email must be configured in the acme configuration section",
-		},
-		{
-			name: "ACME overrides",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					tos_accepted = true
-					cache_dir = ""
-					directory_url = "https://directory.test"
-					email = "admin@domain.test"
-				}
-				server_api {
-					address = "unix:///some/socket/path"
-				}
-			`,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:     "",
-					Email:        "admin@domain.test",
-					DirectoryURL: "https://directory.test",
-					RawCacheDir:  stringPtr(""),
-					ToSAccepted:  true,
-				},
-				ServerAPI: &ServerAPIConfig{
-					Address:      "unix:///some/socket/path",
-					PollInterval: defaultPollInterval,
-				},
-			},
-		},
-		{
-			name: "both acme and insecure_addr configured",
-			in: `
-				domains = ["domain.test"]
-				insecure_addr = ":8080"
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "insecure_addr and the acme section are mutually exclusive",
-		},
-		{
-			name: "both acme and socket_listen_path configured",
-			in: `
-				domains = ["domain.test"]
-				listen_socket_path = "test"
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "listen_socket_path and the acme section are mutually exclusive",
-		},
-		{
-			name: "both insecure_addr and socket_listen_path configured",
-			in: `
-				domains = ["domain.test"]
-				insecure_addr = ":8080"
-				listen_socket_path = "test"
-				server_api {
-					socket_path = "/other/socket/path"
-				}
-			`,
-			err: "insecure_addr and listen_socket_path are mutually exclusive",
-		},
-		{
-			name: "with insecure addr and key use",
-			in: `
-				domains = ["domain.test"]
-				insecure_addr = ":8080"
-				server_api {
-					address = "unix:///some/socket/path"
-				}
-				set_key_use = true
-			`,
-			out: &Config{
-				LogLevel:     defaultLogLevel,
-				Domains:      []string{"domain.test"},
-				InsecureAddr: ":8080",
-				ServerAPI: &ServerAPIConfig{
-					Address:      "unix:///some/socket/path",
-					PollInterval: defaultPollInterval,
-				},
-				SetKeyUse: true,
-			},
-		},
-		{
-			name: "with listen_socket_path",
-			in: `
-				domains = ["domain.test"]
-				listen_socket_path = "/a/path/here"
-				server_api {
-					address = "unix:///some/socket/path"
-				}
-			`,
-			out: &Config{
-				LogLevel:         defaultLogLevel,
-				Domains:          []string{"domain.test"},
-				ListenSocketPath: "/a/path/here",
-				ServerAPI: &ServerAPIConfig{
-					Address:      "unix:///some/socket/path",
-					PollInterval: defaultPollInterval,
-				},
-			},
 		},
 		{
 			name: "no source section configured",
@@ -239,209 +63,8 @@ func TestParseConfig(t *testing.T) {
 			`,
 			err: "either the server_api or workload_api section must be configured",
 		},
-		{
-			name: "more than one source section configured",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api { address = "unix:///some/socket/path" }
-				workload_api { socket_path = "/some/socket/path" trust_domain="foo.test" }
-			`,
-			err: "the server_api and workload_api sections are mutually exclusive",
-		},
-		{
-			name: "minimal server API config",
-			in:   minimalServerAPIConfig,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:    defaultCacheDir,
-					Email:       "admin@domain.test",
-					ToSAccepted: true,
-				},
-				ServerAPI: &ServerAPIConfig{
-					Address:      "unix:///some/socket/path",
-					PollInterval: defaultPollInterval,
-				},
-			},
-		},
-		{
-			name: "server API config overrides",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					address = "unix:///other/socket/path"
-					poll_interval = "1h"
-				}
-			`,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:    defaultCacheDir,
-					Email:       "admin@domain.test",
-					ToSAccepted: true,
-				},
-				ServerAPI: &ServerAPIConfig{
-					Address:         "unix:///other/socket/path",
-					PollInterval:    time.Hour,
-					RawPollInterval: "1h",
-				},
-			},
-		},
-		{
-			name: "server API config missing address",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-				}
-			`,
-			err: "address must be configured in the server_api configuration section",
-		},
-		{
-			name: "server API config invalid address",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					address = "localhost:8199"
-				}
-			`,
-			err: "address must use the unix name system in the server_api configuration section",
-		},
-		{
-			name: "server API config invalid poll interval",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				server_api {
-					address = "unix:///some/socket/path"
-					poll_interval = "huh"
-				}
-			`,
-			err: "invalid poll_interval in the server_api configuration section: time: invalid duration \"huh\"",
-		},
-		{
-			name: "minimal workload API config",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				workload_api {
-					socket_path = "/some/socket/path"
-					trust_domain = "domain.test"
-				}
-			`,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:    defaultCacheDir,
-					Email:       "admin@domain.test",
-					ToSAccepted: true,
-				},
-				WorkloadAPI: &WorkloadAPIConfig{
-					SocketPath:   "/some/socket/path",
-					PollInterval: defaultPollInterval,
-					TrustDomain:  "domain.test",
-				},
-			},
-		},
-		{
-			name: "workload API config overrides",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				workload_api {
-					socket_path = "/other/socket/path"
-					poll_interval = "1h"
-					trust_domain = "foo.test"
-				}
-			`,
-			out: &Config{
-				LogLevel: defaultLogLevel,
-				Domains:  []string{"domain.test"},
-				ACME: &ACMEConfig{
-					CacheDir:    defaultCacheDir,
-					Email:       "admin@domain.test",
-					ToSAccepted: true,
-				},
-				WorkloadAPI: &WorkloadAPIConfig{
-					SocketPath:      "/other/socket/path",
-					PollInterval:    time.Hour,
-					RawPollInterval: "1h",
-					TrustDomain:     "foo.test",
-				},
-			},
-		},
-		{
-			name: "workload API config missing socket path",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				workload_api {
-					trust_domain = "domain.test"
-				}
-			`,
-			err: "socket_path must be configured in the workload_api configuration section",
-		},
-		{
-			name: "workload API config invalid poll interval",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				workload_api {
-					socket_path = "/some/socket/path"
-					poll_interval = "huh"
-					trust_domain = "domain.test"
-				}
-			`,
-			err: "invalid poll_interval in the workload_api configuration section: time: invalid duration \"huh\"",
-		},
-		{
-			name: "workload API config missing trust domain",
-			in: `
-				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
-				workload_api {
-					socket_path = "/some/socket/path"
-				}
-			`,
-			err: "trust_domain must be configured in the workload_api configuration section",
-		},
 	}
+	testCases = append(testCases, parseConfigCasesOS()...)
 
 	for _, testCase := range testCases {
 		testCase := testCase

--- a/support/oidc-discovery-provider/config_windows_test.go
+++ b/support/oidc-discovery-provider/config_windows_test.go
@@ -1,0 +1,441 @@
+//go:build windows
+// +build windows
+
+package main
+
+import "time"
+
+var (
+	minimalServerAPIConfig = `
+		domains = ["domain.test"]
+		acme {
+			email = "admin@domain.test"
+			tos_accepted = true
+		}
+		server_api {
+			experimental {
+				named_pipe_name = "\\name\\for\\server\\api"
+			}
+		}
+`
+
+	serverAPIConfig = &ServerAPIConfig{
+		Experimental: experimentalServerAPIConfig{
+			NamedPipeName: "\\name\\for\\server\\api",
+		},
+		PollInterval: defaultPollInterval,
+	}
+)
+
+func parseConfigCasesOS() []parseConfigCase {
+	return []parseConfigCase{
+		{
+			name: "no domain configured",
+			in: `
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			err: "at least one domain must be configured",
+		},
+		{
+			name: "no ACME configuration",
+			in: `
+				domains = ["domain.test"]
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}					
+				}
+			`,
+			err: "either acme or listen_named_pipe_name must be configured",
+		},
+		{
+			name: "ACME ToS not accepted",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			err: "tos_accepted must be set to true in the acme configuration section",
+		},
+		{
+			name: "ACME email not configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			err: "email must be configured in the acme configuration section",
+		},
+		{
+			name: "ACME overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					tos_accepted = true
+					cache_dir = ""
+					directory_url = "https://directory.test"
+					email = "admin@domain.test"
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:     "",
+					Email:        "admin@domain.test",
+					DirectoryURL: "https://directory.test",
+					RawCacheDir:  stringPtr(""),
+					ToSAccepted:  true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Experimental: experimentalServerAPIConfig{
+						NamedPipeName: "\\name\\for\\server\\api",
+					},
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "both acme and insecure_addr configured",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			err: "insecure_addr and the acme section are mutually exclusive",
+		},
+		{
+			name: "both acme and listen_named_pipe_name configured",
+			in: `
+				domains = ["domain.test"]
+				experimental {
+					listen_named_pipe_name = "test"
+				}
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_named_pipe_name and the acme section are mutually exclusive",
+		},
+		{
+			name: "both insecure_addr and listen_named_pipe_name configured",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				experimental {
+					listen_named_pipe_name = "test"
+				}
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "insecure_addr and listen_named_pipe_name are mutually exclusive",
+		},
+		{
+			name: "with insecure addr and key use",
+			in: `
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+				set_key_use = true
+			`,
+			out: &Config{
+				LogLevel:     defaultLogLevel,
+				Domains:      []string{"domain.test"},
+				InsecureAddr: ":8080",
+				ServerAPI: &ServerAPIConfig{
+					Experimental: experimentalServerAPIConfig{
+						NamedPipeName: "\\name\\for\\server\\api",
+					},
+					PollInterval: defaultPollInterval,
+				},
+				SetKeyUse: true,
+			},
+		},
+		{
+			name: "with listen_named_pipe_name",
+			in: `
+				domains = ["domain.test"]
+				experimental {
+					listen_named_pipe_name = "\\name\\for\\listener"
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				Experimental: experimentalConfig{
+					ListenNamedPipeName: "\\name\\for\\listener",
+				},
+				ServerAPI: &ServerAPIConfig{
+					Experimental: experimentalServerAPIConfig{
+						NamedPipeName: "\\name\\for\\server\\api",
+					},
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "more than one source section configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+				}
+				workload_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\workload\\api"
+					}
+					trust_domain="foo.test"
+			}
+			`,
+			err: "the server_api and workload_api sections are mutually exclusive",
+		},
+		{
+			name: "minimal server API config",
+			in:   minimalServerAPIConfig,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Experimental: experimentalServerAPIConfig{
+						NamedPipeName: "\\name\\for\\server\\api",
+					},
+					PollInterval: defaultPollInterval,
+				},
+			},
+		},
+		{
+			name: "server API config overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+					poll_interval = "1h"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				ServerAPI: &ServerAPIConfig{
+					Experimental: experimentalServerAPIConfig{
+						NamedPipeName: "\\name\\for\\server\\api",
+					},
+					PollInterval:    time.Hour,
+					RawPollInterval: "1h",
+				},
+			},
+		},
+		{
+			name: "server API config missing address",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+				}
+			`,
+			err: "named_pipe_name must be configured in the server_api configuration section",
+		},
+		{
+			name: "server API config invalid poll interval",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				server_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\server\\api"
+					}
+					poll_interval = "huh"
+				}
+			`,
+			err: "invalid poll_interval in the server_api configuration section: time: invalid duration \"huh\"",
+		},
+		{
+			name: "minimal workload API config",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\workload\\api"
+					}
+					trust_domain = "domain.test"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				WorkloadAPI: &WorkloadAPIConfig{
+					Experimental: experimentalWorkloadAPIConfig{
+						NamedPipeName: "\\name\\for\\workload\\api",
+					},
+					PollInterval: defaultPollInterval,
+					TrustDomain:  "domain.test",
+				},
+			},
+		},
+		{
+			name: "workload API config overrides",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\workload\\api"
+					}
+					poll_interval = "1h"
+					trust_domain = "foo.test"
+				}
+			`,
+			out: &Config{
+				LogLevel: defaultLogLevel,
+				Domains:  []string{"domain.test"},
+				ACME: &ACMEConfig{
+					CacheDir:    defaultCacheDir,
+					Email:       "admin@domain.test",
+					ToSAccepted: true,
+				},
+				WorkloadAPI: &WorkloadAPIConfig{
+					Experimental: experimentalWorkloadAPIConfig{
+						NamedPipeName: "\\name\\for\\workload\\api",
+					},
+					PollInterval:    time.Hour,
+					RawPollInterval: "1h",
+					TrustDomain:     "foo.test",
+				},
+			},
+		},
+		{
+			name: "workload API config missing named pipe name",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					trust_domain = "domain.test"
+				}
+			`,
+			err: "named_pipe_name must be configured in the workload_api configuration section",
+		},
+		{
+			name: "workload API config invalid poll interval",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\workload\\api"
+					}
+					poll_interval = "huh"
+					trust_domain = "domain.test"
+				}
+			`,
+			err: "invalid poll_interval in the workload_api configuration section: time: invalid duration \"huh\"",
+		},
+		{
+			name: "workload API config missing trust domain",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				workload_api {
+					experimental {
+						named_pipe_name = "\\name\\for\\workload\\api"
+					}					
+				}
+			`,
+			err: "trust_domain must be configured in the workload_api configuration section",
+		},
+	}
+}

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/log"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/zeebo/errs"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
@@ -64,19 +65,15 @@ func run(configPath string) error {
 			return err
 		}
 		log.WithField("address", config.InsecureAddr).Warn("Serving HTTP (insecure)")
-	case config.ListenSocketPath != "":
-		_ = os.Remove(config.ListenSocketPath)
-
-		listener, err = net.Listen("unix", config.ListenSocketPath)
+	case config.ListenSocketPath != "" || config.Experimental.ListenNamedPipeName != "":
+		listener, err = listenLocal(config)
 		if err != nil {
 			return err
 		}
-
-		if err := os.Chmod(config.ListenSocketPath, os.ModePerm); err != nil {
-			return err
-		}
-
-		log.WithField("socket", config.ListenSocketPath).Info("Serving HTTP (unix)")
+		log.WithFields(logrus.Fields{
+			telemetry.Network: listener.Addr().Network(),
+			telemetry.Address: listener.Addr().String(),
+		}).Info("Serving HTTP")
 	default:
 		listener = acmeListener(log, config)
 		log.Info("Serving HTTPS via ACME")
@@ -95,13 +92,17 @@ func newSource(log logrus.FieldLogger, config *Config) (JWKSSource, error) {
 	case config.ServerAPI != nil:
 		return NewServerAPISource(ServerAPISourceConfig{
 			Log:          log,
-			Address:      config.ServerAPI.Address,
+			GRPCTarget:   config.getServerAPITargetName(),
 			PollInterval: config.ServerAPI.PollInterval,
 		})
 	case config.WorkloadAPI != nil:
+		workloadAPIAddr, err := config.getWorkloadAPIAddr()
+		if err != nil {
+			return nil, errs.New(err.Error())
+		}
 		return NewWorkloadAPISource(WorkloadAPISourceConfig{
 			Log:          log,
-			SocketPath:   config.WorkloadAPI.SocketPath,
+			Addr:         workloadAPIAddr,
 			PollInterval: config.WorkloadAPI.PollInterval,
 			TrustDomain:  config.WorkloadAPI.TrustDomain,
 		})

--- a/support/oidc-discovery-provider/main_posix.go
+++ b/support/oidc-discovery-provider/main_posix.go
@@ -1,0 +1,68 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"net"
+	"os"
+	"strings"
+
+	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/zeebo/errs"
+)
+
+func (c *Config) getWorkloadAPIAddr() (net.Addr, error) {
+	return util.GetUnixAddrWithAbsPath(c.WorkloadAPI.SocketPath)
+}
+
+func (c *Config) getServerAPITargetName() string {
+	return c.ServerAPI.Address
+}
+
+// validateOS performs os specific validations of the configuration
+func (c *Config) validateOS() (err error) {
+	switch {
+	case c.ACME == nil:
+		if c.InsecureAddr == "" && c.ListenSocketPath == "" {
+			return errs.New("either acme or listen_socket_path must be configured")
+		}
+		if c.InsecureAddr != "" && c.ListenSocketPath != "" {
+			return errs.New("insecure_addr and listen_socket_path are mutually exclusive")
+		}
+	case c.ListenSocketPath != "":
+		return errs.New("listen_socket_path and the acme section are mutually exclusive")
+	}
+
+	if c.ServerAPI != nil {
+		if c.ServerAPI.Address == "" {
+			return errs.New("address must be configured in the server_api configuration section")
+		}
+		if !strings.HasPrefix(c.ServerAPI.Address, "unix:") {
+			return errs.New("address must use the unix name system in the server_api configuration section")
+		}
+	}
+
+	if c.WorkloadAPI != nil {
+		if c.WorkloadAPI.SocketPath == "" {
+			return errs.New("socket_path must be configured in the workload_api configuration section")
+		}
+	}
+
+	return nil
+}
+
+func listenLocal(c *Config) (net.Listener, error) {
+	_ = os.Remove(c.ListenSocketPath)
+
+	listener, err := net.Listen("unix", c.ListenSocketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Chmod(c.ListenSocketPath, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	return listener, nil
+}

--- a/support/oidc-discovery-provider/main_windows.go
+++ b/support/oidc-discovery-provider/main_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/zeebo/errs"
+)
+
+func (c *Config) getWorkloadAPIAddr() (net.Addr, error) {
+	return util.GetNamedPipeAddr(c.WorkloadAPI.Experimental.NamedPipeName), nil
+}
+
+func (c *Config) getServerAPITargetName() string {
+	return fmt.Sprintf(`\\.\%s`, filepath.Join("pipe", c.ServerAPI.Experimental.NamedPipeName))
+}
+
+// validateOS performs os specific validations of the configuration
+func (c *Config) validateOS() (err error) {
+	switch {
+	case c.ACME == nil:
+		if c.InsecureAddr == "" && c.Experimental.ListenNamedPipeName == "" {
+			return errs.New("either acme or listen_named_pipe_name must be configured")
+		}
+		if c.InsecureAddr != "" && c.Experimental.ListenNamedPipeName != "" {
+			return errs.New("insecure_addr and listen_named_pipe_name are mutually exclusive")
+		}
+	case c.Experimental.ListenNamedPipeName != "":
+		return errs.New("listen_named_pipe_name and the acme section are mutually exclusive")
+	}
+
+	if c.ServerAPI != nil {
+		if c.ServerAPI.Experimental.NamedPipeName == "" {
+			return errs.New("named_pipe_name must be configured in the server_api configuration section")
+		}
+	}
+
+	if c.WorkloadAPI != nil {
+		if c.WorkloadAPI.Experimental.NamedPipeName == "" {
+			return errs.New("named_pipe_name must be configured in the workload_api configuration section")
+		}
+	}
+
+	return nil
+}
+
+func listenLocal(c *Config) (net.Listener, error) {
+	return winio.ListenPipe(util.GetNamedPipeAddr(c.Experimental.ListenNamedPipeName).String(),
+		&winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+}

--- a/support/oidc-discovery-provider/server_api.go
+++ b/support/oidc-discovery-provider/server_api.go
@@ -10,9 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/zeebo/errs"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/square/go-jose.v2"
 )
@@ -23,7 +23,7 @@ const (
 
 type ServerAPISourceConfig struct {
 	Log          logrus.FieldLogger
-	Address      string
+	GRPCTarget   string
 	PollInterval time.Duration
 	Clock        clock.Clock
 }
@@ -48,7 +48,7 @@ func NewServerAPISource(config ServerAPISourceConfig) (*ServerAPISource, error) 
 		config.Clock = clock.New()
 	}
 
-	conn, err := grpc.Dial(config.Address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := util.GRPCDialContext(context.Background(), config.GRPCTarget)
 	if err != nil {
 		return nil, errs.Wrap(err)
 	}

--- a/support/oidc-discovery-provider/server_api_test.go
+++ b/support/oidc-discovery-provider/server_api_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -19,25 +19,22 @@ import (
 )
 
 func TestServerAPISource(t *testing.T) {
-	// TODO: workload source is not supported on windows until we solve workload API
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
-
 	const pollInterval = time.Second
 
 	api := &fakeServerAPIServer{}
 
-	socketPath := spiretest.StartGRPCServer(t, func(s *grpc.Server) {
+	addr := spiretest.StartGRPCServer(t, func(s *grpc.Server) {
 		bundlev1.RegisterBundleServer(s, api)
 	})
 
 	log, _ := test.NewNullLogger()
 	clock := clock.NewMock(t)
 
+	target, err := util.GetTargetName(addr)
+	require.NoError(t, err)
 	source, err := NewServerAPISource(ServerAPISourceConfig{
 		Log:          log,
-		Address:      "unix://" + socketPath.String(),
+		GRPCTarget:   target,
 		PollInterval: pollInterval,
 		Clock:        clock,
 	})

--- a/support/oidc-discovery-provider/workload_api_posix_test.go
+++ b/support/oidc-discovery-provider/workload_api_posix_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+// +build !windows
+
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/spire/test/spiretest"
+)
+
+func startWorkloadAPI(t *testing.T, server workload.SpiffeWorkloadAPIServer) net.Addr {
+	return spiretest.StartWorkloadAPI(t, server)
+}

--- a/support/oidc-discovery-provider/workload_api_test.go
+++ b/support/oidc-discovery-provider/workload_api_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"net"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -11,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	"github.com/spiffe/spire/test/clock"
-	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -19,22 +16,17 @@ import (
 )
 
 func TestWorkloadAPISource(t *testing.T) {
-	// TODO: workload source is not supported on windows until we solve workload API
-	if runtime.GOOS == "windows" {
-		t.Skip()
-	}
 	const pollInterval = time.Second
 
 	api := &fakeWorkloadAPIServer{}
 
-	socketPath := spiretest.StartWorkloadAPI(t, api).(*net.UnixAddr).Name
-
+	addr := startWorkloadAPI(t, api)
 	log, _ := test.NewNullLogger()
 	clock := clock.NewMock(t)
 
 	source, err := NewWorkloadAPISource(WorkloadAPISourceConfig{
 		Log:          log,
-		SocketPath:   socketPath,
+		Addr:         addr,
 		TrustDomain:  "domain.test",
 		PollInterval: pollInterval,
 		Clock:        clock,

--- a/support/oidc-discovery-provider/workload_api_windows_test.go
+++ b/support/oidc-discovery-provider/workload_api_windows_test.go
@@ -1,0 +1,17 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/test/spiretest"
+)
+
+func startWorkloadAPI(t *testing.T, server workload.SpiffeWorkloadAPIServer) net.Addr {
+	return util.GetNamedPipeAddr(util.GetPipeName(spiretest.StartWorkloadAPI(t, server).String()))
+}


### PR DESCRIPTION
This PR makes the necessary changes to be able to run the SPIRE  OIDC Discovery Provider on Windows.
Connection to the Workload API and Server APIs are done over named pipes. Also, the listener listens in a named pipe in Windows instead of using a UDS.

Fixes #2824.