### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -4,6 +4,9 @@ on:
     # Random minute number to avoid GH scheduler stampede
     - cron: '37 21 * * *'
   workflow_dispatch: {}
+permissions:
+  contents: read
+
 jobs:
   build-and-publish-images:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch: {}
 env:
   GO_VERSION: 1.18.1
+permissions:
+  contents: read
+
 jobs:
   cache-deps:
     name: cache-deps (linux)


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>

