### PR TITLE
CredentialComposer facade and catalog support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.1.2
 	github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944
-	github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33
+	github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230203133000-75d7213a0ba0
 	github.com/stretchr/testify v1.8.1
 	github.com/uber-go/tally/v4 v4.1.5
 	github.com/zeebo/errs v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spiffe/go-spiffe/v2 v2.1.2
 	github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944
-	github.com/spiffe/spire-plugin-sdk v1.4.1-0.20220912221658-c42ab2d657f6
+	github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33
 	github.com/stretchr/testify v1.8.1
 	github.com/uber-go/tally/v4 v4.1.5
 	github.com/zeebo/errs v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1819,8 +1819,6 @@ github.com/spiffe/go-spiffe/v2 v2.1.2 h1:nfNwopOP7q0qsWU6AUASqmbtYViwHA6vuHyAtqF
 github.com/spiffe/go-spiffe/v2 v2.1.2/go.mod h1:cbQmFrxsOpbm5tWURAYip9ZK0dOSFeoFG3/5Ub9Hvy0=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944 h1:yoKYON+goNlajhkpKSfwVPB1qvmeh9MmWDyj5zc4C7o=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33 h1:ABMlJLDYCGtyEXy8ZZWmutdPpeHfpN7ky0C9ELy3OPw=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
 github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230203133000-75d7213a0ba0 h1:+ETVN721ZSZvi8CmR0oGf2KRSIkVMvWC8PqON9IknrM=
 github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230203133000-75d7213a0ba0/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=

--- a/go.sum
+++ b/go.sum
@@ -1819,8 +1819,8 @@ github.com/spiffe/go-spiffe/v2 v2.1.2 h1:nfNwopOP7q0qsWU6AUASqmbtYViwHA6vuHyAtqF
 github.com/spiffe/go-spiffe/v2 v2.1.2/go.mod h1:cbQmFrxsOpbm5tWURAYip9ZK0dOSFeoFG3/5Ub9Hvy0=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944 h1:yoKYON+goNlajhkpKSfwVPB1qvmeh9MmWDyj5zc4C7o=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
-github.com/spiffe/spire-plugin-sdk v1.4.1-0.20220912221658-c42ab2d657f6 h1:QViYo6JR+v2lTMV/w9Py1mWJEXTrLn1Hb6ZsCWSVVek=
-github.com/spiffe/spire-plugin-sdk v1.4.1-0.20220912221658-c42ab2d657f6/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33 h1:ABMlJLDYCGtyEXy8ZZWmutdPpeHfpN7ky0C9ELy3OPw=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/go.sum
+++ b/go.sum
@@ -1821,6 +1821,8 @@ github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944 h1:yoKYON+g
 github.com/spiffe/spire-api-sdk v1.2.5-0.20221020001527-5895a0279944/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
 github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33 h1:ABMlJLDYCGtyEXy8ZZWmutdPpeHfpN7ky0C9ELy3OPw=
 github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230201142558-cfe8dfc2ff33/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230203133000-75d7213a0ba0 h1:+ETVN721ZSZvi8CmR0oGf2KRSIkVMvWC8PqON9IknrM=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20230203133000-75d7213a0ba0/go.mod h1:4KW5J6abGIAyUS8IL7Fi0NOfoWR6jA5LufKPnIdm9FE=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/pkg/server/catalog/catalog.go
