### PR TITLE
Update CRD registrar quickstart to 1.3.0, add note about CN

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-crd/README.md
+++ b/support/k8s/k8s-workload-registrar/mode-crd/README.md
@@ -34,7 +34,7 @@ The configuration file is a **required** by the registrar. It contains
 | `cluster`                       | string   | required | Logical cluster to register nodes/workloads under. Must match the SPIRE SERVER PSAT node attestor configuration. | |
 | `context`                       | map[string]string | optional | The map of key/value pairs of arbitrary string parameters to be used by `identity_template` | |
 | `disabled_namespaces`           | []string | optional | Comma separated list of namespaces to disable auto SVID generation for | `"kube-system", "kube-public"` |
-| `dns_name_templates`            | []string | optional | Comma separated list of templates to be used to generate [additional DNS names](#additional-dns-names) for a workload | `[{{.Pod.Name}}]` |
+| `dns_name_templates`            | []string | optional | Comma separated list of templates to generate [DNS names](#dns-names) for a workload. The first template in the list will also populate the CN of the SVID. | `[{{.Pod.Name}}]` |
 | `identity_template`             | string   | optional | The template for custom [Identity Template Based Workload Registration](#identity-template-based-workload-registration) | `ns/{{.Pod.Namespace}}/sa/{{.Pod.ServiceAccount}}` |
 | `identity_template_label`       | string   | optional | Pod label for selecting pods that get SVIDs whose SPIFFE IDs are defined by `identity_template` format. If not set, applies to all the pods when `identity_template` is set  |  |
 | `leader_election`               | bool     | optional | Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. | `false` |
@@ -389,9 +389,9 @@ spec:
   ...
 ```
 
-### Additional DNS Names
+### DNS Names
 
-If additional DNS names are desired for your workload, they can be specified using the `dns_name_templates` configuration option. Similar to the `identity_template` field, `dns_name_templates` uses Golang
+If DNS names are desired for your workload, they can be specified using the `dns_name_templates` configuration option. Similar to the `identity_template` field, `dns_name_templates` uses Golang
 [text/template](https://pkg.go.dev/text/template) conventions. It can reference arbitrary values provided in the `context` map of strings, in addition to the following Pod-specific arguments:
 * Pod.Name
 * Pod.UID
@@ -413,6 +413,8 @@ and the _example-workload_ pod was deployed in _production_ namespace and _myser
 
 - myserviceacct.production.svc
 - my-domain.example-workload.svc
+
+<table><tr><td>Note: The first template in the list will also populate the Common Name (CN) field of the SVID.</td></tr></table>
 
 ## How it Works
 

--- a/support/k8s/k8s-workload-registrar/mode-crd/config/spire-agent.yaml
+++ b/support/k8s/k8s-workload-registrar/mode-crd/config/spire-agent.yaml
@@ -117,7 +117,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:1.1.0
+          image: gcr.io/spiffe-io/spire-agent:1.3.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/support/k8s/k8s-workload-registrar/mode-crd/config/spire-server-registrar.yaml
+++ b/support/k8s/k8s-workload-registrar/mode-crd/config/spire-server-registrar.yaml
@@ -211,7 +211,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:1.1.0
+          image: gcr.io/spiffe-io/spire-server:1.3.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -240,7 +240,7 @@ spec:
               mountPath: /tmp
               readOnly: false
         - name: k8s-workload-registrar
-          image: gcr.io/spiffe-io/k8s-workload-registrar:1.1.0
+          image: gcr.io/spiffe-io/k8s-workload-registrar:1.3.0
           args:
             - -config
             - /run/spire/config/k8s-workload-registrar.conf


### PR DESCRIPTION
Signed-off-by: Faisal Memon <fymemon@yahoo.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
k8s-workload-registrar quickstart and docs

**Description of change**
Changes in this PR:
- Updates the quickstart to use 1.3.0 release of SPIRE
- Adds a note that the first DNS name in the list of DNS name templates is also used to populate the common name field of the certificate


