### PR TITLE
Update GitHub runners to use ubuntu-22.04

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build-and-publish-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   cache-deps:
     name: cache-deps (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read
@@ -32,7 +32,7 @@ jobs:
 
   lint:
     name: lint (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: cache-deps
 
     permissions:
@@ -67,7 +67,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        OS: [ubuntu-20.04, macos-latest]
+        OS: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.OS }}
     needs: cache-deps
 
@@ -91,7 +91,7 @@ jobs:
 
   unit-test-race-detector:
     name: unit-test (linux with race detection)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: cache-deps
 
     permissions:
@@ -114,7 +114,7 @@ jobs:
 
   artifacts:
     name: artifacts (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps]
 
     permissions:
@@ -147,7 +147,7 @@ jobs:
 
   images:
     name: images (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps]
 
     permissions:
@@ -214,7 +214,7 @@ jobs:
 
   integration:
     name: integration (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps, images]
 
     permissions:
@@ -460,7 +460,7 @@ jobs:
           path: ./artifacts/
 
   success:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, lint-windows, unit-test-windows, artifact-windows, integration-windows]
     permissions:
       contents: read

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -8,7 +8,7 @@ env:
 jobs:
   cache-deps:
     name: cache-deps (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read
@@ -30,7 +30,7 @@ jobs:
 
   lint:
     name: lint (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: cache-deps
 
     permissions:
@@ -65,7 +65,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        OS: [ubuntu-20.04, macos-latest]
+        OS: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.OS }}
     needs: cache-deps
 
@@ -89,7 +89,7 @@ jobs:
 
   unit-test-race-detector:
     name: unit-test (linux with race detection)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: cache-deps
 
     permissions:
@@ -112,7 +112,7 @@ jobs:
 
   artifacts:
     name: artifacts (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps]
 
     permissions:
@@ -145,7 +145,7 @@ jobs:
 
   images:
     name: images (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps]
 
     permissions:
@@ -208,7 +208,7 @@ jobs:
 
   integration:
     name: integration (linux)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [cache-deps, images]
 
     permissions:
@@ -465,7 +465,7 @@ jobs:
           path: ./artifacts/
 
   publish-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, lint-windows, unit-test-windows, artifact-windows, integration-windows]
     permissions:
       contents: write
@@ -491,7 +491,7 @@ jobs:
         run: gh release create "${GITHUB_REF#refs/tags/}" ./artifacts/*.zip ./artifacts/*.tar.gz ./artifacts/*.txt --title "${GITHUB_REF#refs/tags/}"
 
   publish-images:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, lint-windows, unit-test-windows, artifact-windows, integration-windows]
     permissions:
       contents: read

--- a/.github/workflows/scripts/split.sh
+++ b/.github/workflows/scripts/split.sh
@@ -18,7 +18,7 @@ for FILE in test/integration/suites/*; do
         job_set[$current_runner]+="${FILE##test/integration/} "
 
         ((current_runner++))
-        if [ $current_runner -gt "$NUM_RUNNERS" ]; then
+        if [ "$current_runner" -gt "$NUM_RUNNERS" ]; then
                 current_runner=1
         fi
 done

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:jammy
 WORKDIR /spire
 RUN apt-get update && apt-get -y install \
     curl unzip git build-essential ca-certificates libssl-dev


### PR DESCRIPTION
Ubuntu 22.04 is the latest LTS version supported by GitHub actions as a builtin runner type.

Also update the dev Dockerfile to be based on Ubuntu 22.04 Jammy, since it is currently using a really old version of Ubuntu (16.04) that is no longer supported.