### PR TITLE
Fix trust domain json logging in federated bundle updater

### DIFF
--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -261,7 +261,7 @@ func (m *Manager) runUpdater(ctx context.Context, trustDomain spiffeid.TrustDoma
 	timer := m.clock.Timer(time.Hour)
 	defer timer.Stop()
 
-	log := m.log.WithField("trust_domain", trustDomain)
+	log := m.log.WithField("trust_domain", trustDomain.String())
 	for {
 		var nextRefresh time.Duration
 		log.Debug("Polling for bundle update")


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Currently if json log format is in use `trust_domain` isn't logged properly for bundle manager, instead we're getting smth like:
```json
{"at":"2023-02-28T14:27:53Z","level":"debug","msg":"Scheduling next bundle refresh","subsystem_name":"bundle_client","time":"2023-02-28T14:26:38Z","trust_domain":{}}
```
As you can see `"trust_domain":{}` because underlying variable value is object `spiffeid.TrustDomain` with private properties only.

**Description of change**

Use `String()` method of `spiffeid.TrustDomain` to set log field value.


