### PR TITLE
Windows support: make the Workload API listener publicly available

### DIFF
--- a/pkg/agent/api/endpoints_windows.go
+++ b/pkg/agent/api/endpoints_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (e *Endpoints) createListener() (net.Listener, error) {
-	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
 	if err != nil {
 		return nil, fmt.Errorf("error creating named pipe listener: %w", err)
 	}

--- a/pkg/agent/endpoints/endpoints_windows.go
+++ b/pkg/agent/endpoints/endpoints_windows.go
@@ -7,14 +7,16 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/Microsoft/go-winio"
 	"github.com/spiffe/spire/pkg/common/peertracker"
+	"github.com/spiffe/spire/pkg/common/util"
 )
 
 func (e *Endpoints) createPipeListener() (net.Listener, error) {
 	pipeListener := &peertracker.ListenerFactory{
 		Log: e.log,
 	}
-	l, err := pipeListener.ListenPipe(e.addr.String(), nil)
+	l, err := pipeListener.ListenPipe(e.addr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPublicListener})
 	if err != nil {
 		return nil, fmt.Errorf("create named pipe listener: %w", err)
 	}

--- a/pkg/common/util/addr_windows.go
+++ b/pkg/common/util/addr_windows.go
@@ -18,13 +18,22 @@ import (
 )
 
 const (
-	// SDDLSecureListener describes a security descriptor using the
+	// SDDLPrivateListener describes a security descriptor using the
 	// security descriptor definition language (SDDL) that is meant
 	// to be used to define the access control to named pipes
 	// listeners that only need to be accessed locally by the owner
 	// of the service, granting read, write and execute permissions
 	// to the creator owner only.
-	SDDLSecureListener = "D:P(A;;GRGWGX;;;OW)"
+	// E.g.: SPIRE Server APIs, Admin APIs.
+	SDDLPrivateListener = "D:P(A;;GRGWGX;;;OW)"
+
+	// SDDLPublicListener describes a security descriptor using the
+	// security descriptor definition language (SDDL) that is meant
+	// to be used to define the access control to named pipes
+	// listeners that need to be publicly accessed, granting read,
+	// write and execute permissions to everyone.
+	// E.g.: SPIFFE Workload API.
+	SDDLPublicListener = "D:P(A;;GRGWGX;;;WD)"
 )
 
 type NamedPipeAddr struct {

--- a/pkg/server/endpoints/endpoints_windows.go
+++ b/pkg/server/endpoints/endpoints_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (e *Endpoints) listen() (net.Listener, error) {
-	return winio.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+	return winio.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
 }
 
 func (e *Endpoints) listenWithAuditLog() (*peertracker.Listener, error) {
@@ -20,7 +20,7 @@ func (e *Endpoints) listenWithAuditLog() (*peertracker.Listener, error) {
 		Log: e.Log,
 	}
 
-	return lf.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+	return lf.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
 }
 
 func (e *Endpoints) restrictLocalAddr() error {

--- a/support/oidc-discovery-provider/main_windows.go
+++ b/support/oidc-discovery-provider/main_windows.go
@@ -52,5 +52,5 @@ func (c *Config) validateOS() (err error) {
 
 func listenLocal(c *Config) (net.Listener, error) {
 	return winio.ListenPipe(util.GetNamedPipeAddr(c.Experimental.ListenNamedPipeName).String(),
-		&winio.PipeConfig{SecurityDescriptor: util.SDDLSecureListener})
+		&winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
 }


### PR DESCRIPTION
The security descriptor associated with the named pipe listener for the Workload API had the default security descriptor.
The ACLs in the default security descriptor for a named pipe grant full control to the LocalSystem account, administrators, and the creator owner. And they only grant read access to members of the Everyone group and the anonymous account.

Everyone should have read, write and execute permissions over the Workload API. This PR updates the configuration of the Workload API listener to set that.