### PR TITLE
Allow for node reattestation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.7
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.0.1-0.20220414143532-2ed460a8b9d3
-	github.com/spiffe/spire-api-sdk v1.2.2-0.20220317172821-e2705b35aa09
+	github.com/spiffe/spire-api-sdk v1.2.5-0.20220608195902-84fd618158c9
 	github.com/spiffe/spire-plugin-sdk v1.2.1
 	github.com/stretchr/testify v1.8.0
 	github.com/uber-go/tally/v4 v4.1.2

--- a/go.sum
+++ b/go.sum
@@ -1299,8 +1299,8 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/spiffe/go-spiffe/v2 v2.0.1-0.20220414143532-2ed460a8b9d3 h1:FpqM5PfWHs4Ze36HwzMpRefrv8kkmxFgtG9Qc6hL7Dc=
 github.com/spiffe/go-spiffe/v2 v2.0.1-0.20220414143532-2ed460a8b9d3/go.mod h1:ifsAYiK9MOyuGYFUHUQ3K47dj+k/gd4IcWhlCyDJZEU=
-github.com/spiffe/spire-api-sdk v1.2.2-0.20220317172821-e2705b35aa09 h1:2oavALIvyKv+M9Q2CWoz3UlJn4DT+oAhVO1qIgaq0GA=
-github.com/spiffe/spire-api-sdk v1.2.2-0.20220317172821-e2705b35aa09/go.mod h1:73BC0cOGkqRQrqoB1Djk7etxN+bE1ypmzZMkhCQs6kY=
+github.com/spiffe/spire-api-sdk v1.2.5-0.20220608195902-84fd618158c9 h1:RmpSpUHOboDvGhxLW/32DAlV/DsvUURjojPVDMPDkwM=
+github.com/spiffe/spire-api-sdk v1.2.5-0.20220608195902-84fd618158c9/go.mod h1:73BC0cOGkqRQrqoB1Djk7etxN+bE1ypmzZMkhCQs6kY=
 github.com/spiffe/spire-plugin-sdk v1.2.1 h1:w8uJ1P6AUQOJBDsNF34BJsL0ly6wtVMHnDJGqk1Y7yM=
 github.com/spiffe/spire-plugin-sdk v1.2.1/go.mod h1:fzNSP83Z848jZtPQYeZ9qPWZkbSPwmd/JFNux1gxsbM=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/agent/manager/storecache"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/agent/storage"
 	"github.com/spiffe/spire/pkg/agent/svid"
 	"github.com/spiffe/spire/pkg/agent/workloadkey"
@@ -24,6 +25,7 @@ type Config struct {
 	SVID             []*x509.Certificate
 	SVIDKey          keymanager.Key
 	Bundle           *cache.Bundle
+	Reattestable     bool
 	Catalog          catalog.Catalog
 	TrustDomain      spiffeid.TrustDomain
 	Log              logrus.FieldLogger
@@ -34,6 +36,7 @@ type Config struct {
 	SyncInterval     time.Duration
 	RotationInterval time.Duration
 	SVIDStoreCache   *storecache.Cache
+	NodeAttestor     nodeattestor.NodeAttestor
 
 	// Clk is the clock the manager will use to get time
 	Clk clock.Clock
@@ -70,6 +73,8 @@ func newManager(c *Config) *manager {
 		TrustDomain:    c.TrustDomain,
 		Interval:       c.RotationInterval,
 		Clk:            c.Clk,
+		NodeAttestor:   c.NodeAttestor,
+		Reattestable:   c.Reattestable,
 	}
 	svidRotator, client := svid.NewRotator(rotCfg)
 

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -103,7 +103,7 @@ type manager struct {
 }
 
 func (m *manager) Initialize(ctx context.Context) error {
-	m.storeSVID(m.svid.State().SVID)
+	m.storeSVID(m.svid.State().SVID, m.svid.State().Reattestable)
 	m.storeBundle(m.cache.Bundle())
 
 	m.backoff = backoff.NewBackoff(m.clk, m.c.SyncInterval)
@@ -276,7 +276,7 @@ func (m *manager) runSVIDObserver(ctx context.Context) error {
 			return nil
 		case <-svidStream.Changes():
 			s := svidStream.Next().(svid.State)
-			m.storeSVID(s.SVID)
+			m.storeSVID(s.SVID, s.Reattestable)
 		}
 	}
 }
@@ -294,8 +294,8 @@ func (m *manager) runBundleObserver(ctx context.Context) error {
 	}
 }
 
