### PR TITLE
Fix Envoy integration tests on arm64 architecture

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -133,10 +133,11 @@ build-mashup-image() {
 
     cat > Dockerfile <<EOF
 FROM spire-agent:latest-local as spire-agent
-FROM envoyproxy/envoy-alpine:${ENVOY_IMAGE_TAG} AS envoy-agent-mashup
+FROM envoyproxy/envoy:${ENVOY_IMAGE_TAG} AS envoy-agent-mashup
 COPY --from=spire-agent /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent
-RUN apk --no-cache add dumb-init
-RUN apk --no-cache add supervisor
+RUN apt-get update
+RUN apt-get install -y dumb-init
+RUN apt-get install -y supervisor
 COPY conf/supervisord.conf /etc/
 ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration", "/etc/supervisord.conf"]
 CMD []

--- a/test/integration/suites/envoy-sds-v2/00-setup
+++ b/test/integration/suites/envoy-sds-v2/00-setup
@@ -7,10 +7,11 @@ LAST_ENVOY_RELEASE_WITH_V2=v1.16.0
 cat > Dockerfile <<EOF
 FROM spire-agent:latest-local as spire-agent
 
-FROM envoyproxy/envoy-alpine:${LAST_ENVOY_RELEASE_WITH_V2} AS envoy-agent-mashup
+FROM envoyproxy/envoy:${LAST_ENVOY_RELEASE_WITH_V2} AS envoy-agent-mashup
 COPY --from=spire-agent /opt/spire/bin/spire-agent /opt/spire/bin/spire-agent
-RUN apk --no-cache add dumb-init
-RUN apk --no-cache add supervisor
+RUN apt-get update
+RUN apt-get install -y dumb-init
+RUN apt-get install -y supervisor
 COPY conf/supervisord.conf /etc/
 ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration", "/etc/supervisord.conf"]
 CMD []


### PR DESCRIPTION
Our Envoy tests were using Alpine-based release images that are only published for amd64 architecture. However, Envoy also publishes `envoyproxy/envoy` Ubuntu-based release images for both amd64 and arm64 architectures. These images are around 45 MB in size.

Switch the tests to the multiarch Envoy images so we can run them on arm64 machines.

Fixes #3875