### PR TITLE
Credential template builder package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.9
@@ -188,7 +189,6 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/pkg/server/credtemplate/builder.go
+++ b/pkg/server/credtemplate/builder.go
@@ -41,7 +41,7 @@ const (
 )
 
 // DefaultX509CASubject is the default subject set on workload X509SVIDs
-// TODO: this is a historic, but poor default. we should revisit.
+// TODO: This is a historic, but poor, default. We should revisit (see issue #3841).
 func DefaultX509CASubject() pkix.Name {
 	return pkix.Name{
 		Country:      []string{"US"},
@@ -50,7 +50,7 @@ func DefaultX509CASubject() pkix.Name {
 }
 
 // DefaultX509SVIDSubject is the default subject set on workload X509SVIDs
-// TODO: this is a historic, but poor default. we should revisit.
+// TODO: This is a historic, but poor, default. We should revisit (see issue #3841).
 func DefaultX509SVIDSubject() pkix.Name {
 	return pkix.Name{
 		Country:      []string{"US"},
@@ -372,10 +372,9 @@ func (b *Builder) buildX509SVIDTemplate(spiffeID spiffeid.ID, publicKey crypto.P
 		return nil, err
 	}
 
+	tmpl.Subject = b.config.X509SVIDSubject
 	if subject.String() != "" {
 		tmpl.Subject = subject
-	} else {
-		tmpl.Subject = b.config.X509SVIDSubject
 	}
 
 	tmpl.NotBefore, tmpl.NotAfter = b.computeX509SVIDLifetime(parentChain, ttl)

--- a/pkg/server/credtemplate/builder.go
+++ b/pkg/server/credtemplate/builder.go
@@ -1,0 +1,493 @@
+package credtemplate
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"time"
+
+	"github.com/andres-erbsen/clock"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/x509svid"
+	"github.com/spiffe/spire/pkg/common/x509util"
+	"github.com/spiffe/spire/pkg/server/api"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
+)
+
+const (
+	// DefaultX509CATTL is the TTL given to X509 CAs if not overridden by
+	// the server config.
+	DefaultX509CATTL = time.Hour * 24
+
+	// DefaultX509SVIDTTL is the TTL given to X509 SVIDs if not overridden by
+	// the server config.
+	DefaultX509SVIDTTL = time.Hour
+
+	// DefaultJWTSVIDTTL is the TTL given to JWT SVIDs if a different TTL is
+	// not provided in the signing request.
+	DefaultJWTSVIDTTL = time.Minute * 5
+
+	// NotBeforeCushion is how much of a cushion to subtract from the current
+	// time when determining the notBefore field of certificates to account
+	// for clock skew.
+	NotBeforeCushion = 10 * time.Second
+)
+
+// DefaultX509CASubject is the default subject set on workload X509SVIDs
+// TODO: this is a hostoric, but poor default. we should revisit.
+func DefaultX509CASubject() pkix.Name {
+	return pkix.Name{
+		Country:      []string{"US"},
+		Organization: []string{"SPIFFE"},
+	}
+}
+
+// DefaultX509SVIDSubject is the default subject set on workload X509SVIDs
+// TODO: this is a hostoric, but poor default. we should revisit.
+func DefaultX509SVIDSubject() pkix.Name {
+	return pkix.Name{
+		Country:      []string{"US"},
+		Organization: []string{"SPIRE"},
+	}
+}
+
+type SelfSignedX509CAParams struct {
+	PublicKey crypto.PublicKey
+}
+
+type UpstreamSignedX509CAParams struct {
+	PublicKey crypto.PublicKey
+}
+
+type DownstreamX509CAParams struct {
+	ParentChain []*x509.Certificate
+	PublicKey   crypto.PublicKey
+	TTL         time.Duration
+}
+
+type ServerX509SVIDParams struct {
+	ParentChain []*x509.Certificate
+	PublicKey   crypto.PublicKey
+}
+
+type AgentX509SVIDParams struct {
+	ParentChain []*x509.Certificate
+	PublicKey   crypto.PublicKey
+	SPIFFEID    spiffeid.ID
+}
+
+type WorkloadX509SVIDParams struct {
+	ParentChain []*x509.Certificate
+	PublicKey   crypto.PublicKey
+	SPIFFEID    spiffeid.ID
+	DNSNames    []string
+	TTL         time.Duration
+	Subject     pkix.Name
+}
+
+type WorkloadJWTSVIDParams struct {
+	SPIFFEID      spiffeid.ID
+	Audience      []string
+	TTL           time.Duration
+	ExpirationCap time.Time
+}
+
+type Config struct {
+	TrustDomain         spiffeid.TrustDomain
+	Clock               clock.Clock
+	X509CASubject       pkix.Name
+	X509CATTL           time.Duration
+	X509SVIDSubject     pkix.Name
+	X509SVIDTTL         time.Duration
+	JWTSVIDTTL          time.Duration
+	JWTIssuer           string
+	AgentSVIDTTL        time.Duration
+	CredentialComposers []credentialcomposer.CredentialComposer
+	NewSerialNumber     func() (*big.Int, error)
+}
+
+type Builder struct {
+	config Config
+}
+
+func NewBuilder(config Config) (*Builder, error) {
+	if config.TrustDomain.IsZero() {
+		return nil, errors.New("trust domain must be set")
+	}
+	if config.Clock == nil {
+		config.Clock = clock.New()
+	}
+	if config.X509CASubject.String() == "" {
+		config.X509CASubject = DefaultX509CASubject()
+	}
+	if config.X509CATTL == 0 {
+		config.X509CATTL = DefaultX509CATTL
+	}
+	if config.X509SVIDSubject.String() == "" {
+		config.X509SVIDSubject = DefaultX509SVIDSubject()
+	}
+	if config.X509SVIDTTL == 0 {
+		config.X509SVIDTTL = DefaultX509SVIDTTL
+	}
+	if config.JWTSVIDTTL == 0 {
+		config.JWTSVIDTTL = DefaultJWTSVIDTTL
+	}
+	if config.AgentSVIDTTL == 0 {
+		// config.X509SVIDTTL should be initialized by the code above and
+		// therefore safe to use to initialize the AgentSVIDTTL.
+		config.AgentSVIDTTL = config.X509SVIDTTL
+	}
+	if config.NewSerialNumber == nil {
+		config.NewSerialNumber = x509util.NewSerialNumber
+	}
+	return &Builder{
+		config: config,
+	}, nil
+}
+
+func (b *Builder) Config() Config {
+	return b.config
+}
+
+func (b *Builder) BuildSelfSignedX509CATemplate(ctx context.Context, params SelfSignedX509CAParams) (*x509.Certificate, error) {
+	tmpl, err := b.buildX509CATemplate(params.PublicKey, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeServerX509CA(ctx, x509CAAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509CAAttributes(tmpl, attributes)
+	}
+
+	return tmpl, nil
+}
+
+func (b *Builder) BuildUpstreamSignedX509CACSR(ctx context.Context, params UpstreamSignedX509CAParams) (*x509.CertificateRequest, error) {
+	tmpl, err := b.buildX509CATemplate(params.PublicKey, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeServerX509CA(ctx, x509CAAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509CAAttributes(tmpl, attributes)
+	}
+
+	// Create the CertificateRequest from the Certificate template. The
+	// PolicyIdentifiers field is ignored since that can be applied by the
+	// upstream signer and isn't a part of the native CertificateRequest type.
+	// TODO: maybe revisit this if needed and embed the policy identifiers in
+	// the extra extensions.
+	return &x509.CertificateRequest{
+		Subject:         tmpl.Subject,
+		ExtraExtensions: tmpl.ExtraExtensions,
+		URIs:            tmpl.URIs,
+		PublicKey:       tmpl.PublicKey,
+	}, nil
+}
+
+func (b *Builder) BuildDownstreamX509CATemplate(ctx context.Context, params DownstreamX509CAParams) (*x509.Certificate, error) {
+	if len(params.ParentChain) == 0 {
+		return nil, errors.New("parent chain required to build downstream X509 CA template")
+	}
+
+	tmpl, err := b.buildX509CATemplate(params.PublicKey, params.ParentChain, params.TTL)
+	if err != nil {
+		return nil, err
+	}
+	tmpl.Subject = params.ParentChain[0].Subject
+	tmpl.Subject.OrganizationalUnit = []string{fmt.Sprintf("DOWNSTREAM-%d", len(params.ParentChain))}
+
+	// It's a bit gross, but SPIRE has historically signed downstream X509CA's with the X509-SVID ttl, so
+	// let's override the NotBefore/NotAfter fields set by buildX509CATemplate.
+	tmpl.NotBefore, tmpl.NotAfter = b.computeX509SVIDLifetime(params.ParentChain, params.TTL)
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeServerX509CA(ctx, x509CAAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509CAAttributes(tmpl, attributes)
+	}
+
+	return tmpl, nil
+}
+
+func (b *Builder) BuildServerX509SVIDTemplate(ctx context.Context, params ServerX509SVIDParams) (*x509.Certificate, error) {
+	spiffeID, err := idutil.ServerID(b.config.TrustDomain)
+	if err != nil {
+		// This check is purely defensive; idutil.ServerID should not fail since the trust domain is valid.
+		return nil, err
+	}
+
+	tmpl, err := b.buildX509SVIDTemplate(spiffeID, params.PublicKey, params.ParentChain, pkix.Name{}, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeServerX509SVID(ctx, x509SVIDAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509SVIDAttributes(tmpl, attributes)
+	}
+
+	return tmpl, nil
+}
+
+func (b *Builder) BuildAgentX509SVIDTemplate(ctx context.Context, params AgentX509SVIDParams) (*x509.Certificate, error) {
+	tmpl, err := b.buildX509SVIDTemplate(params.SPIFFEID, params.PublicKey, params.ParentChain, pkix.Name{}, b.config.AgentSVIDTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeAgentX509SVID(ctx, params.SPIFFEID, params.PublicKey, x509SVIDAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509SVIDAttributes(tmpl, attributes)
+	}
+
+	return tmpl, nil
+}
+
+func (b *Builder) BuildWorkloadX509SVIDTemplate(ctx context.Context, params WorkloadX509SVIDParams) (*x509.Certificate, error) {
+	subject := b.config.X509SVIDSubject
+	if params.Subject.String() != "" {
+		subject = params.Subject
+	}
+
+	tmpl, err := b.buildX509SVIDTemplate(params.SPIFFEID, params.PublicKey, params.ParentChain, subject, params.TTL)
+	if err != nil {
+		return nil, err
+	}
+
+	// The first DNS name is also added as the CN by default. This happens
+	// even if the subject is provided explicitly in the params for backwards
+	// compatibility. Ideally we wouldn't do override the subject in this
+	// case. It is still overridable via the credential composers however.
+	if len(params.DNSNames) > 0 {
+		tmpl.Subject.CommonName = params.DNSNames[0]
+		tmpl.DNSNames = params.DNSNames
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		attributes, err := cc.ComposeWorkloadX509SVID(ctx, params.SPIFFEID, params.PublicKey, x509SVIDAttributesFromTemplate(tmpl))
+		if err != nil {
+			return nil, err
+		}
+		applyX509SVIDAttributes(tmpl, attributes)
+	}
+
+	return tmpl, nil
+}
+
+func (b *Builder) BuildWorkloadJWTSVIDClaims(ctx context.Context, params WorkloadJWTSVIDParams) (map[string]interface{}, error) {
+	params.Audience = dropEmptyValues(params.Audience)
+
+	if params.SPIFFEID.IsZero() {
+		return nil, fmt.Errorf("invalid JWT-SVID ID: cannot be empty")
+	}
+	if err := api.VerifyTrustDomainMemberID(b.config.TrustDomain, params.SPIFFEID); err != nil {
+		return nil, fmt.Errorf("invalid JWT-SVID ID: %w", err)
+	}
+	if len(params.Audience) == 0 {
+		return nil, fmt.Errorf("invalid JWT-SVID audience: cannot be empty")
+	}
+
+	now := b.config.Clock.Now()
+
+	ttl := params.TTL
+	if ttl <= 0 {
+		ttl = b.config.JWTSVIDTTL
+	}
+	_, expiresAt := computeCappedLifetime(b.config.Clock, ttl, params.ExpirationCap)
+
+	attributes := credentialcomposer.JWTSVIDAttributes{
+		Claims: map[string]interface{}{
+			"sub": params.SPIFFEID.String(),
+			"exp": jwt.NewNumericDate(expiresAt),
+			"aud": params.Audience,
+			"iat": jwt.NewNumericDate(now),
+		},
+	}
+	if b.config.JWTIssuer != "" {
+		attributes.Claims["iss"] = b.config.JWTIssuer
+	}
+
+	for _, cc := range b.config.CredentialComposers {
+		var err error
+		attributes, err = cc.ComposeWorkloadJWTSVID(ctx, params.SPIFFEID, attributes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return attributes.Claims, nil
+}
+
+func (b *Builder) buildX509CATemplate(publicKey crypto.PublicKey, parentChain []*x509.Certificate, ttl time.Duration) (*x509.Certificate, error) {
+	tmpl, err := b.buildBaseTemplate(b.config.TrustDomain.ID(), publicKey, parentChain)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl.Subject = b.config.X509CASubject
+	tmpl.NotBefore, tmpl.NotAfter = b.computeX509CALifetime(parentChain, ttl)
+	tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	tmpl.IsCA = true
+
+	return tmpl, nil
+}
+
+func (b *Builder) buildX509SVIDTemplate(spiffeID spiffeid.ID, publicKey crypto.PublicKey, parentChain []*x509.Certificate, subject pkix.Name, ttl time.Duration) (*x509.Certificate, error) {
+	if len(parentChain) == 0 {
+		return nil, errors.New("parent chain required to build X509-SVID template")
+	}
+	if spiffeID.IsZero() {
+		return nil, fmt.Errorf("invalid X509-SVID ID: cannot be empty")
+	}
+	if err := api.VerifyTrustDomainMemberID(b.config.TrustDomain, spiffeID); err != nil {
+		return nil, fmt.Errorf("invalid X509-SVID ID: %w", err)
+	}
+
+	tmpl, err := b.buildBaseTemplate(spiffeID, publicKey, parentChain)
+	if err != nil {
+		return nil, err
+	}
+
+	if subject.String() != "" {
+		tmpl.Subject = subject
+	} else {
+		tmpl.Subject = b.config.X509SVIDSubject
+	}
+
+	tmpl.NotBefore, tmpl.NotAfter = b.computeX509SVIDLifetime(parentChain, ttl)
+	tmpl.KeyUsage = x509.KeyUsageKeyEncipherment |
+		x509.KeyUsageKeyAgreement |
+		x509.KeyUsageDigitalSignature
+	tmpl.ExtKeyUsage = []x509.ExtKeyUsage{
+		x509.ExtKeyUsageServerAuth,
+		x509.ExtKeyUsageClientAuth,
+	}
+
+	// Append the unique ID to the subject, unless disabled
+	tmpl.Subject.ExtraNames = append(tmpl.Subject.ExtraNames, x509svid.UniqueIDAttribute(spiffeID))
+
+	return tmpl, nil
+}
+
+func (b *Builder) buildBaseTemplate(spiffeID spiffeid.ID, publicKey crypto.PublicKey, parentChain []*x509.Certificate) (*x509.Certificate, error) {
+	serialNumber, err := b.config.NewSerialNumber()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get new serial number: %w", err)
+	}
+
+	subjectKeyID, err := x509util.GetSubjectKeyID(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Explicitly set the AKI on the signed certificate, otherwise it won't be
+	// added if the subject and issuer match (however unlikely).
+	var authorityKeyID []byte
+	if len(parentChain) > 0 {
+		authorityKeyID = parentChain[0].SubjectKeyId
+	}
+
+	return &x509.Certificate{
+		SerialNumber:          serialNumber,
+		URIs:                  []*url.URL{spiffeID.URL()},
+		SubjectKeyId:          subjectKeyID,
+		AuthorityKeyId:        authorityKeyID,
+		BasicConstraintsValid: true,
+		PublicKey:             publicKey,
+	}, nil
+}
+
+func (b *Builder) computeX509CALifetime(parentChain []*x509.Certificate, ttl time.Duration) (notBefore, notAfter time.Time) {
+	if ttl <= 0 {
+		ttl = b.config.X509CATTL
+	}
+	return computeCappedLifetime(b.config.Clock, ttl, parentChainExpiration(parentChain))
+}
+
+func (b *Builder) computeX509SVIDLifetime(parentChain []*x509.Certificate, ttl time.Duration) (notBefore, notAfter time.Time) {
+	if ttl <= 0 {
+		ttl = b.config.X509SVIDTTL
+	}
+	return computeCappedLifetime(b.config.Clock, ttl, parentChainExpiration(parentChain))
+}
+
+func x509CAAttributesFromTemplate(tmpl *x509.Certificate) credentialcomposer.X509CAAttributes {
+	return credentialcomposer.X509CAAttributes{
+		Subject:           tmpl.Subject,
+		PolicyIdentifiers: tmpl.PolicyIdentifiers,
+		ExtraExtensions:   tmpl.ExtraExtensions,
+	}
+}
+func x509SVIDAttributesFromTemplate(tmpl *x509.Certificate) credentialcomposer.X509SVIDAttributes {
+	return credentialcomposer.X509SVIDAttributes{
+		Subject:         tmpl.Subject,
+		DNSNames:        tmpl.DNSNames,
+		ExtraExtensions: tmpl.ExtraExtensions,
+	}
+}
+
+func applyX509CAAttributes(tmpl *x509.Certificate, attribs credentialcomposer.X509CAAttributes) {
+	tmpl.Subject = attribs.Subject
+	tmpl.PolicyIdentifiers = attribs.PolicyIdentifiers
+	tmpl.ExtraExtensions = attribs.ExtraExtensions
+}
+
+func applyX509SVIDAttributes(tmpl *x509.Certificate, attribs credentialcomposer.X509SVIDAttributes) {
+	tmpl.Subject = attribs.Subject
+	tmpl.DNSNames = attribs.DNSNames
+	tmpl.ExtraExtensions = attribs.ExtraExtensions
+}
+
+func computeCappedLifetime(clk clock.Clock, ttl time.Duration, expirationCap time.Time) (notBefore, notAfter time.Time) {
+	now := clk.Now()
+	notBefore = now.Add(-NotBeforeCushion)
+	notAfter = now.Add(ttl)
+	if !expirationCap.IsZero() && notAfter.After(expirationCap) {
+		notAfter = expirationCap
+	}
+	return notBefore, notAfter
+}
+
+func parentChainExpiration(parentChain []*x509.Certificate) time.Time {
+	var expiration time.Time
+	if len(parentChain) > 0 && !parentChain[0].NotAfter.IsZero() {
+		expiration = parentChain[0].NotAfter
+	}
+	return expiration
+}
+
+func dropEmptyValues(ss []string) []string {
+	next := 0
+	for _, s := range ss {
+		if s != "" {
+			ss[next] = s
+			next++
+		}
+	}
+	ss = ss[:next]
+	return ss
+}

--- a/pkg/server/credtemplate/builder.go
+++ b/pkg/server/credtemplate/builder.go
@@ -41,7 +41,7 @@ const (
 )
 
 // DefaultX509CASubject is the default subject set on workload X509SVIDs
-// TODO: this is a hostoric, but poor default. we should revisit.
+// TODO: this is a historic, but poor default. we should revisit.
 func DefaultX509CASubject() pkix.Name {
 	return pkix.Name{
 		Country:      []string{"US"},
@@ -50,7 +50,7 @@ func DefaultX509CASubject() pkix.Name {
 }
 
 // DefaultX509SVIDSubject is the default subject set on workload X509SVIDs
-// TODO: this is a hostoric, but poor default. we should revisit.
+// TODO: this is a historic, but poor default. we should revisit.
 func DefaultX509SVIDSubject() pkix.Name {
 	return pkix.Name{
 		Country:      []string{"US"},
@@ -302,13 +302,13 @@ func (b *Builder) BuildWorkloadJWTSVIDClaims(ctx context.Context, params Workloa
 	params.Audience = dropEmptyValues(params.Audience)
 
 	if params.SPIFFEID.IsZero() {
-		return nil, fmt.Errorf("invalid JWT-SVID ID: cannot be empty")
+		return nil, errors.New("invalid JWT-SVID ID: cannot be empty")
 	}
 	if err := api.VerifyTrustDomainMemberID(b.config.TrustDomain, params.SPIFFEID); err != nil {
 		return nil, fmt.Errorf("invalid JWT-SVID ID: %w", err)
 	}
 	if len(params.Audience) == 0 {
-		return nil, fmt.Errorf("invalid JWT-SVID audience: cannot be empty")
+		return nil, errors.New("invalid JWT-SVID audience: cannot be empty")
 	}
 
 	now := b.config.Clock.Now()
@@ -361,7 +361,7 @@ func (b *Builder) buildX509SVIDTemplate(spiffeID spiffeid.ID, publicKey crypto.P
 		return nil, errors.New("parent chain required to build X509-SVID template")
 	}
 	if spiffeID.IsZero() {
-		return nil, fmt.Errorf("invalid X509-SVID ID: cannot be empty")
+		return nil, errors.New("invalid X509-SVID ID: cannot be empty")
 	}
 	if err := api.VerifyTrustDomainMemberID(b.config.TrustDomain, spiffeID); err != nil {
 		return nil, fmt.Errorf("invalid X509-SVID ID: %w", err)

--- a/pkg/server/credtemplate/builder_test.go
+++ b/pkg/server/credtemplate/builder_test.go
@@ -1,0 +1,1188 @@
+package credtemplate_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/x509svid"
+	"github.com/spiffe/spire/pkg/common/x509util"
+	"github.com/spiffe/spire/pkg/server/credtemplate"
+	"github.com/spiffe/spire/pkg/server/plugin/credentialcomposer"
+	"github.com/spiffe/spire/test/clock"
+	"github.com/spiffe/spire/test/testkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	ctx              = context.Background()
+	now              = time.Now().UTC().Add(time.Hour).Truncate(time.Minute)
+	td               = spiffeid.RequireTrustDomainFromString("domain.test")
+	sn               = big.NewInt(99)
+	publicKey        = testkey.MustEC256().Public()
+	publicKeyID, _   = x509util.GetSubjectKeyID(publicKey)
+	parentTTL        = 7 * 24 * time.Hour
+	parentNotAfter   = now.Add(parentTTL)
+	parentKey        = testkey.MustEC256().Public()
+	parentKeyID, _   = x509util.GetSubjectKeyID(parentKey)
+	parentChain      = []*x509.Certificate{{PublicKey: parentKey, SubjectKeyId: parentKeyID, NotAfter: parentNotAfter}}
+	caID             = td.ID()
+	notBefore        = now.Add(-10 * time.Second)
+	x509CANotAfter   = now.Add(credtemplate.DefaultX509CATTL)
+	x509SVIDNotAfter = now.Add(credtemplate.DefaultX509SVIDTTL)
+	jwtSVIDNotAfter  = now.Add(credtemplate.DefaultJWTSVIDTTL)
+	caKeyUsage       = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+	svidKeyUsage     = x509.KeyUsageKeyEncipherment | x509.KeyUsageKeyAgreement | x509.KeyUsageDigitalSignature
+	svidExtKeyUsage  = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	serverID         = spiffeid.RequireFromPath(td, "/spire/server")
+	agentID          = spiffeid.RequireFromPath(td, "/spire/agent/foo/foo-1")
+	workloadID       = spiffeid.RequireFromPath(td, "/workload")
+)
+
+func TestNewBuilderRequiresTrustDomain(t *testing.T) {
+	_, err := credtemplate.NewBuilder(credtemplate.Config{})
+	assert.EqualError(t, err, "trust domain must be set")
+}
+
+func TestNewBuilderSetsDefaults(t *testing.T) {
+	builder, err := credtemplate.NewBuilder(credtemplate.Config{
+		TrustDomain: td,
+	})
+	require.NoError(t, err)
+
+	config := builder.Config()
+
+	// Assert that the Clock and NewSerialNumber and then set them to nil
+	// before comparing the whole config. Checking the whole config in a single
+	// equality check is more future proof but the defaults for these fields
+	// are hard to compare.
+	assert.NotNil(t, config.Clock)
+	config.Clock = nil
+	assert.NotNil(t, config.NewSerialNumber)
+	config.NewSerialNumber = nil
+
+	assert.Equal(t, credtemplate.Config{
+		TrustDomain:     td,
+		X509CASubject:   credtemplate.DefaultX509CASubject(),
+		X509CATTL:       credtemplate.DefaultX509CATTL,
+		X509SVIDSubject: credtemplate.DefaultX509SVIDSubject(),
+		X509SVIDTTL:     credtemplate.DefaultX509SVIDTTL,
+		JWTSVIDTTL:      credtemplate.DefaultJWTSVIDTTL,
+		JWTIssuer:       "",
+		AgentSVIDTTL:    credtemplate.DefaultX509SVIDTTL,
+	}, config)
+}
+
+func TestNewBuilderAllowsConfigOverrides(t *testing.T) {
+	configIn := credtemplate.Config{
+		TrustDomain:     td,
+		X509CASubject:   pkix.Name{CommonName: "X509CA"},
+		X509SVIDSubject: pkix.Name{CommonName: "X509SVID"},
+		X509CATTL:       1 * time.Minute,
+		X509SVIDTTL:     2 * time.Minute,
+		JWTSVIDTTL:      3 * time.Minute,
+		JWTIssuer:       "ISSUER",
+		AgentSVIDTTL:    4 * time.Minute,
+	}
+	builder, err := credtemplate.NewBuilder(configIn)
+	require.NoError(t, err)
+
+	configOut := builder.Config()
+
+	// Assert that the Clock and NewSerialNumber and then set them to nil
+	// before comparing the whole config. Checking the whole config in a single
+	// equality check is more future proof but the defaults for these fields
+	// are hard to compare.
+	assert.NotNil(t, configOut.Clock)
+	configOut.Clock = nil
+	assert.NotNil(t, configOut.NewSerialNumber)
+	configOut.NewSerialNumber = nil
+
+	assert.Equal(t, configIn, configOut)
+}
+
+func TestBuildSelfSignedX509CATemplate(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.SelfSignedX509CAParams)
+		overrideExpected func(expected *x509.Certificate)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.SelfSignedX509CAParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "override X509CATTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509CATTL = time.Minute * 23
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(time.Minute * 23)
+			},
+		},
+		{
+			desc: "override X509CASubject",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509CASubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.PolicyIdentifiers = []asn1.ObjectIdentifier{{1}}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.PolicyIdentifiers = []asn1.ObjectIdentifier{{2}}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.SelfSignedX509CAParams{
+					PublicKey: publicKey,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildSelfSignedX509CATemplate(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.Certificate{
+					SerialNumber:          sn,
+					URIs:                  idURIs(caID),
+					Subject:               pkix.Name{Country: []string{"US"}, Organization: []string{"SPIFFE"}},
+					SubjectKeyId:          publicKeyID,
+					BasicConstraintsValid: true,
+					IsCA:                  true,
+					KeyUsage:              caKeyUsage,
+					NotBefore:             notBefore,
+					NotAfter:              x509CANotAfter,
+					PublicKey:             publicKey,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildUpstreamSignedX509CACSR(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.UpstreamSignedX509CAParams)
+		overrideExpected func(expected *x509.CertificateRequest)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.UpstreamSignedX509CAParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "override X509CASubject",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509CASubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.CertificateRequest) {
+				expected.Subject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.CertificateRequest) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.CertificateRequest) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.UpstreamSignedX509CAParams{
+					PublicKey: publicKey,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildUpstreamSignedX509CACSR(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.CertificateRequest{
+					Subject:   pkix.Name{Country: []string{"US"}, Organization: []string{"SPIFFE"}},
+					URIs:      idURIs(caID),
+					PublicKey: publicKey,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildDownstreamX509CATemplate(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.DownstreamX509CAParams)
+		overrideExpected func(expected *x509.Certificate)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid parent chain",
+			overrideParams: func(params *credtemplate.DownstreamX509CAParams) {
+				params.ParentChain = nil
+			},
+			expectErr: "parent chain required to build downstream X509 CA template",
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.DownstreamX509CAParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "overridden X509CASubject does not apply to downstream CA",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509CASubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+			},
+		},
+		{
+			desc: "override X509SVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				// Downstream CAs have historically been signed using the default X509-SVID TTL
+				config.X509SVIDTTL = credtemplate.DefaultX509SVIDTTL * 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL * 2)
+			},
+		},
+		{
+			desc: "with ttl",
+			overrideParams: func(params *credtemplate.DownstreamX509CAParams) {
+				params.TTL = credtemplate.DefaultX509SVIDTTL / 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL / 2)
+			},
+		},
+		{
+			desc: "ttl gets capped",
+			overrideParams: func(params *credtemplate.DownstreamX509CAParams) {
+				params.TTL = parentTTL + time.Hour
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(parentTTL)
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.PolicyIdentifiers = []asn1.ObjectIdentifier{{1}}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.PolicyIdentifiers = []asn1.ObjectIdentifier{{2}}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.DownstreamX509CAParams{
+					ParentChain: parentChain,
+					PublicKey:   publicKey,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildDownstreamX509CATemplate(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.Certificate{
+					SerialNumber:          sn,
+					Subject:               pkix.Name{OrganizationalUnit: []string{"DOWNSTREAM-1"}},
+					URIs:                  idURIs(caID),
+					PublicKey:             publicKey,
+					IsCA:                  true,
+					BasicConstraintsValid: true,
+					KeyUsage:              caKeyUsage,
+					SubjectKeyId:          publicKeyID,
+					AuthorityKeyId:        parentKeyID,
+					NotBefore:             notBefore,
+					// Downstream CAs have historically been signed using the default X509-SVID TTL
+					NotAfter: x509SVIDNotAfter,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildServerX509SVIDTemplate(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.ServerX509SVIDParams)
+		overrideExpected func(expected *x509.Certificate)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid parent chain",
+			overrideParams: func(params *credtemplate.ServerX509SVIDParams) {
+				params.ParentChain = nil
+			},
+			expectErr: "parent chain required to build X509-SVID template",
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.ServerX509SVIDParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "override X509SVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDTTL = credtemplate.DefaultX509SVIDTTL * 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL * 2)
+			},
+		},
+		{
+			desc: "ttl capped by parent chain",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDTTL = parentTTL + time.Hour
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(parentTTL)
+			},
+		},
+		{
+			desc: "override X509SVIDSubject",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDSubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject = pkix.Name{
+					CommonName: "OVERRIDE",
+					ExtraNames: []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(serverID)},
+				}
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.DNSNames = []string{"OVERRIDE-1"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.DNSNames = []string{"OVERRIDE-2"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.ServerX509SVIDParams{
+					ParentChain: parentChain,
+					PublicKey:   publicKey,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildServerX509SVIDTemplate(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.Certificate{
+					SerialNumber: sn,
+					Subject: pkix.Name{
+						Country:      []string{"US"},
+						Organization: []string{"SPIRE"},
+						ExtraNames:   []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(serverID)},
+					},
+					SubjectKeyId:          publicKeyID,
+					AuthorityKeyId:        parentKeyID,
+					URIs:                  idURIs(serverID),
+					PublicKey:             publicKey,
+					BasicConstraintsValid: true,
+					IsCA:                  false,
+					KeyUsage:              svidKeyUsage,
+					ExtKeyUsage:           svidExtKeyUsage,
+					NotBefore:             notBefore,
+					NotAfter:              x509SVIDNotAfter,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildAgentX509SVIDTemplate(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.AgentX509SVIDParams)
+		overrideExpected func(expected *x509.Certificate)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid parent chain",
+			overrideParams: func(params *credtemplate.AgentX509SVIDParams) {
+				params.ParentChain = nil
+			},
+			expectErr: "parent chain required to build X509-SVID template",
+		},
+		{
+			desc: "empty SPIFFE ID",
+			overrideParams: func(params *credtemplate.AgentX509SVIDParams) {
+				params.SPIFFEID = spiffeid.ID{}
+			},
+			expectErr: "invalid X509-SVID ID: cannot be empty",
+		},
+		{
+			desc: "SPIFFE ID from another trust domain",
+			overrideParams: func(params *credtemplate.AgentX509SVIDParams) {
+				params.SPIFFEID = spiffeid.RequireFromString("spiffe://otherdomain.test/spire/agent/foo/foo-1")
+			},
+			expectErr: `invalid X509-SVID ID: "spiffe://otherdomain.test/spire/agent/foo/foo-1" is not a member of trust domain "domain.test"`,
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.AgentX509SVIDParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		}, {
+			desc: "override X509SVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDTTL = credtemplate.DefaultX509SVIDTTL * 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL * 2)
+			},
+		},
+		{
+			desc: "override AgentX509SVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				// Set X509SVIDTTL as well just to make sure the AgentX509SVIDTTL is preferred.
+				config.X509SVIDTTL = credtemplate.DefaultX509SVIDTTL * 2
+				config.AgentSVIDTTL = credtemplate.DefaultX509SVIDTTL * 3
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL * 3)
+			},
+		},
+		{
+			desc: "ttl capped by parent chain",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.AgentSVIDTTL = parentTTL + time.Hour
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(parentTTL)
+			},
+		},
+		{
+			desc: "override X509SVIDSubject",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDSubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject = pkix.Name{
+					CommonName: "OVERRIDE",
+					ExtraNames: []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(agentID)},
+				}
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.DNSNames = []string{"OVERRIDE-1"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.DNSNames = []string{"OVERRIDE-2"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.AgentX509SVIDParams{
+					ParentChain: parentChain,
+					PublicKey:   publicKey,
+					SPIFFEID:    agentID,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildAgentX509SVIDTemplate(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.Certificate{
+					SerialNumber: sn,
+					Subject: pkix.Name{
+						Country:      []string{"US"},
+						Organization: []string{"SPIRE"},
+						ExtraNames:   []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(agentID)},
+					},
+					SubjectKeyId:          publicKeyID,
+					AuthorityKeyId:        parentKeyID,
+					URIs:                  idURIs(agentID),
+					PublicKey:             publicKey,
+					BasicConstraintsValid: true,
+					IsCA:                  false,
+					KeyUsage:              svidKeyUsage,
+					ExtKeyUsage:           svidExtKeyUsage,
+					NotBefore:             notBefore,
+					NotAfter:              x509SVIDNotAfter,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildWorkloadX509SVIDTemplate(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.WorkloadX509SVIDParams)
+		overrideExpected func(expected *x509.Certificate)
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "fail to get serial number",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.NewSerialNumber = failNewSerialNumber
+			},
+			expectErr: "failed to get new serial number: oh no",
+		},
+		{
+			desc: "invalid parent chain",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.ParentChain = nil
+			},
+			expectErr: "parent chain required to build X509-SVID template",
+		},
+		{
+			desc: "empty SPIFFE ID",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.SPIFFEID = spiffeid.ID{}
+			},
+			expectErr: "invalid X509-SVID ID: cannot be empty",
+		},
+		{
+			desc: "SPIFFE ID from another trust domain",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.SPIFFEID = spiffeid.RequireFromString("spiffe://otherdomain.test/spire/agent/foo/foo-1")
+			},
+			expectErr: `invalid X509-SVID ID: "spiffe://otherdomain.test/spire/agent/foo/foo-1" is not a member of trust domain "domain.test"`,
+		},
+		{
+			desc: "invalid public key",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "invalid DNS names",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.PublicKey = nil
+			},
+			expectErr: "x509: unsupported public key type: <nil>",
+		},
+		{
+			desc: "override X509SVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDTTL = credtemplate.DefaultX509SVIDTTL * 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL * 2)
+			},
+		},
+		{
+			desc: "ttl capped by parent chain",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDTTL = parentTTL + time.Hour
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(parentTTL)
+			},
+		},
+		{
+			desc: "override X509SVIDSubject",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.X509SVIDSubject = pkix.Name{CommonName: "OVERRIDE"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject = pkix.Name{
+					CommonName: "OVERRIDE",
+					ExtraNames: []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(workloadID)},
+				}
+			},
+		},
+		{
+			desc: "with DNS names",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.DNSNames = []string{"DNSNAME1", "DNSNAME2"}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.DNSNames = []string{"DNSNAME1", "DNSNAME2"}
+				// CommonName is set to first DNS name by default
+				expected.Subject.CommonName = "DNSNAME1"
+			},
+		},
+		{
+			desc: "with DNS names and subject",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.DNSNames = []string{"DNSNAME1", "DNSNAME2"}
+				params.Subject.CommonName = "COMMONNAME"
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.DNSNames = []string{"DNSNAME1", "DNSNAME2"}
+				// CommonName is set to first DNS name by default even when
+				// Subject is explicit.
+				expected.Subject = pkix.Name{
+					CommonName: "DNSNAME1",
+					ExtraNames: []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(workloadID)},
+				}
+			},
+		},
+		{
+			desc: "with ttl",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.TTL = credtemplate.DefaultX509SVIDTTL / 2
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(credtemplate.DefaultX509SVIDTTL / 2)
+			},
+		},
+		{
+			desc: "ttl gets capped",
+			overrideParams: func(params *credtemplate.WorkloadX509SVIDParams) {
+				params.TTL = parentTTL + time.Hour
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.NotAfter = now.Add(parentTTL)
+			},
+		},
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-1"
+				expected.DNSNames = []string{"OVERRIDE-1"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(1), Value: []byte{1}}}
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected *x509.Certificate) {
+				expected.Subject.CommonName = "OVERRIDE-2"
+				expected.DNSNames = []string{"OVERRIDE-2"}
+				expected.ExtraExtensions = []pkix.Extension{{Id: makeOID(2), Value: []byte{2}}}
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.WorkloadX509SVIDParams{
+					ParentChain: parentChain,
+					PublicKey:   publicKey,
+					SPIFFEID:    workloadID,
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildWorkloadX509SVIDTemplate(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := &x509.Certificate{
+					SerialNumber: sn,
+					Subject: pkix.Name{
+						Country:      []string{"US"},
+						Organization: []string{"SPIRE"},
+						ExtraNames:   []pkix.AttributeTypeAndValue{x509svid.UniqueIDAttribute(workloadID)},
+					},
+					SubjectKeyId:          publicKeyID,
+					AuthorityKeyId:        parentKeyID,
+					URIs:                  idURIs(workloadID),
+					PublicKey:             publicKey,
+					BasicConstraintsValid: true,
+					IsCA:                  false,
+					KeyUsage:              svidKeyUsage,
+					ExtKeyUsage:           svidExtKeyUsage,
+					NotBefore:             notBefore,
+					NotAfter:              x509SVIDNotAfter,
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func TestBuildWorkloadJWTSVIDClaims(t *testing.T) {
+	for _, tc := range []struct {
+		desc             string
+		overrideConfig   func(config *credtemplate.Config)
+		overrideParams   func(params *credtemplate.WorkloadJWTSVIDParams)
+		overrideExpected func(expected map[string]interface{})
+		expectErr        string
+	}{
+		{
+			desc: "defaults",
+		},
+		{
+			desc: "empty SPIFFE ID",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.SPIFFEID = spiffeid.ID{}
+			},
+			expectErr: "invalid JWT-SVID ID: cannot be empty",
+		},
+		{
+			desc: "SPIFFE ID from another trust domain",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.SPIFFEID = spiffeid.RequireFromString("spiffe://otherdomain.test/spire/agent/foo/foo-1")
+			},
+			expectErr: `invalid JWT-SVID ID: "spiffe://otherdomain.test/spire/agent/foo/foo-1" is not a member of trust domain "domain.test"`,
+		},
+		{
+			desc: "empty audience",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.Audience = nil
+			},
+			expectErr: "invalid JWT-SVID audience: cannot be empty",
+		},
+		{
+			desc: "empty audience value",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.Audience = []string{""}
+			},
+			expectErr: "invalid JWT-SVID audience: cannot be empty",
+		},
+		{
+			desc: "empty audience value otherwise ignored",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.Audience = []string{"", "AUDIENCE"}
+			},
+		},
+		{
+			desc: "multipler audience value",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.Audience = []string{"AUDIENCE1", "AUDIENCE2"}
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["aud"] = []string{"AUDIENCE1", "AUDIENCE2"}
+			},
+		},
+		{
+			desc: "override JWTSVIDTTL",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.JWTSVIDTTL = credtemplate.DefaultJWTSVIDTTL * 2
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["exp"] = jwt.NewNumericDate(now.Add(credtemplate.DefaultJWTSVIDTTL * 2))
+			},
+		},
+		{
+			desc: "ttl capped by expiration cap",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.JWTSVIDTTL = parentTTL + time.Hour
+			},
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.ExpirationCap = now.Add(parentTTL)
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["exp"] = jwt.NewNumericDate(now.Add(parentTTL))
+			},
+		},
+		{
+			desc: "with ttl",
+			overrideParams: func(params *credtemplate.WorkloadJWTSVIDParams) {
+				params.TTL = credtemplate.DefaultJWTSVIDTTL / 2
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["exp"] = jwt.NewNumericDate(now.Add(credtemplate.DefaultJWTSVIDTTL / 2))
+			},
+		},
+		{
+			desc: "with issuer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.JWTIssuer = "ISSUER"
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["iss"] = "ISSUER"
+			},
+		},
+
+		{
+			desc: "single composer",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1}}
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["foo"] = "VALUE-1"
+			},
+		},
+		{
+			desc: "two composers",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 2}, fakeCC{id: 2}}
+			},
+			overrideExpected: func(expected map[string]interface{}) {
+				expected["foo"] = "VALUE-2"
+			},
+		},
+		{
+			desc: "composer fails",
+			overrideConfig: func(config *credtemplate.Config) {
+				config.CredentialComposers = []credentialcomposer.CredentialComposer{badCC{}}
+			},
+			expectErr: "oh no",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			testBuilder(t, tc.overrideConfig, func(t *testing.T, credBuilder *credtemplate.Builder) {
+				params := credtemplate.WorkloadJWTSVIDParams{
+					SPIFFEID: workloadID,
+					Audience: []string{"AUDIENCE"},
+				}
+				if tc.overrideParams != nil {
+					tc.overrideParams(&params)
+				}
+				template, err := credBuilder.BuildWorkloadJWTSVIDClaims(ctx, params)
+				if tc.expectErr != "" {
+					require.EqualError(t, err, tc.expectErr)
+					return
+				}
+				require.NoError(t, err)
+
+				expected := map[string]interface{}{
+					"aud": []string{"AUDIENCE"},
+					"iat": jwt.NewNumericDate(now),
+					"exp": jwt.NewNumericDate(jwtSVIDNotAfter),
+					"sub": workloadID.String(),
+				}
+				if tc.overrideExpected != nil {
+					tc.overrideExpected(expected)
+				}
+				require.Equal(t, expected, template)
+			})
+		})
+	}
+}
+
+func testBuilder(t *testing.T, overrideConfig func(config *credtemplate.Config), fn func(*testing.T, *credtemplate.Builder)) {
+	config := credtemplate.Config{
+		TrustDomain:     td,
+		Clock:           clock.NewMockAt(t, now),
+		NewSerialNumber: func() (*big.Int, error) { return sn, nil },
+	}
+	if overrideConfig != nil {
+		overrideConfig(&config)
+	}
+	credBuilder, err := credtemplate.NewBuilder(config)
+	require.NoError(t, err)
+	fn(t, credBuilder)
+}
+
+func failNewSerialNumber() (*big.Int, error) { return nil, errors.New("oh no") }
+
+type badCC struct {
+	catalog.PluginInfo
+}
+
+func (badCC) ComposeServerX509CA(ctx context.Context, attributes credentialcomposer.X509CAAttributes) (credentialcomposer.X509CAAttributes, error) {
+	return credentialcomposer.X509CAAttributes{}, errors.New("oh no")
+}
+
+func (badCC) ComposeServerX509SVID(ctx context.Context, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return credentialcomposer.X509SVIDAttributes{}, errors.New("oh no")
+}
+
+func (badCC) ComposeAgentX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return credentialcomposer.X509SVIDAttributes{}, errors.New("oh no")
+}
+
+func (badCC) ComposeWorkloadX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return credentialcomposer.X509SVIDAttributes{}, errors.New("oh no")
+}
+
+func (badCC) ComposeWorkloadJWTSVID(ctx context.Context, id spiffeid.ID, attributes credentialcomposer.JWTSVIDAttributes) (credentialcomposer.JWTSVIDAttributes, error) {
+	return credentialcomposer.JWTSVIDAttributes{}, errors.New("oh no")
+}
+
+type fakeCC struct {
+	catalog.PluginInfo
+
+	id byte
+}
+
+func (cc fakeCC) ComposeServerX509CA(ctx context.Context, attributes credentialcomposer.X509CAAttributes) (credentialcomposer.X509CAAttributes, error) {
+	attributes.Subject.CommonName = cc.applySuffix("OVERRIDE")
+	attributes.PolicyIdentifiers = []asn1.ObjectIdentifier{makeOID(cc.id)}
+	attributes.ExtraExtensions = []pkix.Extension{{Id: makeOID(cc.id), Value: []byte{cc.id}}}
+	return attributes, nil
+}
+
+func (cc fakeCC) ComposeServerX509SVID(ctx context.Context, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return cc.overrideX509SVIDAttributes(attributes), nil
+}
+
+func (cc fakeCC) ComposeAgentX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return cc.overrideX509SVIDAttributes(attributes), nil
+}
+
+func (cc fakeCC) ComposeWorkloadX509SVID(ctx context.Context, id spiffeid.ID, publicKey crypto.PublicKey, attributes credentialcomposer.X509SVIDAttributes) (credentialcomposer.X509SVIDAttributes, error) {
+	return cc.overrideX509SVIDAttributes(attributes), nil
+}
+
+func (cc fakeCC) ComposeWorkloadJWTSVID(ctx context.Context, id spiffeid.ID, attributes credentialcomposer.JWTSVIDAttributes) (credentialcomposer.JWTSVIDAttributes, error) {
+	attributes.Claims["foo"] = cc.applySuffix("VALUE")
+	return attributes, nil
+}
+
+func (cc fakeCC) overrideX509SVIDAttributes(attributes credentialcomposer.X509SVIDAttributes) credentialcomposer.X509SVIDAttributes {
+	attributes.Subject.CommonName = cc.applySuffix("OVERRIDE")
+	attributes.DNSNames = []string{cc.applySuffix("OVERRIDE")}
+	attributes.ExtraExtensions = []pkix.Extension{{Id: makeOID(cc.id), Value: []byte{cc.id}}}
+	return attributes
+}
+
+func (cc fakeCC) applySuffix(s string) string {
+	return fmt.Sprintf("%s-%d", s, cc.id)
+}
+
+func makeOID(id byte) []int {
+	return []int{int(id)}
+}
+
+func idURIs(id spiffeid.ID) []*url.URL {
+	return []*url.URL{id.URL()}
+}

