### PR TITLE
Update cliprinter default flag name

### DIFF
--- a/cmd/spire-agent/cli/api/fetch_jwt.go
+++ b/cmd/spire-agent/cli/api/fetch_jwt.go
@@ -55,8 +55,8 @@ func (c *fetchJWTCommand) run(ctx context.Context, env *common_cli.Env, client *
 func (c *fetchJWTCommand) appendFlags(fs *flag.FlagSet) {
 	fs.Var(&c.audience, "audience", "comma separated list of audience values")
 	fs.StringVar(&c.spiffeID, "spiffeID", "", "SPIFFE ID subject (optional)")
-
-	cliprinter.AppendFlagWithCustomPretty(&c.printer, fs, printPrettyResult)
+	outputValue := cliprinter.AppendFlagWithCustomPretty(&c.printer, fs, printPrettyResult)
+	fs.Var(outputValue, "format", "deprecated; use -output")
 }
 
 func (c *fetchJWTCommand) fetchJWTSVID(ctx context.Context, client *workloadClient) (*workload.JWTSVIDResponse, error) {

--- a/pkg/common/cliprinter/flag.go
+++ b/pkg/common/cliprinter/flag.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 )
 
+const defaultFlagName = "output"
+
 // AppendFlag adds the -format flag to the provided flagset, and populates
 // the referenced Printer interface with a properly configured printer.
-func AppendFlag(p *Printer, fs *flag.FlagSet) {
-	AppendFlagWithCustomPretty(p, fs, nil)
+func AppendFlag(p *Printer, fs *flag.FlagSet) *FormatterFlag {
+	return AppendFlagWithCustomPretty(p, fs, nil)
 }
 
 // AppendFlagWithCustomPretty is the same as AppendFlag, however it also allows
@@ -17,7 +19,7 @@ func AppendFlag(p *Printer, fs *flag.FlagSet) {
 // to override the pretty print logic that normally ships with this package. Its
 // intended use is to allow for the adoption of cliprinter while still retaining
 // backwards compatibility with the legacy/bespoke pretty print output.
-func AppendFlagWithCustomPretty(p *Printer, fs *flag.FlagSet, cp CustomPrettyFunc) {
+func AppendFlagWithCustomPretty(p *Printer, fs *flag.FlagSet, cp CustomPrettyFunc) *FormatterFlag {
 	// Set the default
 	np := newPrinter(defaultFormatType)
 	np.setCustomPrettyPrinter(cp)
@@ -29,7 +31,8 @@ func AppendFlagWithCustomPretty(p *Printer, fs *flag.FlagSet, cp CustomPrettyFun
 		customPretty: cp,
 	}
 
-	fs.Var(f, "format", "Desired output format (pretty, json)")
+	fs.Var(f, defaultFlagName, "Desired output format (pretty, json)")
+	return f
 }
 
 type FormatterFlag struct {
@@ -37,8 +40,9 @@ type FormatterFlag struct {
 
 	// A pointer to our consumer's Printer interface, along with
 	// its format type
-	p *Printer
-	f formatType
+	p     *Printer
+	f     formatType
+	isSet bool
 }
 
 func (f *FormatterFlag) String() string {
@@ -50,6 +54,9 @@ func (f *FormatterFlag) String() string {
 }
 
 func (f *FormatterFlag) Set(formatStr string) error {
+	if f.isSet && formatTypeToStr(f.f) != formatStr {
+		return fmt.Errorf("the output format has already been set to %q", formatTypeToStr(f.f))
+	}
 	if f.p == nil {
 		return errors.New("internal error: formatter flag not correctly invoked; please report this bug")
 	}
@@ -64,5 +71,6 @@ func (f *FormatterFlag) Set(formatStr string) error {
 
 	*f.p = np
 	f.f = format
+	f.isSet = true
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Guilherme Carvalho <guilhermbrsp@gmail.com>

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
spire-agent fetch jwt `-format` flag

**Description of change**
Update default flag name for the cliprinter from `-format` to `-output`. This decisions was taken in the contributor sync after we saw that `-format` flag conflicts with the `-format` flag that is already being used in spire-server bundle commands.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
Ongoing work for https://github.com/spiffe/spire/issues/1354
