### PR TITLE
Remove glob from .build in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.build*
+.build
 .cache
 .data
 .glide


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?

**Affected functionality**
Reduced scope of a `.gitignore` from `.build*` to `.build`

**Description of change**
Make it easier for SPIRE fork maintainers to keep buildkite scripting in `.buildkite` top-level dir of fork.
