### PR TITLE
Honor the `ca_ttl` server config

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -278,6 +278,7 @@ func (s *Server) newCredBuilder(cat catalog.Catalog) (*credtemplate.Builder, err
 	return credtemplate.NewBuilder(credtemplate.Config{
 		TrustDomain:         s.config.TrustDomain,
 		X509CASubject:       s.config.CASubject,
+		X509CATTL:           s.config.CATTL,
 		AgentSVIDTTL:        s.config.AgentTTL,
 		X509SVIDTTL:         s.config.X509SVIDTTL,
 		JWTSVIDTTL:          s.config.JWTSVIDTTL,


### PR DESCRIPTION
The `ca_ttl` server config was not being set in the `credtemplate.Config` struct, hence it was being ignored.
Add the setting of `X509CATTL` with the configured value.