### PR TITLE
Fixes #3436: Properly asserts expected error is returned

### DIFF
--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -2291,7 +2291,7 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 		EntryExpiry:   1000,
 		DnsNames:      []string{"dns2"},
 		Downstream:    false,
-		StoreSvid:     false,
+		StoreSvid:     true,
 	}
 	badEntry := &common.RegistrationEntry{
 		ParentId:      "not a good parent id",
@@ -2368,7 +2368,7 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 			update: func(e *common.RegistrationEntry) { e.Selectors = badEntry.Selectors },
 			result: func(e *common.RegistrationEntry) {}},
 		{name: "Update Selectors, Bad Data, Mask True",
-			mask:   &common.RegistrationEntryMask{Selectors: false},
+			mask:   &common.RegistrationEntryMask{Selectors: true},
 			update: func(e *common.RegistrationEntry) { e.Selectors = badEntry.Selectors },
 			err:    errors.New("invalid registration entry: missing selector list")},
 		{name: "Update Selectors, Bad Data, Mask False",
@@ -2462,7 +2462,7 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 			updatedRegistrationEntry, err := s.ds.UpdateRegistrationEntry(ctx, updateEntry, tt.mask)
 
 			if tt.err != nil {
-				s.Require().Error(tt.err)
+				s.Require().ErrorContains(err, tt.err.Error())
 				return
 			}
 


### PR DESCRIPTION
This fix includes two test setup fixes as well. Both tests expected an error to be returned but the actual test setup code did not result in an error. The bug in `s.Require().Error(tt.err)` missed that failed check. After changing to `s.Require().ErrorContains(err, tt.err.Error())` we saw those two tests now fail. Fortunately, the bug was in the test setup instead of application code. Application code was/is properly checking for valid entry content on an update action.

Fixes #3436 

Signed-off-by: Dennis Gove <dgove1@bloomberg.net>

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

