### PR TITLE
Fix permissions on nightly build action

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch: {}
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-and-publish-images:


### PR DESCRIPTION
Recently changed to only have permissions to read contents (#3098). However, we need to be able to publish the nightly image.

This change adds the `write` scope to `packages.