### PR TITLE
Fail on unknown configuration on docker workload attestor

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/docker/docker/api/types"
@@ -13,7 +14,6 @@ import (
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
-	"github.com/spiffe/spire/pkg/common/telemetry"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -124,8 +124,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	}
 
 	if len(config.UnusedKeys) > 0 {
-		// DEPRECATED: remove in SPIRE 1.4
-		p.log.Warn("Detected unknown configuration; this will be fatal in a future release", telemetry.Keys, config.UnusedKeys)
+		return nil, status.Errorf(codes.InvalidArgument, "unknown configurations detected: %s", strings.Join(config.UnusedKeys, ","))
 	}
 
 	containerHelper, err := createHelper(config)


### PR DESCRIPTION
Fails when an invalid configuration is set on docker workload attestor configuration

**Which issue this PR fixes**
fixes #3054 

