### PR TITLE
Add option to use anonymous authentication in k8s WorkloadAttestor

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -347,6 +347,10 @@ plugins {
             # private_key_path: The path on disk to client key used for kubelet
             # authentication.
             # private_key_path = ""
+            
+            # use_anonymous_authentication: If true, use anonymous authentication
+            # for kubelet communication.
+            # use_anonymous_authentication = false
 
             # node_name_env: The environment variable used to obtain the node
             # name. Default: MY_NODE_NAME.

--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -31,6 +31,12 @@ server name validation against the kubelet certificate.
 > mitigate this issue. A large cache ttl value is not recommended however, as
 > that can impact permission revocation.
 
+> **Note** Anonymous authentication with the kubelet requires that the
+> kubelet be started with the `--anonymous-auth` flag. It is discouraged to use anonymous
+> auth mode in production as it requires authorizing anonymous users to the `nodes/proxy`
+> resource that maps to some privileged operations, such as executing commands in
+> containers and reading pod logs.
+
 **Note** To run on Windows containers, Kubernetes v1.24+ and containerd v1.6+ are required,
 since [hostprocess](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/) container is required on the agent container.
 
@@ -43,6 +49,7 @@ since [hostprocess](https://kubernetes.io/docs/tasks/configure-pod-container/cre
 | `token_path` | The path on disk to the bearer token used for kubelet authentication. Defaults to the service account token `/run/secrets/kubernetes.io/serviceaccount/token` |
 | `certificate_path` | The path on disk to client certificate used for kubelet authentication |
 | `private_key_path` | The path on disk to client key used for kubelet authentication |
+| `use_anonymous_authentication` | If true, use anonymous authentication for kubelet communication |
 | `node_name_env` | The environment variable used to obtain the node name. Defaults to `MY_NODE_NAME`. |
 | `node_name` | The name of the node. Overrides the value obtained by the environment variable specified by `node_name_env`. |
 

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -17,9 +17,6 @@ import (
 	"sync"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
 	"github.com/andres-erbsen/clock"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
@@ -31,6 +28,8 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
`k8s` WorkloadAttestor plugin integration with kubelet

**Description of change**
The `k8s` WorkloadAttestor plugin does not provide a way to obtain selectors from the kubelet over the secure port when the kubelet is configured to use anonymous authentication. Add a configuration field `use_anonymous_authentication` that allows the plugin to send unauthenticated requests to the kubelet secure port.

**Which issue this PR fixes**
#3193

Tested this with the `k8s-reconcile` test with these changes applied in my local branch: https://github.com/spiffe/spire/commit/0d59a37267d564a8e042d07c3c94cd2859109b3b