### PR TITLE
Disable fsync for postgres datastore tests

### DIFF
--- a/test/integration/suites/datastore-postgres-replication/docker-compose.yaml
+++ b/test/integration/suites/datastore-postgres-replication/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   postgres-10-readwrite:
     image: postgres:10
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
@@ -14,6 +15,7 @@ services:
       - "9999:5432"
   postgres-10-readonly:
     image: postgres:10
+    command: -c fsync=off
     user: postgres
     environment:
       - POSTGRES_PASSWORD=password
@@ -28,6 +30,7 @@ services:
       - "10000:5432"
   postgres-11-readwrite:
     image: postgres:11
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
@@ -40,6 +43,7 @@ services:
       - "9999:5432"
   postgres-11-readonly:
     image: postgres:11
+    command: -c fsync=off
     user: postgres
     environment:
       - POSTGRES_PASSWORD=password
@@ -54,6 +58,7 @@ services:
       - "10000:5432"
   postgres-12-readwrite:
     image: postgres:12
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres
@@ -66,6 +71,7 @@ services:
       - "9999:5432"
   postgres-12-readonly:
     image: postgres:12
+    command: -c fsync=off
     user: postgres
     environment:
       - POSTGRES_PASSWORD=password

--- a/test/integration/suites/datastore-postgres/docker-compose.yaml
+++ b/test/integration/suites/datastore-postgres/docker-compose.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   postgres-10:
     image: postgres:10
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
     tmpfs:
@@ -10,6 +11,7 @@ services:
       - "9999:5432"
   postgres-11:
     image: postgres:11
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
     tmpfs:
@@ -18,6 +20,7 @@ services:
       - "9999:5432"
   postgres-12:
     image: postgres:12
+    command: -c fsync=off
     environment:
       - POSTGRES_PASSWORD=password
     tmpfs:


### PR DESCRIPTION
Disabling fsync reduces the datastore-postgres integration test from 8m30s to 1m30s on my machine. We don't need the safety that fsync provides for data integrity on the integration tests.