### PR TITLE
Avoids using the TPM Simulator on Darwin based systems

### DIFF
--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 package tpmdevid_test
 
 import (

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 package tpmutil_test
 
 import (

--- a/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 package tpmdevid_test
 
 import (

--- a/test/tpmsimulator/simulator.go
+++ b/test/tpmsimulator/simulator.go
@@ -1,3 +1,6 @@
+//go:build !darwin
+// +build !darwin
+
 package tpmsimulator
 
 import (


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
This change allows all tests to pass and avoids linting errors on Darwin-based systems. The result is that tests depending on the TPM Simulator will not run on Darwin machines.

**Description of change**
This change adds build-time constraints to test files which should not execute on Darwin machines.

**Which issue this PR fixes**
Fixes #2875

Signed-off-by: Dennis Gove <dgove1@bloomberg.net>

