### PR TITLE
Re-introduce entry output mask on agent sync

### DIFF
--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -311,7 +311,18 @@ func (c *client) fetchEntries(ctx context.Context) ([]*types.Entry, error) {
 	}
 	defer connection.Release()
 
-	resp, err := entryClient.GetAuthorizedEntries(ctx, &entryv1.GetAuthorizedEntriesRequest{})
+	resp, err := entryClient.GetAuthorizedEntries(ctx, &entryv1.GetAuthorizedEntriesRequest{
+		OutputMask: &types.EntryMask{
+			SpiffeId:       true,
+			Selectors:      true,
+			FederatesWith:  true,
+			Admin:          true,
+			Downstream:     true,
+			ExpiresAt:      true,
+			RevisionNumber: true,
+			StoreSvid:      true,
+		},
+	})
 	if err != nil {
 		c.release(connection)
 		c.c.Log.WithError(err).Error("Failed to fetch authorized entries")

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -318,7 +318,6 @@ func (c *client) fetchEntries(ctx context.Context) ([]*types.Entry, error) {
 			FederatesWith:  true,
 			Admin:          true,
 			Downstream:     true,
-			ExpiresAt:      true,
 			RevisionNumber: true,
 			StoreSvid:      true,
 		},

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -778,7 +778,6 @@ func (c *fakeEntryClient) GetAuthorizedEntries(ctx context.Context, in *entryv1.
 		FederatesWith:  true,
 		Admin:          true,
 		Downstream:     true,
-		ExpiresAt:      true,
 		RevisionNumber: true,
 		StoreSvid:      true,
 	}, protocmp.Transform()); diff != "" {

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	agentv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1"
@@ -22,6 +23,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var (
@@ -769,6 +772,19 @@ func (c *fakeEntryClient) GetAuthorizedEntries(ctx context.Context, in *entryv1.
 	if c.err != nil {
 		return nil, c.err
 	}
+	if diff := cmp.Diff(in.OutputMask, &types.EntryMask{
+		SpiffeId:       true,
+		Selectors:      true,
+		FederatesWith:  true,
+		Admin:          true,
+		Downstream:     true,
+		ExpiresAt:      true,
+		RevisionNumber: true,
+		StoreSvid:      true,
+	}, protocmp.Transform()); diff != "" {
+		return nil, status.Error(codes.InvalidArgument, "invalid output mask requested")
+	}
+
 	return &entryv1.GetAuthorizedEntriesResponse{
 		Entries: c.entries,
 	}, nil


### PR DESCRIPTION
This was accidentally backed out. However, the original mask is too restrictive with the addition of the delegated API, which introspects more fields on entries (e.g. admin, downstream, expiresAt).

The mask now retrieves everything but ParentId, DnsNames, and Ttl.

Fixes: #1361