### PR TITLE
Change GH workflow tools cache key

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -54,9 +54,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Lint
         run: make lint
       - name: Tidy check
@@ -138,9 +136,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Build artifacts
         run: ./.github/workflows/scripts/build_artifacts.sh
       - name: Archive artifacts
@@ -173,9 +169,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # ratchet:docker/setup-qemu-action@v2.1.0
       - name: Set up Docker Buildx
@@ -255,9 +249,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Download archived images
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # ratchet:actions/download-artifact@v3.0.2
         with:
@@ -302,9 +294,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:
@@ -373,9 +363,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:
@@ -450,9 +438,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -52,9 +52,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Lint
         run: make lint
       - name: Tidy check
@@ -136,9 +134,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Build artifacts
         run: ./.github/workflows/scripts/build_artifacts.sh
       - name: Archive artifacts
@@ -171,9 +167,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Build images
         run: make images
       - name: Export images
@@ -258,9 +252,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Download archived images
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # ratchet:actions/download-artifact@v3.0.2
         with:
@@ -307,9 +299,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:
@@ -378,9 +368,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:
@@ -455,9 +443,7 @@ jobs:
         uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # ratchet:actions/cache@v3.2.4
         with:
           path: .build
-          key: ${{ runner.os }}-tools-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-tools-
+          key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Install msys2
         uses: msys2/setup-msys2@d40200dc2db4c351366b048a9565ad82919e1c24 # ratchet:msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
Current cache key causes each job to upload to the cache with the commit sha based key. This causes two problems:
1. Cache entries is large (one per PR) for no benefit
2. Toolchain changes are not considered when reusing the cache

This change updates the cache key for the tools cache to essentially be keyed off of the Go version and the Makefile (which contains the versions of tools in use)