### PR TITLE
Remove strategy from Windows jobs

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -278,8 +278,6 @@ jobs:
     name: integration (windows)
     runs-on: windows-2022
     needs: images-windows
-    strategy:
-      fail-fast: false
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -287,8 +287,6 @@ jobs:
     name: integration (windows)
     runs-on: windows-2022
     needs: images-windows
-    strategy:
-      fail-fast: false
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
strategy required matrix and only has effect on matrix builds.

My vscode has linting against the scheme and showed a squigly at this element in the yaml

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

