### PR TITLE
Publish arm64 artifacts in release and PR builds for Linux

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -143,7 +143,7 @@ jobs:
           path: .build
           key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Build artifacts
-        run: ./.github/workflows/scripts/build_artifacts.sh
+        run: ./.github/workflows/scripts/build_artifacts.sh ${{ runner.os }}
       - name: Archive artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
@@ -460,7 +460,7 @@ jobs:
           install: >-
             git base-devel mingw-w64-x86_64-toolchain zip unzip
       - name: Build artifacts
-        run: ./.github/workflows/scripts/build_artifacts.sh
+        run: ./.github/workflows/scripts/build_artifacts.sh ${{ runner.os }}
       - name: Archive binaries
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -136,7 +136,7 @@ jobs:
           path: .build
           key: ${{ runner.os }}-tools-${{ hashFiles('.go-version','Makefile') }}
       - name: Build artifacts
-        run: ./.github/workflows/scripts/build_artifacts.sh
+        run: ./.github/workflows/scripts/build_artifacts.sh ${{ runner.os }}
       - name: Archive artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
@@ -452,7 +452,7 @@ jobs:
           install: >-
             git base-devel mingw-w64-x86_64-toolchain zip unzip
       - name: Build artifacts
-        run: ./.github/workflows/scripts/build_artifacts.sh
+        run: ./.github/workflows/scripts/build_artifacts.sh ${{ runner.os }}
       - name: Archive binaries
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:

--- a/.github/workflows/scripts/build_artifacts.sh
+++ b/.github/workflows/scripts/build_artifacts.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
+# Builds all SPIRE artifacts for all supported architectures for the provided operating system.
+# Usage: build_artifacts.sh <Linux|Windows|macOS>
 
 set -e
+
+usage() {
+    echo "usage: ${BASH_SOURCE[0]} <Linux|Windows|macOS>"
+    exit 1
+}
+
+[[ $# -eq 1 ]] || usage
+
+os="$1"
+declare -a supported_archs
+if [[ "${os}" == "Linux" ]] || [[ "${os}" == "macOS" ]]; then
+    supported_archs=(amd64 arm64)
+elif [[ "${os}" == "Windows" ]]; then
+    supported_archs=(amd64)
+else
+    echo "unrecognized OS: ${os}"
+    usage
+fi
 
 export TAG=
 if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9.]+$ ]]; then
@@ -11,4 +31,6 @@ if [[ "$GITHUB_REF" =~ ^refs/tags/v[0-9.]+$ ]]; then
 fi
 
 # Make references the $TAG environment variable set above
-make artifact
+for arch in ${supported_archs[@]}; do
+    GOARCH=$arch make artifact
+done

--- a/script/build-artifact.sh
+++ b/script/build-artifact.sh
@@ -9,7 +9,9 @@ TAG=${TAG:-$(git log -n1 --pretty=%h)}
 OUTDIR=${OUTDIR:-"${REPODIR}/artifacts"}
 
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
+
+# If GOARCH is already set in the environment, use it, otherwise default to local architecture.
+[ -z "${GOARCH}" ] && ARCH=$(uname -m) || ARCH="${GOARCH}"
 
 # change OS name to windows
 if [[ "$OS" == msys_nt-10.0-* ]] || [[ "$OS" == mingw64_nt-10.0-* ]]; then


### PR DESCRIPTION
The project started publishing release Docker images for Linux arm64 starting in SPIRE v1.6.0, but the Linux release binary artifacts were still only generated for amd64 architecture.

Publish binary artifacts in releases for Linux arm64 to provide consistent architecture support for both binaries and Docker images. Also build and publish the Linux arm64 artifacts on PR builds to prevent breaking changes for this platform from being merged into the project.

**Which issue this PR fixes**
#4083

