### PR TITLE
.Pod.pod_name should be .Pod.Name in example

### DIFF
--- a/support/k8s/k8s-workload-registrar/mode-crd/README.md
+++ b/support/k8s/k8s-workload-registrar/mode-crd/README.md
@@ -287,7 +287,7 @@ in addition to the following Pod-specific arguments:
 
 For example if the registrar was configured with the following:
 ```
-identity_template = "region/{{.Context.Region}}/cluster/{{.Context.ClusterName}}/sa/{{.Pod.ServiceAccount}}/pod_name/{{.Pod.pod_name}}"
+identity_template = "region/{{.Context.Region}}/cluster/{{.Context.ClusterName}}/sa/{{.Pod.ServiceAccount}}/pod_name/{{.Pod.Name}}"
 context {
   Region = "US-NORTH"
   ClusterName = "MYCLUSTER"


### PR DESCRIPTION
This is just a documentation fix. The example doesn't use the correct variable to reference to pod name.