+++ b/pkg/server/catalog/catalog.go
@@ -24,6 +24,7 @@ import (
 	ds_sql "github.com/spiffe/spire/pkg/server/datastore/sqlstore"
 	"github.com/spiffe/spire/pkg/server/hostservice/agentstore"
 	"github.com/spiffe/spire/pkg/server/hostservice/identityprovider"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/jointoken"
@@ -32,14 +33,16 @@ import (
 )
 
 const (
-	dataStoreType         = "DataStore"
-	keyManagerType        = "KeyManager"
-	nodeAttestorType      = "NodeAttestor"
-	notifierType          = "Notifier"
-	upstreamAuthorityType = "UpstreamAuthority"
+	credentialComposerType = "CredentialComposer" //nolint: gosec // this is not a hardcoded credential...
+	dataStoreType          = "DataStore"
+	keyManagerType         = "KeyManager"
+	nodeAttestorType       = "NodeAttestor"
+	notifierType           = "Notifier"
+	upstreamAuthorityType  = "UpstreamAuthority"
 )
 
 type Catalog interface {
+	GetCredentialComposers() []credentialcomposer.CredentialComposer
 	GetDataStore() datastore.DataStore
 	GetNodeAttestorNamed(name string) (nodeattestor.NodeAttestor, bool)
 	GetKeyManager() keymanager.KeyManager
@@ -63,6 +66,7 @@ type Config struct {
 type datastoreRepository struct{ datastore.Repository }
 
 type Repository struct {
+	credentialComposerRepository
 	datastoreRepository
 	keyManagerRepository
 	nodeAttestorRepository
@@ -76,6 +80,8 @@ type Repository struct {
 
 func (repo *Repository) Plugins() map[string]catalog.PluginRepo {
 	return map[string]catalog.PluginRepo{
+		// TODO: wire this up once we're ready to release the feature
+		//credentialComposerType: &repo.credentialComposerRepository,
 		keyManagerType:        &repo.keyManagerRepository,
 		nodeAttestorType:      &repo.nodeAttestorRepository,
 		notifierType:          &repo.notifierRepository,

--- a/pkg/server/catalog/credentialcomposer.go
+++ b/pkg/server/catalog/credentialcomposer.go
@@ -1,0 +1,31 @@
+package catalog
+
+import (
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
+)
+
+type credentialComposerRepository struct {
+	credentialcomposer.Repository
+}
+
+func (repo *credentialComposerRepository) Binder() interface{} {
+	return repo.AddCredentialComposer
+}
+
+func (repo *credentialComposerRepository) Constraints() catalog.Constraints {
+	return catalog.ZeroOrMore()
+}
+
+func (repo *credentialComposerRepository) Versions() []catalog.Version {
+	return []catalog.Version{credentialComposerV1{}}
+}
+
+func (repo *credentialComposerRepository) BuiltIns() []catalog.BuiltIn {
+	return nil
+}
+
+type credentialComposerV1 struct{}
+
+func (credentialComposerV1) New() catalog.Facade { return new(credentialcomposer.V1) }
+func (credentialComposerV1) Deprecated() bool    { return false }

--- a/pkg/server/plugin/credentialcomposer/credentialcomposer.go
+++ b/pkg/server/plugin/credentialcomposer/credentialcomposer.go
@@ -1,0 +1,37 @@
+package credentialcomposer
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/catalog"
+)
+
+type CredentialComposer interface {
+	catalog.PluginInfo
+
+	ComposeServerX509CA(ctx context.Context, attributes X509CAAttributes) (X509CAAttributes, error)
+	ComposeServerX509SVID(ctx context.Context, attributes X509SVIDAttributes) (X509SVIDAttributes, error)
+	ComposeAgentX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes X509SVIDAttributes) (X509SVIDAttributes, error)
+	ComposeWorkloadX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes X509SVIDAttributes) (X509SVIDAttributes, error)
+	ComposeWorkloadJWTSVID(ctx context.Context, id spiffeid.ID, attributes JWTSVIDAttributes) (JWTSVIDAttributes, error)
+}
+
+type X509CAAttributes struct {
+	Subject           pkix.Name
+	PolicyIdentifiers []asn1.ObjectIdentifier
+	ExtraExtensions   []pkix.Extension
+}
+
+type X509SVIDAttributes struct {
+	Subject         pkix.Name
+	DNSNames        []string
+	ExtraExtensions []pkix.Extension
+}
+
+type JWTSVIDAttributes struct {
+	Claims map[string]interface{}
+}

--- a/pkg/server/plugin/credentialcomposer/repository.go
+++ b/pkg/server/plugin/credentialcomposer/repository.go
@@ -1,0 +1,17 @@
+package credentialcomposer
+
+type Repository struct {
+	CredentialComposers []CredentialComposer
+}
+
+func (repo *Repository) GetCredentialComposers() []CredentialComposer {
+	return repo.CredentialComposers
+}
+
+func (repo *Repository) AddCredentialComposer(credentialComposer CredentialComposer) {
+	repo.CredentialComposers = append(repo.CredentialComposers, credentialComposer)
+}
+
+func (repo *Repository) Clear() {
+	repo.CredentialComposers = nil
+}

--- a/pkg/server/plugin/credentialcomposer/v1.go
+++ b/pkg/server/plugin/credentialcomposer/v1.go
@@ -1,0 +1,384 @@
+package credentialcomposer
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	credentialcomposerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/credentialcomposer/v1"
+	"github.com/spiffe/spire/pkg/common/plugin"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var _ CredentialComposer = (*V1)(nil)
+
+type V1 struct {
+	plugin.Facade
+	credentialcomposerv1.CredentialComposerPluginClient
+}
+
+func (v1 V1) ComposeServerX509CA(ctx context.Context, attributes X509CAAttributes) (X509CAAttributes, error) {
+	attributesIn, err := x509CAAttributesToV1(attributes)
+	if err != nil {
+		return X509CAAttributes{}, v1.Errorf(codes.Internal, "invalid X509CA attributes: %v", err)
+	}
+	resp, err := v1.CredentialComposerPluginClient.ComposeServerX509CA(ctx, &credentialcomposerv1.ComposeServerX509CARequest{
+		Attributes: attributesIn,
+	})
+	return v1.handleX509CAAttributesResponse(attributes, resp, err)
+}
+
+func (v1 V1) ComposeServerX509SVID(ctx context.Context, attributes X509SVIDAttributes) (X509SVIDAttributes, error) {
+	attributesIn, err := x509SVIDAttributesToV1(attributes)
+	if err != nil {
+		return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "invalid server X509SVID attributes: %v", err)
+	}
+	resp, err := v1.CredentialComposerPluginClient.ComposeServerX509SVID(ctx, &credentialcomposerv1.ComposeServerX509SVIDRequest{
+		Attributes: attributesIn,
+	})
+	return v1.handleX509SVIDAttributesResponse(attributes, resp, err)
+}
+
+func (v1 V1) ComposeAgentX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes X509SVIDAttributes) (X509SVIDAttributes, error) {
+	if id.IsZero() {
+		return X509SVIDAttributes{}, v1.Error(codes.Internal, "invalid agent ID: empty")
+	}
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "invalid agent X509SVID public key: %v", err)
+	}
+
+	attributesIn, err := x509SVIDAttributesToV1(attributes)
+	if err != nil {
+		return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "invalid agent X509SVID attributes: %v", err)
+	}
+	resp, err := v1.CredentialComposerPluginClient.ComposeAgentX509SVID(ctx, &credentialcomposerv1.ComposeAgentX509SVIDRequest{
+		Attributes: attributesIn,
+		SpiffeId:   id.String(),
+		PublicKey:  publicKeyBytes,
+	})
+	return v1.handleX509SVIDAttributesResponse(attributes, resp, err)
+}
+
+func (v1 V1) ComposeWorkloadX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes X509SVIDAttributes) (X509SVIDAttributes, error) {
+	if id.IsZero() {
+		return X509SVIDAttributes{}, v1.Error(codes.Internal, "invalid workload ID: empty")
+	}
+
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	if err != nil {
+		return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "invalid workload X509SVID public key: %v", err)
+	}
+
+	attributesIn, err := x509SVIDAttributesToV1(attributes)
+	if err != nil {
+		return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "invalid workload X509SVID attributes: %v", err)
+	}
+	resp, err := v1.CredentialComposerPluginClient.ComposeWorkloadX509SVID(ctx, &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
+		Attributes: attributesIn,
+		SpiffeId:   id.String(),
+		PublicKey:  publicKeyBytes,
+	})
+	return v1.handleX509SVIDAttributesResponse(attributes, resp, err)
+}
+
+func (v1 V1) ComposeWorkloadJWTSVID(ctx context.Context, id spiffeid.ID, attributes JWTSVIDAttributes) (JWTSVIDAttributes, error) {
+	if id.IsZero() {
+		return JWTSVIDAttributes{}, v1.Error(codes.Internal, "invalid workload ID: empty")
+	}
+	attributesIn, err := jwtSVIDAttributesToV1(attributes)
+	if err != nil {
+		return JWTSVIDAttributes{}, v1.Errorf(codes.Internal, "invalid workload JWTSVID attributes: %v", err)
+	}
+	resp, err := v1.CredentialComposerPluginClient.ComposeWorkloadJWTSVID(ctx, &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{
+		SpiffeId:   id.String(),
+		Attributes: attributesIn,
+	})
+	return v1.handleJWTSVIDAttributesResponse(attributes, resp, err)
+}
+
+func (v1 V1) handleX509CAAttributesResponse(attributes X509CAAttributes, resp x509CAAttributesResponseV1, respErr error) (_ X509CAAttributes, err error) {
+	if respErr != nil {
+		if status.Code(respErr) == codes.Unimplemented {
+			return attributes, nil
+		}
+		return X509CAAttributes{}, v1.WrapErr(respErr)
+	}
+	if pb := resp.GetAttributes(); pb != nil {
+		attributes, err = x509CAAttributesFromV1(pb)
+		if err != nil {
+			return X509CAAttributes{}, v1.Errorf(codes.Internal, "plugin returned invalid X509CA attributes: %v", err)
+		}
+	}
+	return attributes, nil
+}
+
+func (v1 V1) handleX509SVIDAttributesResponse(attributes X509SVIDAttributes, resp x509SVIDAttributesResponseV1, respErr error) (_ X509SVIDAttributes, err error) {
+	if respErr != nil {
+		if status.Code(respErr) == codes.Unimplemented {
+			return attributes, nil
+		}
+		return X509SVIDAttributes{}, v1.WrapErr(respErr)
+	}
+	if pb := resp.GetAttributes(); pb != nil {
+		attributes, err = x509SVIDAttributesFromV1(pb)
+		if err != nil {
+			return X509SVIDAttributes{}, v1.Errorf(codes.Internal, "plugin returned invalid X509SVID attributes: %v", err)
+		}
+	}
+	return attributes, nil
+}
+
+func (v1 V1) handleJWTSVIDAttributesResponse(attributes JWTSVIDAttributes, resp jwtSVIDAttributesResponseV1, respErr error) (_ JWTSVIDAttributes, err error) {
+	if respErr != nil {
+		if status.Code(respErr) == codes.Unimplemented {
+			return attributes, nil
+		}
+		return JWTSVIDAttributes{}, v1.WrapErr(respErr)
+	}
+	if pb := resp.GetAttributes(); pb != nil {
+		attributes = jwtSVIDAttributesFromV1(pb)
+	}
+	return attributes, nil
+}
+
+func x509CAAttributesToV1(attributes X509CAAttributes) (*credentialcomposerv1.X509CAAttributes, error) {
+	subject, err := subjectToV1(attributes.Subject)
+	if err != nil {
+		return nil, err
+	}
+	return &credentialcomposerv1.X509CAAttributes{
+		Subject:           subject,
+		PolicyIdentifiers: policyIdentifiersToV1(attributes.PolicyIdentifiers),
+		ExtraExtensions:   extraExtensionsToV1(attributes.ExtraExtensions),
+	}, nil
+}
+
+type x509CAAttributesResponseV1 interface {
+	GetAttributes() *credentialcomposerv1.X509CAAttributes
+}
+
+func x509CAAttributesFromV1(pb *credentialcomposerv1.X509CAAttributes) (attributes X509CAAttributes, err error) {
+	attributes.Subject, err = subjectFromV1(pb.Subject)
+	if err != nil {
+		return X509CAAttributes{}, fmt.Errorf("subject: %w", err)
+	}
+	attributes.PolicyIdentifiers, err = policyIdentifiersFromV1(pb.PolicyIdentifiers)
+	if err != nil {
+		return X509CAAttributes{}, fmt.Errorf("policy identifiers: %w", err)
+	}
+	attributes.ExtraExtensions, err = extraExtensionsFromV1(pb.ExtraExtensions)
+	if err != nil {
+		return X509CAAttributes{}, fmt.Errorf("extra extensions: %w", err)
+	}
+	return attributes, nil
+}
+
+type x509SVIDAttributesResponseV1 interface {
+	GetAttributes() *credentialcomposerv1.X509SVIDAttributes
+}
+
+func x509SVIDAttributesToV1(attributes X509SVIDAttributes) (*credentialcomposerv1.X509SVIDAttributes, error) {
+	subject, err := subjectToV1(attributes.Subject)
+	if err != nil {
+		return nil, err
+	}
+	return &credentialcomposerv1.X509SVIDAttributes{
+		Subject:         subject,
+		DnsSans:         attributes.DNSNames,
+		ExtraExtensions: extraExtensionsToV1(attributes.ExtraExtensions),
+	}, nil
+}
+
+func x509SVIDAttributesFromV1(pb *credentialcomposerv1.X509SVIDAttributes) (attributes X509SVIDAttributes, err error) {
+	attributes.Subject, err = subjectFromV1(pb.Subject)
+	if err != nil {
+		return X509SVIDAttributes{}, fmt.Errorf("subject: %w", err)
+	}
+	attributes.DNSNames = pb.DnsSans
+	attributes.ExtraExtensions, err = extraExtensionsFromV1(pb.ExtraExtensions)
+	if err != nil {
+		return X509SVIDAttributes{}, fmt.Errorf("extra extensions: %w", err)
+	}
+	return attributes, nil
+}
+
+type jwtSVIDAttributesResponseV1 interface {
+	GetAttributes() *credentialcomposerv1.JWTSVIDAttributes
+}
+
+func jwtSVIDAttributesToV1(attributes JWTSVIDAttributes) (*credentialcomposerv1.JWTSVIDAttributes, error) {
+	if len(attributes.Claims) == 0 {
+		return nil, errors.New("invalid claims: cannot be empty")
+	}
+	claims, err := structpb.NewStruct(attributes.Claims)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode claims: %w", err)
+	}
+	return &credentialcomposerv1.JWTSVIDAttributes{
+		Claims: claims,
+	}, nil
+}
+
+func jwtSVIDAttributesFromV1(pb *credentialcomposerv1.JWTSVIDAttributes) JWTSVIDAttributes {
+	return JWTSVIDAttributes{
+		Claims: pb.Claims.AsMap(),
+	}
+}
+
+func subjectFromV1(in *credentialcomposerv1.DistinguishedName) (pkix.Name, error) {
+	if in == nil {
+		return pkix.Name{}, errors.New("cannot be empty")
+	}
+	extraNames, err := extraNamesFromV1(in.ExtraNames)
+	if err != nil {
+		return pkix.Name{}, fmt.Errorf("extra names: %w", err)
+	}
+	return pkix.Name{
+		Country:            in.Country,
+		Organization:       in.Organization,
+		OrganizationalUnit: in.OrganizationalUnit,
+		Locality:           in.Locality,
+		Province:           in.Province,
+		SerialNumber:       in.SerialNumber,
+		CommonName:         in.CommonName,
+		ExtraNames:         extraNames,
+	}, nil
+}
+
+func subjectToV1(in pkix.Name) (*credentialcomposerv1.DistinguishedName, error) {
+	extraNames, err := extraNamesToV1(in.ExtraNames)
+	if err != nil {
+		return nil, err
+	}
+	return &credentialcomposerv1.DistinguishedName{
+		Country:            in.Country,
+		Organization:       in.Organization,
+		OrganizationalUnit: in.OrganizationalUnit,
+		Locality:           in.Locality,
+		Province:           in.Province,
+		SerialNumber:       in.SerialNumber,
+		CommonName:         in.CommonName,
+		ExtraNames:         extraNames,
+	}, nil
+}
+
+func policyIdentifiersFromV1(ins []string) ([]asn1.ObjectIdentifier, error) {
+	if ins == nil {
+		return nil, nil
+	}
+	outs := make([]asn1.ObjectIdentifier, 0, len(ins))
+	for _, in := range ins {
+		out, err := parseOID(in)
+		if err != nil {
+			return nil, err
+		}
+		outs = append(outs, out)
+	}
+	return outs, nil
+}
+
+func policyIdentifiersToV1(ins []asn1.ObjectIdentifier) []string {
+	if ins == nil {
+		return nil
+	}
+	outs := make([]string, 0, len(ins))
+	for _, in := range ins {
+		outs = append(outs, in.String())
+	}
+	return outs
+}
+
+func extraExtensionsFromV1(ins []*credentialcomposerv1.X509Extension) ([]pkix.Extension, error) {
+	if ins == nil {
+		return nil, nil
+	}
+	outs := make([]pkix.Extension, 0, len(ins))
+	for _, in := range ins {
+		id, err := parseOID(in.Oid)
+		if err != nil {
+			return nil, err
+		}
+		outs = append(outs, pkix.Extension{
+			Id:       id,
+			Value:    in.Value,
+			Critical: in.Critical,
+		})
+	}
+	return outs, nil
+}
+
+func extraExtensionsToV1(ins []pkix.Extension) []*credentialcomposerv1.X509Extension {
+	if ins == nil {
+		return nil
+	}
+	outs := make([]*credentialcomposerv1.X509Extension, 0, len(ins))
+	for _, in := range ins {
+		outs = append(outs, &credentialcomposerv1.X509Extension{
+			Oid:      in.Id.String(),
+			Value:    in.Value,
+			Critical: in.Critical,
+		})
+	}
+	return outs
+}
+
+func extraNamesToV1(ins []pkix.AttributeTypeAndValue) ([]*credentialcomposerv1.AttributeTypeAndValue, error) {
+	if ins == nil {
+		return nil, nil
+	}
+	outs := make([]*credentialcomposerv1.AttributeTypeAndValue, 0, len(ins))
+	for _, in := range ins {
+		stringValue, ok := in.Value.(string)
+		if !ok {
+			return nil, errors.New("only string values are allowed in extra name attributes")
+		}
+		outs = append(outs, &credentialcomposerv1.AttributeTypeAndValue{
+			Oid:         in.Type.String(),
+			StringValue: stringValue,
+		})
+	}
+	return outs, nil
+}
+
+func extraNamesFromV1(ins []*credentialcomposerv1.AttributeTypeAndValue) ([]pkix.AttributeTypeAndValue, error) {
+	if ins == nil {
+		return nil, nil
+	}
+	outs := make([]pkix.AttributeTypeAndValue, 0, len(ins))
+	for _, in := range ins {
+		typ, err := parseOID(in.Oid)
+		if err != nil {
+			return nil, err
+		}
+		outs = append(outs, pkix.AttributeTypeAndValue{
+			Type:  typ,
+			Value: in.StringValue,
+		})
+	}
+	return outs, nil
+}
+
+func parseOID(s string) (_ asn1.ObjectIdentifier, err error) {
+	if len(s) == 0 {
+		return nil, errors.New("invalid OID: cannot be empty")
+	}
+	parts := strings.Split(s, ".")
+	oid := make(asn1.ObjectIdentifier, len(parts))
+	for i, part := range parts {
+		if oid[i], err = strconv.Atoi(part); err != nil {
+			return nil, fmt.Errorf("invalid OID: non-integer part %q", part)
+		}
+	}
+	return oid, nil
+}

