### PR TITLE
Add known issues to k8s workload attestor

### DIFF
--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -131,3 +131,7 @@ WorkloadAttestor "k8s" {
 ### Platform support
 
 This plugin is only supported on Unix systems.
+
+### Known issues
+
+* This plugin may fail to correctly attest workloads in pods that use lifecycle hooks to alter pod start behavior. This includes Istio workloads when the `holdApplicationUntilProxyStarts` configurable is set to true. Please see [#3092](https://github.com/spiffe/spire/issues/3092) for more information.


### PR DESCRIPTION
The issue described in #3092 is unlikely to be solved any time. Adding it to the docs so its more easily discovered.

Signed-off-by: Evan Gilman <evan2645@gmail.com>