### PR TITLE
Prepare v1.1.5 release

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -38,11 +38,12 @@ const (
 	defaultConfigPath = "conf/agent/agent.conf"
 
 	// TODO: Make my defaults sane
-	defaultDataDir               = "."
-	defaultLogLevel              = "INFO"
-	defaultDefaultSVIDName       = "default"
-	defaultDefaultBundleName     = "ROOTCA"
-	defaultDefaultAllBundlesName = "ALL"
+	defaultDataDir                     = "."
+	defaultLogLevel                    = "INFO"
+	defaultDefaultSVIDName             = "default"
+	defaultDefaultBundleName           = "ROOTCA"
+	defaultDefaultAllBundlesName       = "ALL"
+	defaultDisableSPIFFECertValidation = false
 )
 
 // Config contains all available configurables, arranged by section
@@ -88,9 +89,10 @@ type agentConfig struct {
 }
 
 type sdsConfig struct {
-	DefaultSVIDName       string `hcl:"default_svid_name"`
-	DefaultBundleName     string `hcl:"default_bundle_name"`
-	DefaultAllBundlesName string `hcl:"default_all_bundles_name"`
+	DefaultSVIDName             string `hcl:"default_svid_name"`
+	DefaultBundleName           string `hcl:"default_bundle_name"`
+	DefaultAllBundlesName       string `hcl:"default_all_bundles_name"`
+	DisableSPIFFECertValidation bool   `hcl:"disable_spiffe_cert_validation"`
 }
 
 type experimentalConfig struct {
@@ -556,9 +558,10 @@ func defaultConfig() *Config {
 			LogFormat:  log.DefaultFormat,
 			SocketPath: common.DefaultSocketPath,
 			SDS: sdsConfig{
-				DefaultBundleName:     defaultDefaultBundleName,
-				DefaultSVIDName:       defaultDefaultSVIDName,
-				DefaultAllBundlesName: defaultDefaultAllBundlesName,
+				DefaultBundleName:           defaultDefaultBundleName,
+				DefaultSVIDName:             defaultDefaultSVIDName,
+				DefaultAllBundlesName:       defaultDefaultAllBundlesName,
+				DisableSPIFFECertValidation: defaultDisableSPIFFECertValidation,
 			},
 		},
 	}

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -257,6 +257,26 @@ func TestMergeInput(t *testing.T) {
 			},
 		},
 		{
+			msg:       "disable_custom_validation should default value of false",
+			fileInput: func(c *Config) {},
+			cliInput:  func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, false, c.Agent.SDS.DisableSPIFFECertValidation)
+			},
+		},
+		{
+			msg: "disable_custom_validation should be configurable by file",
+			fileInput: func(c *Config) {
+				c.Agent.SDS = sdsConfig{
+					DisableSPIFFECertValidation: true,
+				}
+			},
+			cliInput: func(ac *agentConfig) {},
+			test: func(t *testing.T, c *Config) {
+				require.Equal(t, true, c.Agent.SDS.DisableSPIFFECertValidation)
+			},
+		},
+		{
 			msg: "insecure_bootstrap should be configurable by file",
 			fileInput: func(c *Config) {
 				c.Agent.InsecureBootstrap = true

--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -63,6 +63,9 @@ agent {
     #     # all bundles (including federated bundles) with Envoy SDS. Cannot be used with
     #     # Envoy releases prior to 1.18.
     #     # default_all_bundles_name = "ALL"
+    
+    #     # disable_spiffe_cert_validation: disable Envoy SDS custom SPIFFE validation. Default: false
+    #     # disable_spiffe_cert_validation = false
     # }
     
     # allowed_foreign_jwt_claims: set a list of trusted claims to be returned when validating foreign JWTSVIDs

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -316,7 +316,7 @@ support for the [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/en
 extension, which is only available starting with Envoy 1.18.
 The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration).
 
-The [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) configures Envoy to perform SPIFFE authentication. It is used by default but can be disabled by setting `disable_spiffe_cert_validation` to `true` in [SDS Configuration](#sds-configuration). Alternatively, to disable for an individual envoy instance, the `disable_spiffe_cert_validation` key can be configured and set to `true` in the Envoy node metadata. When used, Envoy will perform standard X.509 certificate chain validation. 
+The [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) configures Envoy to perform SPIFFE authentication. The validation context returned by SPIRE Agent contains this extension by default. However, if standard X.509 chain validation is desired, SPIRE Agent can be configured to omit the extension. The default behavior can be changed by configuring `disable_spiffe_cert_validation` in [SDS Configuration](#sds-configuration). Individual Envoy instances can also override the default behavior by configuring setting a `disable_spiffe_cert_validation` key in the Envoy node metadata.
 
 ## OpenShift Support
 

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -316,6 +316,8 @@ support for the [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/en
 extension, which is only available starting with Envoy 1.18.
 The default name is configurable (see `default_all_bundles_name` under [SDS Configuration](#sds-configuration).
 
+The [SPIFFE Certificate Validator](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls_spiffe_validator_config.proto) configures Envoy to perform SPIFFE authentication. It is used by default but can be disabled by setting `disable_spiffe_cert_validation` to `true` in [SDS Configuration](#sds-configuration). Alternatively, to disable for an individual envoy instance, the `disable_spiffe_cert_validation` key can be configured and set to `true` in the Envoy node metadata. When used, Envoy will perform standard X.509 certificate chain validation. 
+
 ## OpenShift Support
 
 The default security profile of [OpenShift](https://www.openshift.com/products/container-platform) forbids access to host level resources. A custom set of policies can be applied to enable the level of access needed by Spire to operate within OpenShift.

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -75,11 +75,12 @@ Only one of these three options may be set at a time.
 
 ### SDS Configuration
 
-| Configuration              | Description                                                                                      | Default           |
-| -------------------------- | ------------------------------------------------------------------------------------------------ | ----------------- |
-| `default_svid_name`        | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS                | default           |
-| `default_bundle_name`      | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS          | ROOTCA            |
-| `default_all_bundles_name` | The Validation Context resource name to use for all bundles (including federated) with Envoy SDS | ALL               |
+| Configuration                    | Description                                                                                      | Default           |
+| -------------------------------- | ------------------------------------------------------------------------------------------------ | ----------------- |
+| `default_svid_name`              | The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS                | default           |
+| `default_bundle_name`            | The Validation Context resource name to use for the default X.509 bundle with Envoy SDS          | ROOTCA            |
+| `default_all_bundles_name`       | The Validation Context resource name to use for all bundles (including federated) with Envoy SDS | ALL               |
+| `disable_spiffe_cert_validation` | Disable Envoy SDS custom validation                                                              | false             |
 
 ### Profiling Names
 These are the available profiles that can be set in the `profiling_freq` configuration value:

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -249,6 +249,7 @@ func (a *Agent) newEndpoints(metrics telemetry.Metrics, mgr manager.Manager, att
 		DefaultSVIDName:               a.c.DefaultSVIDName,
 		DefaultBundleName:             a.c.DefaultBundleName,
 		DefaultAllBundlesName:         a.c.DefaultAllBundlesName,
+		DisableSPIFFECertValidation:   a.c.DisableSPIFFECertValidation,
 		AllowUnauthenticatedVerifiers: a.c.AllowUnauthenticatedVerifiers,
 		AllowedForeignJWTClaims:       a.c.AllowedForeignJWTClaims,
 		TrustDomain:                   a.c.TrustDomain,

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -28,6 +28,9 @@ type Config struct {
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 
+	// Disable custom Envoy SDS validator
+	DisableSPIFFECertValidation bool
+
 	// The TLS Certificate resource name to use for the default X509-SVID with Envoy SDS
 	DefaultSVIDName string
 

--- a/pkg/agent/endpoints/config.go
+++ b/pkg/agent/endpoints/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// The Validation Context resource name to use for the default X.509 bundle with Envoy SDS
 	DefaultBundleName string
 
+	// Disable custom Envoy SDS validator
+	DisableSPIFFECertValidation bool
+
 	AllowUnauthenticatedVerifiers bool
 
 	AllowedForeignJWTClaims []string

--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -81,11 +81,12 @@ func New(c Config) *Endpoints {
 	})
 
 	sdsv3Server := c.newSDSv3Server(sdsv3.Config{
-		Attestor:              attestor,
-		Manager:               c.Manager,
-		DefaultSVIDName:       c.DefaultSVIDName,
-		DefaultBundleName:     c.DefaultBundleName,
-		DefaultAllBundlesName: c.DefaultAllBundlesName,
+		Attestor:                    attestor,
+		Manager:                     c.Manager,
+		DefaultSVIDName:             c.DefaultSVIDName,
+		DefaultBundleName:           c.DefaultBundleName,
+		DefaultAllBundlesName:       c.DefaultAllBundlesName,
+		DisableSPIFFECertValidation: c.DisableSPIFFECertValidation,
 	})
 
 	healthServer := c.newHealthServer(healthv1.Config{

--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -166,14 +166,15 @@ func TestEndpoints(t *testing.T) {
 					Net:  "unix",
 					Name: udsPath,
 				},
-				Log:                     log,
-				Metrics:                 metrics,
-				Attestor:                FakeAttestor{},
-				Manager:                 FakeManager{},
-				DefaultSVIDName:         "DefaultSVIDName",
-				DefaultBundleName:       "DefaultBundleName",
-				DefaultAllBundlesName:   "DefaultAllBundlesName",
-				AllowedForeignJWTClaims: tt.allowedClaims,
+				Log:                         log,
+				Metrics:                     metrics,
+				Attestor:                    FakeAttestor{},
+				Manager:                     FakeManager{},
+				DefaultSVIDName:             "DefaultSVIDName",
+				DefaultBundleName:           "DefaultBundleName",
+				DefaultAllBundlesName:       "DefaultAllBundlesName",
+				DisableSPIFFECertValidation: true,
+				AllowedForeignJWTClaims:     tt.allowedClaims,
 
 				// Assert the provided config and return a fake Workload API server
 				newWorkloadAPIServer: func(c workload.Config) workload_pb.SpiffeWorkloadAPIServer {
@@ -206,6 +207,7 @@ func TestEndpoints(t *testing.T) {
 					assert.Equal(t, "DefaultSVIDName", c.DefaultSVIDName)
 					assert.Equal(t, "DefaultBundleName", c.DefaultBundleName)
 					assert.Equal(t, "DefaultAllBundlesName", c.DefaultAllBundlesName)
+					assert.Equal(t, true, c.DisableSPIFFECertValidation)
 					return FakeSDSv3Server{Attestor: attestor}
 				},
 

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -38,11 +38,12 @@ type Manager interface {
 }
 
 type Config struct {
-	Attestor              Attestor
-	Manager               Manager
-	DefaultAllBundlesName string
-	DefaultBundleName     string
-	DefaultSVIDName       string
+	Attestor                    Attestor
+	Manager                     Manager
+	DefaultAllBundlesName       string
+	DefaultBundleName           string
+	DefaultSVIDName             string
+	DisableSPIFFECertValidation bool
 }
 
 type Handler struct {
@@ -250,7 +251,7 @@ func (h *Handler) buildResponse(versionInfo string, req *discovery_v3.DiscoveryR
 
 	// Use RootCA as default, but replace with SPIFFE auth when Envoy version is at least v1.18.0
 	var builder validationContextBuilder
-	if supportsSPIFFEAuthExtension(req) {
+	if !h.c.DisableSPIFFECertValidation && supportsSPIFFEAuthExtension(req) {
 		builder, err = newSpiffeBuilder(upd.Bundle, upd.FederatedBundles)
 		if err != nil {
 			return nil, err

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var (
@@ -470,6 +471,66 @@ func TestStreamSecrets(t *testing.T) {
 			},
 			expectSecrets: []*tls_v3.Secret{tdValidationContext3},
 		},
+		{
+			name: "Disable custom validation per instance",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewBoolValue(true),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable SPIFFE cert validation per instance with string value",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewStringValue("true"),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable SPIFFE cert validation set to false per instance",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewBoolValue(false),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
+		},
+		{
+			name: "Disable SPIFFE cert validation set unknown string value",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewStringValue("test"),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupTestWithConfig(t, tt.config)
@@ -852,6 +913,66 @@ func TestFetchSecrets(t *testing.T) {
 				DisableSPIFFECertValidation: true,
 			},
 			expectSecrets: []*tls_v3.Secret{tdValidationContext3},
+		},
+		{
+			name: "Disable custom validation per instance",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewBoolValue(true),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable SPIFFE cert validation per instance with string value",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewStringValue("true"),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable SPIFFE cert validation set to false per instance",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewBoolValue(false),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
+		},
+		{
+			name: "Disable SPIFFE cert validation set unknown string value",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"spiffe://domain.test"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							disableSPIFFECertValidationKey: structpb.NewStringValue("test"),
+						},
+					},
+				},
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContextSpiffeValidator},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/agent/endpoints/sdsv3/handler_test.go
+++ b/pkg/agent/endpoints/sdsv3/handler_test.go
@@ -14,6 +14,7 @@ import (
 	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/imdario/mergo"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
@@ -91,6 +92,19 @@ var (
 				CustomValidatorConfig: &core_v3.TypedExtensionConfig{
 					Name:        "envoy.tls.cert_validator.spiffe",
 					TypedConfig: tdCustomValidationConfig,
+				},
+			},
+		},
+	}
+
+	tdValidationContext3 = &tls_v3.Secret{
+		Name: "ALL",
+		Type: &tls_v3.Secret_ValidationContext{
+			ValidationContext: &tls_v3.CertificateValidationContext{
+				TrustedCa: &core_v3.DataSource{
+					Specifier: &core_v3.DataSource_InlineBytes{
+						InlineBytes: []byte("-----BEGIN CERTIFICATE-----\nQlVORExF\n-----END CERTIFICATE-----\n"),
+					},
 				},
 			},
 		},
@@ -255,6 +269,7 @@ func TestStreamSecrets(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
 		req           *discovery_v3.DiscoveryRequest
+		config        Config
 		expectSecrets []*tls_v3.Secret
 		expectCode    codes.Code
 		expectMsg     string
@@ -407,9 +422,57 @@ func TestStreamSecrets(t *testing.T) {
 			expectCode: codes.InvalidArgument,
 			expectMsg:  "unable to retrieve all requested identities, missing map[spiffe://domain.test/WHATEVER:true]",
 		},
+		{
+			name: "Disable custom validation",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ROOTCA",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable custom validation and set default bundle name to ALL",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ALL",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable custom validation and set default bundle name to ALL",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ALL",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext3},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			test := setupTest(t)
+			test := setupTestWithConfig(t, tt.config)
 			defer test.cleanup()
 
 			stream, err := test.handler.StreamSecrets(context.Background())
@@ -627,6 +690,7 @@ func TestFetchSecrets(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
 		req           *discovery_v3.DiscoveryRequest
+		config        Config
 		expectSecrets []*tls_v3.Secret
 		expectCode    codes.Code
 		expectMsg     string
@@ -741,9 +805,57 @@ func TestFetchSecrets(t *testing.T) {
 			expectCode: codes.InvalidArgument,
 			expectMsg:  `unable to retrieve all requested identities, missing map[spiffe://domain.test/other:true]`,
 		},
+		{
+			name: "Disable custom validation",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ROOTCA",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable custom validation and set default bundle name to ALL",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"default"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ALL",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{workloadTLSCertificate3},
+		},
+		{
+			name: "Disable custom validation and set default bundle name to ALL",
+			req: &discovery_v3.DiscoveryRequest{
+				ResourceNames: []string{"ALL"},
+				Node: &core_v3.Node{
+					UserAgentVersionType: userAgentVersionTypeV18,
+				},
+			},
+			config: Config{
+				DefaultSVIDName:             "default",
+				DefaultBundleName:           "ALL",
+				DefaultAllBundlesName:       "ALL",
+				DisableSPIFFECertValidation: true,
+			},
+			expectSecrets: []*tls_v3.Secret{tdValidationContext3},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			test := setupTest(t)
+			test := setupTestWithConfig(t, tt.config)
 			defer test.server.Stop()
 
 			resp, err := test.handler.FetchSecrets(context.Background(), tt.req)
@@ -774,14 +886,21 @@ func DeltaSecretsTest(t *testing.T) {
 }
 
 func setupTest(t *testing.T) *handlerTest {
+	return setupTestWithConfig(t, Config{})
+}
+
+func setupTestWithConfig(t *testing.T, c Config) *handlerTest {
 	manager := NewFakeManager(t)
-	handler := New(Config{
-		Attestor:              FakeAttestor(workloadSelectors),
-		Manager:               manager,
-		DefaultSVIDName:       "default",
-		DefaultBundleName:     "ROOTCA",
-		DefaultAllBundlesName: "ALL",
-	})
+	defaultConfig := Config{
+		Manager:                     manager,
+		Attestor:                    FakeAttestor(workloadSelectors),
+		DefaultSVIDName:             "default",
+		DefaultBundleName:           "ROOTCA",
+		DefaultAllBundlesName:       "ALL",
+		DisableSPIFFECertValidation: false,
+	}
+	require.NoError(t, mergo.Merge(&c, defaultConfig))
+	handler := New(c)
 
 	received := make(chan struct{})
 	handler.hooks.received = received


### PR DESCRIPTION
This prepares the v1.1.5 release branch by cherry-picking the commits that add the new disable_spiffe_cert_validation functionality from the following PRs:

- #3009 
- #3014 
- #3020