--- a/pkg/server/plugin/credentialcomposer/v1.go
+++ b/pkg/server/plugin/credentialcomposer/v1.go
@@ -250,6 +250,8 @@ func subjectFromV1(in *credentialcomposerv1.DistinguishedName) (pkix.Name, error
 		OrganizationalUnit: in.OrganizationalUnit,
 		Locality:           in.Locality,
 		Province:           in.Province,
+		StreetAddress:      in.StreetAddress,
+		PostalCode:         in.PostalCode,
 		SerialNumber:       in.SerialNumber,
 		CommonName:         in.CommonName,
 		ExtraNames:         extraNames,
@@ -266,6 +268,8 @@ func subjectToV1(in pkix.Name) (*credentialcomposerv1.DistinguishedName, error) 
 		Organization:       in.Organization,
 		OrganizationalUnit: in.OrganizationalUnit,
 		Locality:           in.Locality,
+		StreetAddress:      in.StreetAddress,
+		PostalCode:         in.PostalCode,
 		Province:           in.Province,
 		SerialNumber:       in.SerialNumber,
 		CommonName:         in.CommonName,
@@ -370,9 +374,6 @@ func extraNamesFromV1(ins []*credentialcomposerv1.AttributeTypeAndValue) ([]pkix
 }
 
 func parseOID(s string) (_ asn1.ObjectIdentifier, err error) {
-	if len(s) == 0 {
-		return nil, errors.New("invalid OID: cannot be empty")
-	}
 	parts := strings.Split(s, ".")
 	oid := make(asn1.ObjectIdentifier, len(parts))
 	for i, part := range parts {

--- a/pkg/server/plugin/credentialcomposer/v1_test.go
+++ b/pkg/server/plugin/credentialcomposer/v1_test.go
@@ -25,6 +25,66 @@ import (
 var (
 	publicKey         = testkey.MustEC256().Public()
 	publicKeyBytes, _ = x509.MarshalPKIXPublicKey(publicKey)
+
+	subject1 = pkix.Name{
+		Country:            []string{"C1"},
+		Organization:       []string{"O1"},
+		OrganizationalUnit: []string{"OU1"},
+		Locality:           []string{"L1"},
+		Province:           []string{"P1"},
+		StreetAddress:      []string{"SA1"},
+		PostalCode:         []string{"PC1"},
+		SerialNumber:       "SN1",
+		CommonName:         "CN1",
+		ExtraNames: []pkix.AttributeTypeAndValue{
+			{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "EXTRA1"},
+		},
+	}
+
+	subject1v1 = &credentialcomposerv1.DistinguishedName{
+		Country:            []string{"C1"},
+		Organization:       []string{"O1"},
+		OrganizationalUnit: []string{"OU1"},
+		Locality:           []string{"L1"},
+		Province:           []string{"P1"},
+		StreetAddress:      []string{"SA1"},
+		PostalCode:         []string{"PC1"},
+		SerialNumber:       "SN1",
+		CommonName:         "CN1",
+		ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+			{Oid: "1.2.3.4", StringValue: "EXTRA1"},
+		},
+	}
+
+	subject2 = pkix.Name{
+		Country:            []string{"C2"},
+		Organization:       []string{"O2"},
+		OrganizationalUnit: []string{"OU2"},
+		Locality:           []string{"L2"},
+		Province:           []string{"P2"},
+		StreetAddress:      []string{"SA2"},
+		PostalCode:         []string{"PC2"},
+		SerialNumber:       "SN2",
+		CommonName:         "CN2",
+		ExtraNames: []pkix.AttributeTypeAndValue{
+			{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "EXTRA2"},
+		},
+	}
+
+	subject2v1 = &credentialcomposerv1.DistinguishedName{
+		Country:            []string{"C2"},
+		Organization:       []string{"O2"},
+		OrganizationalUnit: []string{"OU2"},
+		Locality:           []string{"L2"},
+		Province:           []string{"P2"},
+		StreetAddress:      []string{"SA2"},
+		PostalCode:         []string{"PC2"},
+		SerialNumber:       "SN2",
+		CommonName:         "CN2",
+		ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+			{Oid: "4.3.2.1", StringValue: "EXTRA2"},
+		},
+	}
 )
 
 func TestV1ComposeServerX509CA(t *testing.T) {
@@ -63,52 +123,42 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 			test:      "attributes unchanged if unimplemented",
 			pluginErr: status.Error(codes.Unimplemented, "not implemented"),
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			expectAttributesOut: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
 			test: "attributes unchanged if plugin does not respond with attributes",
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{},
 			expectAttributesOut: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
 			test: "attributes overridden by plugin",
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{
-					CommonName: "ORIGINAL",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
-					},
-				},
+				Subject:           subject1,
 				PolicyIdentifiers: []asn1.ObjectIdentifier{{1, 2, 3, 4}},
 				ExtraExtensions:   []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "ORIGINAL",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
-						},
-					},
+					Subject:           subject1v1,
 					PolicyIdentifiers: []string{"1.2.3.4"},
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
@@ -121,12 +171,7 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "NEW",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "4.3.2.1", StringValue: "NEW"},
-						},
-					},
+					Subject:           subject2v1,
 					PolicyIdentifiers: []string{"4.3.2.1"},
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
@@ -138,20 +183,15 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 				},
 			},
 			expectAttributesOut: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{
-					CommonName: "NEW",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
-					},
-				},
+				Subject:           subject2,
 				PolicyIdentifiers: []asn1.ObjectIdentifier{{4, 3, 2, 1}},
 				ExtraExtensions:   []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
 			},
 		},
 		{
-			test: "plugin returns invalid attributes subject",
+			test: "plugin returns invalid attributes subject extra name",
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
@@ -168,11 +208,11 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 		{
 			test: "plugin returns invalid attributes policy identifiers",
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject:           &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject:           subject1v1,
 					PolicyIdentifiers: []string{"NOT AN OID"},
 				},
 			},
