### PR TITLE
Fail if join token plugin override is configured

### DIFF
--- a/pkg/agent/catalog/catalog.go
+++ b/pkg/agent/catalog/catalog.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/sirupsen/logrus"
@@ -77,10 +78,8 @@ func (repo *Repository) Close() {
 }
 
 func Load(ctx context.Context, config Config) (_ *Repository, err error) {
-	// DEPRECATE: make this an error in SPIRE 1.5
 	if c, ok := config.PluginConfig[nodeAttestorType][jointoken.PluginName]; ok && c.IsEnabled() && c.IsExternal() {
-		config.Log.Warn("The built-in join_token node attestor cannot be overridden by an external plugin. The external plugin will be ignored; this will be a configuration error in a future release.")
-		config.PluginConfig[nodeAttestorType][jointoken.PluginName] = catalog.HCLPluginConfig{}
+		return nil, fmt.Errorf("the built-in join_token node attestor cannot be overridden by an external plugin")
 	}
 
 	pluginConfigs, err := catalog.PluginConfigsFromHCL(config.PluginConfig)

--- a/pkg/agent/catalog/catalog_test.go
+++ b/pkg/agent/catalog/catalog_test.go
@@ -5,16 +5,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/catalog"
-	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestJoinTokenNodeAttestorCannotBeOverriden(t *testing.T) {
 	dir := t.TempDir()
-	log, hook := test.NewNullLogger()
+	log, _ := test.NewNullLogger()
 
 	minimalConfig := func() catalog.Config {
 		return catalog.Config{
@@ -42,11 +40,5 @@ func TestJoinTokenNodeAttestorCannotBeOverriden(t *testing.T) {
 	if repo != nil {
 		repo.Close()
 	}
-	require.NoError(t, err)
-	spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
-		{
-			Level:   logrus.WarnLevel,
-			Message: "The built-in join_token node attestor cannot be overridden by an external plugin. The external plugin will be ignored; this will be a configuration error in a future release.",
-		},
-	})
+	require.EqualError(t, err, "the built-in join_token node attestor cannot be overridden by an external plugin")
 }

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -122,10 +122,8 @@ func Load(ctx context.Context, config Config) (_ *Repository, err error) {
 		config.Log.Warn("The node resolver plugin type is deprecated and will be removed from a future release")
 	}
 
-	// DEPRECATE: make this an error in SPIRE 1.5
 	if c, ok := config.PluginConfig[nodeAttestorType][jointoken.PluginName]; ok && c.IsEnabled() && c.IsExternal() {
-		config.Log.Warn("The built-in join_token node attestor cannot be overridden by an external plugin. The external plugin will be ignored; this will be a configuration error in a future release.")
-		config.PluginConfig[nodeAttestorType][jointoken.PluginName] = catalog.HCLPluginConfig{}
+		return nil, fmt.Errorf("the built-in join_token node attestor cannot be overridden by an external plugin")
 	}
 
 	repo := &Repository{

--- a/pkg/server/catalog/catalog_test.go
+++ b/pkg/server/catalog/catalog_test.go
@@ -30,12 +30,7 @@ func Test(t *testing.T) {
 					PluginCmd: filepath.Join(dir, "does-not-exist"),
 				}
 			},
-			expectLogs: []spiretest.LogEntry{
-				{
-					Level:   logrus.WarnLevel,
-					Message: "The built-in join_token node attestor cannot be overridden by an external plugin. The external plugin will be ignored; this will be a configuration error in a future release.",
-				},
-			},
+			expectErr: "the built-in join_token node attestor cannot be overridden by an external plugin",
 		},
 		{
 			desc: "warn for deprecated node resolver",


### PR DESCRIPTION
The external plugin has previously been ignored. In 1.4.0, we deprecated this ability and logged a warning.

This configuration is now an error for 1.5.0.

Fixes: #3048
