### PR TITLE
[dependabot] Ignore patch versions of AWS SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   # go-sqlite3 v2 is not the latest release. See the repo for more information.
   - dependency-name: "github.com/mattn/go-sqlite3"
     versions: ["2.x"]
-  - dependency-name: "github.com/aws/aws-sdk-go"
+  - dependency-name: "github.com/aws/aws-sdk-go-v2*"
     update-types: ["version-update:semver-patch"]
   open-pull-requests-limit: 5
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
The AWS SDK v2 is decomposed into Go modules per service, and each of these modules has new patch releases almost weekly, if not more frequently. There is not currently a lot of active development of AWS-related features in SPIRE. Handling these patch updates has proved to be very time-consuming with little to no value.

We used to ignore these updates for the AWS SDK v1 before we fully upgraded to using the v2 SDK. Update the dependabot settings to ignore all the AWS SDK v2 module patch updates.