@@ -182,11 +222,11 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 		{
 			test: "plugin returns invalid attributes extra extensions",
 			attributesIn: credentialcomposer.X509CAAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
 				Attributes: &credentialcomposerv1.X509CAAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{Oid: "NOT AN OID"},
 					},
@@ -248,52 +288,42 @@ func TestV1ComposeServerX509SVID(t *testing.T) {
 			test:      "attributes unchanged if unimplemented",
 			pluginErr: status.Error(codes.Unimplemented, "not implemented"),
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
 			test: "attributes unchanged if plugin does not respond with attributes",
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
 			test: "attributes overridden by plugin",
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "ORIGINAL",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
-					},
-				},
+				Subject:         subject1,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "ORIGINAL",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
-						},
-					},
+					Subject: subject1v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: false,
@@ -305,12 +335,7 @@ func TestV1ComposeServerX509SVID(t *testing.T) {
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "NEW",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "4.3.2.1", StringValue: "NEW"},
-						},
-					},
+					Subject: subject2v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: true,
@@ -321,19 +346,14 @@ func TestV1ComposeServerX509SVID(t *testing.T) {
 				},
 			},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "NEW",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
-					},
-				},
+				Subject:         subject2,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
 			},
 		},
 		{
 			test: "plugin returns invalid attributes subject",
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -344,16 +364,13 @@ func TestV1ComposeServerX509SVID(t *testing.T) {
 					},
 				},
 			},
