### PR TITLE
Disable in-mem telemetry collection by default

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -801,7 +801,7 @@ plugins {
 #     ]
 
 #     InMem {
-#         # enabled: Enable this collector. Default: true.
+#         # enabled: Enable this collector. This field is deprecated and will be removed in a future release. Default: false.
 #         # enabled = true
 #     }
 # }

--- a/doc/telemetry_config.md
+++ b/doc/telemetry_config.md
@@ -51,8 +51,8 @@ You may use all, some, or none of the collectors. The following collectors suppo
 | `env`         | `string` | M3 environment, e.g. `production`, `staging` |
 
 #### `In-Mem`
-| Configuration | Type   | Description           | Default |
-|---------------|--------|-----------------------|---------|
+| Configuration | Type   | Description                                                                                                                                                                    | Default |
+|---------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `enabled`     | `bool` | Enable this collector. This flag is deprecated and will be removed in a future release. To disable in-memory telemetry collection omit the InMem configuration block entirely. | `false` |
 
 Here is a sample configuration:

--- a/doc/telemetry_config.md
+++ b/doc/telemetry_config.md
@@ -53,7 +53,7 @@ You may use all, some, or none of the collectors. The following collectors suppo
 #### `In-Mem`
 | Configuration | Type   | Description           | Default |
 |---------------|--------|-----------------------|---------|
-| `enabled`     | `bool` | Enable this collector | `true`  |
+| `enabled`     | `bool` | Enable this collector. This flag is deprecated and will be removed in a future release. To disable in-memory telemetry collection omit the InMem configuration block entirely. | `false` |
 
 Here is a sample configuration:
 
@@ -76,9 +76,7 @@ telemetry {
             { address = "localhost:9000" env = "prod" },
         ]
 
-        InMem {
-            enabled = false
-        }
+        InMem {}
 
         AllowedLabels = []
         BlockedLabels = []

--- a/pkg/common/telemetry/config.go
+++ b/pkg/common/telemetry/config.go
@@ -49,6 +49,7 @@ type M3Config struct {
 }
 
 type InMem struct {
-	Enabled    *bool    `hcl:"enabled"`
-	UnusedKeys []string `hcl:",unusedKeys"`
+	// TODO: remove in SPIRE 1.6.0
+	DeprecatedEnabled *bool    `hcl:"enabled"`
+	UnusedKeys        []string `hcl:",unusedKeys"`
 }

--- a/pkg/common/telemetry/inmem.go
+++ b/pkg/common/telemetry/inmem.go
@@ -3,9 +3,6 @@ package telemetry
 import (
 	"context"
 	"io"
-	"os"
-	"os/signal"
-	"sync"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -21,8 +18,6 @@ type inmemRunner struct {
 	log        logrus.FieldLogger
 	w          io.Writer
 	loadedSink *metrics.InmemSink
-
-	inMemBlockSet bool
 }
 
 func newInmemRunner(c *MetricsConfig) (sinkRunner, error) {
@@ -30,10 +25,16 @@ func newInmemRunner(c *MetricsConfig) (sinkRunner, error) {
 		log: c.Logger,
 	}
 
-	if c.FileConfig.InMem != nil && c.FileConfig.InMem.Enabled != nil {
-		runner.inMemBlockSet = true
-
-		if !*c.FileConfig.InMem.Enabled {
+	// Don't enable If the InMem block is not present, or is present with
+	// the deprecated "enabled" flag explicitly set to false.
+	// TODO: Remove the deprecated "enabled" flag in 1.6.0.
+	inMem := c.FileConfig.InMem
+	switch {
+	case inMem == nil:
+		return runner, nil
+	case inMem.DeprecatedEnabled != nil:
+		c.Logger.Warn("The enabled flag is deprecated in the InMem configuration and will be removed in a future release; omit the InMem block to disable in-memory telemetry")
+		if !*inMem.DeprecatedEnabled {
 			return runner, nil
 		}
 	}
@@ -66,45 +67,10 @@ func (i *inmemRunner) run(ctx context.Context) error {
 		return nil
 	}
 
-	var wg sync.WaitGroup
-
-	i.startInMemMetrics(ctx, &wg)
-
-	if !i.inMemBlockSet {
-		i.startConfigWarning(ctx, &wg)
-	}
-
-	wg.Wait()
-	return nil
-}
-
-func (i *inmemRunner) startConfigWarning(ctx context.Context, wg *sync.WaitGroup) {
-	wg.Add(1)
-	sigChannel := make(chan os.Signal, 1)
-	signal.Notify(sigChannel, metrics.DefaultSignal)
-	go func() {
-		defer wg.Done()
-		for {
-			select {
-			case <-sigChannel:
-				i.log.Warn("The in-memory telemetry sink will be disabled by default in a future release." +
-					" If you wish to continue using it, please enable it in the telemetry configuration")
-			case <-ctx.Done():
-				signal.Stop(sigChannel)
-				return
-			}
-		}
-	}()
-}
-
-func (i *inmemRunner) startInMemMetrics(ctx context.Context, wg *sync.WaitGroup) {
-	wg.Add(1)
 	signalHandler := metrics.NewInmemSignal(i.loadedSink, metrics.DefaultSignal, i.w)
-	go func() {
-		defer wg.Done()
-		<-ctx.Done()
-		signalHandler.Stop()
-	}()
+	defer signalHandler.Stop()
+	<-ctx.Done()
+	return nil
 }
 
 func (i *inmemRunner) requiresTypePrefix() bool {


### PR DESCRIPTION
PR #1248 provided a mechanism to disable the in-memory telemetry collector, which until that point had been always on. The new configuration block and `enabled` configurable were introduced in a backwards compatible way, with a warning that the in-memory telemetry collector would default to disabled in a future release.

This commit changes the behavior to disable the in-memory telemetry collector by default. In addition, it adds a warning log level that the "enabled" flag is now deprecated and will be removed in a future release. We can remove this flag in SPIRE 1.6.0.