### PR TITLE
Fix data race in "spire" UpstreamAuthority tests

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -227,8 +227,8 @@ func TestMintX509CA(t *testing.T) {
 			// Setup servers
 			server := testHandler{}
 			server.startTestServers(t, ca, serverCert, serverKey, svidCert, svidKey)
-			server.sAPIServer.err = c.sAPIError
-			server.sAPIServer.downstreamResponse = c.downstreamResp
+			server.sAPIServer.setError(c.sAPIError)
+			server.sAPIServer.setDownstreamResponse(c.downstreamResp)
 
 			serverAddr := server.sAPIServer.addr
 			workloadAPIAddr := server.wAPIServer.workloadAPIAddr
@@ -356,7 +356,7 @@ func TestPublishJWTKey(t *testing.T) {
 	// Fail to push JWT authority
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	server.sAPIServer.err = errors.New("some error")
+	server.sAPIServer.setError(errors.New("some error"))
 	upstreamJwtKeys, _, err = ua.PublishJWTKey(ctx, &common.PublicKey{
 		Kid:       "kid-2",
 		PkixBytes: pkixBytes,


### PR DESCRIPTION
The err and downstreamResponse are accessed by multiple goroutines.
Putting them behind a mutex.

Signed-off-by: Andrew Harding <aharding@vmware.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

