### PR TITLE
Skip upgrade test on arm64 until 1.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,9 @@ endif
 integration:
 ifeq ($(os1), windows)
 	$(error Integration tests are not supported on windows)
+else ifeq (,$(filter $(arch2),arm64,aarch64))
+	# TODO: Remove this special handling of arm64 in 1.7.0
+	$(E)(export IGNORE_SUITES=suites/upgrade && ./test/integration/test.sh $(SUITES))
 else
 	$(E)./test/integration/test.sh $(SUITES)
 endif

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -14,11 +14,14 @@ if [[ -n $1 ]]; then
         SUITES=$@
 fi
 
+ignore_suites=(${IGNORE_SUITES})
 echo "Testing $SUITES"
 
 failed=()
 for suite in $SUITES; do
-    if ! ./test-one.sh "${suite}"; then
+    if [[ " ${ignore_suites[*]} " =~ " ${suite} " ]]; then
+        log-warn "Ignoring ${suite} suite..."
+    elif ! ./test-one.sh "${suite}"; then
         echo "STATUS=$?"
         failed+=( "$(basename "${suite}")" )
     fi


### PR DESCRIPTION
We are publishing arm64 images starting with the 1.6.0 release. Since the upgrade test uses images from the previous minor release series, this means the upgrade test cannot be run on arm64 until 1.7.0, at which point the prior minor release series will all have arm64 images.

Fixes #3877