### PR TITLE
Prepare v1.6.4 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.6.4] - 2023-05-17
+
+### Added
+
+- ARM64 binaries are now included in the release artifacts (#4143)
+- Various build script improvements (#4062, #4081, #4096, #4127)
+- Various doc improvements (#4076)
+- Workload API hint support (#3993, #4074)
+- Improved performance when listing queries for PostgreSQL (#4111)
+- Support for SPIFFE bundle sequence numbers (#4061)
+- New Systemd Workload Attestor plugin (#4058)
+- New [BundlePublisher](https://github.com/spiffe/spire-plugin-sdk/blob/v1.6.4/proto/spire/plugin/server/bundlepublisher/v1/bundlepublisher.proto) plugin type (#4022)
+- New `agent purge` command for removing stale agent records (#3982)
+
+### Fixed
+
+- Bug determining if an entry was unique (#4063)
+
 ## [1.6.3] - 2023-04-12
 
 ### Added


### PR DESCRIPTION
Omitted the following PRs that are not user facing:

4085	Version bump after v1.6.3 release
4052	Update go directive in go.mod to 1.20
4045	Use go spiffe types server unit
4070	Use latest version of github.com/gofrs/uuid
4094	Resolve envoy IT issues
4112	Upgrade cosign v2:
4104	SPIRE agent knows to reattest if SVID has CanReattest set 4055	Use Go from build directory in integration tests instead of requiring a Go installation

Note that the link to the BundlePublisher will not be available until we've cut the release tags.
