### PR TITLE
Stop datastore on catalog shutdown

### DIFF
--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -71,7 +71,10 @@ type Repository struct {
 	nodeResolverRepository
 	notifierRepository
 	upstreamAuthorityRepository
-	io.Closer
+
+	log             logrus.FieldLogger
+	dataStoreCloser io.Closer
+	catalogCloser   io.Closer
 }
 
 func (repo *Repository) Plugins() map[string]catalog.PluginRepo {
@@ -88,23 +91,50 @@ func (repo *Repository) Services() []catalog.ServiceRepo {
 	return nil
 }
 
+func (repo *Repository) Close() {
+	// Must close in reverse initialization order!
+
+	repo.log.Debug("Closing catalog")
+	if err := repo.catalogCloser.Close(); err == nil {
+		repo.log.Info("Catalog closed")
+	} else {
+		repo.log.WithError(err).Error("Failed to close catalog")
+	}
+
+	repo.log.Debug("Closing DataStore")
+	if err := repo.dataStoreCloser.Close(); err == nil {
+		repo.log.Info("DataStore closed")
+	} else {
+		repo.log.WithError(err).Error("Failed to close DataStore")
+	}
+}
+
 func Load(ctx context.Context, config Config) (_ *Repository, err error) {
+	repo := &Repository{
+		log: config.Log,
+	}
+	defer func() {
+		if err != nil {
+			repo.Close()
+		}
+	}()
+
 	// Strip out the Datastore plugin configuration and load the SQL plugin
 	// directly. This allows us to bypass gRPC and get rid of response limits.
 	dataStoreConfig := config.PluginConfig[dataStoreType]
 	delete(config.PluginConfig, dataStoreType)
-	dataStore, err := loadSQLDataStore(config.Log, dataStoreConfig)
+	sqlDataStore, err := loadSQLDataStore(config.Log, dataStoreConfig)
 	if err != nil {
 		return nil, err
 	}
+	repo.dataStoreCloser = sqlDataStore
 
 	pluginConfigs, err := catalog.PluginConfigsFromHCL(config.PluginConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	repo := new(Repository)
-	repo.Closer, err = catalog.Load(ctx, catalog.Config{
+	repo.catalogCloser, err = catalog.Load(ctx, catalog.Config{
 		Log: config.Log,
 		CoreConfig: catalog.CoreConfig{
 			TrustDomain: config.TrustDomain,
@@ -120,6 +150,7 @@ func Load(ctx context.Context, config Config) (_ *Repository, err error) {
 		return nil, err
 	}
 
+	var dataStore datastore.DataStore = sqlDataStore
 	_ = config.HealthChecker.AddCheck("catalog.datastore", &datastore.Health{
 		DataStore: dataStore,
 	})
@@ -133,7 +164,7 @@ func Load(ctx context.Context, config Config) (_ *Repository, err error) {
 	return repo, nil
 }
 
-func loadSQLDataStore(log logrus.FieldLogger, datastoreConfig map[string]catalog.HCLPluginConfig) (datastore.DataStore, error) {
+func loadSQLDataStore(log logrus.FieldLogger, datastoreConfig map[string]catalog.HCLPluginConfig) (*ds_sql.Plugin, error) {
 	switch {
 	case len(datastoreConfig) == 0:
 		return nil, errors.New("expecting a DataStore plugin")

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -580,14 +580,16 @@ func (ds *Plugin) openConnection(config *configuration, isReadOnly bool) error {
 	return nil
 }
 
-func (ds *Plugin) closeDB() {
+func (ds *Plugin) Close() error {
+	var errs errs.Group
 	if ds.db != nil {
-		ds.db.Close()
+		errs.Add(ds.db.Close())
 	}
 
 	if ds.roDb != nil {
-		ds.roDb.Close()
+		errs.Add(ds.roDb.Close())
 	}
+	return errs.Err()
 }
 
 // withReadModifyWriteTx wraps the operation in a transaction appropriate for

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -119,7 +119,7 @@ func (s *PluginSuite) SetupTest() {
 
 func (s *PluginSuite) TearDownTest() {
 	if s.ds != nil {
-		s.ds.closeDB()
+		s.ds.Close()
 	}
 }
 
@@ -616,7 +616,7 @@ func (s *PluginSuite) TestFetchAttestedNodeMissing() {
 
 func (s *PluginSuite) TestListAttestedNodes() {
 	// Connection is never used, each test creates a connection to a diffent database
-	s.ds.closeDB()
+	s.ds.Close()
 
 	now := time.Now()
 	expired := now.Add(-time.Hour)
@@ -869,7 +869,7 @@ func (s *PluginSuite) TestListAttestedNodes() {
 				}
 				s.T().Run(name, func(t *testing.T) {
 					s.ds = s.newPlugin()
-					defer s.ds.closeDB()
+					defer s.ds.Close()
 
 					// Create entries for the test. For convenience, map the actual
 					// entry ID to the "test" entry ID, so we can easily pinpoint
@@ -983,7 +983,7 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 	updatedNewExpires := int64(0)
 
 	// This connection is never used, each plugin is creating a connection to a new database
-	s.ds.closeDB()
+	s.ds.Close()
 
 	for _, tt := range []struct {
 		name           string
@@ -1066,7 +1066,7 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 		tt := tt
 		s.T().Run(tt.name, func(t *testing.T) {
 			s.ds = s.newPlugin()
-			defer s.ds.closeDB()
+			defer s.ds.Close()
 
 			_, err := s.ds.CreateAttestedNode(ctx, &common.AttestedNode{
 				SpiffeId:            nodeID,
@@ -1453,7 +1453,7 @@ func (s *PluginSuite) TestFetchInexistentRegistrationEntry() {
 
 func (s *PluginSuite) TestListRegistrationEntries() {
 	// Connection is never used, each test creates new connection to a different database
-	s.ds.closeDB()
+	s.ds.Close()
 
 	s.testListRegistrationEntries(datastore.RequireCurrent)
 	s.testListRegistrationEntries(datastore.TolerateStale)
@@ -2066,7 +2066,7 @@ func (s *PluginSuite) testListRegistrationEntries(dataConsistency datastore.Data
 			}
 			s.T().Run(name, func(t *testing.T) {
 				s.ds = s.newPlugin()
-				defer s.ds.closeDB()
+				defer s.ds.Close()
 
 				s.createBundle("spiffe://federated1.test")
 				s.createBundle("spiffe://federated2.test")
@@ -2558,7 +2558,7 @@ func (s *PluginSuite) TestListParentIDEntries() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			for _, entry := range test.registrationEntries {
 				registrationEntry, err := ds.CreateRegistrationEntry(ctx, entry)
 				require.NoError(t, err)
@@ -2606,7 +2606,7 @@ func (s *PluginSuite) TestListSelectorEntries() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			for _, entry := range test.registrationEntries {
 				registrationEntry, err := ds.CreateRegistrationEntry(ctx, entry)
 				require.NoError(t, err)
@@ -2661,7 +2661,7 @@ func (s *PluginSuite) TestListEntriesBySelectorSubset() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			for _, entry := range test.registrationEntries {
 				registrationEntry, err := ds.CreateRegistrationEntry(ctx, entry)
 				require.NoError(t, err)
@@ -2716,7 +2716,7 @@ func (s *PluginSuite) TestListSelectorEntriesSuperset() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			for _, entry := range test.registrationEntries {
 				registrationEntry, err := ds.CreateRegistrationEntry(ctx, entry)
 				require.NoError(t, err)
@@ -2782,7 +2782,7 @@ func (s *PluginSuite) TestListEntriesBySelectorMatchAny() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			for _, entry := range test.registrationEntries {
 				registrationEntry, err := ds.CreateRegistrationEntry(ctx, entry)
 				require.NoError(t, err)
@@ -2848,7 +2848,7 @@ func (s *PluginSuite) TestListEntriesByFederatesWithExact() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			createBundles(t, ds, []string{
 				"spiffe://td1.org",
 				"spiffe://td2.org",
@@ -2912,7 +2912,7 @@ func (s *PluginSuite) TestListEntriesByFederatesWithSubset() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			createBundles(t, ds, []string{
 				"spiffe://td1.org",
 				"spiffe://td2.org",
@@ -2983,7 +2983,7 @@ func (s *PluginSuite) TestListEntriesByFederatesWithMatchAny() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			createBundles(t, ds, []string{
 				"spiffe://td1.org",
 				"spiffe://td2.org",
@@ -3053,7 +3053,7 @@ func (s *PluginSuite) TestListEntriesByFederatesWithSuperset() {
 		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
-			defer ds.closeDB()
+			defer ds.Close()
 			createBundles(t, ds, []string{
 				"spiffe://td1.org",
 				"spiffe://td2.org",
@@ -4100,7 +4100,7 @@ func (s *PluginSuite) TestConfigure() {
 				%s
 			`, dbPath, tt.giveDBConfig))
 			require.NoError(t, err)
-			defer p.closeDB()
+			defer p.Close()
 
 			db := p.db.DB.DB()
 			require.Equal(t, tt.expectMaxOpenConns, db.Stats().MaxOpenConnections)


### PR DESCRIPTION
The datastore is not closed when the catalog is shut down. While this isn't necessarily problematic in practice, it can cause problems in testing (see test failures on catalog tests introduced in #3045).

In any case, it is hygienic to close down all components that were opened by a given subsystem when the subsystem is closed.

This PR exports the datastore close method and calls it when the catalog is closed. It also adds some logging to both server and agent around catalog closure.