### PR TITLE
Use `default_x509_svid_ttl` instead of the deprecated `default_svid_ttl` config

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -74,7 +74,6 @@ type serverConfig struct {
 	CASubject          *caSubjectConfig   `hcl:"ca_subject"`
 	CATTL              string             `hcl:"ca_ttl"`
 	DataDir            string             `hcl:"data_dir"`
-	DefaultSVIDTTL     string             `hcl:"default_svid_ttl"`
 	DefaultX509SVIDTTL string             `hcl:"default_x509_svid_ttl"`
 	DefaultJWTSVIDTTL  string             `hcl:"default_jwt_svid_ttl"`
 	Experimental       experimentalConfig `hcl:"experimental"`
@@ -84,11 +83,9 @@ type serverConfig struct {
 	LogFile            string             `hcl:"log_file"`
 	LogLevel           string             `hcl:"log_level"`
 	LogFormat          string             `hcl:"log_format"`
-	// Deprecated: remove in SPIRE 1.6.0
-	OmitX509SVIDUID *bool           `hcl:"omit_x509svid_uid"`
-	RateLimit       rateLimitConfig `hcl:"ratelimit"`
-	SocketPath      string          `hcl:"socket_path"`
-	TrustDomain     string          `hcl:"trust_domain"`
+	RateLimit          rateLimitConfig    `hcl:"ratelimit"`
+	SocketPath         string             `hcl:"socket_path"`
+	TrustDomain        string             `hcl:"trust_domain"`
 
 	ConfigPath string
 	ExpandEnv  bool
@@ -98,6 +95,10 @@ type serverConfig struct {
 	ProfilingPort    int      `hcl:"profiling_port"`
 	ProfilingFreq    int      `hcl:"profiling_freq"`
 	ProfilingNames   []string `hcl:"profiling_names"`
+
+	// Deprecated: remove in SPIRE 1.6.0
+	DefaultSVIDTTL  string `hcl:"default_svid_ttl"`
+	OmitX509SVIDUID *bool  `hcl:"omit_x509svid_uid"`
 
 	UnusedKeys []string `hcl:",unusedKeys"`
 }

--- a/release/posix/spire/conf/server/server.conf
+++ b/release/posix/spire/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "./data/server"
     log_level = "DEBUG"
     ca_ttl = "168h"
-    default_svid_ttl = "48h"
+    default_x509_svid_ttl = "48h"
 }
 
 plugins {

--- a/release/windows/spire/conf/server/server.conf
+++ b/release/windows/spire/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "./data/server"
     log_level = "DEBUG"
     ca_ttl = "168h"
-    default_svid_ttl = "48h"
+    default_x509_svid_ttl = "48h"
 }
 
 plugins {

--- a/support/k8s/k8s-workload-registrar/mode-crd/config/spire-server-registrar.yaml
+++ b/support/k8s/k8s-workload-registrar/mode-crd/config/spire-server-registrar.yaml
@@ -71,7 +71,7 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      default_svid_ttl = "1h"
+      default_x509_svid_ttl = "1h"
       ca_subject = {
         country = ["US"],
         organization = ["SPIFFE"],

--- a/test/integration/suites-windows/windows-workload-attestor/conf/server/server.conf
+++ b/test/integration/suites-windows/windows-workload-attestor/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "c:/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/admin-endpoints/conf/server/server.conf
+++ b/test/integration/suites/admin-endpoints/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/debug-endpoints/conf/server/server.conf
+++ b/test/integration/suites/debug-endpoints/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/delegatedidentity/conf/server/server.conf
+++ b/test/integration/suites/delegatedidentity/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/downstream-endpoints/conf/server/server.conf
+++ b/test/integration/suites/downstream-endpoints/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/envoy-sds-v2/conf/server/server.conf
+++ b/test/integration/suites/envoy-sds-v2/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "1m"
+    default_x509_svid_ttl = "1m"
 }
 
 plugins {

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/conf/downstream-federated/server/server.conf
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/conf/downstream-federated/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "5m"
+    default_x509_svid_ttl = "5m"
 
     federation {
         bundle_endpoint {

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/conf/upstream/server/server.conf
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/conf/upstream/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "5m"
+    default_x509_svid_ttl = "5m"
 
     federation {
         bundle_endpoint {

--- a/test/integration/suites/envoy-sds-v3/conf/server/server.conf
+++ b/test/integration/suites/envoy-sds-v3/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "1m"
+    default_x509_svid_ttl = "1m"
 }
 
 plugins {

--- a/test/integration/suites/evict-agent/conf/server/server.conf
+++ b/test/integration/suites/evict-agent/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
         ca_ttl = "20m"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/fetch-x509-svids/conf/server/server.conf
+++ b/test/integration/suites/fetch-x509-svids/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/fetch-x509-svids/conf/server/server.conf
+++ b/test/integration/suites/fetch-x509-svids/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_svid_ttl = "10m" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/fetch-x509-svids/conf/server/server.conf
+++ b/test/integration/suites/fetch-x509-svids/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
+	default_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/ghostunnel-federation/conf/downstream/server/server.conf
+++ b/test/integration/suites/ghostunnel-federation/conf/downstream/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "5m"
+    default_x509_svid_ttl = "5m"
 
     federation {
         bundle_endpoint {

--- a/test/integration/suites/ghostunnel-federation/conf/upstream/server/server.conf
+++ b/test/integration/suites/ghostunnel-federation/conf/upstream/server/server.conf
@@ -5,7 +5,7 @@ server {
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
     ca_ttl = "1h"
-    default_svid_ttl = "5m"
+    default_x509_svid_ttl = "5m"
 
     federation {
         bundle_endpoint {

--- a/test/integration/suites/k8s-crd-mode/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-crd-mode/conf/server/spire-server.yaml
@@ -64,7 +64,7 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      default_svid_ttl = "1h"
+      default_x509_svid_ttl = "1h"
       ca_subject = {
         country = ["US"],
         organization = ["SPIFFE"],

--- a/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-reconcile/conf/server/spire-server.yaml
@@ -114,7 +114,7 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      default_svid_ttl = "1h"
+      default_x509_svid_ttl = "1h"
       ca_ttl = "12h"
       ca_subject {
         country = ["US"]

--- a/test/integration/suites/nested-rotation/intermediateA/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_x509_svid_ttl = "15s"
+	default_svid_ttl = "15s" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/intermediateA/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "15s"
+	default_x509_svid_ttl = "15s"
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/intermediateB/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_x509_svid_ttl = "15s"
+	default_svid_ttl = "15s" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/intermediateB/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "15s"
+	default_x509_svid_ttl = "15s"
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/leafA/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafA/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "90s"
-	default_x509_svid_ttl = "15s"
+	default_svid_ttl = "15s" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/leafA/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafA/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "90s"
-	default_svid_ttl = "15s"
+	default_x509_svid_ttl = "15s"
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/leafB/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafB/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "90s"
-	default_x509_svid_ttl = "15s"
+	default_svid_ttl = "15s" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/leafB/server/server.conf
+++ b/test/integration/suites/nested-rotation/leafB/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "90s"
-	default_svid_ttl = "15s"
+	default_x509_svid_ttl = "15s"
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/root/server/server.conf
+++ b/test/integration/suites/nested-rotation/root/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_x509_svid_ttl = "15s"
+	default_svid_ttl = "15s" # TODO: Update to use default_x509_svid_ttl in 1.6.0. Keep in previous releases for testing.
 }
 
 plugins {

--- a/test/integration/suites/nested-rotation/root/server/server.conf
+++ b/test/integration/suites/nested-rotation/root/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "15s"
+	default_x509_svid_ttl = "15s"
 }
 
 plugins {

--- a/test/integration/suites/node-attestation/conf/server/server.conf
+++ b/test/integration/suites/node-attestation/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/rotation/conf/server/server.conf
+++ b/test/integration/suites/rotation/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
     ca_ttl = "1m"
-	default_svid_ttl = "10s"
+	default_x509_svid_ttl = "10s"
 }
 
 plugins {

--- a/test/integration/suites/spire-server-cli/conf/server/server.conf
+++ b/test/integration/suites/spire-server-cli/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
 	ca_ttl = "1h"
-	default_svid_ttl = "10m"
+	default_x509_svid_ttl = "10m"
 }
 
 plugins {

--- a/test/integration/suites/upgrade/conf/server/server.conf
+++ b/test/integration/suites/upgrade/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
     ca_ttl = "1m"
-	default_svid_ttl = "10s"
+	default_x509_svid_ttl = "10s"
 }
 
 plugins {

--- a/test/integration/suites/upgrade/conf/server/server.conf
+++ b/test/integration/suites/upgrade/conf/server/server.conf
@@ -5,7 +5,7 @@ server {
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
     ca_ttl = "1m"
-	default_x509_svid_ttl = "10s"
+	default_svid_ttl = "10s" # TODO: Update to use default_x509_svid_ttl in 1.6.0.
 }
 
 plugins {

--- a/test/integration/suites/upstream-authority-cert-manager/conf/server/spire-server.yaml
+++ b/test/integration/suites/upstream-authority-cert-manager/conf/server/spire-server.yaml
@@ -53,7 +53,7 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      default_svid_ttl = "1h"
+      default_x509_svid_ttl = "1h"
       ca_ttl = "12h"
       ca_subject {
         country = ["US"]


### PR DESCRIPTION
Update our release template config files to use `default_x509_svid_ttl` instead of the deprecated `default_svid_ttl` config setting.
Update the tests also (except for one that purposely is kept to exercise the deprecated setting).