### PR TITLE
Windows support: restrict access to data directories

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" //nolint: gosec // import registers routes on DefaultServeMux
-	"os"
 	"path"
 	"runtime"
 	"sync"
@@ -20,6 +19,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager"
 	"github.com/spiffe/spire/pkg/agent/manager/storecache"
 	"github.com/spiffe/spire/pkg/agent/svid/store"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/profiling"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -40,7 +40,7 @@ type Agent struct {
 // and then blocks on the main event loop.
 func (a *Agent) Run(ctx context.Context) error {
 	a.c.Log.Infof("Starting agent with data directory: %q", a.c.DataDir)
-	if err := os.MkdirAll(a.c.DataDir, 0755); err != nil {
+	if err := diskutil.CreateDataDirectory(a.c.DataDir); err != nil {
 		return err
 	}
 

--- a/pkg/agent/api/endpoints_windows.go
+++ b/pkg/agent/api/endpoints_windows.go
@@ -8,11 +8,11 @@ import (
 	"net"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/sddl"
 )
 
 func (e *Endpoints) createListener() (net.Listener, error) {
-	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
+	l, err := e.listener.ListenPipe(e.c.BindAddr.String(), &winio.PipeConfig{SecurityDescriptor: sddl.PrivateListener})
 	if err != nil {
 		return nil, fmt.Errorf("error creating named pipe listener: %w", err)
 	}

--- a/pkg/agent/endpoints/endpoints_windows.go
+++ b/pkg/agent/endpoints/endpoints_windows.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/spiffe/spire/pkg/common/peertracker"
-	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/sddl"
 )
 
 func (e *Endpoints) createPipeListener() (net.Listener, error) {
 	pipeListener := &peertracker.ListenerFactory{
 		Log: e.log,
 	}
-	l, err := pipeListener.ListenPipe(e.addr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPublicListener})
+	l, err := pipeListener.ListenPipe(e.addr.String(), &winio.PipeConfig{SecurityDescriptor: sddl.PublicListener})
 	if err != nil {
 		return nil, fmt.Errorf("create named pipe listener: %w", err)
 	}

--- a/pkg/common/diskutil/file_posix.go
+++ b/pkg/common/diskutil/file_posix.go
@@ -35,6 +35,10 @@ func AtomicWriteFile(path string, data []byte, mode os.FileMode) error {
 	return dir.Close()
 }
 
+func CreateDataDirectory(path string) error {
+	return os.MkdirAll(path, 0755)
+}
+
 func write(tmpPath string, data []byte, mode os.FileMode) error {
 	file, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {

--- a/pkg/common/sddl/sddl_windows.go
+++ b/pkg/common/sddl/sddl_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+// +build windows
+
+package sddl
+
+const (
+	// PrivateFile describes a security descriptor using the security
+	// descriptor definition language (SDDL) that is meant to be used
+	// to define the access control to files that only need to be
+	// accessed by the owner of the file, granting full access
+	// to the creator owner only.
+	PrivateFile = "D:P(A;;FA;;;OW)"
+
+	// PrivateListener describes a security descriptor using the
+	// security descriptor definition language (SDDL) that is meant
+	// to be used to define the access control to named pipes
+	// listeners that only need to be accessed locally by the owner
+	// of the service, granting read, write and execute permissions
+	// to the creator owner only.
+	// E.g.: SPIRE Server APIs, Admin APIs.
+	PrivateListener = "D:P(A;;GRGWGX;;;OW)"
+
+	// PublicListener describes a security descriptor using the
+	// security descriptor definition language (SDDL) that is meant
+	// to be used to define the access control to named pipes
+	// listeners that need to be publicly accessed, granting read,
+	// write and execute permissions to everyone.
+	// E.g.: SPIFFE Workload API.
+	PublicListener = "D:P(A;;GRGWGX;;;WD)"
+)

--- a/pkg/common/util/addr_windows.go
+++ b/pkg/common/util/addr_windows.go
@@ -17,25 +17,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	// SDDLPrivateListener describes a security descriptor using the
-	// security descriptor definition language (SDDL) that is meant
-	// to be used to define the access control to named pipes
-	// listeners that only need to be accessed locally by the owner
-	// of the service, granting read, write and execute permissions
-	// to the creator owner only.
-	// E.g.: SPIRE Server APIs, Admin APIs.
-	SDDLPrivateListener = "D:P(A;;GRGWGX;;;OW)"
-
-	// SDDLPublicListener describes a security descriptor using the
-	// security descriptor definition language (SDDL) that is meant
-	// to be used to define the access control to named pipes
-	// listeners that need to be publicly accessed, granting read,
-	// write and execute permissions to everyone.
-	// E.g.: SPIFFE Workload API.
-	SDDLPublicListener = "D:P(A;;GRGWGX;;;WD)"
-)
-
 type NamedPipeAddr struct {
 	serverName string
 	pipeName   string

--- a/pkg/server/endpoints/endpoints_windows.go
+++ b/pkg/server/endpoints/endpoints_windows.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/spiffe/spire/pkg/common/peertracker"
-	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/sddl"
 )
 
 func (e *Endpoints) listen() (net.Listener, error) {
-	return winio.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
+	return winio.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: sddl.PrivateListener})
 }
 
 func (e *Endpoints) listenWithAuditLog() (*peertracker.Listener, error) {
@@ -20,7 +20,7 @@ func (e *Endpoints) listenWithAuditLog() (*peertracker.Listener, error) {
 		Log: e.Log,
 	}
 
-	return lf.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
+	return lf.ListenPipe(e.LocalAddr.String(), &winio.PipeConfig{SecurityDescriptor: sddl.PrivateListener})
 }
 
 func (e *Endpoints) restrictLocalAddr() error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	_ "net/http/pprof" //nolint: gosec // import registers routes on DefaultServeMux
 	"net/url"
-	"os"
 	"runtime"
 	"sync"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
 	server_util "github.com/spiffe/spire/cmd/spire-server/util"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/profiling"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -68,7 +68,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 	}).Info("Configured")
 
 	// create the data directory if needed
-	if err := os.MkdirAll(s.config.DataDir, 0755); err != nil {
+	if err := diskutil.CreateDataDirectory(s.config.DataDir); err != nil {
 		return err
 	}
 

--- a/support/oidc-discovery-provider/main_windows.go
+++ b/support/oidc-discovery-provider/main_windows.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/Microsoft/go-winio"
+	"github.com/spiffe/spire/pkg/common/sddl"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/zeebo/errs"
 )
@@ -52,5 +53,5 @@ func (c *Config) validateOS() (err error) {
 
 func listenLocal(c *Config) (net.Listener, error) {
 	return winio.ListenPipe(util.GetNamedPipeAddr(c.Experimental.ListenNamedPipeName).String(),
-		&winio.PipeConfig{SecurityDescriptor: util.SDDLPrivateListener})
+		&winio.PipeConfig{SecurityDescriptor: sddl.PrivateListener})
 }


### PR DESCRIPTION
Agent and server data directories on Windows are currently created using a NULL security descriptor. As a result, the directories get a default security descriptor and the ACLs are inherited from the parent directory. This is because of the lack of support of security descriptors in the `os.MkdirAll function`.

This change introduces a custom implementation of the `os.MkdirAll` function so that a security descriptor can be applied.
Data directories are now created with a security descriptor that grants full access to the owner only.

This is part of #3189.