### PR TITLE
CRD k8s-workload-registrar: cleanup entries with entryid is not set

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller_test.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller_test.go
@@ -131,7 +131,7 @@ func (s *SpiffeIDControllerTestSuite) TestCreateAndDeleteSpiffeID() {
 	s.Require().NoError(err)
 
 	// Check that the entry was deleted on SPIRE Server
-	entry, err = s.entryClient.GetEntry(ctx, &entryv1.GetEntryRequest{
+	_, err = s.entryClient.GetEntry(ctx, &entryv1.GetEntryRequest{
 		Id: *createdSpiffeID.Status.EntryId,
 	})
 	s.Require().Contains(err.Error(), "not found")
@@ -195,7 +195,7 @@ func (s *SpiffeIDControllerTestSuite) TestCreateAndDeleteSpiffeIDWithNoEntryID()
 	s.Require().NoError(err)
 
 	// Check that the entry was deleted on SPIRE Server
-	entry, err = s.entryClient.GetEntry(ctx, &entryv1.GetEntryRequest{
+	_, err = s.entryClient.GetEntry(ctx, &entryv1.GetEntryRequest{
 		Id: *entryID,
 	})
 	s.Require().Contains(err.Error(), "not found")


### PR DESCRIPTION
Signed-off-by: Faisal Memon <fymemon@yahoo.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
k8s-workload-registrar (CRD)

**Description of change**
There is a race condition in the CRD k8s-workload-registrar that can cause entries to not garbage collected:

1. Get retry error trying to set entryID in the crd: [https://github.com/spiffe/spire/blob/ec416f4f6ad35d5554a99a372ca19e888662ce16/supp[…]-workload-registrar/mode-crd/controllers/spiffeid_controller.go](https://github.com/spiffe/spire/blob/ec416f4f6ad35d5554a99a372ca19e888662ce16/support/k8s/k8s-workload-registrar/mode-crd/controllers/spiffeid_controller.go#L136-L141)
2. Pod is deleted
3. Next reconcile event comes in and deletes crd. entryID isn't set so it doesn't clean it up

This change will get the entry from spire server using the selectors, spiffe, and parent id and delete if the entry id is not set.