### PR TITLE
Prevent to run CI on PR that contains only documentation changes

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -1,6 +1,10 @@
 name: PR Build
 on:
-  pull_request: {}
+  pull_request:
+    # Ignore when changes are only on documentation
+    paths-ignore:
+      - '*.md'
+      - "doc/**"
   workflow_dispatch: {}
 env:
   GO_VERSION: 1.19.0

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -4,7 +4,7 @@ on:
     # Ignore when changes are only on documentation
     paths-ignore:
       - '*.md'
-      - "doc/**"
+      - 'doc/**'
   workflow_dispatch: {}
 env:
   GO_VERSION: 1.19.0


### PR DESCRIPTION
It is not necessary to run CI workflows in case changes are only on documentation
