### PR TITLE
Stop dropping can_reattest on SVID renewal

### DIFF
--- a/pkg/server/endpoints/middleware.go
+++ b/pkg/server/endpoints/middleware.go
@@ -97,6 +97,7 @@ func AgentAuthorizer(log logrus.FieldLogger, ds datastore.DataStore, clk clock.C
 				SpiffeId:         attestedNode.SpiffeId,
 				CertNotAfter:     attestedNode.NewCertNotAfter,
 				CertSerialNumber: attestedNode.NewCertSerialNumber,
+				CanReattest:      attestedNode.CanReattest,
 			}, nil)
 			if err != nil {
 				log.WithFields(logrus.Fields{


### PR DESCRIPTION
Ensures the can_reattest flag is propogated when the attested node record is updated. Improves unit-test coverage.

Thanks to @faisal-memon for discovery.