### PR TITLE
Explicitly enable CGO for cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY --link --from=xx / /
 RUN install -d -o root -g root -m 1777 /newtmp
 RUN xx-go --wrap
 RUN set -e ; xx-apk --no-cache --update add build-base musl-dev libseccomp-dev
+ENV CGO_ENABLED=1
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     if [ "$TARGETARCH" = "arm64" ]; then CC=aarch64-alpine-linux-musl; fi && \


### PR DESCRIPTION
CGO_ENABLED gets disabled by default during cross-compilation. Unfortunatly this means that the arm64 spire-server, which has a CGO dependency for sqlite3, does not function.

This change updates the Dockerfile to explicitly enable CGO for cross-compilation.
