### PR TITLE
Simplify PR workflow status check

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -485,3 +485,14 @@ jobs:
         with:
           name: binaries
           path: ./artifacts/
+
+  success:
+    runs-on: ubuntu-20.04
+    needs: [lint, unit-test, unit-test-race-detector, artifacts, integration,
+            lint-windows, unit-test-windows, artifact-windows, integration-windows]
+
+    permissions:
+      contents: read
+    steps:
+      - name: Declare victory!
+        run: echo "# Successful" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The status checks required for branch protection are coupled with the current build matrix on the integration tests.

This change introduces a new job that depends on the integration test jobs for both linux and windows that can be used for the status check.
