### PR TITLE
Do not require that X509 CAs minted by an upstream authority have a URI SAN

### DIFF
--- a/pkg/server/credvalidator/validator_test.go
+++ b/pkg/server/credvalidator/validator_test.go
@@ -74,7 +74,6 @@ func TestValidateX509CA(t *testing.T) {
 			setup: func(ca *x509.Certificate) {
 				ca.URIs = nil
 			},
-			expectErr: "invalid X509 CA: missing URI SAN",
 		},
 		{
 			desc: "more than one URI SAN",


### PR DESCRIPTION
Changed the validation in the `credvalidator` package to not require that X509 CAs minted by an upstream authority have a URI SAN.
When a CA certificate does have a URI SAN, other validations still apply: https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md#32-signing-certificates

Fixes #3996.