-func (m *manager) storeSVID(svidChain []*x509.Certificate) {
-	if err := m.storage.StoreSVID(svidChain); err != nil {
+func (m *manager) storeSVID(svidChain []*x509.Certificate, reattestable bool) {
+	if err := m.storage.StoreSVID(svidChain, reattestable); err != nil {
 		m.c.Log.WithError(err).Warn("Could not store SVID")
 	}
 }

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -147,17 +147,18 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 	sto := openStorage(t, dir)
 
 	c := &Config{
-		SVID:        baseSVID,
-		SVIDKey:     baseSVIDKey,
-		Log:         testLogger,
-		Metrics:     &telemetry.Blackhole{},
-		TrustDomain: trustDomain,
-		Storage:     sto,
-		Clk:         clk,
-		Catalog:     cat,
+		SVID:         baseSVID,
+		SVIDKey:      baseSVIDKey,
+		Reattestable: true,
+		Log:          testLogger,
+		Metrics:      &telemetry.Blackhole{},
+		TrustDomain:  trustDomain,
+		Storage:      sto,
+		Clk:          clk,
+		Catalog:      cat,
 	}
 
-	if _, err := sto.LoadSVID(); !errors.Is(err, storage.ErrNotCached) {
+	if _, _, err := sto.LoadSVID(); !errors.Is(err, storage.ErrNotCached) {
 		t.Fatalf("wanted: %v, got: %v", storage.ErrNotCached, err)
 	}
 
@@ -169,13 +170,14 @@ func TestStoreSVIDOnStartup(t *testing.T) {
 
 	// Although start failed, the SVID should have been saved, because it should be
 	// one of the first thing the manager does at initialization.
-	svid, err := sto.LoadSVID()
+	svid, reattestable, err := sto.LoadSVID()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !svidsEqual(svid, baseSVID) {
 		t.Fatal("SVID was not correctly stored.")
 	}
+	require.True(t, reattestable)
 }
 
 func TestHappyPathWithoutSyncNorRotation(t *testing.T) {

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -4,18 +4,25 @@ import (
 	"context"
 	"crypto"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/andres-erbsen/clock"
 	observer "github.com/imkira/go-observer"
+	agentv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1"
+	node_attestor "github.com/spiffe/spire/pkg/agent/attestor/node"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/common/backoff"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/nodeutil"
 	"github.com/spiffe/spire/pkg/common/rotationutil"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_agent "github.com/spiffe/spire/pkg/common/telemetry/agent"
 	"github.com/spiffe/spire/pkg/common/util"
+	"google.golang.org/grpc"
 )
 
 type Rotator interface {
@@ -54,8 +61,9 @@ type rotator struct {
 }
 
 type State struct {
-	SVID []*x509.Certificate
-	Key  crypto.Signer
+	SVID         []*x509.Certificate
+	Key          crypto.Signer
+	Reattestable bool
 }
 
 // Run runs the rotator. It monitors the server SVID for expiration and rotates
@@ -70,21 +78,25 @@ func (r *rotator) Run(ctx context.Context) error {
 func (r *rotator) runRotation(ctx context.Context) error {
 	for {
 		err := r.rotateSVIDIfNeeded(ctx)
+		state, ok := r.state.Value().(State)
+		if !ok {
+			return fmt.Errorf("unexpected value type: %T", r.state.Value())
+		}
 
 		switch {
-		case err != nil && rotationutil.X509Expired(r.clk.Now(), r.state.Value().(State).SVID[0]):
-			r.c.Log.WithError(err).Error("Could not rotate agent SVID")
+		case err != nil && rotationutil.X509Expired(r.clk.Now(), state.SVID[0]):
+			r.c.Log.WithError(err).Errorf("Could not %s", rotationError(state))
 			// Since our X509 cert has expired, and we weren't able to carry out a rotation request, we're probably unrecoverable without re-attesting.
-			return fmt.Errorf("current SVID has already expired and rotation failed: %w", err)
+			return fmt.Errorf("current SVID has already expired and %s failed: %w", rotationError(state), err)
 		case err != nil && nodeutil.ShouldAgentReattest(err):
-			r.c.Log.WithError(err).Error("Could not rotate agent SVID")
+			r.c.Log.WithError(err).Errorf("Could not %s", rotationError(state))
 			return err
 		case err != nil && nodeutil.ShouldAgentShutdown(err):
-			r.c.Log.WithError(err).Error("Could not rotate agent SVID")
+			r.c.Log.WithError(err).Errorf("Could not %s", rotationError(state))
 			return err
 		case err != nil:
 			// Just log the error and wait for next rotation
-			r.c.Log.WithError(err).Error("Could not rotate agent SVID")
+			r.c.Log.WithError(err).Errorf("Could not %s", rotationError(state))
 		default:
 			r.backoff.Reset()
 		}
@@ -127,13 +139,78 @@ func (r *rotator) SetRotationFinishedHook(f func()) {
 }
 
 func (r *rotator) rotateSVIDIfNeeded(ctx context.Context) (err error) {
-	if rotationutil.ShouldRotateX509(r.clk.Now(), r.state.Value().(State).SVID[0]) {
-		err = r.rotateSVID(ctx)
+	state, ok := r.state.Value().(State)
+	if !ok {
+		return fmt.Errorf("unexpected value type: %T", r.state.Value())
 	}
-	if r.rotationFinishedHook != nil {
-		r.rotationFinishedHook()
+
+	if rotationutil.ShouldRotateX509(r.clk.Now(), state.SVID[0]) {
+		if state.Reattestable && fflag.IsSet(fflag.FlagReattestToRenew) {
+			err = r.reattest(ctx)
+		} else {
+			err = r.rotateSVID(ctx)
+		}
+
+		if err == nil && r.rotationFinishedHook != nil {
+			r.rotationFinishedHook()
+		}
 	}
+
 	return err
+}
+
+// reattest goes through the full attestation process with the server and gets a new SVID.
+func (r *rotator) reattest(ctx context.Context) (err error) {
+	counter := telemetry_agent.StartReattestAgentCall(r.c.Metrics)
+	defer counter.Done(&err)
+
+	// Get the mtx before starting the reattestation
+	// In this way, the client do not create new connections until the new SVID is received
+	r.rotMtx.Lock()
+	defer r.rotMtx.Unlock()
+	r.c.Log.Debug("Reattesting node")
+
+	bundle, err := r.getBundle()
+	if err != nil {
+		return err
+	}
+
+	key, err := r.generateKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	csr, err := util.MakeCSRWithoutURISAN(key)
+	if err != nil {
+		return err
+	}
+
+	conn, err := r.serverConn(ctx, bundle)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	stream := &node_attestor.ServerStream{Client: agentv1.NewAgentClient(conn), Csr: csr, Log: r.c.Log}
+	if err := r.c.NodeAttestor.Attest(ctx, stream); err != nil {
+		return err
+	}
+	r.c.Log.WithField(telemetry.SPIFFEID, stream.SVID[0].URIs[0].String()).Info("Successfully reattested node")
+
+	s := State{
+		SVID:         stream.SVID,
+		Key:          key,
+		Reattestable: stream.Reattestable,
+	}
+
+	r.state.Update(s)
+
+	// We must release the client because its underlaying connection is tied to an
+	// expired SVID, so next time the client is used, it will get a new connection with
+	// the most up-to-date SVID.
+	r.client.Release()
+
+	return nil
 }
 
 // rotateSVID asks SPIRE's server for a new agent's SVID.
@@ -147,12 +224,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	defer r.rotMtx.Unlock()
 	r.c.Log.Debug("Rotating agent SVID")
 
-	var existingKey keymanager.Key
-	if state, ok := r.state.Value().(State); ok && state.Key != nil {
-		existingKey, _ = state.Key.(keymanager.Key)
-	}
-
-	key, err := r.c.SVIDKeyManager.GenerateKey(ctx, existingKey)
+	key, err := r.generateKey(ctx)
 	if err != nil {
 		return err
 	}
@@ -171,6 +243,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	r.c.Log.WithField(telemetry.SPIFFEID, certs[0].URIs[0].String()).Info("Successfully rotated agent SVID")
 
 	s := State{
 		SVID: certs,
@@ -185,4 +258,50 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	r.client.Release()
 
 	return nil
+}
+
+func (r *rotator) getBundle() (*bundleutil.Bundle, error) {
+	r.bsm.RLock()
+	bundles := r.c.BundleStream.Value()
+	r.bsm.RUnlock()
+
+	bundle := bundles[r.c.TrustDomain]
+	if bundle == nil {
+		return nil, errors.New("bundle not found")
+	}
+
+	return bundle, nil
+}
+
+func (r *rotator) generateKey(ctx context.Context) (keymanager.Key, error) {
+	state, ok := r.state.Value().(State)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type: %T", r.state.Value())
+	}
+
+	var existingKey keymanager.Key
+	if state.Key != nil {
+		existingKey, ok = state.Key.(keymanager.Key)
+		if !ok {
+			return nil, fmt.Errorf("unexpected value type: %T", state.Key)
+		}
+	}
+
+	return r.c.SVIDKeyManager.GenerateKey(ctx, existingKey)
+}
+
+func (r *rotator) serverConn(ctx context.Context, bundle *bundleutil.Bundle) (*grpc.ClientConn, error) {
+	return client.DialServer(ctx, client.DialServerConfig{
+		Address:     r.c.ServerAddr,
+		TrustDomain: r.c.TrustDomain,
+		GetBundle:   bundle.RootCAs,
+	})
+}
+
+func rotationError(state State) string {
+	if state.Reattestable {
+		return "reattest agent"
+	}
+
+	return "rotate agent SVID"
 }

--- a/pkg/agent/svid/rotator_config.go
+++ b/pkg/agent/svid/rotator_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/common/backoff"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/agent/plugin/keymanager"
+	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 )
 
@@ -25,6 +26,8 @@ type RotatorConfig struct {
 	Metrics        telemetry.Metrics
 	TrustDomain    spiffeid.TrustDomain
 	ServerAddr     string
+	NodeAttestor   nodeattestor.NodeAttestor
+	Reattestable   bool
 
 	// Initial SVID and key
 	SVID    []*x509.Certificate
@@ -53,8 +56,9 @@ func newRotator(c *RotatorConfig) (*rotator, client.Client) {
 	}
 
 	state := observer.NewProperty(State{
-		SVID: c.SVID,
-		Key:  c.SVIDKey,
+		SVID:         c.SVID,
+		Key:          c.SVIDKey,
+		Reattestable: c.Reattestable,
 	})
 
 	rotMtx := new(sync.RWMutex)

--- a/pkg/common/errorutil/wrapper.go
+++ b/pkg/common/errorutil/wrapper.go
@@ -2,11 +2,25 @@ package errorutil
 
 import (
 	"fmt"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// WrapAndLogError creates a new error in the format: "<newErrStr>: <err>".
+// WrapError creates a new error in the format: "<newErrStr>: <err>".
 // This function is intended to be used to wrap errors
 // when an error is received from calling a function/method inside of a function or private method.
 func WrapError(err error, newErrStr string) error {
 	return fmt.Errorf(newErrStr+": %v", err)
+}
+
+// PermissionDenied formats a PermissionDenied error with an error string.
+func PermissionDenied(reason types.PermissionDeniedDetails_Reason, format string, args ...interface{}) error {
+	st := status.Newf(codes.PermissionDenied, format, args...)
+	if detailed, err := st.WithDetails(&types.PermissionDeniedDetails{Reason: reason}); err == nil {
+		st = detailed
+	}
+
+	return st.Err()
 }

--- a/pkg/common/fflag/fflag.go
+++ b/pkg/common/fflag/fflag.go
@@ -29,6 +29,11 @@ const (
 	// enabled or not. See #1934 for more information.
 	FlagForcedRotation Flag = "forced_rotation"
 
+	// FlagReattestToRenew controls whether or not the agent will reattest to
+	// renew when the SVID expires. Some attestors, such as aws_iid, are not
+	// reattestable. In those cases the agent will still renew without reattesting.
+	FlagReattestToRenew Flag = "reattest_to_renew"
+
 	// FlagTestFlag is defined purely for testing purposes.
 	FlagTestFlag Flag = "i_am_a_test_flag"
 )
@@ -40,8 +45,9 @@ var (
 		mtx    *sync.RWMutex
 	}{
 		flags: map[Flag]bool{
-			FlagForcedRotation: false,
-			FlagTestFlag:       false,
+			FlagForcedRotation:  false,
+			FlagReattestToRenew: false,
+			FlagTestFlag:        false,
 		},
 		loaded: false,
 		mtx:    new(sync.RWMutex),

--- a/pkg/common/nodeutil/node.go
+++ b/pkg/common/nodeutil/node.go
@@ -11,9 +11,10 @@ import (
 
 var (
 	shouldReattest = map[types.PermissionDeniedDetails_Reason]struct{}{
-		types.PermissionDeniedDetails_AGENT_EXPIRED:      {},
-		types.PermissionDeniedDetails_AGENT_NOT_ACTIVE:   {},
-		types.PermissionDeniedDetails_AGENT_NOT_ATTESTED: {},
+		types.PermissionDeniedDetails_AGENT_EXPIRED:       {},
+		types.PermissionDeniedDetails_AGENT_NOT_ACTIVE:    {},
+		types.PermissionDeniedDetails_AGENT_NOT_ATTESTED:  {},
+		types.PermissionDeniedDetails_AGENT_MUST_REATTEST: {},
 	}
 	shouldShutDown = map[types.PermissionDeniedDetails_Reason]struct{}{
 		types.PermissionDeniedDetails_AGENT_BANNED: {},

--- a/pkg/common/telemetry/agent/rotate.go
+++ b/pkg/common/telemetry/agent/rotate.go
@@ -13,4 +13,10 @@ func StartRotateAgentSVIDCall(m telemetry.Metrics) *telemetry.CallCounter {
 	return telemetry.StartCall(m, telemetry.AgentSVID, telemetry.Rotate)
 }
 
+// StartReattestAgentCall return metric for Agent's
+// Reattestation.
+func StartReattestAgentCall(m telemetry.Metrics) *telemetry.CallCounter {
+	return telemetry.StartCall(m, telemetry.Node, telemetry.Attest)
+}
+
 // End Call Counters

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -363,6 +363,9 @@ const (
 	// Reason is the reason for something
 	Reason = "reason"
 
+	// Reattestable declares if the agent should reattest when its SVID expires
+	Reattestable = "rettestable"
+
 	// Received tags a received value, as opposed to the one that is expected. Message should clarify
 	// what kind of value was received, and a different field should show the expected value.
 	Received = "received"

--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	agentv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/errorutil"
+	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/idutil"
 	"github.com/spiffe/spire/pkg/common/nodeutil"
 	"github.com/spiffe/spire/pkg/common/selector"
@@ -357,7 +359,7 @@ func (s *Service) AttestAgent(stream agentv1.Agent_AttestAgentServer) error {
 	}
 
 	// build and send response
-	response := getAttestAgentResponse(agentID, svid)
+	response := getAttestAgentResponse(agentID, svid, attestResult.CanReattest)
 
 	if p, ok := peer.FromContext(ctx); ok {
 		log = log.WithField(telemetry.Address, p.Addr.String())
@@ -386,6 +388,20 @@ func (s *Service) RenewAgent(ctx context.Context, req *agentv1.RenewAgentRequest
 	callerID, ok := rpccontext.CallerID(ctx)
 	if !ok {
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)
+	}
+
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, callerID.String())
+	if err != nil {
+		return nil, api.MakeErr(log, codes.Internal, "failed to fetch agent", err)
+	}
+
+	if attestedNode == nil {
+		return nil, api.MakeErr(log, codes.NotFound, "agent not found", err)
+	}
+
+	// Agent attempted to renew when it should've been reattesting
+	if attestedNode.CanReattest && fflag.IsSet(fflag.FlagReattestToRenew) {
+		return nil, errorutil.PermissionDenied(types.PermissionDeniedDetails_AGENT_MUST_REATTEST, "agent can't renew SVID, must reattest")
 	}
 
 	log.Info("Renewing agent SVID")
@@ -659,7 +675,7 @@ func validateAttestAgentParams(params *agentv1.AttestAgentRequest_Params) error 
 	}
 }
 
-func getAttestAgentResponse(spiffeID spiffeid.ID, certificates []*x509.Certificate) *agentv1.AttestAgentResponse {
+func getAttestAgentResponse(spiffeID spiffeid.ID, certificates []*x509.Certificate, canReattest bool) *agentv1.AttestAgentResponse {
 	svid := &types.X509SVID{
 		Id:        api.ProtoFromID(spiffeID),
 		CertChain: x509util.RawCertsFromCertificates(certificates),
@@ -669,7 +685,8 @@ func getAttestAgentResponse(spiffeID spiffeid.ID, certificates []*x509.Certifica
 	return &agentv1.AttestAgentResponse{
 		Step: &agentv1.AttestAgentResponse_Result_{
 			Result: &agentv1.AttestAgentResponse_Result{
-				Svid: svid,
+				Svid:         svid,
+				Reattestable: canReattest,
 			},
 		},
 	}

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -1718,7 +1718,6 @@ func TestRenewAgent(t *testing.T) {
 		{
 			name: "no attested node",
 			expectLogs: []spiretest.LogEntry{
-				renewingMessage,
 				{
 					Level:   logrus.ErrorLevel,
 					Message: "Agent not found",
@@ -1858,16 +1857,15 @@ func TestRenewAgent(t *testing.T) {
 			expectMsg:  "failed to sign X509 SVID: X509 CA is not available for signing",
 		},
 		{
-			name:       "failed to update attested node",
+			name:       "failed to fetch attested node",
 			createNode: cloneAttestedNode(defaultNode),
 			dsError: []error{
 				errors.New("some error"),
 			},
 			expectLogs: []spiretest.LogEntry{
-				renewingMessage,
 				{
 					Level:   logrus.ErrorLevel,
-					Message: "Failed to update agent",
+					Message: "Failed to fetch agent",
 					Data: logrus.Fields{
 						logrus.ErrorKey: "some error",
 					},
@@ -1880,7 +1878,7 @@ func TestRenewAgent(t *testing.T) {
 						telemetry.Type:          "audit",
 						telemetry.Csr:           csrHash,
 						telemetry.StatusCode:    "Internal",
-						telemetry.StatusMessage: "failed to update agent: some error",
+						telemetry.StatusMessage: "failed to fetch agent: some error",
 					},
 				},
 			},
@@ -1890,7 +1888,7 @@ func TestRenewAgent(t *testing.T) {
 				},
 			},
 			expectCode: codes.Internal,
-			expectMsg:  "failed to update agent: some error",
+			expectMsg:  "failed to fetch agent: some error",
 		},
 	} {
 		tt := tt

--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/errorutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/api/bundle/v1"
@@ -61,19 +62,9 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 		id := agentID.String()
 		log := rpccontext.Logger(ctx)
 
-		permissionDenied := func(reason types.PermissionDeniedDetails_Reason, format string, args ...interface{}) error {
-			st := status.Newf(codes.PermissionDenied, format, args...)
-			if detailed, err := st.WithDetails(&types.PermissionDeniedDetails{
-				Reason: reason,
-			}); err == nil {
-				st = detailed
-			}
-			return st.Err()
-		}
-
 		if clk.Now().After(agentSVID.NotAfter) {
 			log.Error("Agent SVID is expired")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_EXPIRED, "agent %q SVID is expired", id)
+			return errorutil.PermissionDenied(types.PermissionDeniedDetails_AGENT_EXPIRED, "agent %q SVID is expired", id)
 		}
 
 		attestedNode, err := ds.FetchAttestedNode(ctx, id)
@@ -83,10 +74,10 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 			return status.Errorf(codes.Internal, "unable to look up agent information: %v", err)
 		case attestedNode == nil:
 			log.Error("Agent is not attested")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ATTESTED, "agent %q is not attested", id)
+			return errorutil.PermissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ATTESTED, "agent %q is not attested", id)
 		case attestedNode.CertSerialNumber == "":
 			log.Error("Agent is banned")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_BANNED, "agent %q is banned", id)
+			return errorutil.PermissionDenied(types.PermissionDeniedDetails_AGENT_BANNED, "agent %q is banned", id)
 		case attestedNode.CertSerialNumber == agentSVID.SerialNumber.String():
 			// AgentSVID matches the current serial number, access granted
 			return nil
@@ -113,7 +104,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 				telemetry.SVIDSerialNumber: agentSVID.SerialNumber.String(),
 				telemetry.SerialNumber:     attestedNode.CertSerialNumber,
 			}).Error("Agent SVID is not active")
-			return permissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, attestedNode.CertSerialNumber, agentSVID.SerialNumber.String())
+			return errorutil.PermissionDenied(types.PermissionDeniedDetails_AGENT_NOT_ACTIVE, "agent %q expected to have serial number %q; has %q", id, attestedNode.CertSerialNumber, agentSVID.SerialNumber.String())
 		}
 	})
 }

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -48,6 +48,10 @@ func (m *Mock) TimerCh() <-chan time.Duration {
 	return m.timerC
 }
 
+func (m *Mock) WaitForAfterCh() <-chan time.Duration {
+	return m.afterC
+}
+
 // WaitForTimer waits up to the specified timeout for Timer to be called on the clock.
 func (m *Mock) WaitForTimer(timeout time.Duration, format string, args ...interface{}) {
 	select {


### PR DESCRIPTION
Signed-off-by: Faisal Memon <fymemon@yahoo.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Node attestation

**Description of change**
Forces agents that can reattest(https://github.com/spiffe/spire/pull/2698) to reattest the node when its SVID expires, rather than just rotating the SVID. The server notifies the agent that it must reattest by passing a flag to the agent when it successfully attests. The agent stores this flag along with the svid and bundle as its state so it's saved in case the agent is restarted.

If an agent attempts to rotate when its supposed to reattest, the API for rotating SVIDs will print a warning. A future PR will change this to an error that will force the agent to restart and attest.

**Issues**
Closes #2203
Closes #1434