### PR TITLE
Add random ID template value to x509pop agent IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.3.1] - 2022-06-09
+
+### Added
+- The `windows` workload attestor gained a new `sha256` selector that can attest the SHA256 digest of the workload binary (#3100)
+
+### Fixed
+- Database rows related to registration entries are now properly removed (#3127, #3132)
+- Agent reduces bandwidth use by requesting only required information when syncing with the server (#3123)
+- Issue with read-modify-write operations when using PostgreSQL datastore in hot standby mode (#3103)
+
+### Changed
+- FetchX509Bundles RPC no longer sends spurious updates that contain no changes (#3102)
+- Warn if the built-in `join_token` node attestor is attempted to be overridden by an external plugin (#3045)
+- Database connections are now proactively closed when SPIRE server is shut down (#3047)
+
 ## [1.3.0] - 2022-05-12
 
 ### Added

--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -34,6 +34,7 @@ type agentPathTemplateData struct {
 	Fingerprint string
 	PluginName  string
 	TrustDomain string
+	RandID      string
 }
 
 type AttestationData struct {
@@ -271,12 +272,13 @@ func MakeAgentID(td spiffeid.TrustDomain, agentPathTemplate *agentpathtemplate.T
 		Certificate: cert,
 		PluginName:  PluginName,
 		Fingerprint: Fingerprint(cert),
+		RandID:      generateAgentIDPostfix(8),
 	})
 	if err != nil {
 		return spiffeid.ID{}, err
 	}
 
-	return idutil.AgentID(td, agentPath+"/"+generateAgentIDPostfix(8))
+	return idutil.AgentID(td, agentPath)
 }
 
 func generateAgentIDPostfix(n int) string {

--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	mrand "math/rand"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
@@ -275,7 +276,18 @@ func MakeAgentID(td spiffeid.TrustDomain, agentPathTemplate *agentpathtemplate.T
 		return spiffeid.ID{}, err
 	}
 
-	return idutil.AgentID(td, agentPath)
+	return idutil.AgentID(td, agentPath+"/"+generateAgentIDPostfix(8))
+}
+
+func generateAgentIDPostfix(n int) string {
+	runes := []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+	postfix := make([]rune, n)
+
+	for i := range postfix {
+		postfix[i] = runes[mrand.Intn(len(runes))]
+	}
+
+	return string(postfix)
 }
 
 func generateNonce() ([]byte, error) {

--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -272,7 +272,7 @@ func MakeAgentID(td spiffeid.TrustDomain, agentPathTemplate *agentpathtemplate.T
 		Certificate: cert,
 		PluginName:  PluginName,
 		Fingerprint: Fingerprint(cert),
-		RandID:      generateAgentIDPostfix(8),
+		RandID:      generateAgentIDRandomness(8),
 	})
 	if err != nil {
 		return spiffeid.ID{}, err
@@ -281,15 +281,15 @@ func MakeAgentID(td spiffeid.TrustDomain, agentPathTemplate *agentpathtemplate.T
 	return idutil.AgentID(td, agentPath)
 }
 
-func generateAgentIDPostfix(n int) string {
+func generateAgentIDRandomness(n int) string {
 	runes := []rune("abcdefghijklmnopqrstuvwxyz1234567890")
-	postfix := make([]rune, n)
+	id := make([]rune, n)
 
-	for i := range postfix {
-		postfix[i] = runes[mrand.Intn(len(runes))]
+	for i := range id {
+		id[i] = runes[mrand.Intn(len(runes))]
 	}
 
-	return string(postfix)
+	return string(id)
 }
 
 func generateNonce() ([]byte, error) {

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	mrand "math/rand"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -130,6 +131,7 @@ func createBadCertificate(privateKey, publicKey interface{}) (*x509.Certificate,
 }
 
 func TestMakeAgentID(t *testing.T) {
+	mrand.Seed(2121)
 	tests := []struct {
 		desc      string
 		template  *agentpathtemplate.Template
@@ -145,6 +147,11 @@ func TestMakeAgentID(t *testing.T) {
 			desc:     "custom template with subject identifiers",
 			template: agentpathtemplate.MustParse("/foo/{{ .Subject.CommonName }}"),
 			expectID: "spiffe://example.org/spire/agent/foo/test-cert",
+		},
+		{
+			desc:     "custom template with random suffix",
+			template: agentpathtemplate.MustParse("/foo/{{ .RandID }}"),
+			expectID: "spiffe://example.org/spire/agent/foo/4yfbxurj",
 		},
 		{
 			desc:      "custom template with nonexistant fields",

--- a/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
@@ -5,6 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"sync"
+	"time"
+
+	"math/rand"
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -157,6 +160,7 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 }
 
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
+	rand.Seed(time.Now().UnixNano())
 	hclConfig := new(Config)
 	if err := hcl.Decode(hclConfig, req.HclConfiguration); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)


### PR DESCRIPTION
This will allow users who are using x509pop with a shared leaf certificate to distinguish between agents and avoid cases where a new agent coming online will invalidate the SPIFFE IDs of any previously running agents. 