### PR TITLE
Rename spire-oidc-provider scratch image to oidc-discovery-provider

### DIFF
--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -17,14 +17,6 @@ echo "Pushing images tagged as $IMAGETAG..."
 
 for img in spire-server spire-agent oidc-discovery-provider; do
     ghcrimg="ghcr.io/${ORGNAME}/${img}:${IMAGETAG}"
-
-    # Detect the oidc image and give it a different name for GHCR
-    # TODO: Remove this hack and fully rename the image once we move
-    # off of GCR.
-    if [ "$img" == "oidc-discovery-provider" ]; then
-            ghcrimg="ghcr.io/${ORGNAME}/spire-oidc-provider:${IMAGETAG}"
-    fi
-
     echo "Executing: docker tag $img-scratch:latest-local $ghcrimg"
     docker tag "$img"-scratch:latest-local "$ghcrimg"
     echo "Executing: docker push $ghcrimg"


### PR DESCRIPTION
In order to preserve the same naming as the alpine-based image published to GCR, rename the spire-oidc-provider image to oidc-discovery-provider to match the name referenced in documentation, examples, and the source code.

The rename to spire-oidc-provider was previously done to convey that the service is only usable with SPIRE and does not depend on SPIFFE APIs, since the image is published under the `spiffe` image namespace.