### PR TITLE
Update list of required permissions in "gcp_kms" plugin documentation

### DIFF
--- a/doc/plugin_server_keymanager_gcp_kms.md
+++ b/doc/plugin_server_keymanager_gcp_kms.md
@@ -78,7 +78,11 @@ The plugin requires the following IAM permissions be granted to the
 authenticated service account in the configured key ring:
 
 ```text
-cloudkms.cryptoKeys.*
+cloudkms.cryptoKeys.create
+cloudkms.cryptoKeys.getIamPolicy
+cloudkms.cryptoKeys.list
+cloudkms.cryptoKeys.setIamPolicy
+cloudkms.cryptoKeys.update
 cloudkms.cryptoKeyVersions.create
 cloudkms.cryptoKeyVersions.destroy
 cloudkms.cryptoKeyVersions.get


### PR DESCRIPTION
Update the list of required permissions in the "gcp_kms" plugin documentation to be more precise about the minimum set of permissions required.