### PR TITLE
Fix racy AttestAgent tests

### DIFF
--- a/.github/workflows/scripts/run_unit_tests_under_race_detector.sh
+++ b/.github/workflows/scripts/run_unit_tests_under_race_detector.sh
@@ -8,7 +8,7 @@ if [ -n "${COVERALLS_TOKEN}" ]; then
     go install github.com/mattn/goveralls@v0.0.7
 fi
 
-COVERPROFILE="${COVERPROFILE}" make ci-race-test
+COVERPROFILE="${COVERPROFILE}" make race-test
 
 if [ -n "${COVERALLS_TOKEN}" ]; then
     "$(go env GOPATH)"/bin/goveralls -coverprofile="${COVERPROFILE}" \

--- a/Makefile
+++ b/Makefile
@@ -299,13 +299,6 @@ else
 	$(E)$(go_path) go test $(go_flags) $(go_test_flags) -race ./...
 endif
 
-ci-race-test: | go-check
-ifneq ($(COVERPROFILE),)
-	$(E)SKIP_FLAKY_TESTS_UNDER_RACE_DETECTOR=1 $(go_path) go test $(go_flags) $(go_test_flags) -race -count=1 -coverprofile="$(COVERPROFILE)" ./...
-else
-	$(E)SKIP_FLAKY_TESTS_UNDER_RACE_DETECTOR=1 $(go_path) go test $(go_flags) $(go_test_flags) -race -count=1 ./...
-endif
-
 integration:
 ifeq ($(os1), windows)
 	$(error Integration tests are not supported on windows)

--- a/test/spiretest/apiserver.go
+++ b/test/spiretest/apiserver.go
@@ -43,7 +43,7 @@ func newAPIServer(t *testing.T, registerFn func(s *grpc.Server), server *grpc.Se
 
 	done := func() {
 		assert.NoError(t, conn.Close())
-		server.Stop()
+		server.GracefulStop()
 		err := <-errCh
 		switch {
 		case err == nil, errors.Is(err, grpc.ErrServerStopped):

--- a/test/util/race.go
+++ b/test/util/race.go
@@ -3,12 +3,9 @@ package util
 import (
 	"fmt"
 	"os"
-	"regexp"
 	"strconv"
 	"testing"
 )
-
-const flakyTestEnvKey = "SKIP_FLAKY_TESTS_UNDER_RACE_DETECTOR"
 
 var (
 	raceTestNumThreads = 2
@@ -45,19 +42,4 @@ func getEnvInt(name string, fallback int) int {
 		return val
 	}
 	return fallback
-}
-
-func SkipFlakyTestUnderRaceDetectorWithFiledIssue(t *testing.T, issue string) {
-	t.Helper()
-	const issuePattern = "https://github.com/spiffe/spire/issues/[[:digit:]]{4,}"
-	issueRegexp := regexp.MustCompile(issuePattern)
-	if !issueRegexp.Match([]byte(issue)) {
-		msg := "Skip only allowed with associated issue. "
-		msg += "%q does not appear to be an issue. "
-		msg += "File an issue and specify it to skip a test under race detector."
-		t.Fatalf(fmt.Sprintf(msg, issue))
-	}
-	if _, skip := os.LookupEnv(flakyTestEnvKey); skip {
-		t.Skipf("Skipping under race decector until %s is resolved.", issue)
-	}
 }


### PR DESCRIPTION
The AttestAgent tests assert log contents at the end of the test. These tests fail with race detection since it is very possible for the server to still be emitting logs (e.g. audit logs) to the test log hook when the test code does the assertion. This is due to the streaming nature of the AttestAgent RPC.

The fix here is to move the code that asserts logs until after the test server has been fully shut down and cleaned up. The server shutdown code waits for outstanding RPCs to fully complete. This guarantees that the server code is finished emitting logs to the log hook by the time the contents are asserted.

Since this is the last test that used the temporary infrastructure to skip certain known racy tests under CI/CD, that infrastructure is also removed as part of this PR.

Fixes: #2841