### PR TITLE
Bump max received msg size for Agent fetchEntries to 32MB

### DIFF
--- a/pkg/agent/client/dial.go
+++ b/pkg/agent/client/dial.go
@@ -20,13 +20,7 @@ import (
 )
 
 const (
-	defaultDialTimeout = 30 * time.Second
-	// TODO #2675 / #2845: For very large registration entry sets, Agent
-	// will fail to sync with Server due to default grpc max received
-	// message size of 4MB.
-	// For now, we set the maximum to 32MB as a stopgap.
-	// The long-term solution is to be discussed in the Github issues.
-	maxCallRecvMsgSize      = 32 * 1024 * 1024
+	defaultDialTimeout      = 30 * time.Second
 	roundRobinServiceConfig = `{ "loadBalancingConfig": [ { "round_robin": {} } ] }`
 )
 
@@ -75,9 +69,6 @@ func DialServer(ctx context.Context, config DialServerConfig) (*grpc.ClientConn,
 		grpc.WithBlock(),
 		grpc.WithReturnConnectionError(),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize),
-		),
 	)
 	switch {
 	case err == nil:

--- a/pkg/agent/client/dial.go
+++ b/pkg/agent/client/dial.go
@@ -24,9 +24,9 @@ const (
 	// TODO #2675 / #2845: For very large registration entry sets, Agent
 	// will fail to sync with Server due to default grpc max received
 	// message size of 4MB.
-	// For now, we set the maximum to 16MB as a stopgap.
+	// For now, we set the maximum to 32MB as a stopgap.
 	// The long-term solution is to be discussed in the Github issues.
-	maxCallRecvMsgSize      = 16 * 1024 * 1024
+	maxCallRecvMsgSize      = 32 * 1024 * 1024
 	roundRobinServiceConfig = `{ "loadBalancingConfig": [ { "round_robin": {} } ] }`
 )
 


### PR DESCRIPTION
Signed-off-by: amoore877 <andrew.s.moore@uber.com>

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [N/A] Documentation updated?

**Affected functionality**
Agent grpc max received message size over connections with Server to get authorized entries.

**Description of change**
The default max size is 4MB. Per [investigation](https://github.com/spiffe/spire/issues/2675#issuecomment-1035237101) and local reproduction of results this is about 17k registration entries.

Set the new maximum to 32MB.

Using the same quick check script as above, this bumps the limit to about 135.5k entries, which is theorized to be more than sufficient for operators while #2675 and #2845 are being addressed with long-term solutions for reduction of overhead + batching and/or changing the API to a streaming RPC / pagination.

This high limit was chosen to ensure that we do not need to patch this again in the meantime.

Anticipate that any operators who would regress from this change are either:
- already in a broken state due Agent being unable to sync registrations from Server. Unbreaking this portion of their ecosystem either fixes their ecosystem or reveals the next issue with their configuration, like not properly setting resource configs for the Agent.
- created a situation that would normally prevent Agent syncing but instead increases Agent resource usage.

Anticipate that removal of this patch later when we have a true solution to the problem in place will have no regressive effect, as the long-term solution should lower or eliminate chances of exceeding max message sizes.

**Which issue this PR fixes**
Does not provide a permanent fix to any PR.