### PR TITLE
Upgrade golangci-lint to 1.47.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ endif
 
 go_path := PATH="$(go_bin_dir):$(PATH)"
 
-golangci_lint_version = v1.46.0
+golangci_lint_version = v1.47.3
 golangci_lint_dir = $(build_dir)/golangci_lint/$(golangci_lint_version)
 golangci_lint_bin = $(golangci_lint_dir)/golangci-lint
 golangci_lint_cache = $(golangci_lint_dir)/cache

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	_ "net/http/pprof" //nolint: gosec // import registers routes on DefaultServeMux
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	admin_api "github.com/spiffe/spire/pkg/agent/api"
@@ -141,8 +142,9 @@ func (a *Agent) setupProfiling(ctx context.Context) (stop func()) {
 		grpc.EnableTracing = true
 
 		server := http.Server{
-			Addr:    fmt.Sprintf("localhost:%d", a.c.ProfilingPort),
-			Handler: http.DefaultServeMux,
+			Addr:              fmt.Sprintf("localhost:%d", a.c.ProfilingPort),
+			Handler:           http.DefaultServeMux,
+			ReadHeaderTimeout: time.Second * 10,
 		}
 
 		// kick off a goroutine to serve the pprof endpoints and one to

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -77,8 +77,9 @@ func NewChecker(config Config, log logrus.FieldLogger) ServableChecker {
 		handler.HandleFunc(config.getLivePath(), c.liveHandler)
 
 		c.server = &http.Server{
-			Addr:    config.getAddress(),
-			Handler: handler,
+			Addr:              config.getAddress(),
+			Handler:           handler,
+			ReadHeaderTimeout: time.Second * 10,
 		}
 	}
 

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	prommetrics "github.com/armon/go-metrics/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -50,8 +51,9 @@ func newPrometheusRunner(c *MetricsConfig) (sinkRunner, error) {
 	}
 
 	runner.server = &http.Server{
-		Addr:    fmt.Sprintf("%s:%d", runner.c.Host, runner.c.Port),
-		Handler: handler,
+		Addr:              fmt.Sprintf("%s:%d", runner.c.Host, runner.c.Port),
+		Handler:           handler,
+		ReadHeaderTimeout: time.Second * 10,
 	}
 
 	return runner, nil

--- a/pkg/server/endpoints/bundle/server.go
+++ b/pkg/server/endpoints/bundle/server.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
@@ -62,8 +63,9 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 	tlsConfig.MinVersion = tls.VersionTLS12
 
 	server := &http.Server{
-		Handler:   http.HandlerFunc(s.serveHTTP),
-		TLSConfig: tlsConfig,
+		Handler:           http.HandlerFunc(s.serveHTTP),
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: time.Second * 10,
 	}
 
 	errCh := make(chan error, 1)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
@@ -202,8 +203,9 @@ func (s *Server) setupProfiling(ctx context.Context) (stop func()) {
 		grpc.EnableTracing = true
 
 		server := http.Server{
-			Addr:    fmt.Sprintf("localhost:%d", s.config.ProfilingPort),
-			Handler: http.DefaultServeMux,
+			Addr:              fmt.Sprintf("localhost:%d", s.config.ProfilingPort),
+			Handler:           http.DefaultServeMux,
+			ReadHeaderTimeout: time.Second * 10,
 		}
 
 		// kick off a goroutine to serve the pprof endpoints and one to


### PR DESCRIPTION
- This version supports all of the linters we have enabled with go1.18+.
- Applies a ReadHeaderTimeout to all of our HTTP servers