-			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "NEW"},
-			},
 			expectCode:    codes.Internal,
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
 		},
 		{
 			test: "plugin returns invalid attributes extra extensions",
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -440,18 +457,18 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
@@ -459,18 +476,18 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
@@ -478,24 +495,14 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "ORIGINAL",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
-					},
-				},
+				Subject:         subject1,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "ORIGINAL",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
-						},
-					},
+					Subject: subject1v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: false,
@@ -507,12 +514,7 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			},
 			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "NEW",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "4.3.2.1", StringValue: "NEW"},
-						},
-					},
+					Subject: subject2v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: true,
@@ -523,12 +525,7 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 				},
 			},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "NEW",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
-					},
-				},
+				Subject:         subject2,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
 			},
 		},
@@ -537,7 +534,7 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -548,9 +545,6 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 					},
 				},
 			},
-			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "NEW"},
-			},
 			expectCode:    codes.Internal,
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
 		},
@@ -559,7 +553,7 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -646,18 +640,18 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
@@ -665,18 +659,18 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					Subject: subject1v1,
 				},
 			},
 			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 		},
 		{
@@ -684,24 +678,14 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "ORIGINAL",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
-					},
-				},
+				Subject:         subject1,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
 			},
 			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
 				SpiffeId:  id.String(),
 				PublicKey: publicKeyBytes,
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "ORIGINAL",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
-						},
-					},
+					Subject: subject1v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: false,
@@ -713,12 +697,7 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			},
 			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
-					Subject: &credentialcomposerv1.DistinguishedName{
-						CommonName: "NEW",
-						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
-							{Oid: "4.3.2.1", StringValue: "NEW"},
-						},
-					},
+					Subject: subject2v1,
 					ExtraExtensions: []*credentialcomposerv1.X509Extension{
 						{
 							Critical: true,
@@ -729,12 +708,7 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 				},
 			},
 			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{
-					CommonName: "NEW",
-					ExtraNames: []pkix.AttributeTypeAndValue{
-						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
-					},
-				},
+				Subject:         subject2,
 				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
 			},
 		},
@@ -743,7 +717,7 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -754,9 +728,6 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 					},
 				},
 			},
-			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "NEW"},
-			},
 			expectCode:    codes.Internal,
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
 		},
