### PR TITLE
Log agent SPIFFE ID when TOFU check fails

### DIFF
--- a/pkg/server/hostservice/agentstore/attestation.go
+++ b/pkg/server/hostservice/agentstore/attestation.go
@@ -3,7 +3,6 @@ package agentstore
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
 	"google.golang.org/grpc/codes"
@@ -26,12 +25,13 @@ func IsAttested(ctx context.Context, store agentstorev1.AgentStoreClient, agentI
 	_, err := store.GetAgentInfo(ctx, &agentstorev1.GetAgentInfoRequest{
 		AgentId: agentID,
 	})
-	switch status.Code(err) {
+	st := status.Convert(err)
+	switch st.Code() {
 	case codes.OK:
 		return true, nil
 	case codes.NotFound:
 		return false, nil
 	default:
-		return false, fmt.Errorf("unable to get agent info: %w", err)
+		return false, status.Errorf(st.Code(), "unable to get agent info: %s", st.Message())
 	}
 }

--- a/pkg/server/hostservice/agentstore/attestation_test.go
+++ b/pkg/server/hostservice/agentstore/attestation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -23,7 +24,7 @@ func TestEnsureNotAttested(t *testing.T) {
 	assert.NoError(err)
 
 	err = EnsureNotAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/bad")
-	assert.EqualError(err, "unable to get agent info: ohno")
+	spiretest.AssertGRPCStatus(t, err, codes.Unknown, "unable to get agent info: ohno")
 }
 
 func TestIsAttested(t *testing.T) {
@@ -39,7 +40,7 @@ func TestIsAttested(t *testing.T) {
 	assert.False(attested)
 
 	attested, err = IsAttested(context.Background(), store, "spiffe://domain.test/spire/agent/test/bad")
-	assert.EqualError(err, "unable to get agent info: ohno")
+	spiretest.AssertGRPCStatus(t, err, codes.Unknown, "unable to get agent info: ohno")
 	assert.False(attested)
 }
 

--- a/pkg/server/plugin/nodeattestor/aws/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/aws/iid_test.go
@@ -112,7 +112,7 @@ func TestAttest(t *testing.T) {
 			name:            "already attested",
 			alreadyAttested: true,
 			expectCode:      codes.PermissionDenied,
-			expectMsgPrefix: "nodeattestor(aws_iid): IID has already been used to attest an agent",
+			expectMsgPrefix: "nodeattestor(aws_iid): attestation data has already been used to attest an agent",
 		},
 		{
 			name:                   "DescribeInstances fails",

--- a/pkg/server/plugin/nodeattestor/azure/msi_test.go
+++ b/pkg/server/plugin/nodeattestor/azure/msi_test.go
@@ -229,7 +229,7 @@ func (s *MSIAttestorSuite) TestAttestFailsWhenAttestedBefore() {
 	})
 	s.requireAttestError(s.T(), s.signAttestPayload("KEYID", resourceID, "TENANTID", "PRINCIPALID"),
 		codes.PermissionDenied,
-		"nodeattestor(azure_msi): MSI token has already been used to attest an agent")
+		"nodeattestor(azure_msi): attestation data has already been used to attest an agent")
 }
 
 func (s *MSIAttestorSuite) TestConfigure() {

--- a/pkg/server/plugin/nodeattestor/base/base.go
+++ b/pkg/server/plugin/nodeattestor/base/base.go
@@ -4,9 +4,13 @@ import (
 	"context"
 	"errors"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
 	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/hostservice/agentstore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Base struct {
@@ -22,6 +26,15 @@ func (p *Base) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
 	return nil
 }
 
-func (p *Base) IsAttested(ctx context.Context, agentID string) (bool, error) {
-	return agentstore.IsAttested(ctx, p.store, agentID)
+func (p *Base) AssessTOFU(ctx context.Context, agentID string, log hclog.Logger) error {
+	attested, err := agentstore.IsAttested(ctx, p.store, agentID)
+	switch {
+	case err != nil:
+		return err
+	case attested:
+		log.Error("Attestation data has already been used to attest an agent", telemetry.SPIFFEID, agentID)
+		return status.Error(codes.PermissionDenied, "attestation data has already been used to attest an agent")
+	default:
+		return nil
+	}
 }

--- a/pkg/server/plugin/nodeattestor/base/base.go
+++ b/pkg/server/plugin/nodeattestor/base/base.go
@@ -2,7 +2,6 @@ package base
 
 import (
 	"context"
-	"errors"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/spiffe/spire-plugin-sdk/pluginsdk"
@@ -21,7 +20,7 @@ var _ pluginsdk.NeedsHostServices = (*Base)(nil)
 
 func (p *Base) BrokerHostServices(broker pluginsdk.ServiceBroker) error {
 	if !broker.BrokerClient(&p.store) {
-		return errors.New("required AgentStore host service not available")
+		return status.Error(codes.Internal, "required AgentStore host service not available")
 	}
 	return nil
 }

--- a/pkg/server/plugin/nodeattestor/base/base_test.go
+++ b/pkg/server/plugin/nodeattestor/base/base_test.go
@@ -1,0 +1,120 @@
+package base_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	agentstorev1 "github.com/spiffe/spire-plugin-sdk/proto/spire/hostservice/server/agentstore/v1"
+	nodeattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/nodeattestor/v1"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
+	"github.com/spiffe/spire/test/fakes/fakeagentstore"
+	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestBaseRequiresAgentStoreHostService(t *testing.T) {
+	var err error
+	plugintest.Load(t, fakeBuiltIn(), nil, plugintest.CaptureLoadError(&err))
+	spiretest.RequireGRPCStatus(t, err, codes.Internal, "required AgentStore host service not available")
+}
+
+func TestBaseAssessTOFU(t *testing.T) {
+	const unattestedID = "spiffe://domain.test/spire/agent/unattested"
+	const attestedID = "spiffe://domain.test/spire/agent/attested"
+	const errorID = "spiffe://domain.test/spire/agent/error"
+
+	log, hook := test.NewNullLogger()
+
+	agentStore := fakeagentstore.New()
+	agentStore.SetAgentInfo(&agentstorev1.AgentInfo{AgentId: attestedID})
+	agentStore.SetAgentErr(errorID, status.Error(codes.Internal, "ohno"))
+	na := new(nodeattestor.V1)
+	plugintest.Load(t, fakeBuiltIn(), na,
+		plugintest.HostServices(agentstorev1.AgentStoreServiceServer(agentStore)),
+		plugintest.Log(log),
+	)
+
+	failOnChallenge := func(context.Context, []byte) ([]byte, error) {
+		return nil, errors.New("unexpected challenge")
+	}
+
+	t.Run("with unattested agent", func(t *testing.T) {
+		hook.Reset()
+		result, err := na.Attest(context.Background(), []byte(unattestedID), failOnChallenge)
+		require.NoError(t, err)
+		require.Equal(t, &nodeattestor.AttestResult{
+			AgentID: unattestedID,
+		}, result)
+		spiretest.AssertLogs(t, hook.AllEntries(), nil)
+	})
+
+	t.Run("with already attested agent", func(t *testing.T) {
+		hook.Reset()
+		result, err := na.Attest(context.Background(), []byte(attestedID), failOnChallenge)
+		spiretest.RequireGRPCStatus(t, err, codes.PermissionDenied, "nodeattestor(fake): attestation data has already been used to attest an agent")
+		require.Nil(t, result)
+		spiretest.AssertLogs(t, hook.AllEntries(), []spiretest.LogEntry{
+			{
+				Level:   logrus.ErrorLevel,
+				Message: "Attestation data has already been used to attest an agent",
+				Data: logrus.Fields{
+					"spiffe_id": "spiffe://domain.test/spire/agent/attested",
+				},
+			},
+		})
+	})
+
+	t.Run("fails to query agent store", func(t *testing.T) {
+		hook.Reset()
+		result, err := na.Attest(context.Background(), []byte(errorID), failOnChallenge)
+		spiretest.RequireGRPCStatus(t, err, codes.Internal, "nodeattestor(fake): unable to get agent info: ohno")
+		require.Nil(t, result)
+	})
+}
+
+func fakeBuiltIn() catalog.BuiltIn {
+	return catalog.BuiltIn{
+		Name:   "fake",
+		Plugin: nodeattestorv1.NodeAttestorPluginServer(&fakePlugin{}),
+	}
+}
+
+type fakePlugin struct {
+	nodeattestorv1.UnimplementedNodeAttestorServer
+	base.Base
+	log hclog.Logger
+}
+
+func (p *fakePlugin) SetLogger(log hclog.Logger) {
+	p.log = log
+}
+
+func (p *fakePlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
+	req, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	spiffeID := string(req.GetPayload())
+
+	if err := p.AssessTOFU(stream.Context(), spiffeID, p.log); err != nil {
+		return err
+	}
+
+	return stream.Send(&nodeattestorv1.AttestResponse{
+		Response: &nodeattestorv1.AttestResponse_AgentAttributes{
+			AgentAttributes: &nodeattestorv1.AgentAttributes{
+				SpiffeId: spiffeID,
+			},
+		},
+	})
+}

--- a/pkg/server/plugin/nodeattestor/gcp/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit.go
@@ -126,12 +126,8 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 		return status.Errorf(codes.Internal, "failed to create agent ID: %v", err)
 	}
 
-	attested, err := p.IsAttested(stream.Context(), id.String())
-	switch {
-	case err != nil:
+	if err := p.AssessTOFU(stream.Context(), id.String(), p.log); err != nil {
 		return err
-	case attested:
-		return status.Error(codes.PermissionDenied, "IIT has already been used to attest an agent")
 	}
 
 	var instance *compute.Instance

--- a/pkg/server/plugin/nodeattestor/gcp/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcp/iit_test.go
@@ -103,7 +103,7 @@ func (s *IITAttestorSuite) TestErrorOnAttestedBefore() {
 		AgentId: testAgentID,
 	})
 
-	s.requireAttestError(s.T(), payload, codes.PermissionDenied, "nodeattestor(gcp_iit): IIT has already been used to attest an agent")
+	s.requireAttestError(s.T(), payload, codes.PermissionDenied, "nodeattestor(gcp_iit): attestation data has already been used to attest an agent")
 }
 
 func (s *IITAttestorSuite) TestErrorOnProjectIdMismatch() {

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat.go
@@ -162,12 +162,8 @@ func (p *AttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer)
 	// It is incredibly unlikely the agent will have already attested since we
 	// generate a new UUID on each attestation but just in case...
 	agentID := k8s.AgentID(pluginName, config.trustDomain, attestationData.Cluster, uuid)
-	attested, err := p.IsAttested(stream.Context(), agentID)
-	switch {
-	case err != nil:
+	if err := p.AssessTOFU(stream.Context(), agentID, p.log); err != nil {
 		return err
-	case attested:
-		return status.Error(codes.PermissionDenied, "SAT has already been used to attest an agent with the same UUID")
 	}
 
 	var namespace, serviceAccountName string

--- a/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8s/sat/sat_test.go
@@ -135,7 +135,7 @@ func (s *AttestorSuite) TestAttestFailsWhenAttestedBefore() {
 	token := s.signToken(s.fooSigner, "NS1", "SA1")
 	s.requireAttestError(makePayload("FOO", token),
 		codes.PermissionDenied,
-		"nodeattestor(k8s_sat): SAT has already been used to attest an agent with the same UUID")
+		"nodeattestor(k8s_sat): attestation data has already been used to attest an agent")
 }
 
 func (s *AttestorSuite) TestAttestFailsWithMalformedPayload() {


### PR DESCRIPTION
Attestors currently do not return to the agent or even log which agent failed a TOFU check during attestation.

To prevent information leakage, we probably don't want to include the agent ID in the error returned from the server. However, we should be at least logging this information on the server to facilitate debugging.

Due to the current attestation flow, this is a little hard to log from the core service handler. However, each nodeattestor that enforces TOFU obtains that information from a common helper.

This change updates that helper to log a message that includes the SPIFFE ID as well as a uniform PermissionDenied status to callers.

Fixes: #3205