### PR TITLE
Add a random ID as a template option to distinguish shared agent certificates

### DIFF
--- a/pkg/common/plugin/x509pop/x509pop.go
+++ b/pkg/common/plugin/x509pop/x509pop.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	mrand "math/rand"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/agentpathtemplate"
@@ -33,6 +34,7 @@ type agentPathTemplateData struct {
 	Fingerprint string
 	PluginName  string
 	TrustDomain string
+	RandID      string
 }
 
 type AttestationData struct {
@@ -270,12 +272,24 @@ func MakeAgentID(td spiffeid.TrustDomain, agentPathTemplate *agentpathtemplate.T
 		Certificate: cert,
 		PluginName:  PluginName,
 		Fingerprint: Fingerprint(cert),
+		RandID:      generateAgentIDRandomness(8),
 	})
 	if err != nil {
 		return spiffeid.ID{}, err
 	}
 
 	return idutil.AgentID(td, agentPath)
+}
+
+func generateAgentIDRandomness(n int) string {
+	runes := []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+	id := make([]rune, n)
+
+	for i := range id {
+		id[i] = runes[mrand.Intn(len(runes))]
+	}
+
+	return string(id)
 }
 
 func generateNonce() ([]byte, error) {

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	mrand "math/rand"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -130,6 +131,7 @@ func createBadCertificate(privateKey, publicKey interface{}) (*x509.Certificate,
 }
 
 func TestMakeAgentID(t *testing.T) {
+	mrand.Seed(2121)
 	tests := []struct {
 		desc      string
 		template  *agentpathtemplate.Template
@@ -145,6 +147,11 @@ func TestMakeAgentID(t *testing.T) {
 			desc:     "custom template with subject identifiers",
 			template: agentpathtemplate.MustParse("/foo/{{ .Subject.CommonName }}"),
 			expectID: "spiffe://example.org/spire/agent/foo/test-cert",
+		},
+		{
+			desc:     "custom template with random suffix",
+			template: agentpathtemplate.MustParse("/foo/{{ .RandID }}"),
+			expectID: "spiffe://example.org/spire/agent/foo/4yfbxurj",
 		},
 		{
 			desc:      "custom template with nonexistant fields",

--- a/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
+++ b/pkg/server/plugin/nodeattestor/x509pop/x509pop.go
@@ -5,6 +5,9 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"sync"
+	"time"
+
+	"math/rand"
 
 	"github.com/hashicorp/hcl"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -157,6 +160,7 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 }
 
 func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
+	rand.Seed(time.Now().UnixNano())
 	hclConfig := new(Config)
 	if err := hcl.Decode(hclConfig, req.HclConfiguration); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unable to decode configuration: %v", err)


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
When using x509pop, any agents sharing the same certificate will get the same SPIFFE ID. In some cases however, it may be desirable to share certificates between agents (such as ECS tasks running multiple replicas) without granting all of them the same SPIFFE ID. Otherwise, when a new replica comes online, its attestation process will invalidate the SPIFFE IDs of all existing task instances due to SPIRE's certificate serial number checks.