@@ -765,7 +736,7 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			idIn:        id,
 			publicKeyIn: publicKey,
 			attributesIn: credentialcomposer.X509SVIDAttributes{
-				Subject: pkix.Name{CommonName: "ORIGINAL"},
+				Subject: subject1,
 			},
 			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
 				Attributes: &credentialcomposerv1.X509SVIDAttributes{
@@ -859,7 +830,7 @@ func TestV1ComposeWorkloadJWTSVID(t *testing.T) {
 			expectAttributesOut: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
 		},
 		{
-			test:         "attributes unchanged if plugin does not respond with attributes",
+			test:         "attributes overridden by plugin",
 			idIn:         id,
 			attributesIn: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
 			expectRequestIn: &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{

--- a/pkg/server/plugin/credentialcomposer/v1_test.go
+++ b/pkg/server/plugin/credentialcomposer/v1_test.go
@@ -1,0 +1,941 @@
+package credentialcomposer_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	credentialcomposerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/credentialcomposer/v1"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
+	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/spiffe/spire/test/testkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+var (
+	publicKey         = testkey.MustEC256().Public()
+	publicKeyBytes, _ = x509.MarshalPKIXPublicKey(publicKey)
+)
+
+func TestV1ComposeServerX509CA(t *testing.T) {
+	for _, tt := range []struct {
+		test      string
+		pluginErr error
+
+		attributesIn    credentialcomposer.X509CAAttributes
+		expectRequestIn *credentialcomposerv1.ComposeServerX509CARequest
+
+		responseOut         *credentialcomposerv1.ComposeServerX509CAResponse
+		expectAttributesOut credentialcomposer.X509CAAttributes
+
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "plugin fails",
+			pluginErr:     status.Error(codes.Internal, "oh no"),
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): oh no",
+		},
+		{
+			test: "invalid subject extra names input",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Value: 3}, // only string values are allowed
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid X509CA attributes: only string values are allowed in extra name attributes",
+		},
+		{
+			test:      "attributes unchanged if unimplemented",
+			pluginErr: status.Error(codes.Unimplemented, "not implemented"),
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test: "attributes unchanged if plugin does not respond with attributes",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{},
+			expectAttributesOut: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test: "attributes overridden by plugin",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{
+					CommonName: "ORIGINAL",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
+					},
+				},
+				PolicyIdentifiers: []asn1.ObjectIdentifier{{1, 2, 3, 4}},
+				ExtraExtensions:   []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509CARequest{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "ORIGINAL",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
+						},
+					},
+					PolicyIdentifiers: []string{"1.2.3.4"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: false,
+							Oid:      "1.2.3.4",
+							Value:    []byte("ORIGINAL"),
+						},
+					},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "NEW",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "4.3.2.1", StringValue: "NEW"},
+						},
+					},
+					PolicyIdentifiers: []string{"4.3.2.1"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: true,
+							Oid:      "4.3.2.1",
+							Value:    []byte("NEW"),
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{
+					CommonName: "NEW",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
+					},
+				},
+				PolicyIdentifiers: []asn1.ObjectIdentifier{{4, 3, 2, 1}},
+				ExtraExtensions:   []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
+			},
+		},
+		{
+			test: "plugin returns invalid attributes subject",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "NOT AN OID"},
+						},
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509CA attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
+		},
+		{
+			test: "plugin returns invalid attributes policy identifiers",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject:           &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					PolicyIdentifiers: []string{"NOT AN OID"},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509CA attributes: policy identifiers: invalid OID: non-integer part "NOT AN OID"`,
+		},
+		{
+			test: "plugin returns invalid attributes extra extensions",
+			attributesIn: credentialcomposer.X509CAAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509CAResponse{
+				Attributes: &credentialcomposerv1.X509CAAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{Oid: "NOT AN OID"},
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509CA attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			plugin := &fakeV1Plugin{err: tt.pluginErr, composeServerX509CAResponseOut: tt.responseOut}
+			cc := loadV1Plugin(t, plugin)
+			attributesOut, err := cc.ComposeServerX509CA(context.Background(), tt.attributesIn)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, plugin.composeServerX509CARequestIn, tt.expectRequestIn)
+			assert.Equal(t, attributesOut, tt.expectAttributesOut)
+		})
+	}
+}
+
+func TestV1ComposeServerX509SVID(t *testing.T) {
+	for _, tt := range []struct {
+		test      string
+		pluginErr error
+
+		attributesIn    credentialcomposer.X509SVIDAttributes
+		expectRequestIn *credentialcomposerv1.ComposeServerX509SVIDRequest
+
+		responseOut         *credentialcomposerv1.ComposeServerX509SVIDResponse
+		expectAttributesOut credentialcomposer.X509SVIDAttributes
+
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "plugin fails",
+			pluginErr:     status.Error(codes.Internal, "oh no"),
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): oh no",
+		},
+		{
+			test: "invalid subject extra names input",
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Value: 3}, // only string values are allowed
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid server X509SVID attributes: only string values are allowed in extra name attributes",
+		},
+		{
+			test:      "attributes unchanged if unimplemented",
+			pluginErr: status.Error(codes.Unimplemented, "not implemented"),
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test: "attributes unchanged if plugin does not respond with attributes",
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test: "attributes overridden by plugin",
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "ORIGINAL",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeServerX509SVIDRequest{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "ORIGINAL",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: false,
+							Oid:      "1.2.3.4",
+							Value:    []byte("ORIGINAL"),
+						},
+					},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "NEW",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "4.3.2.1", StringValue: "NEW"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: true,
+							Oid:      "4.3.2.1",
+							Value:    []byte("NEW"),
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "NEW",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
+			},
+		},
+		{
+			test: "plugin returns invalid attributes subject",
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "NOT AN OID"},
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "NEW"},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
+		},
+		{
+			test: "plugin returns invalid attributes extra extensions",
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeServerX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{Oid: "NOT AN OID"},
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			plugin := &fakeV1Plugin{err: tt.pluginErr, composeServerX509SVIDResponseOut: tt.responseOut}
+			cc := loadV1Plugin(t, plugin)
+			attributesOut, err := cc.ComposeServerX509SVID(context.Background(), tt.attributesIn)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, plugin.composeServerX509SVIDRequestIn, tt.expectRequestIn)
+			assert.Equal(t, attributesOut, tt.expectAttributesOut)
+		})
+	}
+}
+
+func TestV1ComposeAgentX509SVID(t *testing.T) {
+	id := spiffeid.RequireFromString("spiffe://domain.test/spire/agent/foo")
+	for _, tt := range []struct {
+		test      string
+		pluginErr error
+
+		idIn            spiffeid.ID
+		publicKeyIn     crypto.PublicKey
+		attributesIn    credentialcomposer.X509SVIDAttributes
+		expectRequestIn *credentialcomposerv1.ComposeAgentX509SVIDRequest
+
+		responseOut         *credentialcomposerv1.ComposeAgentX509SVIDResponse
+		expectAttributesOut credentialcomposer.X509SVIDAttributes
+
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "invalid ID",
+			publicKeyIn:   publicKey,
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid agent ID: empty",
+		},
+		{
+			test:          "invalid public key",
+			idIn:          id,
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid agent X509SVID public key: x509: unsupported public key type: <nil>",
+		},
+		{
+			test:          "plugin fails",
+			idIn:          id,
+			publicKeyIn:   publicKey,
+			pluginErr:     status.Error(codes.Internal, "oh no"),
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): oh no",
+		},
+		{
+			test:        "invalid subject extra names input",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Value: 3}, // only string values are allowed
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid agent X509SVID attributes: only string values are allowed in extra name attributes",
+		},
+		{
+			test:        "attributes unchanged if unimplemented",
+			pluginErr:   status.Error(codes.Unimplemented, "not implemented"),
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test:        "attributes unchanged if plugin does not respond with attributes",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test:        "attributes overridden by plugin",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "ORIGINAL",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeAgentX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "ORIGINAL",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: false,
+							Oid:      "1.2.3.4",
+							Value:    []byte("ORIGINAL"),
+						},
+					},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "NEW",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "4.3.2.1", StringValue: "NEW"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: true,
+							Oid:      "4.3.2.1",
+							Value:    []byte("NEW"),
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "NEW",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
+			},
+		},
+		{
+			test:        "plugin returns invalid attributes subject",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "NOT AN OID"},
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "NEW"},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
+		},
+		{
+			test:        "plugin returns invalid attributes extra extensions",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeAgentX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{Oid: "NOT AN OID"},
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			plugin := &fakeV1Plugin{err: tt.pluginErr, composeAgentX509SVIDResponseOut: tt.responseOut}
+			cc := loadV1Plugin(t, plugin)
+			attributesOut, err := cc.ComposeAgentX509SVID(context.Background(), tt.idIn, tt.publicKeyIn, tt.attributesIn)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, plugin.composeAgentX509SVIDRequestIn, tt.expectRequestIn)
+			assert.Equal(t, attributesOut, tt.expectAttributesOut)
+		})
+	}
+}
+
+func TestV1ComposeWorkloadX509SVID(t *testing.T) {
+	id := spiffeid.RequireFromString("spiffe://domain.test/workload")
+	for _, tt := range []struct {
+		test      string
+		pluginErr error
+
+		idIn            spiffeid.ID
+		publicKeyIn     crypto.PublicKey
+		attributesIn    credentialcomposer.X509SVIDAttributes
+		expectRequestIn *credentialcomposerv1.ComposeWorkloadX509SVIDRequest
+
+		responseOut         *credentialcomposerv1.ComposeWorkloadX509SVIDResponse
+		expectAttributesOut credentialcomposer.X509SVIDAttributes
+
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "invalid ID",
+			publicKeyIn:   publicKey,
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid workload ID: empty",
+		},
+		{
+			test:          "invalid public key",
+			idIn:          id,
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid workload X509SVID public key: x509: unsupported public key type: <nil>",
+		},
+		{
+			test:          "plugin fails",
+			idIn:          id,
+			publicKeyIn:   publicKey,
+			pluginErr:     status.Error(codes.Internal, "oh no"),
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): oh no",
+		},
+		{
+			test:        "invalid subject extra names input",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Value: 3}, // only string values are allowed
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid workload X509SVID attributes: only string values are allowed in extra name attributes",
+		},
+		{
+			test:        "attributes unchanged if unimplemented",
+			pluginErr:   status.Error(codes.Unimplemented, "not implemented"),
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test:        "attributes unchanged if plugin does not respond with attributes",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+		},
+		{
+			test:        "attributes overridden by plugin",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "ORIGINAL",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: "ORIGINAL"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{1, 2, 3, 4}, Value: []byte("ORIGINAL")}},
+			},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadX509SVIDRequest{
+				SpiffeId:  id.String(),
+				PublicKey: publicKeyBytes,
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "ORIGINAL",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "1.2.3.4", StringValue: "ORIGINAL"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: false,
+							Oid:      "1.2.3.4",
+							Value:    []byte("ORIGINAL"),
+						},
+					},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						CommonName: "NEW",
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "4.3.2.1", StringValue: "NEW"},
+						},
+					},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{
+							Critical: true,
+							Oid:      "4.3.2.1",
+							Value:    []byte("NEW"),
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{
+					CommonName: "NEW",
+					ExtraNames: []pkix.AttributeTypeAndValue{
+						{Type: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: "NEW"},
+					},
+				},
+				ExtraExtensions: []pkix.Extension{{Id: asn1.ObjectIdentifier{4, 3, 2, 1}, Value: []byte("NEW"), Critical: true}},
+			},
+		},
+		{
+			test:        "plugin returns invalid attributes subject",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{
+						ExtraNames: []*credentialcomposerv1.AttributeTypeAndValue{
+							{Oid: "NOT AN OID"},
+						},
+					},
+				},
+			},
+			expectAttributesOut: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "NEW"},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: subject: extra names: invalid OID: non-integer part "NOT AN OID"`,
+		},
+		{
+			test:        "plugin returns invalid attributes extra extensions",
+			idIn:        id,
+			publicKeyIn: publicKey,
+			attributesIn: credentialcomposer.X509SVIDAttributes{
+				Subject: pkix.Name{CommonName: "ORIGINAL"},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadX509SVIDResponse{
+				Attributes: &credentialcomposerv1.X509SVIDAttributes{
+					Subject: &credentialcomposerv1.DistinguishedName{CommonName: "ORIGINAL"},
+					ExtraExtensions: []*credentialcomposerv1.X509Extension{
+						{Oid: "NOT AN OID"},
+					},
+				},
+			},
+			expectCode:    codes.Internal,
+			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			plugin := &fakeV1Plugin{err: tt.pluginErr, composeWorkloadX509SVIDResponseOut: tt.responseOut}
+			cc := loadV1Plugin(t, plugin)
+			attributesOut, err := cc.ComposeWorkloadX509SVID(context.Background(), tt.idIn, tt.publicKeyIn, tt.attributesIn)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, plugin.composeWorkloadX509SVIDRequestIn, tt.expectRequestIn)
+			assert.Equal(t, attributesOut, tt.expectAttributesOut)
+		})
+	}
+}
+
+func TestV1ComposeWorkloadJWTSVID(t *testing.T) {
+	id := spiffeid.RequireFromString("spiffe://domain.test/workload")
+	for _, tt := range []struct {
+		test      string
+		pluginErr error
+
+		idIn            spiffeid.ID
+		attributesIn    credentialcomposer.JWTSVIDAttributes
+		expectRequestIn *credentialcomposerv1.ComposeWorkloadJWTSVIDRequest
+
+		responseOut         *credentialcomposerv1.ComposeWorkloadJWTSVIDResponse
+		expectAttributesOut credentialcomposer.JWTSVIDAttributes
+
+		expectCode    codes.Code
+		expectMessage string
+	}{
+		{
+			test:          "invalid ID",
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid workload ID: empty",
+		},
+		{
+			test:          "plugin fails",
+			idIn:          id,
+			attributesIn:  credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+			pluginErr:     status.Error(codes.Internal, "oh no"),
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): oh no",
+		},
+		{
+			test:          "invalid claims input",
+			idIn:          id,
+			attributesIn:  credentialcomposer.JWTSVIDAttributes{},
+			expectCode:    codes.Internal,
+			expectMessage: "credentialcomposer(test): invalid workload JWTSVID attributes: invalid claims: cannot be empty",
+		},
+		{
+			test:         "attributes unchanged if unimplemented",
+			pluginErr:    status.Error(codes.Unimplemented, "not implemented"),
+			idIn:         id,
+			attributesIn: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{
+				SpiffeId: id.String(),
+				Attributes: &credentialcomposerv1.JWTSVIDAttributes{
+					Claims: &structpb.Struct{Fields: map[string]*structpb.Value{"ORIGINAL_KEY": structpb.NewStringValue("ORIGINAL_VALUE")}},
+				},
+			},
+			responseOut:         &credentialcomposerv1.ComposeWorkloadJWTSVIDResponse{},
+			expectAttributesOut: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+		},
+		{
+			test:         "attributes unchanged if plugin does not respond with attributes",
+			idIn:         id,
+			attributesIn: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{
+				SpiffeId: id.String(),
+				Attributes: &credentialcomposerv1.JWTSVIDAttributes{
+					Claims: &structpb.Struct{Fields: map[string]*structpb.Value{"ORIGINAL_KEY": structpb.NewStringValue("ORIGINAL_VALUE")}},
+				},
+			},
+			responseOut:         &credentialcomposerv1.ComposeWorkloadJWTSVIDResponse{},
+			expectAttributesOut: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+		},
+		{
+			test:         "attributes unchanged if plugin does not respond with attributes",
+			idIn:         id,
+			attributesIn: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"ORIGINAL_KEY": "ORIGINAL_VALUE"}},
+			expectRequestIn: &credentialcomposerv1.ComposeWorkloadJWTSVIDRequest{
+				SpiffeId: id.String(),
+				Attributes: &credentialcomposerv1.JWTSVIDAttributes{
+					Claims: &structpb.Struct{Fields: map[string]*structpb.Value{"ORIGINAL_KEY": structpb.NewStringValue("ORIGINAL_VALUE")}},
+				},
+			},
+			responseOut: &credentialcomposerv1.ComposeWorkloadJWTSVIDResponse{
+				Attributes: &credentialcomposerv1.JWTSVIDAttributes{
+					Claims: &structpb.Struct{Fields: map[string]*structpb.Value{"NEW_KEY": structpb.NewStringValue("NEW_VALUE")}},
+				},
+			},
+			expectAttributesOut: credentialcomposer.JWTSVIDAttributes{Claims: map[string]interface{}{"NEW_KEY": "NEW_VALUE"}},
+		},
+	} {
+		tt := tt
+		t.Run(tt.test, func(t *testing.T) {
+			plugin := &fakeV1Plugin{err: tt.pluginErr, composeWorkloadJWTSVIDResponseOut: tt.responseOut}
+			cc := loadV1Plugin(t, plugin)
+			attributesOut, err := cc.ComposeWorkloadJWTSVID(context.Background(), tt.idIn, tt.attributesIn)
+			if tt.expectCode != codes.OK {
+				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMessage)
+				return
+			}
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, plugin.composeWorkloadJWTSVIDRequestIn, tt.expectRequestIn)
+			assert.Equal(t, attributesOut, tt.expectAttributesOut)
+		})
+	}
+}
+
+func loadV1Plugin(t *testing.T, plugin *fakeV1Plugin) credentialcomposer.CredentialComposer {
+	server := credentialcomposerv1.CredentialComposerPluginServer(plugin)
+	cc := new(credentialcomposer.V1)
+	plugintest.Load(t, catalog.MakeBuiltIn("test", server), cc)
+	return cc
+}
+
+type fakeV1Plugin struct {
+	credentialcomposerv1.UnimplementedCredentialComposerServer
+
+	err                                error
+	composeServerX509CARequestIn       *credentialcomposerv1.ComposeServerX509CARequest
+	composeServerX509CAResponseOut     *credentialcomposerv1.ComposeServerX509CAResponse
+	composeServerX509SVIDRequestIn     *credentialcomposerv1.ComposeServerX509SVIDRequest
+	composeServerX509SVIDResponseOut   *credentialcomposerv1.ComposeServerX509SVIDResponse
+	composeAgentX509SVIDRequestIn      *credentialcomposerv1.ComposeAgentX509SVIDRequest
+	composeAgentX509SVIDResponseOut    *credentialcomposerv1.ComposeAgentX509SVIDResponse
+	composeWorkloadX509SVIDRequestIn   *credentialcomposerv1.ComposeWorkloadX509SVIDRequest
+	composeWorkloadX509SVIDResponseOut *credentialcomposerv1.ComposeWorkloadX509SVIDResponse
+	composeWorkloadJWTSVIDRequestIn    *credentialcomposerv1.ComposeWorkloadJWTSVIDRequest
+	composeWorkloadJWTSVIDResponseOut  *credentialcomposerv1.ComposeWorkloadJWTSVIDResponse
+}
+
+func (p *fakeV1Plugin) ComposeServerX509CA(ctx context.Context, req *credentialcomposerv1.ComposeServerX509CARequest) (*credentialcomposerv1.ComposeServerX509CAResponse, error) {
+	p.composeServerX509CARequestIn = req
+	return p.composeServerX509CAResponseOut, p.err
+}
+
+func (p *fakeV1Plugin) ComposeServerX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeServerX509SVIDRequest) (*credentialcomposerv1.ComposeServerX509SVIDResponse, error) {
+	p.composeServerX509SVIDRequestIn = req
+	return p.composeServerX509SVIDResponseOut, p.err
+}
+
+func (p *fakeV1Plugin) ComposeAgentX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeAgentX509SVIDRequest) (*credentialcomposerv1.ComposeAgentX509SVIDResponse, error) {
+	p.composeAgentX509SVIDRequestIn = req
+	return p.composeAgentX509SVIDResponseOut, p.err
+}
+
+func (p *fakeV1Plugin) ComposeWorkloadX509SVID(ctx context.Context, req *credentialcomposerv1.ComposeWorkloadX509SVIDRequest) (*credentialcomposerv1.ComposeWorkloadX509SVIDResponse, error) {
+	p.composeWorkloadX509SVIDRequestIn = req
+	return p.composeWorkloadX509SVIDResponseOut, p.err
+}
+
+func (p *fakeV1Plugin) ComposeWorkloadJWTSVID(ctx context.Context, req *credentialcomposerv1.ComposeWorkloadJWTSVIDRequest) (*credentialcomposerv1.ComposeWorkloadJWTSVIDResponse, error) {
+	p.composeWorkloadJWTSVIDRequestIn = req
+	return p.composeWorkloadJWTSVIDResponseOut, p.err
+}

