### PR TITLE
Remove deprecated `enabled` flag from InMem telemetry config

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -435,10 +435,7 @@ plugins {
 #         { address = "collector.example.org:9000" env = "prod" },
 #     ]
 
-#     InMem {
-#         # enabled: Enable this collector. Default: true.
-#         # enabled = true
-#     }
+#     InMem {}
 # }
 
 # health_checks: If health checking is desired use this section to configure

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -830,10 +830,7 @@ plugins {
 #         { address = "collector.example.org:9000" env = "prod" },
 #     ]
 
-#     InMem {
-#         # enabled: Enable this collector. This field is deprecated and will be removed in a future release. Default: false.
-#         # enabled = true
-#     }
+#     InMem {}
 # }
 
 # health_checks: If health checking is desired use this section to configure

--- a/doc/telemetry_config.md
+++ b/doc/telemetry_config.md
@@ -18,7 +18,7 @@ You may use all, some, or none of the collectors. The following collectors suppo
 
 | Configuration     | Type          | Description                                                   | Default |
 |-------------------|---------------|---------------------------------------------------------------|---------|
-| `InMem`           | `InMem`       | In-memory configuration                                       | running |
+| `InMem`           | `InMem`       | In-memory configuration                                       |         |
 | `Prometheus`      | `Prometheus`  | Prometheus configuration                                      |         |
 | `DogStatsd`       | `[]DogStatsd` | List of DogStatsd configurations                              |         |
 | `Statsd`          | `[]Statsd`    | List of Statsd configurations                                 |         |
@@ -56,11 +56,9 @@ You may use all, some, or none of the collectors. The following collectors suppo
 
 ### `In-Mem`
 
-| Configuration | Type   | Description                                                                                                                                                                    | Default |
-|---------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `enabled`     | `bool` | Enable this collector. This flag is deprecated and will be removed in a future release. To disable in-memory telemetry collection omit the InMem configuration block entirely. | `false` |
+The In-Memory metrics collector does not have configuration settings.
 
-Here is a sample configuration:
+### Sample telemetry configuration
 
 ```hcl
 telemetry {

--- a/pkg/common/telemetry/config.go
+++ b/pkg/common/telemetry/config.go
@@ -49,7 +49,5 @@ type M3Config struct {
 }
 
 type InMem struct {
-	// TODO: remove in SPIRE 1.6.0
-	DeprecatedEnabled *bool    `hcl:"enabled"`
-	UnusedKeys        []string `hcl:",unusedKeys"`
+	UnusedKeys []string `hcl:",unusedKeys"`
 }

--- a/pkg/common/telemetry/inmem.go
+++ b/pkg/common/telemetry/inmem.go
@@ -25,18 +25,8 @@ func newInmemRunner(c *MetricsConfig) (sinkRunner, error) {
 		log: c.Logger,
 	}
 
-	// Don't enable If the InMem block is not present, or is present with
-	// the deprecated "enabled" flag explicitly set to false.
-	// TODO: Remove the deprecated "enabled" flag in 1.6.0.
-	inMem := c.FileConfig.InMem
-	switch {
-	case inMem == nil:
+	if c.FileConfig.InMem == nil {
 		return runner, nil
-	case inMem.DeprecatedEnabled != nil:
-		c.Logger.Warn("The enabled flag is deprecated in the InMem configuration and will be removed in a future release; omit the InMem block to disable in-memory telemetry")
-		if !*inMem.DeprecatedEnabled {
-			return runner, nil
-		}
 	}
 
 	if logger, ok := c.Logger.(interface{ Writer() *io.PipeWriter }); ok {

--- a/pkg/common/telemetry/inmem_test.go
+++ b/pkg/common/telemetry/inmem_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestInMem(t *testing.T) {
-	enabled := true
-	disabled := false
-
 	for _, tt := range []struct {
 		test               string
 		inMemConfig        *InMem
@@ -28,31 +25,9 @@ func TestInMem(t *testing.T) {
 			expectEnabled: false,
 		},
 		{
-			test:          "enabled when InMem block declared but deprecated enabled flag unset",
+			test:          "enabled when InMem block declared",
 			inMemConfig:   &InMem{},
 			expectEnabled: true,
-		},
-		{
-			test:          "enabled when InMem block declared and deprecated enabled flag set to true",
-			inMemConfig:   &InMem{DeprecatedEnabled: &enabled},
-			expectEnabled: true,
-			expectLogs: []spiretest.LogEntry{
-				{
-					Level:   logrus.WarnLevel,
-					Message: "The enabled flag is deprecated in the InMem configuration and will be removed in a future release; omit the InMem block to disable in-memory telemetry",
-				},
-			},
-		},
-		{
-			test:          "disabled when InMem block declared and deprecated enabled flag set to false",
-			inMemConfig:   &InMem{DeprecatedEnabled: &disabled},
-			expectEnabled: false,
-			expectLogs: []spiretest.LogEntry{
-				{
-					Level:   logrus.WarnLevel,
-					Message: "The enabled flag is deprecated in the InMem configuration and will be removed in a future release; omit the InMem block to disable in-memory telemetry",
-				},
-			},
 		},
 		{
 			test:               "disabled when unexpected logger passed",


### PR DESCRIPTION
Removed the deprecated `enabled` flag from InMem telemetry config.

Fixes #3497.