### PR TITLE
Revert "Refactor push-images script to reduce duplication (#3656)"

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -34,4 +34,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push images
-        run: ./.github/workflows/scripts/push-images.sh nightly -scratch
+        run: ./.github/workflows/scripts/push-scratch-images.sh nightly

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -524,13 +524,15 @@ jobs:
           registry: gcr.io
           username: _json_key
           password: ${{ secrets.GCR_JSON_KEY }}
+      # Push the images to GCR using the version number (without the "v" prefix).
       - name: Push images
-        run: ./.github/workflows/scripts/push-images.sh "${GITHUB_REF}"
+        run: ./.github/workflows/scripts/push-images.sh "${GITHUB_REF#refs/tags/v}"
       - name: Log in to GHCR
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # Push the images to GHCR using the version number (without the "v" prefix).
       - name: Push images
-        run: ./.github/workflows/scripts/push-images.sh "${GITHUB_REF}" -scratch
+        run: ./.github/workflows/scripts/push-scratch-images.sh "${GITHUB_REF#refs/tags/v}"

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -1,66 +1,20 @@
-#!/usr/bin/env bash
-# shellcheck shell=bash
-##
-## USAGE: __PROG__
-##
-## "__PROG__" publishes images to a registry.
-##
-## Usage example(s):
-##   ./__PROG__ 1.5.2
-##   ./__PROG__ v1.5.2
-##   ./__PROG__ v1.5.2 -scratch
-##   ./__PROG__ refs/tags/v1.5.2
-##   ./__PROG__ refs/tags/v1.5.2 -scratch
-##
-## Commands
-## - ./__PROG__ <version> [image-variant]   pushes images to the registry using given version.
+#!/bin/bash
 
 set -e
 
-function usage {
-  grep '^##' "$0" | sed -e 's/^##//' -e "s/__PROG__/$me/" >&2
-}
-
-me=$(basename "$0")
-
-version="$1"
-if [ -z "${version}" ]; then
-  usage
-  echo -e "\n Errors:\n * the version must be provided." >&2
-  exit 1
+IMAGETAG="$1"
+if [ -z "$IMAGETAG" ]; then
+    echo "IMAGETAG not provided!" 1>&2
+    echo "Usage: push-images.sh IMAGETAG" 1>&2
+    exit 1
 fi
 
-# remove the git tag prefix
-# Push the images using the version tag (without the "v" prefix).
-# Also strips the refs/tags part if the GITHUB_REF variable is used.
-version="${version#refs/tags/v}"
-version="${version#v}"
+echo "Pushing images tagged as $IMAGETAG..."
 
-variant="$2"
-if [ -n "${variant}" ] && [ "${variant}" != "-scratch" ]; then
-  usage
-  echo -e "\n Errors:\n * The only supported variant is '-scratch'." >&2
-  exit 1
-fi
-
-OCI_IMAGES=(
-  spire-server spire-agent k8s-workload-registrar oidc-discovery-provider
-)
-
-registry=gcr.io/spiffe-io
-if [ "${variant}" = "-scratch" ] ; then
-  org_name=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
-  org_name="${org_name:-spiffe}" # default to spiffe in case ran on local
-  registry=ghcr.io/${org_name}
-fi
-
-echo "Pushing images ${OCI_IMAGES[*]} to ${registry} with tag ${version}".
-for img in "${OCI_IMAGES[@]}"; do
-  image_variant="${img}${variant}"
-  image_to_push="${registry}/${img}:${version}"
-  if [ "${variant}" = "-scratch" ] && [ "${img}" == "oidc-discovery-provider" ] ; then
-    image_to_push="${registry}/spire-oidc-provider:${version}"
-  fi
-  docker tag "${image_variant}:latest-local" "${image_to_push}"
-  docker push "${image_to_push}"
+for img in spire-server spire-agent k8s-workload-registrar oidc-discovery-provider; do
+    gcrimg=gcr.io/spiffe-io/"$img":"${IMAGETAG}"
+    echo "Executing: docker tag $img:latest-local $gcrimg"
+    docker tag "$img":latest-local "$gcrimg"
+    echo "Executing: docker push $gcrimg"
+    docker push "$gcrimg"
 done

--- a/.github/workflows/scripts/push-scratch-images.sh
+++ b/.github/workflows/scripts/push-scratch-images.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+IMAGETAG="$1"
+if [ -z "$IMAGETAG" ]; then
+    echo "IMAGETAG not provided!" 1>&2
+    echo "Usage: push-images.sh IMAGETAG" 1>&2
+    exit 1
+fi
+
+# Extracting org name rather than hardcoding allows this
+# action to be portable across forks
+ORGNAME=$(echo "$GITHUB_REPOSITORY" | tr '/' "\n" | head -1 | tr -d "\n")
+
+echo "Pushing images tagged as $IMAGETAG..."
+
+for img in spire-server spire-agent oidc-discovery-provider; do
+    ghcrimg="ghcr.io/${ORGNAME}/${img}:${IMAGETAG}"
+
+    # Detect the oidc image and give it a different name for GHCR
+    # TODO: Remove this hack and fully rename the image once we move
+    # off of GCR.
+    if [ "$img" == "oidc-discovery-provider" ]; then
+            ghcrimg="ghcr.io/${ORGNAME}/spire-oidc-provider:${IMAGETAG}"
+    fi
+
+    echo "Executing: docker tag $img-scratch:latest-local $ghcrimg"
+    docker tag "$img"-scratch:latest-local "$ghcrimg"
+    echo "Executing: docker push $ghcrimg"
+    docker push "$ghcrimg"
+done


### PR DESCRIPTION
This reverts commit fde87a667d2fdab7086db70c3c3a5041c6bc0099.

This change causes the k8s-workload-registrar scratch image to be published to GHCR, which is not something we have done in the past and do not want to do for future releases. Backing this change out on main for now to unblock the 1.5.3 release.