### PR TITLE
Remove X509-SVID-TTL field from datastore model

### DIFF
--- a/pkg/server/datastore/sqlstore/models.go
+++ b/pkg/server/datastore/sqlstore/models.go
@@ -98,10 +98,6 @@ type RegisteredEntry struct {
 	// multiple SVIDs
 	Hint string
 
-	// TTL of X509 identities derived from this entry
-	// Deprecated: remove this in 1.6.0. The purpose of this column will be fulfilled by the TTL column
-	X509SvidTTL int32 `gorm:"column:x509_svid_ttl"`
-
 	// TTL of JWT identities derived from this entry
 	JWTSvidTTL int32 `gorm:"column:jwt_svid_ttl"`
 }


### PR DESCRIPTION
In order to remove the x509_svid_ttl column in 1.6.0, and still support downgrading, we need to remove the X509SvidTtl column from the GORM model in 1.5.0. Otherwise entry creation/updates will fail after the downgrade as the 1.5.x code will still try and set the column, which won't exist anymore.

Removing the field from the model does mean that new 1.5.x deployments will not have the x509_svid_ttl column. This shouldn't be problematic on upgrade as long as the column removal migration we do in 1.6.0 is idempotent.