### PR TITLE
Fixes #3581: Ensures that config default_svid_ttl can still be used

### DIFF
--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -639,8 +639,6 @@ func TestNewServerConfig(t *testing.T) {
 			msg: "default_svid_ttl is correctly parsed",
 			input: func(c *Config) {
 				c.Server.DefaultSVIDTTL = "1m"
-				c.Server.DefaultX509SVIDTTL = ""
-				c.Server.DefaultJWTSVIDTTL = ""
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Equal(t, time.Minute, c.X509SVIDTTL)


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Which issue this PR fixes**
Fixes #3581 

