### PR TITLE
Revert GitHub permission changes

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -1,13 +1,12 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3

--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -4,6 +4,9 @@ on:
     # Random minute number to avoid GH scheduler stampede
     - cron: '37 21 * * *'
   workflow_dispatch: {}
+permissions:
+  contents: read
+  packages: write
 
 env:
   NIGHTLY: true
@@ -11,11 +14,6 @@ env:
 jobs:
   build-and-publish-images:
     runs-on: ubuntu-20.04
-
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -11,10 +11,6 @@ jobs:
   cache-deps:
     name: cache-deps (linux)
     runs-on: ubuntu-20.04
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -34,10 +30,6 @@ jobs:
     name: lint (linux)
     runs-on: ubuntu-20.04
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -72,10 +64,6 @@ jobs:
         OS: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.OS }}
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -95,10 +83,6 @@ jobs:
     name: unit-test (linux with race detection)
     runs-on: ubuntu-20.04
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -118,10 +102,6 @@ jobs:
     name: artifacts (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -153,10 +133,6 @@ jobs:
     name: images (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -190,10 +166,6 @@ jobs:
     name: images (windows)
     runs-on: windows-2022
     needs: artifact-windows
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -217,10 +189,6 @@ jobs:
   scratch-images:
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -254,10 +222,6 @@ jobs:
     name: integration (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps, images, scratch-images]
-
-    permissions:
-      contents: read
-
     strategy:
       fail-fast: false
       matrix:
@@ -314,10 +278,6 @@ jobs:
     name: integration (windows)
     runs-on: windows-2022
     needs: images-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -365,10 +325,6 @@ jobs:
   cache-deps-windows:
     name: cache-deps (windows)
     runs-on: windows-2022
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -388,10 +344,6 @@ jobs:
     name: lint (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -435,10 +387,6 @@ jobs:
     name: unit-test (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -471,10 +419,6 @@ jobs:
     name: artifact (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -9,10 +9,6 @@ jobs:
   cache-deps:
     name: cache-deps (linux)
     runs-on: ubuntu-20.04
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -32,10 +28,6 @@ jobs:
     name: lint (linux)
     runs-on: ubuntu-20.04
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,10 +62,6 @@ jobs:
         OS: [ubuntu-20.04, macos-latest]
     runs-on: ${{ matrix.OS }}
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -93,10 +81,6 @@ jobs:
     name: unit-test (linux with race detection)
     runs-on: ubuntu-20.04
     needs: cache-deps
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -116,10 +100,6 @@ jobs:
     name: artifacts (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -151,10 +131,6 @@ jobs:
     name: images (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -188,10 +164,6 @@ jobs:
     name: images (windows)
     runs-on: windows-2022
     needs: artifact-windows
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -215,10 +187,6 @@ jobs:
   scratch-images:
     runs-on: ubuntu-20.04
     needs: [cache-deps]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -252,10 +220,6 @@ jobs:
     name: integration (linux)
     runs-on: ubuntu-20.04
     needs: [cache-deps, images, scratch-images]
-
-    permissions:
-      contents: read
-
     strategy:
       fail-fast: false
       matrix:
@@ -323,10 +287,6 @@ jobs:
     name: integration (windows)
     runs-on: windows-2022
     needs: images-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -374,10 +334,6 @@ jobs:
   cache-deps-windows:
     name: cache-deps (windows)
     runs-on: windows-2022
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -397,10 +353,6 @@ jobs:
     name: lint (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -444,10 +396,6 @@ jobs:
     name: unit-test (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -480,10 +428,6 @@ jobs:
     name: artifact (windows)
     runs-on: windows-2022
     needs: cache-deps-windows
-
-    permissions:
-      contents: read
-
     defaults:
       run:
         shell: msys2 {0}
@@ -534,10 +478,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration,
             lint-windows, unit-test-windows, artifact-windows, integration-windows]
-
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -561,11 +501,6 @@ jobs:
   publish-images:
     runs-on: ubuntu-20.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration]
-
-    permissions:
-      contents: read
-      packages: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This change does not set the proper permissions and is blocking the v1.5.4 release.