### PR TITLE
Directly write the output of the hashing command into the file

### DIFF
--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -19,6 +19,7 @@ fi
 # handle the case that we're building for alpine
 if [ "$OS" = "linux" ]; then
     case $(ldd --version 2>&1) in
+        *GNU\ libc*) LIBC="-glibc" ;;
         *GLIB*) LIBC="-glibc" ;;
         *muslr*) LIBC="-musl" ;;
         *) LIBC="-unknown" ;;
@@ -76,13 +77,13 @@ if [ $OS == "windows" ]; then
     (cd "${TMPDIR}/spire"; zip -rv "${ARTIFACT}" -- *)
     (cd "${TMPDIR}/spire-extras"; zip -rv "${EXTRAS_ARTIFACT}" -- *)
 
-    echo "$(CertUtil -hashfile "${ARTIFACT}" SHA256 | sed -n '2p') $(basename "${ARTIFACT}")" > "${CHECKSUM}"
-    echo "$(CertUtil -hashfile "${EXTRAS_ARTIFACT}" SHA256 | sed -n '2p') $(basename "${EXTRAS_ARTIFACT}")" > "${EXTRAS_CHECKSUM}"
+    (cd "$(dirname "${ARTIFACT}")"; CertUtil -hashfile "$(basename "${ARTIFACT}")" SHA256 > "${CHECKSUM}")
+    (cd "$(dirname "${EXTRAS_ARTIFACT}")"; CertUtil -hashfile "$(basename "${EXTRAS_ARTIFACT}")" SHA256 > "${EXTRAS_CHECKSUM}")
 else 
     # Create the tarballs and checksums
     (cd "${TMPDIR}/spire"; tar -cvzf "${ARTIFACT}" "${TAROPTS[@]}" -- *)
     (cd "${TMPDIR}/spire-extras"; tar -cvzf "${EXTRAS_ARTIFACT}" "${TAROPTS[@]}" -- *)
 
-    echo "$(shasum -a 256 "${ARTIFACT}" | cut -d' ' -f1) $(basename "${ARTIFACT}")" > "${CHECKSUM}"
-    echo "$(shasum -a 256 "${EXTRAS_ARTIFACT}" | cut -d' ' -f1) $(basename "${EXTRAS_ARTIFACT}")" > "${EXTRAS_CHECKSUM}"
+    (cd "$(dirname "${ARTIFACT}")"; shasum -a 256 "$(basename "${ARTIFACT}")" > "${CHECKSUM}" )
+    (cd "$(dirname "${EXTRAS_ARTIFACT}")"; shasum -a 256 "$(basename "${EXTRAS_ARTIFACT}")" > "${EXTRAS_CHECKSUM}" )
 fi


### PR DESCRIPTION



**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
checksum file generation approach, output should be identical.

**Description of change**
Directly write the output of the hashing command into the checksum files.

This avoids the cut and pasting that we do to take the hash from the hashing algorithm and format it with the file from the trimmed full-file path.  It does so by opening a sub-shell, changing directory to the parent of the file to be hashed, generating the hash on the file name only (relative to the current working directory), and then writing the output to the checksum file.

This avoids the need to cut the hashing output to get the hash so we can then reconstruct the hash line with a file name lacking parent directories.  This will greatly improve the ability of the --check command to work, as now we don't alter the format of the sha256sum line.

**Which issue this PR fixes**
Fixes #4095

