### PR TITLE
Deterministic plugin ordering

### DIFF
--- a/cmd/spire-agent/cli/run/run_posix_test.go
+++ b/cmd/spire-agent/cli/run/run_posix_test.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/spiffe/spire/pkg/agent"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	commoncli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -181,38 +181,40 @@ func TestParseConfigGood(t *testing.T) {
 	assert.Equal(t, true, c.Agent.AllowUnauthenticatedVerifiers)
 	assert.Equal(t, []string{"c1", "c2", "c3"}, c.Agent.AllowedForeignJWTClaims)
 
+	// Parse/reprint cycle trims outer whitespace
+	const data = `join_token = "PLUGIN-AGENT-NOT-A-SECRET"`
+
 	// Check for plugins configurations
-	pluginConfigs := *c.Plugins
-	expectedData := "join_token = \"PLUGIN-AGENT-NOT-A-SECRET\""
-	var data bytes.Buffer
-	err = printer.DefaultConfig.Fprint(&data, pluginConfigs["plugin_type_agent"]["plugin_name_agent"].PluginData)
-	assert.NoError(t, err)
+	expectedPluginConfigs := catalog.PluginConfigs{
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_name_agent",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_disabled",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: true,
+		},
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_enabled",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+	}
 
-	assert.Len(t, pluginConfigs, 1)
-	assert.Len(t, pluginConfigs["plugin_type_agent"], 3)
-
-	pluginConfig := pluginConfigs["plugin_type_agent"]["plugin_name_agent"]
-	assert.Nil(t, pluginConfig.Enabled)
-	assert.Equal(t, true, pluginConfig.IsEnabled())
-	assert.Equal(t, "pluginAgentChecksum", pluginConfig.PluginChecksum)
-	assert.Equal(t, "./pluginAgentCmd", pluginConfig.PluginCmd)
-	assert.Equal(t, data.String(), expectedData)
-
-	// Disabled plugin
-	pluginConfig = pluginConfigs["plugin_type_agent"]["plugin_disabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, false, pluginConfig.IsEnabled())
-	assert.Equal(t, "pluginAgentChecksum", pluginConfig.PluginChecksum)
-	assert.Equal(t, "./pluginAgentCmd", pluginConfig.PluginCmd)
-	assert.Equal(t, data.String(), expectedData)
-
-	// Enabled plugin
-	pluginConfig = pluginConfigs["plugin_type_agent"]["plugin_enabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, true, pluginConfig.IsEnabled())
-	assert.Equal(t, "pluginAgentChecksum", pluginConfig.PluginChecksum)
-	assert.Equal(t, "./pluginAgentCmd", pluginConfig.PluginCmd)
-	assert.Equal(t, data.String(), expectedData)
+	pluginConfigs, err := catalog.PluginConfigsFromHCLNode(c.Plugins)
+	require.NoError(t, err)
+	require.Equal(t, expectedPluginConfigs, pluginConfigs)
 }
 
 func mergeInputCasesOS() []mergeInputCase {

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/agent/workloadkey"
-	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/log"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/util"
@@ -911,7 +911,7 @@ func defaultValidConfig() *Config {
 	c.Agent.TrustBundlePath = path.Join(util.ProjectRoot(), "conf/agent/dummy_root_ca.crt")
 	c.Agent.TrustDomain = "example.org"
 
-	c.Plugins = &catalog.HCLPluginConfigMap{}
+	c.Plugins = &ast.ObjectList{}
 
 	return c
 }

--- a/cmd/spire-agent/cli/run/run_windows_test.go
+++ b/cmd/spire-agent/cli/run/run_windows_test.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/hcl/hcl/printer"
 	"github.com/spiffe/spire/pkg/agent"
+	"github.com/spiffe/spire/pkg/common/catalog"
 	commoncli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/log"

--- a/cmd/spire-agent/cli/run/run_windows_test.go
+++ b/cmd/spire-agent/cli/run/run_windows_test.go
@@ -168,38 +168,40 @@ func TestParseConfigGood(t *testing.T) {
 	assert.Equal(t, true, c.Agent.AllowUnauthenticatedVerifiers)
 	assert.Equal(t, []string{"c1", "c2", "c3"}, c.Agent.AllowedForeignJWTClaims)
 
+	// Parse/reprint cycle trims outer whitespace
+	const data = `join_token = "PLUGIN-AGENT-NOT-A-SECRET"`
+
 	// Check for plugins configurations
-	pluginConfigs := *c.Plugins
-	expectedData := "join_token = \"PLUGIN-AGENT-NOT-A-SECRET\""
-	var data bytes.Buffer
-	err = printer.DefaultConfig.Fprint(&data, pluginConfigs["plugin_type_agent"]["plugin_name_agent"].PluginData)
-	assert.NoError(t, err)
+	expectedPluginConfigs := catalog.PluginConfigs{
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_name_agent",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_disabled",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: true,
+		},
+		{
+			Type:     "plugin_type_agent",
+			Name:     "plugin_enabled",
+			Path:     "./pluginAgentCmd",
+			Checksum: "pluginAgentChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+	}
 
-	assert.Len(t, pluginConfigs, 1)
-	assert.Len(t, pluginConfigs["plugin_type_agent"], 3)
-
-	pluginConfig := pluginConfigs["plugin_type_agent"]["plugin_name_agent"]
-	assert.Nil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), true)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, "./pluginAgentCmd")
-	assert.Equal(t, expectedData, data.String())
-
-	// Disabled plugin
-	pluginConfig = pluginConfigs["plugin_type_agent"]["plugin_disabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), false)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, ".\\pluginAgentCmd")
-	assert.Equal(t, expectedData, data.String())
-
-	// Enabled plugin
-	pluginConfig = pluginConfigs["plugin_type_agent"]["plugin_enabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), true)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginAgentChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, "c:/temp/pluginAgentCmd")
-	assert.Equal(t, expectedData, data.String())
+	pluginConfigs, err := catalog.PluginConfigsFromHCLNode(c.Plugins)
+	require.NoError(t, err)
+	require.Equal(t, expectedPluginConfigs, pluginConfigs)
 }
 
 func mergeInputCasesOS() []mergeInputCase {

--- a/cmd/spire-agent/cli/run/run_windows_test.go
+++ b/cmd/spire-agent/cli/run/run_windows_test.go
@@ -184,7 +184,7 @@ func TestParseConfigGood(t *testing.T) {
 		{
 			Type:     "plugin_type_agent",
 			Name:     "plugin_disabled",
-			Path:     "./pluginAgentCmd",
+			Path:     ".\\pluginAgentCmd",
 			Checksum: "pluginAgentChecksum",
 			Data:     data,
 			Disabled: true,
@@ -192,7 +192,7 @@ func TestParseConfigGood(t *testing.T) {
 		{
 			Type:     "plugin_type_agent",
 			Name:     "plugin_enabled",
-			Path:     "./pluginAgentCmd",
+			Path:     "c:/temp/pluginAgentCmd",
 			Checksum: "pluginAgentChecksum",
 			Data:     data,
 			Disabled: false,

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -57,11 +57,11 @@ var (
 
 // Config contains all available configurables, arranged by section
 type Config struct {
-	Server       *serverConfig               `hcl:"server"`
-	Plugins      *catalog.HCLPluginConfigMap `hcl:"plugins"`
-	Telemetry    telemetry.FileConfig        `hcl:"telemetry"`
-	HealthChecks health.Config               `hcl:"health_checks"`
-	UnusedKeys   []string                    `hcl:",unusedKeys"`
+	Server       *serverConfig        `hcl:"server"`
+	Plugins      ast.Node             `hcl:"plugins"`
+	Telemetry    telemetry.FileConfig `hcl:"telemetry"`
+	HealthChecks health.Config        `hcl:"health_checks"`
+	UnusedKeys   []string             `hcl:",unusedKeys"`
 }
 
 type serverConfig struct {
@@ -594,7 +594,10 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		sc.CASubject = defaultCASubject
 	}
 
-	sc.PluginConfigs = *c.Plugins
+	sc.PluginConfigs, err = catalog.PluginConfigsFromHCLNode(c.Plugins)
+	if err != nil {
+		return nil, err
+	}
 	sc.Telemetry = c.Telemetry
 	sc.HealthChecks = c.HealthChecks
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"bytes"
 	"crypto/x509/pkix"
 	"io"
 	"os"
@@ -11,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl"
-	"github.com/hashicorp/hcl/hcl/printer"
+	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -66,39 +65,40 @@ func TestParseConfigGood(t *testing.T) {
 	assert.True(t, c.Server.AuditLogEnabled)
 	testParseConfigGoodOS(t, c)
 
+	// Parse/reprint cycle trims outer whitespace
+	const data = `join_token = "PLUGIN-SERVER-NOT-A-SECRET"`
+
 	// Check for plugins configurations
-	pluginConfigs := *c.Plugins
-	expectedData := "join_token = \"PLUGIN-SERVER-NOT-A-SECRET\""
-	var data bytes.Buffer
-	err = printer.DefaultConfig.Fprint(&data, pluginConfigs["plugin_type_server"]["plugin_name_server"].PluginData)
-	assert.NoError(t, err)
+	expectedPluginConfigs := catalog.PluginConfigs{
+		{
+			Type:     "plugin_type_server",
+			Name:     "plugin_name_server",
+			Path:     "./pluginServerCmd",
+			Checksum: "pluginServerChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+		{
+			Type:     "plugin_type_server",
+			Name:     "plugin_disabled",
+			Path:     "./pluginServerCmd",
+			Checksum: "pluginServerChecksum",
+			Data:     data,
+			Disabled: true,
+		},
+		{
+			Type:     "plugin_type_server",
+			Name:     "plugin_enabled",
+			Path:     "./pluginServerCmd",
+			Checksum: "pluginServerChecksum",
+			Data:     data,
+			Disabled: false,
+		},
+	}
 
-	assert.Len(t, pluginConfigs, 1)
-	assert.Len(t, pluginConfigs["plugin_type_server"], 3)
-
-	// Default config
-	pluginConfig := pluginConfigs["plugin_type_server"]["plugin_name_server"]
-	assert.Nil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), true)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
-	assert.Equal(t, expectedData, data.String())
-
-	// Disabled plugin
-	pluginConfig = pluginConfigs["plugin_type_server"]["plugin_disabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), false)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
-	assert.Equal(t, expectedData, data.String())
-
-	// Enabled plugin
-	pluginConfig = pluginConfigs["plugin_type_server"]["plugin_enabled"]
-	assert.NotNil(t, pluginConfig.Enabled)
-	assert.Equal(t, pluginConfig.IsEnabled(), true)
-	assert.Equal(t, pluginConfig.PluginChecksum, "pluginServerChecksum")
-	assert.Equal(t, pluginConfig.PluginCmd, "./pluginServerCmd")
-	assert.Equal(t, expectedData, data.String())
+	pluginConfigs, err := catalog.PluginConfigsFromHCLNode(c.Plugins)
+	require.NoError(t, err)
+	require.Equal(t, expectedPluginConfigs, pluginConfigs)
 }
 
 func TestMergeInput(t *testing.T) {
@@ -1010,7 +1010,7 @@ func defaultValidConfig() *Config {
 	c.Server.DataDir = "."
 	c.Server.TrustDomain = "example.org"
 
-	c.Plugins = &catalog.HCLPluginConfigMap{}
+	c.Plugins = &ast.ObjectList{}
 
 	return c
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -71,10 +71,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	uptime.ReportMetrics(ctx, metrics)
 
 	cat, err := catalog.Load(ctx, catalog.Config{
-		Log:          a.c.Log.WithField(telemetry.SubsystemName, telemetry.Catalog),
-		Metrics:      metrics,
-		TrustDomain:  a.c.TrustDomain,
-		PluginConfig: a.c.PluginConfigs,
+		Log:           a.c.Log.WithField(telemetry.SubsystemName, telemetry.Catalog),
+		Metrics:       metrics,
+		TrustDomain:   a.c.TrustDomain,
+		PluginConfigs: a.c.PluginConfigs,
 	})
 	if err != nil {
 		return err

--- a/pkg/agent/catalog/catalog_test.go
+++ b/pkg/agent/catalog/catalog_test.go
@@ -17,24 +17,25 @@ func TestJoinTokenNodeAttestorCannotBeOverriden(t *testing.T) {
 	minimalConfig := func() catalog.Config {
 		return catalog.Config{
 			Log: log,
-			PluginConfig: catalog.HCLPluginConfigMap{
-				"KeyManager": {
-					"memory": {},
+			PluginConfigs: catalog.PluginConfigs{
+				{
+					Type: "KeyManager",
+					Name: "memory",
 				},
-				"NodeAttestor": {
-					"join_token": {},
+				{
+					Type: "NodeAttestor",
+					Name: "join_token",
 				},
-				"WorkloadAttestor": {
-					"docker": {},
+				{
+					Type: "WorkloadAttestor",
+					Name: "docker",
 				},
 			},
 		}
 	}
 
 	config := minimalConfig()
-	config.PluginConfig["NodeAttestor"]["join_token"] = catalog.HCLPluginConfig{
-		PluginCmd: filepath.Join(dir, "does-not-exist"),
-	}
+	config.PluginConfigs[1].Path = filepath.Join(dir, "does-not-exist")
 
 	repo, err := catalog.Load(context.Background(), config)
 	if repo != nil {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	HealthChecks health.Config
 
 	// Configurations for agent plugins
-	PluginConfigs catalog.HCLPluginConfigMap
+	PluginConfigs catalog.PluginConfigs
 
 	Log logrus.FieldLogger
 

--- a/pkg/common/catalog/config.go
+++ b/pkg/common/catalog/config.go
@@ -2,16 +2,40 @@ package catalog
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/hcl/hcl/printer"
-	"github.com/zeebo/errs"
+	"github.com/hashicorp/hcl/hcl/token"
 )
 
+type PluginConfigs []PluginConfig
+
+func (cs PluginConfigs) FilterByType(pluginType string) (matching PluginConfigs, remaining PluginConfigs) {
+	for _, c := range cs {
+		if c.Type == pluginType {
+			matching = append(matching, c)
+		} else {
+			remaining = append(remaining, c)
+		}
+	}
+	return matching, remaining
+}
+
+func (cs PluginConfigs) Find(pluginType, pluginName string) (PluginConfig, bool) {
+	for _, c := range cs {
+		if c.Type == pluginType && c.Name == pluginName {
+			return c, true
+		}
+	}
+	return PluginConfig{}, false
+}
+
 type PluginConfig struct {
-	Name     string
 	Type     string
+	Name     string
 	Path     string
 	Args     []string
 	Checksum string
@@ -19,14 +43,15 @@ type PluginConfig struct {
 	Disabled bool
 }
 
+func (c PluginConfig) IsEnabled() bool {
+	return !c.Disabled
+}
+
 func (c *PluginConfig) IsExternal() bool {
 	return c.Path != ""
 }
 
-// HCLPluginConfig serves as an intermediary struct. We pass this to the
-// HCL library for parsing, except the parser won't parse pluginData
-// as a string.
-type HCLPluginConfig struct {
+type hclPluginConfig struct {
 	PluginCmd      string   `hcl:"plugin_cmd"`
 	PluginArgs     []string `hcl:"plugin_args"`
 	PluginChecksum string   `hcl:"plugin_checksum"`
@@ -34,42 +59,57 @@ type HCLPluginConfig struct {
 	Enabled        *bool    `hcl:"enabled"`
 }
 
-func (c HCLPluginConfig) IsEnabled() bool {
+func (c hclPluginConfig) IsEnabled() bool {
 	if c.Enabled == nil {
 		return true
 	}
 	return *c.Enabled
 }
 
-func (c HCLPluginConfig) IsExternal() bool {
+func (c hclPluginConfig) IsExternal() bool {
 	return c.PluginCmd != ""
 }
 
-type HCLPluginConfigMap map[string]map[string]HCLPluginConfig
-
-func ParsePluginConfigsFromHCL(config string) ([]PluginConfig, error) {
-	var hclConfig HCLPluginConfigMap
-	if err := hcl.Decode(&hclConfig, config); err != nil {
-		return nil, errs.New("unable to decode plugin config: %v", err)
+func PluginConfigsFromHCLNode(pluginsNode ast.Node) (PluginConfigs, error) {
+	if pluginsNode == nil {
+		return nil, errors.New("plugins node is nil")
 	}
-	return PluginConfigsFromHCL(hclConfig)
-}
-
-func PluginConfigsFromHCL(hclPlugins HCLPluginConfigMap) ([]PluginConfig, error) {
-	var pluginConfigs []PluginConfig
-	for pluginType, pluginsForType := range hclPlugins {
-		for pluginName, hclPluginConfig := range pluginsForType {
-			pluginConfig, err := PluginConfigFromHCL(pluginType, pluginName, hclPluginConfig)
-			if err != nil {
-				return nil, err
-			}
-			pluginConfigs = append(pluginConfigs, pluginConfig)
+	pluginsList, ok := pluginsNode.(*ast.ObjectList)
+	if !ok {
+		return nil, fmt.Errorf("expected plugins node type %T but got %T", pluginsList, pluginsNode)
+	}
+	var pluginConfigs PluginConfigs
+	for _, pluginObject := range pluginsList.Items {
+		if len(pluginObject.Keys) != 2 {
+			return nil, fmt.Errorf("plugin item expected to have two keys (type then name)")
 		}
+
+		pluginType, err := stringFromToken(pluginObject.Keys[0].Token)
+		if err != nil {
+			return nil, fmt.Errorf("invalid plugin type key %q: %w", pluginObject.Keys[0].Token.Text, err)
+		}
+
+		pluginName, err := stringFromToken(pluginObject.Keys[1].Token)
+		if err != nil {
+			return nil, fmt.Errorf("invalid plugin type name %q: %w", pluginObject.Keys[1].Token.Text, err)
+		}
+
+		var hclPluginConfig hclPluginConfig
+		if err := hcl.DecodeObject(&hclPluginConfig, pluginObject.Val); err != nil {
+			return nil, fmt.Errorf("failed to decode plugin config for %q/%q: %w", pluginType, pluginName, err)
+		}
+
+		pluginConfig, err := pluginConfigFromHCL(pluginType, pluginName, hclPluginConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plugin config for %q/%q: %w", pluginType, pluginName, err)
+		}
+
+		pluginConfigs = append(pluginConfigs, pluginConfig)
 	}
 	return pluginConfigs, nil
 }
 
-func PluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig HCLPluginConfig) (PluginConfig, error) {
+func pluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig hclPluginConfig) (PluginConfig, error) {
 	var data bytes.Buffer
 	if hclPluginConfig.PluginData != nil {
 		if err := printer.DefaultConfig.Fprint(&data, hclPluginConfig.PluginData); err != nil {
@@ -86,4 +126,19 @@ func PluginConfigFromHCL(pluginType, pluginName string, hclPluginConfig HCLPlugi
 		Data:     data.String(),
 		Disabled: !hclPluginConfig.IsEnabled(),
 	}, nil
+}
+
+func stringFromToken(keyToken token.Token) (string, error) {
+	switch keyToken.Type {
+	case token.STRING, token.IDENT:
+	default:
+		return "", fmt.Errorf("expected STRING or IDENT but got %s", keyToken.Type)
+	}
+	value := keyToken.Value()
+	stringValue, ok := value.(string)
+	if !ok {
+		// purely defensive
+		return "", fmt.Errorf("expected %T but got %T", stringValue, value)
+	}
+	return stringValue, nil
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -20,7 +20,7 @@ import (
 
 type Config struct {
 	// Configurations for server plugins
-	PluginConfigs common.HCLPluginConfigMap
+	PluginConfigs common.PluginConfigs
 
 	Log logrus.FieldLogger
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -255,7 +255,7 @@ func (s *Server) loadCatalog(ctx context.Context, metrics telemetry.Metrics, ide
 		Log:              s.config.Log.WithField(telemetry.SubsystemName, telemetry.Catalog),
 		Metrics:          metrics,
 		TrustDomain:      s.config.TrustDomain,
-		PluginConfig:     s.config.PluginConfigs,
+		PluginConfigs:    s.config.PluginConfigs,
 		IdentityProvider: identityProvider,
 		AgentStore:       agentStore,
 		HealthChecker:    healthChecker,


### PR DESCRIPTION
Future features (i.e. CredentialComposer work) rely on deterministic plugin execution order. The order that plugins are defined is a nice implied ordering. Unfortunately, decoding the plugins node into a map of maps hides the order that they were defined.

This change updates the catalog to instead decode configuration from an HCL ast.Node so that ordering can be preserved.