--- a/pkg/server/credtemplate/builder_test.go
+++ b/pkg/server/credtemplate/builder_test.go
@@ -64,10 +64,10 @@ func TestNewBuilderSetsDefaults(t *testing.T) {
 
 	config := builder.Config()
 
-	// Assert that the Clock and NewSerialNumber and then set them to nil
-	// before comparing the whole config. Checking the whole config in a single
-	// equality check is more future proof but the defaults for these fields
-	// are hard to compare.
+	// Assert that the Clock and NewSerialNumber are not nil and then set them
+	// to nil before comparing the whole config. Checking the whole config in a
+	// single equality check is more future proof but the defaults for these
+	// fields are hard to compare.
 	assert.NotNil(t, config.Clock)
 	config.Clock = nil
 	assert.NotNil(t, config.NewSerialNumber)
@@ -101,10 +101,10 @@ func TestNewBuilderAllowsConfigOverrides(t *testing.T) {
 
 	configOut := builder.Config()
 
-	// Assert that the Clock and NewSerialNumber and then set them to nil
-	// before comparing the whole config. Checking the whole config in a single
-	// equality check is more future proof but the defaults for these fields
-	// are hard to compare.
+	// Assert that the Clock and NewSerialNumber are not nil and then set them
+	// to nil before comparing the whole config. Checking the whole config in a
+	// single equality check is more future proof but the defaults for these
+	// fields are hard to compare.
 	assert.NotNil(t, configOut.Clock)
 	configOut.Clock = nil
 	assert.NotNil(t, configOut.NewSerialNumber)

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -24,6 +24,11 @@ type Mock struct {
 
 // NewMock creates a mock clock which can be precisely controlled
 func NewMock(t testing.TB) *Mock {
+	return NewMockAt(t, time.Now())
+}
+
+// NewMockAt creates a mock clock which can be precisely controlled at a specific time.
+func NewMockAt(t testing.TB, now time.Time) *Mock {
 	m := &Mock{
 		Mock:    clock.NewMock(),
 		t:       t,
@@ -40,7 +45,7 @@ func NewMock(t testing.TB) *Mock {
 	//
 	// TODO: plumb the clock into the TLS configs. (Clock).Now should be passed to "crypto/tls".(Config).Time
 	// and then this can be removed as a clock could be use with a zero value at that point.
-	m.Set(time.Now().Truncate(time.Second))
+	m.Set(now.Truncate(time.Second))
 	return m
 }
 


### PR DESCRIPTION
This package consolidates all of the CA and SVID template building logic into one spot where the Credential Composers can be applied.

The package does perform some input validation of parameters but does unfortunately does not perform validation against alterations returned by credential composers. This is because it is not possible to know how the extra extensions will impact the certificates until after they have passed through CreateCertificate, and we don't want to sign a credential after each CredentialComposer invocation.

As such, the validation will be left to the server CA layer after signing has taken place.