### PR TITLE
Prevent nil panic from derefeence nil context in authorization middleware

### DIFF
--- a/pkg/server/api/middleware/authorization.go
+++ b/pkg/server/api/middleware/authorization.go
@@ -55,12 +55,14 @@ func (m *authorizationMiddleware) Preprocess(ctx context.Context, methodName str
 		ctx = rpccontext.WithLogger(ctx, rpccontext.Logger(ctx).WithFields(fields))
 	}
 
+	logger := rpccontext.Logger(ctx)
+
 	var deniedDetails *types.PermissionDeniedDetails
 	ctx, allow, err := m.opaAuth(ctx, req, methodName)
 	if err != nil {
 		statusErr := status.Convert(err)
 		if statusErr.Code() != codes.PermissionDenied {
-			rpccontext.Logger(ctx).WithError(err).Error("Authorization failure from OPA auth")
+			logger.WithError(err).Error("Authorization failure from OPA auth")
 			return nil, err
 		}
 
@@ -79,7 +81,7 @@ func (m *authorizationMiddleware) Preprocess(ctx context.Context, methodName str
 	}
 
 	deniedErr := st.Err()
-	rpccontext.Logger(ctx).WithError(deniedErr).Error("Failed to authenticate caller")
+	logger.WithError(deniedErr).Error("Failed to authenticate caller")
 	return nil, deniedErr
 }
 

--- a/pkg/server/api/middleware/authorization_opa.go
+++ b/pkg/server/api/middleware/authorization_opa.go
@@ -39,7 +39,7 @@ func (m *authorizationMiddleware) opaAuth(ctx context.Context, req interface{}, 
 
 	ctx, allow, err := m.reconcileResult(ctx, result)
 	if err != nil {
-		return ctx, false, err
+		return nil, false, err
 	}
 
 	return ctx, allow, nil
@@ -71,7 +71,7 @@ func (m *authorizationMiddleware) reconcileResult(ctx context.Context, res authp
 	if res.AllowIfAdmin || res.AllowIfDownstream {
 		ctx, entries, err := WithCallerEntries(ctx, m.entryFetcher)
 		if err != nil {
-			return ctx, false, err
+			return nil, false, err
 		}
 
 		if res.AllowIfAdmin {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

Prevent a nil panic when a database operation failure happens during retrieving entries.

**Description of change**
<!-- Please provide a description of the change -->

Nil panic happens in authorization middleware's Preprocess function when a nil context is passed down from a failed database operation while fetching entries in function WithCallerEntries. This change addresses this risk by introduce a new variable to hold the returned context so as to avoid dereferencing a potential nil ctx.

Extended explanation:

WithCallerEntries returns error when a database operation failure happens. The error itself is not fatal, however, it returns a nil context. Returns zero value when errors is correct behavior. However, the reconcileResult function and opaAuth function bubble up the nil context as if it is populated. In the authorization middleware's Preprocess function, it attempts to retrieve a logger from the context thus cased a nil panic.

Fix:

The fix is simple: Since the dereference happens for the purpose of fetching a logger, a new variable is introduced to store returned context and deferencing will happen on the original contexty. This is simplest fix of all the forms. Other alternative fix include introduce a separate variable to hold mutated context and I believe it overcomplicates the code.

Other changes:

This change also include a fix in the `authorization_opa.go` to explicitly returns nil context in when functions errored out. It doesn't change the logic because it is already returning nil.


**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