--- a/test/fakes/fakeservercatalog/catalog.go
+++ b/test/fakes/fakeservercatalog/catalog.go
@@ -2,6 +2,7 @@ package fakeservercatalog
 
 import (
 	"github.com/spiffe/spire/pkg/server/datastore"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
 	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	"github.com/spiffe/spire/pkg/server/plugin/notifier"
@@ -13,6 +14,7 @@ func New() *Catalog {
 }
 
 type Catalog struct {
+	credentialComposerRepository
 	dataStoreRepository
 	keyManagerRepository
 	nodeAttestorRepository
@@ -22,6 +24,7 @@ type Catalog struct {
 
 // We need distinct type names to embed in the Catalog above, since the types
 // we want to actually embed are all named the same.
+type credentialComposerRepository struct{ credentialcomposer.Repository }
 type dataStoreRepository struct{ datastore.Repository }
 type keyManagerRepository struct{ keymanager.Repository }
 type nodeAttestorRepository struct{ nodeattestor.Repository }


### PR DESCRIPTION
This change supplies a facade for the v1 CredentialComposer plugin interface.

It also provides the catalog scaffolding but does not yet have the catalog load CredentialComposer plugins until the rest of the supporting code is in place in future changes.

This is the first of a set of PRs to introduce the feature tracked by https://github.com/spiffe/spire/issues/3253.