### PR TITLE
Fix stale comment around InMem config

### DIFF
--- a/pkg/common/telemetry/inmem.go
+++ b/pkg/common/telemetry/inmem.go
@@ -25,9 +25,7 @@ func newInmemRunner(c *MetricsConfig) (sinkRunner, error) {
 		log: c.Logger,
 	}
 
-	// Don't enable If the InMem block is not present, or is present with
-	// the deprecated "enabled" flag explicitly set to false.
-	// TODO: Remove the deprecated "enabled" flag in 1.6.0.
+	// Don't enable If the InMem block is not present.
 	inMem := c.FileConfig.InMem
 	if inMem == nil {
 		return runner, nil


### PR DESCRIPTION
The deprecated "enabled" flag was recently removed. This change fixes up a related stale comment.