### PR TITLE
Add option to disable Envoy SDS custom validation

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -40,11 +40,12 @@ const (
 	defaultConfigPath = "conf/agent/agent.conf"
 
 	// TODO: Make my defaults sane
-	defaultDataDir               = "."
-	defaultLogLevel              = "INFO"
-	defaultDefaultSVIDName       = "default"
-	defaultDefaultBundleName     = "ROOTCA"
-	defaultDefaultAllBundlesName = "ALL"
+	defaultDataDir                 = "."
+	defaultLogLevel                = "INFO"
+	defaultDefaultSVIDName         = "default"
+	defaultDefaultBundleName       = "ROOTCA"
+	defaultDefaultAllBundlesName   = "ALL"
+	defaultDisableCustomValidation = false
 )
 
 // Config contains all available configurables, arranged by section
@@ -90,9 +91,10 @@ type agentConfig struct {
 }
 
 type sdsConfig struct {
-	DefaultSVIDName       string `hcl:"default_svid_name"`
-	DefaultBundleName     string `hcl:"default_bundle_name"`
-	DefaultAllBundlesName string `hcl:"default_all_bundles_name"`
+	DefaultSVIDName         string `hcl:"default_svid_name"`
+	DefaultBundleName       string `hcl:"default_bundle_name"`
+	DefaultAllBundlesName   string `hcl:"default_all_bundles_name"`
+	DisableCustomValidation bool   `hcl:"disable_custom_validation"`
 }
 
 type experimentalConfig struct {
@@ -582,9 +584,10 @@ func defaultConfig() *Config {
 			LogLevel:  defaultLogLevel,
 			LogFormat: log.DefaultFormat,
 			SDS: sdsConfig{
-				DefaultBundleName:     defaultDefaultBundleName,
-				DefaultSVIDName:       defaultDefaultSVIDName,
-				DefaultAllBundlesName: defaultDefaultAllBundlesName,
+				DefaultBundleName:       defaultDefaultBundleName,
+				DefaultSVIDName:         defaultDefaultSVIDName,
+				DefaultAllBundlesName:   defaultDefaultAllBundlesName,
+				DisableCustomValidation: defaultDisableCustomValidation,
 			},
 		},
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -194,6 +194,26 @@ func TestMergeInput(t *testing.T) {
 			},
 		},
 		{
+			msg:       "disable_custom_validation should default value of false",
+			fileInput: func(c *Config) {},
+			cliInput:  func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, false, c.Agent.SDS.DisableCustomValidation)
+			},
+		},
+		{
+			msg: "disable_custom_validation should be configurable by file",
+			fileInput: func(c *Config) {
+				c.Agent.SDS = sdsConfig{
+					DisableCustomValidation: true,
+				}
+			},
+			cliInput: func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, true, c.Agent.SDS.DisableCustomValidation)
+			},
+		},
+		{
 			msg: "insecure_bootstrap should be configurable by file",
 			fileInput: func(c *Config) {
 				c.Agent.InsecureBootstrap = true

--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -78,6 +78,9 @@ agent {
     #     # all bundles (including federated bundles) with Envoy SDS. Cannot be used with
     #     # Envoy releases prior to 1.18.
     #     # default_all_bundles_name = "ALL"
+    
+    #     # disable_custom_validation: disable Envoy SDS custom SPIFFE validation. Default: false
+    #     # disable_custom_validation = false
     # }
     
     # allowed_foreign_jwt_claims: set a list of trusted claims to be returned when validating foreign JWTSVIDs

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -80,11 +80,12 @@ Only one of these three options may be set at a time.
 
 ### SDS Configuration
 
-| Configuration              | Description                                                                                      | Default           |
-| -------------------------- | ------------------------------------------------------------------------------------------------ | ----------------- |
-| `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS                | default           |
-| `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS          | ROOTCA            |
-| `default_all_bundles_name` | The Validation Context resource name to use for all bundles (including federated) with Envoy SDS | ALL               |
+| Configuration               | Description                                                                                      | Default           |
+| --------------------------- | ------------------------------------------------------------------------------------------------ | ----------------- |
+| `default_svid_name`         | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS                | default           |
+| `default_bundle_name`       | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS          | ROOTCA            |
+| `default_all_bundles_name`  | The Validation Context resource name to use for all bundles (including federated) with Envoy SDS | ALL               |
+| `disable_custom_validation` | Disable Envoy SDS custom validation                                                              | false             |
 
 ### Profiling Names
 These are the available profiles that can be set in the `profiling_freq` configuration value:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -252,6 +252,7 @@ func (a *Agent) newEndpoints(metrics telemetry.Metrics, mgr manager.Manager, att
 		DefaultSVIDName:               a.c.DefaultSVIDName,
 		DefaultBundleName:             a.c.DefaultBundleName,
 		DefaultAllBundlesName:         a.c.DefaultAllBundlesName,
+		DisableCustomValidation:       a.c.DisableCustomValidation,
 		AllowUnauthenticatedVerifiers: a.c.AllowUnauthenticatedVerifiers,
 		AllowedForeignJWTClaims:       a.c.AllowedForeignJWTClaims,
 		TrustDomain:                   a.c.TrustDomain,

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 
+	// Disable custom Envoy SDS validator
+	DisableCustomValidation bool
+
 	// The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS
 	DefaultSVIDName string
 

--- a/pkg/agent/endpoints/config.go
+++ b/pkg/agent/endpoints/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 
+	// Disable custom Envoy SDS validator
+	DisableCustomValidation bool
+
 	AllowUnauthenticatedVerifiers bool
 
 	AllowedForeignJWTClaims []string

--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -84,11 +84,12 @@ func New(c Config) *Endpoints {
 	})
 
 	sdsv3Server := c.newSDSv3Server(sdsv3.Config{
-		Attestor:              attestor,
-		Manager:               c.Manager,
-		DefaultSVIDName:       c.DefaultSVIDName,
-		DefaultBundleName:     c.DefaultBundleName,
-		DefaultAllBundlesName: c.DefaultAllBundlesName,
+		Attestor:                attestor,
+		Manager:                 c.Manager,
+		DefaultSVIDName:         c.DefaultSVIDName,
+		DefaultBundleName:       c.DefaultBundleName,
+		DefaultAllBundlesName:   c.DefaultAllBundlesName,
+		DisableCustomValidation: c.DisableCustomValidation,
 	})
 
 	healthServer := c.newHealthServer(healthv1.Config{

--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -166,6 +166,7 @@ func TestEndpoints(t *testing.T) {
 				DefaultSVIDName:         "DefaultSVIDName",
 				DefaultBundleName:       "DefaultBundleName",
 				DefaultAllBundlesName:   "DefaultAllBundlesName",
+				DisableCustomValidation: true,
 				AllowedForeignJWTClaims: tt.allowedClaims,
 
 				// Assert the provided config and return a fake Workload API server
@@ -199,6 +200,7 @@ func TestEndpoints(t *testing.T) {
 					assert.Equal(t, "DefaultSVIDName", c.DefaultSVIDName)
 					assert.Equal(t, "DefaultBundleName", c.DefaultBundleName)
 					assert.Equal(t, "DefaultAllBundlesName", c.DefaultAllBundlesName)
+					assert.Equal(t, true, c.DisableCustomValidation)
 					return FakeSDSv3Server{Attestor: attestor}
 				},
 

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -38,11 +38,12 @@ type Manager interface {
 }
 
 type Config struct {
-	Attestor              Attestor
-	Manager               Manager
-	DefaultAllBundlesName string
-	DefaultBundleName     string
-	DefaultSVIDName       string
+	Attestor                Attestor
+	Manager                 Manager
+	DefaultAllBundlesName   string
+	DefaultBundleName       string
+	DefaultSVIDName         string
+	DisableCustomValidation bool
 }
 
 type Handler struct {
@@ -250,7 +251,7 @@ func (h *Handler) buildResponse(versionInfo string, req *discovery_v3.DiscoveryR
 
 	// Use RootCA as default, but replace with SPIFFE auth when Envoy version is at least v1.18.0
 	var builder validationContextBuilder
-	if supportsSPIFFEAuthExtension(req) {
+	if !h.c.DisableCustomValidation && supportsSPIFFEAuthExtension(req) {
 		builder, err = newSpiffeBuilder(upd.Bundle, upd.FederatedBundles)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Description of change**
Added option `disable_custom_validation` to disable Envoy SDS custom validation so you will be able to get old behaviour for Envoy with version >1.17

**Which issue this PR fixes**
fixes #3001

