### PR TITLE
Use Go from build directory in integration tests instead of requiring a Go installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,9 +306,9 @@ ifeq ($(os1), windows)
 	$(error Integration tests are not supported on windows)
 else ifeq (,$(filter $(arch2),arm64,aarch64))
 	# TODO: Remove this special handling of arm64 in 1.7.0
-	$(E)(export IGNORE_SUITES=suites/upgrade && ./test/integration/test.sh $(SUITES))
+	$(E)(export IGNORE_SUITES=suites/upgrade && $(go_path) ./test/integration/test.sh $(SUITES))
 else
-	$(E)./test/integration/test.sh $(SUITES)
+	$(E)$(go_path) ./test/integration/test.sh $(SUITES)
 endif
 
 integration-windows:


### PR DESCRIPTION
Some integration tests need to build Go programs.
If the PATH is not properly set to use Go from the SPIRE `.build` directory, it either fails because Go is not found in the system, or uses the Go from the system (which is not ideal since the targeted Go version for the SPIRE release should be used).
This PR fixes that in the Makefile.