### PR TITLE
Fix racy bundle client tests

### DIFF
--- a/pkg/server/bundle/client/sources_test.go
+++ b/pkg/server/bundle/client/sources_test.go
@@ -21,15 +21,15 @@ var (
 )
 
 func TestMergedTrustDomainConfigSource(t *testing.T) {
-	sourceA := client.TrustDomainConfigMap{
+	sourceA := client.NewTrustDomainConfigSet(client.TrustDomainConfigMap{
 		domain1: client.TrustDomainConfig{EndpointURL: "A"},
-	}
-	sourceB := client.TrustDomainConfigMap{
+	})
+	sourceB := client.NewTrustDomainConfigSet(client.TrustDomainConfigMap{
 		domain1: client.TrustDomainConfig{EndpointURL: "B"},
-	}
-	sourceC := client.TrustDomainConfigMap{
+	})
+	sourceC := client.NewTrustDomainConfigSet(client.TrustDomainConfigMap{
 		domain2: client.TrustDomainConfig{EndpointURL: "A"},
-	}
+	})
 
 	t.Run("context is passed through and error returned", func(t *testing.T) {
 		expectedCtx, cancel := context.WithCancel(context.Background())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -353,7 +353,7 @@ func (s *Server) newBundleManager(cat catalog.Catalog, metrics telemetry.Metrics
 		Metrics:   metrics,
 		DataStore: cat.GetDataStore(),
 		Source: bundle_client.MergeTrustDomainConfigSources(
-			bundle_client.TrustDomainConfigMap(s.config.Federation.FederatesWith),
+			bundle_client.NewTrustDomainConfigSet(s.config.Federation.FederatesWith),
 			bundle_client.DataStoreTrustDomainConfigSource(log, cat.GetDataStore()),
 		),
 	})


### PR DESCRIPTION
This change fixes test failures in the bundle client package. The failures were caused by non-goroutine safe manipulation of a map of configurations used as a config source and also an errant assertion that didn't account for production code behavior.

To fix the non-goroutine safe config source, a new type was introduced that protected the underlying config map with a RW mutex.

The errant assertion assumed that only one bundle refresh would be performed for a newly discovered trust domain. However, since the manual refresh operation ends up kicking off a goroutine that will also periodically refresh the bundle, under certain timing conditions, the bundle is refreshed twice. The assertion was updated to ensure that the bundle is updated at least once.

Fixes: #2840,#3401