### PR TITLE
Extend unix workload attestor

### DIFF
--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -33,6 +33,8 @@ Workload path enabled selectors (available when configured with `discover_worklo
 | Selector      | Value                                                                                                                          |
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `unix:path`   | The path to the workload binary (e.g. `unix:path:/usr/bin/nginx`)                                                              |
+| `unix:process_name`   | The process name of the workload (e.g. `unix:path:python`)                                                              |
+| `unix:arg1`   | The first arguement of the workload command line (e.g. `unix:path:hello.py`)                                                              |
 | `unix:sha256` | The SHA256 digest of the workload binary (e.g. `unix:sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7`) |
 
 Security Considerations:

--- a/doc/plugin_agent_workloadattestor_unix.md
+++ b/doc/plugin_agent_workloadattestor_unix.md
@@ -34,7 +34,7 @@ Workload path enabled selectors (available when configured with `discover_worklo
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `unix:path`   | The path to the workload binary (e.g. `unix:path:/usr/bin/nginx`)                                                              |
 | `unix:process_name`   | The process name of the workload (e.g. `unix:path:python`)                                                              |
-| `unix:arg1`   | The first arguement of the workload command line (e.g. `unix:path:hello.py`)                                                              |
+| `unix:arg1`   | The first argument of the workload command line (e.g. `unix:path:hello.py`)                                                              |
 | `unix:sha256` | The SHA256 digest of the workload binary (e.g. `unix:sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7`) |
 
 Security Considerations:

--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix.go
@@ -62,7 +62,7 @@ func (ps PSProcessInfo) Arg1() (string, error) {
 		return "", err
 	}
 
-	// return the first arguement
+	// return the first argument
 	if len(list) >= 2 {
 		return list[1], nil
 	}
@@ -206,7 +206,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 
 		selectorValues = append(selectorValues, makeSelectorValue("process_name", processName))
 
-		// add first arguement selector value
+		// add first argument selector value
 		arg1, err := p.getFirstArgument(proc)
 
 		if err != nil {

--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
@@ -172,6 +172,8 @@ func (s *Suite) TestAttest() {
 				"gid:2000",
 				"group:g2000",
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
+				"process_name:exe",
+				"arg1:",
 				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
 			},
 			expectCode: codes.OK,
@@ -186,6 +188,8 @@ func (s *Suite) TestAttest() {
 				"gid:2000",
 				"group:g2000",
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
+				"process_name:exe",
+				"arg1:",
 				"sha256:3a6eb0790f39ac87c94f3856b2dd2c5d110e6811602261a9a923d3bb23adc8b7",
 			},
 			expectCode: codes.OK,
@@ -200,6 +204,8 @@ func (s *Suite) TestAttest() {
 				"gid:2000",
 				"group:g2000",
 				fmt.Sprintf("path:%s", filepath.Join(s.dir, "exe")),
+				"process_name:exe",
+				"arg1:",
 			},
 			expectCode: codes.OK,
 		},
@@ -352,6 +358,32 @@ func (p fakeProcess) NamespacedExe() string {
 		return filepath.Join(p.dir, "exe")
 	default:
 		return filepath.Join("/proc", strconv.Itoa(int(p.pid)), "unreadable-exe")
+	}
+}
+
+func (p fakeProcess) Name() (string, error) {
+	switch p.pid {
+	case 7, 8, 9:
+		return "", fmt.Errorf("unable to get EXE for PID %d", p.pid)
+	case 10:
+		return filepath.Join(p.dir, "unreadable-exe"), nil
+	case 11, 12:
+		return "exe", nil
+	default:
+		return "", fmt.Errorf("unhandled exe test case %d", p.pid)
+	}
+}
+
+func (p fakeProcess) Arg1() (string, error) {
+	switch p.pid {
+	case 7, 8, 9:
+		return "", fmt.Errorf("unable to get EXE for PID %d", p.pid)
+	case 10:
+		return filepath.Join(p.dir, "unreadable-exe"), nil
+	case 11, 12:
+		return "", nil
+	default:
+		return "", fmt.Errorf("unhandled exe test case %d", p.pid)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Kaizhe Huang <khuang@aurora.tech>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ x] Commit conforms to CONTRIBUTING.md?
- [ x] Proper tests/regressions included?
- [ x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Extend the Unix workload attestor.

**Description of change**
<!-- Please provide a description of the change -->

Extend unix workload attestor to support two other selectors:
1. `process_name`: the process name is the executable without the absolute path. Though some security concerns may arise to use such selector (it should be documented), it provides flexibility for binary which is built under random directory (e.g. bazel)
2. `arg1`: the first argument of the command line. It supports scenario using interpret language like python. `python hello.py`

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

