### PR TITLE
Write files on Windows with a specific security descriptor

### DIFF
--- a/cmd/spire-agent/cli/api/fetch_x509.go
+++ b/cmd/spire-agent/cli/api/fetch_x509.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 	"path"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 )
 
 func NewFetchX509Command() cli.Command {
@@ -139,7 +139,7 @@ func (c *fetchX509Command) writeCerts(filename string, certs []*x509.Certificate
 		pemData = append(pemData, pem.EncodeToMemory(b)...)
 	}
 
-	return c.writeFile(filename, pemData)
+	return diskutil.WritePubliclyReadableFile(filename, pemData)
 }
 
 // writeKey takes a private key, formats as PEM, and writes it to filename
@@ -153,12 +153,7 @@ func (c *fetchX509Command) writeKey(filename string, privateKey crypto.PrivateKe
 		Bytes: data,
 	}
 
-	return os.WriteFile(filename, pem.EncodeToMemory(b), 0600)
-}
-
-// writeFile creates or truncates filename, and writes data to it
-func (c *fetchX509Command) writeFile(filename string, data []byte) error {
-	return os.WriteFile(filename, data, 0644) // nolint: gosec // expected permission for certificates
+	return diskutil.WritePrivateFile(filename, pem.EncodeToMemory(b))
 }
 
 type X509SVID struct {

--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/cmd/spire-server/cli/common"
 	"github.com/spiffe/spire/cmd/spire-server/util"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -338,7 +338,7 @@ func TestSet(t *testing.T) {
 			if tt.fileData != "" {
 				tmpDir := spiretest.TempDir(t)
 				bundlePath := filepath.Join(tmpDir, "bundle_data")
-				require.NoError(t, os.WriteFile(bundlePath, []byte(tt.fileData), 0600))
+				require.NoError(t, diskutil.WritePrivateFile(bundlePath, []byte(tt.fileData)))
 				extraArgs = append(extraArgs, "-path", bundlePath)
 			}
 

--- a/cmd/spire-server/cli/federation/common_test.go
+++ b/cmd/spire-server/cli/federation/common_test.go
@@ -3,7 +3,6 @@ package federation
 import (
 	"bytes"
 	"context"
-	"os"
 	"path"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/cmd/spire-server/cli/common"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/test/fakes/fakeserverca"
 	"github.com/spiffe/spire/test/spiretest"
@@ -239,7 +239,7 @@ func createBundle(t *testing.T, trustDomain string) (*types.Bundle, string) {
 	td := spiffeid.RequireTrustDomainFromString(trustDomain)
 	bundlePath := path.Join(t.TempDir(), "bundle.pem")
 	ca := fakeserverca.New(t, td, &fakeserverca.Options{})
-	require.NoError(t, pemutil.SaveCertificates(bundlePath, ca.Bundle(), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(bundlePath, pemutil.EncodeCertificates(ca.Bundle())))
 
 	return &types.Bundle{
 		TrustDomain: td.String(),
@@ -251,12 +251,12 @@ func createBundle(t *testing.T, trustDomain string) (*types.Bundle, string) {
 
 func createCorruptedBundle(t *testing.T) string {
 	bundlePath := path.Join(t.TempDir(), "bundle.pem")
-	require.NoError(t, os.WriteFile(bundlePath, []byte("corrupted-bundle"), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(bundlePath, []byte("corrupted-bundle")))
 	return bundlePath
 }
 
 func createJSONDataFile(t *testing.T, data string) string {
 	jsonDataFilePath := path.Join(t.TempDir(), "bundle.pem")
-	require.NoError(t, os.WriteFile(jsonDataFilePath, []byte(data), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(jsonDataFilePath, []byte(data)))
 	return jsonDataFilePath
 }

--- a/cmd/spire-server/cli/jwt/mint.go
+++ b/cmd/spire-server/cli/jwt/mint.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/mitchellh/cli"
@@ -14,6 +13,7 @@ import (
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -81,7 +81,7 @@ func (c *mintCommand) Run(ctx context.Context, env *common_cli.Env, serverClient
 
 	// Save in file
 	tokenPath := env.JoinPath(c.write)
-	if err := os.WriteFile(tokenPath, []byte(token), 0600); err != nil {
+	if err := diskutil.WritePrivateFile(tokenPath, []byte(token)); err != nil {
 		return fmt.Errorf("unable to write token: %w", err)
 	}
 	return env.Printf("JWT-SVID written to %s\n", tokenPath)

--- a/cmd/spire-server/cli/jwt/mint_test.go
+++ b/cmd/spire-server/cli/jwt/mint_test.go
@@ -203,7 +203,7 @@ func TestMintRun(t *testing.T) {
 				},
 			},
 			write:  "/",
-			stderr: fmt.Sprintf("Error: unable to write token: open %s: is a directory\n", dir),
+			stderr: "Error: unable to write token",
 		},
 		{
 			name:     "malformed token",
@@ -290,7 +290,7 @@ func TestMintRun(t *testing.T) {
 			code := cmd.Run(args)
 
 			assert.Equal(t, tt.code, code, "exit code does not match")
-			assert.Equal(t, tt.stderr, stderr.String(), "stderr does not match")
+			assert.Contains(t, stderr.String(), tt.stderr, "stderr does not match")
 
 			req := server.lastMintJWTSVIDRequest()
 			if tt.noRequestExpected {

--- a/cmd/spire-server/cli/x509/mint.go
+++ b/cmd/spire-server/cli/x509/mint.go
@@ -13,7 +13,6 @@ import (
 	"flag"
 	"fmt"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/mitchellh/cli"
@@ -22,6 +21,7 @@ import (
 	svidv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/svid/v1"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 )
 
 type generateKeyFunc func() (crypto.Signer, error)
@@ -157,21 +157,21 @@ func (c *mintCommand) Run(ctx context.Context, env *common_cli.Env, serverClient
 	keyPath := env.JoinPath(c.write, "key.pem")
 	bundlePath := env.JoinPath(c.write, "bundle.pem")
 
-	if err := os.WriteFile(svidPath, svidPEM.Bytes(), 0644); err != nil { // nolint: gosec // expected permission
+	if err := diskutil.WritePubliclyReadableFile(svidPath, svidPEM.Bytes()); err != nil {
 		return fmt.Errorf("unable to write SVID: %w", err)
 	}
 	if err := env.Printf("X509-SVID written to %s\n", svidPath); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(keyPath, keyPEM.Bytes(), 0600); err != nil {
+	if err := diskutil.WritePrivateFile(keyPath, keyPEM.Bytes()); err != nil {
 		return fmt.Errorf("unable to write key: %w", err)
 	}
 	if err := env.Printf("Private key written to %s\n", keyPath); err != nil {
 		return err
 	}
 
-	if err := os.WriteFile(bundlePath, bundlePEM.Bytes(), 0644); err != nil { // nolint: gosec // expected permission
+	if err := diskutil.WritePubliclyReadableFile(bundlePath, bundlePEM.Bytes()); err != nil {
 		return fmt.Errorf("unable to write bundle: %w", err)
 	}
 	return env.Printf("Root CAs written to %s\n", bundlePath)

--- a/pkg/agent/plugin/nodeattestor/k8spsat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8spsat/psat_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	sat_common "github.com/spiffe/spire/pkg/common/plugin/k8s"
 	"github.com/spiffe/spire/test/plugintest"
@@ -114,7 +115,7 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	valuePath := s.joinPath(path)
 	err := os.MkdirAll(filepath.Dir(valuePath), 0755)
 	s.Require().NoError(err)
-	err = os.WriteFile(valuePath, []byte(data), 0600)
+	err = diskutil.WritePrivateFile(valuePath, []byte(data))
 	s.Require().NoError(err)
 	return valuePath
 }

--- a/pkg/agent/plugin/nodeattestor/k8ssat/sat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8ssat/sat_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"google.golang.org/grpc/codes"
@@ -93,7 +94,7 @@ func (s *AttestorSuite) writeValue(path, data string) string {
 	valuePath := s.joinPath(path)
 	err := os.MkdirAll(filepath.Dir(valuePath), 0755)
 	s.Require().NoError(err)
-	err = os.WriteFile(valuePath, []byte(data), 0600)
+	err = diskutil.WritePrivateFile(valuePath, []byte(data))
 	s.Require().NoError(err)
 	return valuePath
 }

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"runtime"
 	"testing"
@@ -21,6 +20,7 @@ import (
 	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	common_devid "github.com/spiffe/spire/pkg/common/plugin/tpmdevid"
 	server_devid "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/tpmdevid"
 	"github.com/spiffe/spire/test/plugintest"
@@ -91,18 +91,16 @@ func writeDevIDFiles(t *testing.T) {
 	devIDPubPath = path.Join(dir, "devid-pub-path")
 	devIDWithoutIntermediatesPath = path.Join(dir, "devid-without-intermediates.pem")
 
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, diskutil.WritePrivateFile(
 		devIDCertPath,
-		devID.ChainPem(),
-		0600),
+		devID.ChainPem()),
 	)
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, diskutil.WritePrivateFile(
 		devIDWithoutIntermediatesPath,
-		devID.ChainPem(),
-		0600),
+		devID.ChainPem()),
 	)
-	require.NoError(t, os.WriteFile(devIDPrivPath, devID.PrivateBlob, 0600))
-	require.NoError(t, os.WriteFile(devIDPubPath, devID.PublicBlob, 0600))
+	require.NoError(t, diskutil.WritePrivateFile(devIDPrivPath, devID.PrivateBlob))
+	require.NoError(t, diskutil.WritePrivateFile(devIDPubPath, devID.PublicBlob))
 }
 
 func TestConfigureCommon(t *testing.T) {

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -576,7 +577,7 @@ func (s *Suite) setServer(server *httptest.Server) {
 func (s *Suite) writeFile(path, data string) {
 	realPath := filepath.Join(s.dir, path)
 	s.Require().NoError(os.MkdirAll(filepath.Dir(realPath), 0755))
-	s.Require().NoError(os.WriteFile(realPath, []byte(data), 0600))
+	s.Require().NoError(diskutil.WritePrivateFile(realPath, []byte(data)))
 }
 
 func (s *Suite) serveHTTP(w http.ResponseWriter, req *http.Request) {

--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
@@ -6,7 +6,6 @@ package unix
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
@@ -230,7 +230,7 @@ func (s *Suite) TestAttest() {
 	}
 
 	// prepare the "exe" for hashing
-	s.writeFile("exe", []byte("data"))
+	s.Require().NoError(diskutil.WritePrivateFile(filepath.Join(s.dir, "exe"), []byte("data")))
 
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -257,10 +257,6 @@ func (s *Suite) TestAttest() {
 			spiretest.AssertLogs(t, s.logHook.AllEntries(), testCase.expectLogs)
 		})
 	}
-}
-
-func (s *Suite) writeFile(path string, data []byte) {
-	s.Require().NoError(os.WriteFile(filepath.Join(s.dir, path), data, 0600))
 }
 
 func (s *Suite) loadPlugin(t *testing.T, config string) workloadattestor.WorkloadAttestor {

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent/plugin/workloadattestor"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/test/plugintest"
 	"github.com/spiffe/spire/test/spiretest"
@@ -46,7 +46,7 @@ var (
 func TestAttest(t *testing.T) {
 	d := t.TempDir()
 	exe := filepath.Join(d, "exe")
-	require.NoError(t, os.WriteFile(exe, []byte("data"), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(exe, []byte("data")))
 
 	testCases := []struct {
 		name            string

--- a/pkg/common/diskutil/file_posix.go
+++ b/pkg/common/diskutil/file_posix.go
@@ -34,13 +34,13 @@ func CreateDataDirectory(path string) error {
 }
 
 // WritePrivateFile writes data out to a private file. The file is created if it
-// does not exist. If exists, the contents is replaced.
+// does not exist. If exists, it's overwritten.
 func WritePrivateFile(path string, data []byte) error {
 	return write(path, data, fileModePrivate, false)
 }
 
 // WritePubliclyReadableFile writes data out to a publicly readable file. The
-// file is created if it does not exist. If exists, the contents is replaced.
+// file is created if it does not exist. If exists, it's overwritten.
 func WritePubliclyReadableFile(path string, data []byte) error {
 	return write(path, data, fileModePubliclyReadable, false)
 }
@@ -72,6 +72,10 @@ func rename(tmpPath, path string) error {
 	return dir.Close()
 }
 
+// write writes to a file in the specified path with the specified
+// security descriptor using the provided data. The sync boolean
+// argument is used to indicate whether flushing to disk is required
+// or not.
 func write(tmpPath string, data []byte, mode os.FileMode, sync bool) error {
 	file, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {

--- a/pkg/common/diskutil/file_posix.go
+++ b/pkg/common/diskutil/file_posix.go
@@ -8,29 +8,46 @@ import (
 	"path/filepath"
 )
 
-// AtomicWritePrivateFile writes data out.  It writes to a temp file first, fsyncs that file,
-// then swaps the file in.  os.Rename is an atomic operation, so this sequence avoids having
-// a partially written file at the final location.  Finally, fsync is called on the directory
-// to ensure the rename is persisted.
+const (
+	fileModePrivate          = 0600
+	fileModePubliclyReadable = 0644
+)
+
+// AtomicWritePrivateFile writes data out to a private file.
+// It writes to a temp file first, fsyncs that file, then swaps the file in.
+// Rename file using a custom MoveFileEx that uses 'MOVEFILE_WRITE_THROUGH'
+// witch waits until file is synced to disk.
 func AtomicWritePrivateFile(path string, data []byte) error {
-	return atomicWrite(path, data, 0600)
+	return atomicWrite(path, data, fileModePrivate)
 }
 
-// AtomicWritePubliclyReadableFile writes data out.  It writes to a temp file first, fsyncs that file,
-// then swaps the file in.  os.Rename is an atomic operation, so this sequence avoids having
-// a partially written file at the final location.  Finally, fsync is called on the directory
-// to ensure the rename is persisted.
+// AtomicWritePubliclyReadableFile writes data out to a publicly readable file.
+// It writes to a temp file first, fsyncs that file, then swaps the file in.
+// Rename file using a custom MoveFileEx that uses 'MOVEFILE_WRITE_THROUGH'
+// witch waits until file is synced to disk.
 func AtomicWritePubliclyReadableFile(path string, data []byte) error {
-	return atomicWrite(path, data, 0644)
+	return atomicWrite(path, data, fileModePubliclyReadable)
 }
 
 func CreateDataDirectory(path string) error {
 	return os.MkdirAll(path, 0755)
 }
 
+// WritePrivateFile writes data out to a private file. The file is created if it
+// does not exist. If exists, the contents is replaced.
+func WritePrivateFile(path string, data []byte) error {
+	return write(path, data, fileModePrivate, false)
+}
+
+// WritePubliclyReadableFile writes data out to a publicly readable file. The
+// file is created if it does not exist. If exists, the contents is replaced.
+func WritePubliclyReadableFile(path string, data []byte) error {
+	return write(path, data, fileModePubliclyReadable, false)
+}
+
 func atomicWrite(path string, data []byte, mode os.FileMode) error {
 	tmpPath := path + ".tmp"
-	if err := write(tmpPath, data, mode); err != nil {
+	if err := write(tmpPath, data, mode, true); err != nil {
 		return err
 	}
 
@@ -55,7 +72,7 @@ func rename(tmpPath, path string) error {
 	return dir.Close()
 }
 
-func write(tmpPath string, data []byte, mode os.FileMode) error {
+func write(tmpPath string, data []byte, mode os.FileMode, sync bool) error {
 	file, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
@@ -66,9 +83,11 @@ func write(tmpPath string, data []byte, mode os.FileMode) error {
 		return err
 	}
 
-	if err := file.Sync(); err != nil {
-		file.Close()
-		return err
+	if sync {
+		if err := file.Sync(); err != nil {
+			file.Close()
+			return err
+		}
 	}
 
 	return file.Close()

--- a/pkg/common/diskutil/file_posix_test.go
+++ b/pkg/common/diskutil/file_posix_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAtomicWritePrivateFile(t *testing.T) {
+func TestWriteFile(t *testing.T) {
 	dir := spiretest.TempDir(t)
 
 	tests := []struct {
@@ -55,6 +55,42 @@ func TestAtomicWritePrivateFile(t *testing.T) {
 			name:            "binary - AtomicWritePubliclyReadableFile",
 			data:            []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
 			atomicWriteFunc: AtomicWritePubliclyReadableFile,
+			expectMode:      0644,
+		},
+		{
+			name:            "basic - WritePrivateFile",
+			data:            []byte("Hello, World"),
+			atomicWriteFunc: WritePrivateFile,
+			expectMode:      0600,
+		},
+		{
+			name:            "empty - WritePrivateFile",
+			data:            []byte{},
+			atomicWriteFunc: WritePrivateFile,
+			expectMode:      0600,
+		},
+		{
+			name:            "binary - WritePrivateFile",
+			data:            []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
+			atomicWriteFunc: WritePrivateFile,
+			expectMode:      0600,
+		},
+		{
+			name:            "basic - WritePubliclyReadableFile",
+			data:            []byte("Hello, World"),
+			atomicWriteFunc: WritePubliclyReadableFile,
+			expectMode:      0644,
+		},
+		{
+			name:            "empty - WritePubliclyReadableFile",
+			data:            []byte{},
+			atomicWriteFunc: WritePubliclyReadableFile,
+			expectMode:      0644,
+		},
+		{
+			name:            "binary - WritePubliclyReadableFile",
+			data:            []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
+			atomicWriteFunc: WritePubliclyReadableFile,
 			expectMode:      0644,
 		},
 	}

--- a/pkg/common/diskutil/file_windows.go
+++ b/pkg/common/diskutil/file_windows.go
@@ -89,13 +89,13 @@ func MkdirAll(path string, sddl string) error {
 }
 
 // WritePrivateFile writes data out to a private file. The file is created if it
-// does not exist. If exists, the contents is replaced.
+// does not exist. If exists, it's overwritten.
 func WritePrivateFile(path string, data []byte) error {
 	return write(path, data, sddl.PrivateFile, false)
 }
 
 // WritePubliclyReadableFile writes data out to a publicly readable file. The
-// file is created if it does not exist. If exists, the contents is replaced.
+// file is created if it does not exist. If exists, it's overwritten.
 func WritePubliclyReadableFile(path string, data []byte) error {
 	return write(path, data, sddl.PubliclyReadableFile, false)
 }

--- a/pkg/common/diskutil/file_windows_test.go
+++ b/pkg/common/diskutil/file_windows_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-func TestAtomicWritePrivateFile(t *testing.T) {
+func TestWriteFile(t *testing.T) {
 	dir := spiretest.TempDir(t)
 
 	tests := []struct {
@@ -58,6 +58,42 @@ func TestAtomicWritePrivateFile(t *testing.T) {
 			data:                     []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
 			expectSecurityDescriptor: sddl.PubliclyReadableFile,
 			atomicWriteFunc:          AtomicWritePubliclyReadableFile,
+		},
+		{
+			name:                     "basic - WritePrivateFile",
+			data:                     []byte("Hello, World"),
+			expectSecurityDescriptor: sddl.PrivateFile,
+			atomicWriteFunc:          WritePrivateFile,
+		},
+		{
+			name:                     "empty - WritePrivateFile",
+			data:                     []byte{},
+			expectSecurityDescriptor: sddl.PrivateFile,
+			atomicWriteFunc:          WritePrivateFile,
+		},
+		{
+			name:                     "binary - WritePrivateFile",
+			data:                     []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
+			expectSecurityDescriptor: sddl.PrivateFile,
+			atomicWriteFunc:          WritePrivateFile,
+		},
+		{
+			name:                     "basic - WritePubliclyReadableFile",
+			data:                     []byte("Hello, World"),
+			expectSecurityDescriptor: sddl.PubliclyReadableFile,
+			atomicWriteFunc:          WritePubliclyReadableFile,
+		},
+		{
+			name:                     "empty - WritePubliclyReadableFile",
+			data:                     []byte{},
+			expectSecurityDescriptor: sddl.PubliclyReadableFile,
+			atomicWriteFunc:          WritePubliclyReadableFile,
+		},
+		{
+			name:                     "binary - WritePubliclyReadableFile",
+			data:                     []byte{0xFF, 0, 0xFF, 0x3D, 0xD8, 0xA9, 0xDC, 0xF0, 0x9F, 0x92, 0xA9},
+			expectSecurityDescriptor: sddl.PubliclyReadableFile,
+			atomicWriteFunc:          WritePubliclyReadableFile,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/common/pemutil/certs.go
+++ b/pkg/common/pemutil/certs.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"os"
 )
 
 func ParseCertificate(pemBytes []byte) (*x509.Certificate, error) {
@@ -48,18 +47,10 @@ func EncodeCertificates(certs []*x509.Certificate) []byte {
 	return buf.Bytes()
 }
 
-func SaveCertificates(path string, certs []*x509.Certificate, mode os.FileMode) error {
-	return os.WriteFile(path, EncodeCertificates(certs), mode)
-}
-
 func EncodeCertificate(cert *x509.Certificate) []byte {
 	var buf bytes.Buffer
 	encodeCertificate(&buf, cert)
 	return buf.Bytes()
-}
-
-func SaveCertificate(path string, cert *x509.Certificate, mode os.FileMode) error {
-	return os.WriteFile(path, EncodeCertificate(cert), mode)
 }
 
 func certFromObject(object interface{}) (*x509.Certificate, error) {

--- a/pkg/common/pemutil/pemutil_test.go
+++ b/pkg/common/pemutil/pemutil_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -270,38 +269,6 @@ func (s *Suite) TestEncodeCertificate() {
 	expCertPem, err := os.ReadFile("testdata/cert.pem")
 	s.Require().NoError(err)
 	s.Require().Equal(expCertPem, EncodeCertificate(cert))
-}
-
-func (s *Suite) TestSaveCertificate() {
-	dir, err := os.MkdirTemp("", "pemutil-test")
-	s.Require().NoError(err)
-	defer os.Remove(dir)
-
-	certPath := path.Join(dir, "cert")
-	cert, err := LoadCertificate("testdata/cert.pem")
-	s.Require().NoError(err)
-	err = SaveCertificate(certPath, cert, 0600)
-	s.Require().NoError(err)
-
-	fileContent, err := os.ReadFile(certPath)
-	s.Require().NoError(err)
-	s.Require().Equal(EncodeCertificate(cert), fileContent)
-}
-
-func (s *Suite) TestSaveCertificates() {
-	dir, err := os.MkdirTemp("", "pemutil-test")
-	s.Require().NoError(err)
-	defer os.Remove(dir)
-
-	certsPath := path.Join(dir, "certs")
-	certs, err := LoadCertificates("testdata/certs.pem")
-	s.Require().NoError(err)
-	err = SaveCertificates(certsPath, certs, 0600)
-	s.Require().NoError(err)
-
-	fileContent, err := os.ReadFile(certsPath)
-	s.Require().NoError(err)
-	s.Require().Equal(EncodeCertificates(certs), fileContent)
 }
 
 func (s *Suite) TestLoadSigner() {

--- a/pkg/common/plugin/k8s/apiserver/client_test.go
+++ b/pkg/common/plugin/k8s/apiserver/client_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/spiretest"
 	authv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/core/v1"
@@ -338,18 +338,18 @@ func createNode(nodeName string) *v1.Node {
 
 func (s *ClientSuite) createSampleKubeConfigFile(kubeConfigPath string) {
 	caPath := filepath.Join(s.dir, "ca.crt")
-	err := os.WriteFile(caPath, kubeConfigCA, 0600)
+	err := diskutil.WritePrivateFile(caPath, kubeConfigCA)
 	s.Require().NoError(err)
 
 	clientCrtPath := filepath.Join(s.dir, "client.crt")
-	err = os.WriteFile(clientCrtPath, kubeConfigClientCert, 0600)
+	err = diskutil.WritePrivateFile(clientCrtPath, kubeConfigClientCert)
 	s.Require().NoError(err)
 
 	clientKeyPath := filepath.Join(s.dir, "client.key")
-	err = os.WriteFile(clientKeyPath, kubeConfigClientKey, 0600)
+	err = diskutil.WritePrivateFile(clientKeyPath, kubeConfigClientKey)
 	s.Require().NoError(err)
 
 	kubeConfigContent := []byte(fmt.Sprintf(kubeConfig, caPath, clientCrtPath, clientKeyPath))
-	err = os.WriteFile(kubeConfigPath, kubeConfigContent, 0600)
+	err = diskutil.WritePrivateFile(kubeConfigPath, kubeConfigContent)
 	s.Require().NoError(err)
 }

--- a/pkg/common/util/hash_test.go
+++ b/pkg/common/util/hash_test.go
@@ -1,16 +1,16 @@
 package util
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_GetSHA256Digest(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "file")
-	require.NoError(t, os.WriteFile(path, []byte("some data"), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(path, []byte("some data")))
 	hash, err := GetSHA256Digest(path, -1)
 	require.NoError(t, err)
 	require.Equal(t, "1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee", hash)
@@ -18,7 +18,7 @@ func Test_GetSHA256Digest(t *testing.T) {
 
 func Test_GetSHA256Digest_BelowLimit(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "file")
-	require.NoError(t, os.WriteFile(path, []byte("some data"), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(path, []byte("some data")))
 	hash, err := GetSHA256Digest(path, 100)
 	require.NoError(t, err)
 	require.Equal(t, "1307990e6ba5ca145eb35e99182a9bec46531bc54ddf656a602c780fa0240dee", hash)
@@ -26,7 +26,7 @@ func Test_GetSHA256Digest_BelowLimit(t *testing.T) {
 
 func Test_GetSHA256Digest_AboveLimit(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "file")
-	require.NoError(t, os.WriteFile(path, []byte("some data"), 0600))
+	require.NoError(t, diskutil.WritePrivateFile(path, []byte("some data")))
 	hash, err := GetSHA256Digest(path, 5)
 	require.ErrorContains(t, err, "exceeds size limit")
 	require.Empty(t, hash)

--- a/pkg/server/authpolicy/policy_test.go
+++ b/pkg/server/authpolicy/policy_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/util"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/server/authpolicy"
 	"github.com/stretchr/testify/require"
 )
@@ -230,11 +231,11 @@ func TestPolicy(t *testing.T) {
 
 			// Check with NewEngineFromConfigOrDefault
 			regoFile := filepath.Join(tmpDir, "rego_file")
-			err = os.WriteFile(regoFile, []byte(tt.rego), 0600)
+			err = diskutil.WritePrivateFile(regoFile, []byte(tt.rego))
 			require.Nil(t, err, "failed to create rego_file")
 
 			permsFile := filepath.Join(tmpDir, "perms_file")
-			err = os.WriteFile(permsFile, []byte(tt.jsonData), 0600)
+			err = diskutil.WritePrivateFile(permsFile, []byte(tt.jsonData))
 			require.Nil(t, err, "failed to create perms_file")
 
 			ec := authpolicy.OpaEngineConfig{
@@ -271,20 +272,20 @@ func TestNewEngineFromConfig(t *testing.T) {
 
 	// Create good policy/perms files
 	validRegoFile := filepath.Join(tmpDir, "valid_rego_file")
-	err = os.WriteFile(validRegoFile, []byte(rego), 0600)
+	err = diskutil.WritePrivateFile(validRegoFile, []byte(rego))
 	require.Nil(t, err, "failed to create valid_rego_file")
 
 	validPermsFile := filepath.Join(tmpDir, "valid_perms_file")
-	err = os.WriteFile(validPermsFile, []byte(jsonData), 0600)
+	err = diskutil.WritePrivateFile(validPermsFile, []byte(jsonData))
 	require.Nil(t, err, "failed to create valid_perms_file")
 
 	// Create bad policy/perms files
 	invalidRegoFile := filepath.Join(tmpDir, "invalid_rego_file")
-	err = os.WriteFile(invalidRegoFile, []byte("invalid rego"), 0600)
+	err = diskutil.WritePrivateFile(invalidRegoFile, []byte("invalid rego"))
 	require.Nil(t, err, "failed to create invalid_rego_file")
 
 	invalidPermsFile := filepath.Join(tmpDir, "invalid_perms_file")
-	err = os.WriteFile(invalidPermsFile, []byte("{"), 0600)
+	err = diskutil.WritePrivateFile(invalidPermsFile, []byte("{"))
 	require.Nil(t, err, "failed to create invalid_perms_file")
 
 	// Create permissions tmp file

--- a/pkg/server/ca/journal_test.go
+++ b/pkg/server/ca/journal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
@@ -290,7 +291,7 @@ func (s *JournalSuite) writeString(path, data string) {
 }
 
 func (s *JournalSuite) writeBytes(path string, data []byte) {
-	s.Require().NoError(os.WriteFile(path, data, 0600))
+	s.Require().NoError(diskutil.WritePrivateFile(path, data))
 }
 
 func (s *JournalSuite) now() time.Time {

--- a/pkg/server/ca/manager_test.go
+++ b/pkg/server/ca/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
@@ -481,7 +482,7 @@ func (s *ManagerSuite) TestMigration() {
 	// assert that we migrate on load by writing junk data to the old JSON file
 	// and making sure initialization fails. The journal tests exercise this
 	// code more carefully.
-	s.Require().NoError(os.WriteFile(filepath.Join(s.dir, "certs.json"), []byte("NOTJSON"), 0600))
+	s.Require().NoError(diskutil.WritePrivateFile(filepath.Join(s.dir, "certs.json"), []byte("NOTJSON")))
 	s.m = NewManager(s.selfSignedConfig())
 	err := s.m.Initialize(context.Background())
 	s.RequireErrorContains(err, "failed to migrate old JSON data: unable to decode JSON")

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -23,6 +23,7 @@ import (
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -947,7 +948,7 @@ func createServerID(idPath string) (string, error) {
 	id := u.String()
 
 	// persist id
-	err = os.WriteFile(idPath, []byte(id), 0600)
+	err = diskutil.WritePrivateFile(idPath, []byte(id))
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "failed to persist server id on path: %v", err)
 	}

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -21,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	keymanagertest "github.com/spiffe/spire/pkg/server/plugin/keymanager/test"
 	"github.com/spiffe/spire/test/plugintest"
@@ -1979,7 +1979,7 @@ func serializedConfiguration(accessKeyID, secretAccessKey, region string, keyMet
 func getKeyMetadataFile(t *testing.T) string {
 	tempDir := t.TempDir()
 	tempFilePath := path.Join(tempDir, validServerIDFile)
-	err := os.WriteFile(tempFilePath, []byte(validServerID), 0600)
+	err := diskutil.WritePrivateFile(tempFilePath, []byte(validServerID))
 	if err != nil {
 		t.Error(err)
 	}
@@ -2001,7 +2001,7 @@ func getEmptyKeyMetadataFile(t *testing.T) string {
 func getCustomPolicyFile(t *testing.T) string {
 	tempDir := t.TempDir()
 	tempFilePath := path.Join(tempDir, validPolicyFile)
-	err := os.WriteFile(tempFilePath, []byte(customPolicy), 0600)
+	err := diskutil.WritePrivateFile(tempFilePath, []byte(customPolicy))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/server/plugin/nodeattestor/k8spsat/psat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8spsat/psat_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	sat_common "github.com/spiffe/spire/pkg/common/plugin/k8s"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
@@ -473,7 +473,7 @@ func createAndWriteSelfSignedCert(cn string, signer crypto.Signer, path string) 
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0600)
+	return diskutil.WritePrivateFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
 }
 
 func createTokenStatus(tokenData *TokenData, authenticated bool, audience []string) *authv1.TokenReviewStatus {

--- a/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"runtime"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil"
 	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	common_devid "github.com/spiffe/spire/pkg/common/plugin/tpmdevid"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
@@ -57,18 +57,16 @@ func setupSimulator(t *testing.T, provisioningCA *tpmsimulator.ProvisioningAutho
 
 	// Write provisioning root certificates into temp directory
 	devIDBundlePath = path.Join(dir, "devid-provisioning-ca.pem")
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, diskutil.WritePrivateFile(
 		devIDBundlePath,
-		pemutil.EncodeCertificate(provisioningCA.RootCert),
-		0600),
+		pemutil.EncodeCertificate(provisioningCA.RootCert)),
 	)
 
 	// Write endorsement root certificate into temp directory
 	endorsementBundlePath = path.Join(dir, "endorsement-ca.pem")
-	require.NoError(t, os.WriteFile(
+	require.NoError(t, diskutil.WritePrivateFile(
 		endorsementBundlePath,
-		pemutil.EncodeCertificate(sim.GetEKRoot()),
-		0600),
+		pemutil.EncodeCertificate(sim.GetEKRoot())),
 	)
 	return sim
 }

--- a/pkg/server/plugin/upstreamauthority/disk/disk_test.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk_test.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"math/big"
 	"net/url"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,6 +18,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/cryptoutil"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/x509svid"
 	"github.com/spiffe/spire/pkg/server/plugin/upstreamauthority"
@@ -466,6 +466,6 @@ func certPEM(certs ...*x509.Certificate) []byte {
 }
 
 func writeFile(t *testing.T, path string, data []byte) {
-	err := os.WriteFile(path, data, 0600)
+	err := diskutil.WritePrivateFile(path, data)
 	require.NoError(t, err)
 }

--- a/pkg/server/plugin/upstreamauthority/vault/testdata/generate.go
+++ b/pkg/server/plugin/upstreamauthority/vault/testdata/generate.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"math/big"
 	"net"
-	"os"
 	"time"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 )
 
@@ -81,7 +81,7 @@ func certPEM(certs ...*x509.Certificate) []byte {
 }
 
 func writeFile(path string, data []byte) {
-	err := os.WriteFile(path, data, 0600)
+	err := diskutil.WritePrivateFile(path, data)
 	checkErr(err)
 }
 

--- a/support/k8s/k8s-workload-registrar/config_crd_test.go
+++ b/support/k8s/k8s-workload-registrar/config_crd_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +34,7 @@ func TestLoadModeCRD(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 
-	err = os.WriteFile(confPath, []byte(minimalWithTemplate), 0600)
+	err = diskutil.WritePrivateFile(confPath, []byte(minimalWithTemplate))
 	require.NoError(err)
 
 	config, err := LoadMode(confPath)
@@ -372,7 +372,7 @@ func TestLoadModeCRD(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase // alias loop variable as it is used in the closure
 		t.Run(testCase.name, func(t *testing.T) {
-			err := os.WriteFile(confPath, []byte(testCase.in), 0600)
+			err := diskutil.WritePrivateFile(confPath, []byte(testCase.in))
 			require.NoError(err)
 
 			actual, err := LoadMode(confPath)

--- a/support/k8s/k8s-workload-registrar/config_test.go
+++ b/support/k8s/k8s-workload-registrar/config_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
@@ -30,7 +30,7 @@ func TestLoadMode(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 
-	err = os.WriteFile(confPath, []byte(testMinimalConfig), 0600)
+	err = diskutil.WritePrivateFile(confPath, []byte(testMinimalConfig))
 	require.NoError(err)
 
 	config, err := LoadMode(confPath)
@@ -155,7 +155,7 @@ func TestLoadMode(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase // alias loop variable as it is used in the closure
 		t.Run(testCase.name, func(t *testing.T) {
-			err := os.WriteFile(confPath, []byte(testCase.in), 0600)
+			err := diskutil.WritePrivateFile(confPath, []byte(testCase.in))
 			require.NoError(err)
 
 			actual, err := LoadMode(confPath)

--- a/support/k8s/k8s-workload-registrar/mode-crd/webhook/webhook_svid.go
+++ b/support/k8s/k8s-workload-registrar/mode-crd/webhook/webhook_svid.go
@@ -21,14 +21,13 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	svidv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/svid/v1"
 	spiretypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
 
 const (
 	certDirMode   = os.FileMode(0o700)
-	certsFileMode = os.FileMode(0o644)
-	keyFileMode   = os.FileMode(0o600)
 	certsFileName = "tls.crt"
 	keyFileName   = "tls.key"
 )
@@ -181,13 +180,13 @@ func (e *SVID) dumpSVID(svid *spiretypes.X509SVID, key crypto.Signer) error {
 
 	// Write certificates to disk
 	certsFileName := path.Join(e.c.WebhookCertDir, certsFileName)
-	if err := os.WriteFile(certsFileName, svidPEM.Bytes(), certsFileMode); err != nil {
+	if err := diskutil.WritePubliclyReadableFile(certsFileName, svidPEM.Bytes()); err != nil {
 		return err
 	}
 
 	// Write key to disk
 	keyFileName := path.Join(e.c.WebhookCertDir, keyFileName)
-	return os.WriteFile(keyFileName, keyPEM.Bytes(), keyFileMode)
+	return diskutil.WritePrivateFile(keyFileName, keyPEM.Bytes())
 }
 
 func certHalfLife(cert *x509.Certificate) time.Time {

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +27,7 @@ func TestLoadConfig(t *testing.T) {
 	require.Error(err)
 	require.Contains(err.Error(), "unable to load configuration:")
 
-	err = os.WriteFile(confPath, []byte(minimalServerAPIConfig), 0600)
+	err = diskutil.WritePrivateFile(confPath, []byte(minimalServerAPIConfig))
 	require.NoError(err)
 
 	config, err := LoadConfig(confPath)

--- a/test/fixture/nodeattestor/x509pop/generate.go
+++ b/test/fixture/nodeattestor/x509pop/generate.go
@@ -8,8 +8,9 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
-	"os"
 	"time"
+
+	"github.com/spiffe/spire/pkg/common/diskutil"
 )
 
 func panice(err error) {
@@ -81,7 +82,7 @@ func writeKey(path string, key interface{}) {
 		Type:  "PRIVATE KEY",
 		Bytes: keyBytes,
 	})
-	err = os.WriteFile(path, pemBytes, 0600)
+	err = diskutil.WritePrivateFile(path, pemBytes)
 	panice(err)
 }
 
@@ -94,6 +95,6 @@ func writeCerts(path string, certs ...*x509.Certificate) {
 		})
 		panice(err)
 	}
-	err := os.WriteFile(path, data.Bytes(), 0600)
+	err := diskutil.WritePrivateFile(path, data.Bytes())
 	panice(err)
 }

--- a/test/integration/setup/x509pop/gencerts.go
+++ b/test/integration/setup/x509pop/gencerts.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/spiffe/spire/pkg/common/diskutil"
 )
 
 func main() {
@@ -74,7 +76,7 @@ func writeKey(path string, key crypto.Signer) {
 		Type:  "PRIVATE KEY",
 		Bytes: keyBytes,
 	})
-	writeFile(path, pemBytes, 0600)
+	writePrivateFile(path, pemBytes)
 }
 
 func writeCerts(path string, certs ...*x509.Certificate) {
@@ -86,11 +88,16 @@ func writeCerts(path string, certs ...*x509.Certificate) {
 		})
 		checkErr(err)
 	}
-	writeFile(path, data.Bytes(), 0644)
+	writePubliclyReadableFile(path, data.Bytes())
 }
 
-func writeFile(path string, data []byte, mode os.FileMode) {
-	err := os.WriteFile(path, data, mode)
+func writePrivateFile(path string, data []byte) {
+	err := diskutil.WritePrivateFile(path, data)
+	checkErr(err)
+}
+
+func writePubliclyReadableFile(path string, data []byte) {
+	err := diskutil.WritePubliclyReadableFile(path, data)
 	checkErr(err)
 }
 

--- a/test/testkey/bucket.go
+++ b/test/testkey/bucket.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 )
 
@@ -108,7 +109,7 @@ func (b *bucket[KT, K]) save() error {
 			Bytes: keyBytes,
 		})
 	}
-	return os.WriteFile(b.path(), buf.Bytes(), 0600)
+	return diskutil.WritePrivateFile(b.path(), buf.Bytes())
 }
 
 func (b *bucket[KT, K]) path() string {


### PR DESCRIPTION
The `os.WriteFile` function is used in SPIRE to write to a file with specific permission bits. This works well in Unix platforms but it doesn't allow to specify a specific security descriptor on Windows.
This PR adds two new functions to our `diskutil` package: `WritePrivateFile` and `WritePubliclyReadableFile`. Those functions have os-specific implementations that respect the intended permissions in each platform.

Fixes part of #3189.