### PR TITLE
Do not try to close `gcp_kms` client if not initialized

### DIFF
--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
@@ -151,6 +151,9 @@ func newPlugin(
 }
 
 func (p *Plugin) Close() error {
+	if p.kmsClient == nil {
+		return nil
+	}
 	p.log.Debug("Closing the connection to the Cloud KMS API service")
 	return p.kmsClient.Close()
 }


### PR DESCRIPTION
If there is a configuration error in the "gcp_kms" plugin, the client will not be initialized and the Close() operation should not be attempted, because there is no client.