### PR TITLE
Fix flaky AttestAgent tests

### DIFF
--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -1484,12 +1484,14 @@ func TestGetAgent(t *testing.T) {
 		},
 		{
 			name: "success - with mask",
-			req: &agentv1.GetAgentRequest{Id: &types.SPIFFEID{TrustDomain: "example.org", Path: "/spire/agent/agent-1"},
+			req: &agentv1.GetAgentRequest{
+				Id: &types.SPIFFEID{TrustDomain: "example.org", Path: "/spire/agent/agent-1"},
 				OutputMask: &types.AgentMask{
 					AttestationType:      true,
 					X509SvidExpiresAt:    true,
 					X509SvidSerialNumber: true,
-				}},
+				},
+			},
 			agent: &types.Agent{
 				Id:                   expectedAgents[agent1].Id,
 				AttestationType:      expectedAgents[agent1].AttestationType,
@@ -1510,8 +1512,10 @@ func TestGetAgent(t *testing.T) {
 		},
 		{
 			name: "success - with all false mask",
-			req: &agentv1.GetAgentRequest{Id: &types.SPIFFEID{TrustDomain: "example.org", Path: "/spire/agent/agent-1"},
-				OutputMask: &types.AgentMask{}},
+			req: &agentv1.GetAgentRequest{
+				Id:         &types.SPIFFEID{TrustDomain: "example.org", Path: "/spire/agent/agent-1"},
+				OutputMask: &types.AgentMask{},
+			},
 			agent: &types.Agent{
 				Id: expectedAgents[agent1].Id,
 			},
@@ -1832,7 +1836,8 @@ func TestRenewAgent(t *testing.T) {
 					Level:   logrus.ErrorLevel,
 					Message: "Invalid argument: failed to parse CSR",
 					Data: logrus.Fields{
-						logrus.ErrorKey: malformedError.Error()},
+						logrus.ErrorKey: malformedError.Error(),
+					},
 				},
 				{
 					Level:   logrus.InfoLevel,
@@ -2211,7 +2216,6 @@ func TestAttestAgent(t *testing.T) {
 		rateLimiterErr    error
 		dsError           []error
 	}{
-
 		{
 			name:       "empty request",
 			request:    &agentv1.AttestAgentRequest{},
@@ -2517,6 +2521,25 @@ func TestAttestAgent(t *testing.T) {
 			expectMsg:  "failed to attest: join token does not exist or has already been used",
 			expectLogs: []spiretest.LogEntry{
 				{
+					Level:   logrus.InfoLevel,
+					Message: "Agent attestation request completed",
+					Data: logrus.Fields{
+						telemetry.Address:          "",
+						telemetry.AgentID:          "spiffe://example.org/spire/agent/join_token/test_token",
+						telemetry.NodeAttestorType: "join_token",
+					},
+				},
+				{
+					Level:   logrus.InfoLevel,
+					Message: "API accessed",
+					Data: logrus.Fields{
+						telemetry.AgentID:          "spiffe://example.org/spire/agent/join_token/test_token",
+						telemetry.Status:           "success",
+						telemetry.Type:             "audit",
+						telemetry.NodeAttestorType: "join_token",
+					},
+				},
+				{
 					Level:   logrus.ErrorLevel,
 					Message: "Invalid argument: failed to attest: join token does not exist or has already been used",
 					Data: logrus.Fields{
@@ -2576,6 +2599,25 @@ func TestAttestAgent(t *testing.T) {
 				{Type: "test_type", Value: "result"},
 			},
 			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "Agent attestation request completed",
+					Data: logrus.Fields{
+						telemetry.AgentID:          "spiffe://example.org/spire/agent/test_type/id_with_result",
+						telemetry.NodeAttestorType: "test_type",
+						telemetry.Address:          "",
+					},
+				},
+				{
+					Level:   logrus.InfoLevel,
+					Message: "API accessed",
+					Data: logrus.Fields{
+						telemetry.Status:           "success",
+						telemetry.Type:             "audit",
+						telemetry.AgentID:          "spiffe://example.org/spire/agent/test_type/id_with_result",
+						telemetry.NodeAttestorType: "test_type",
+					},
+				},
 				{
 					Level:   logrus.InfoLevel,
 					Message: "Agent attestation request completed",
@@ -3065,12 +3107,8 @@ func TestAttestAgent(t *testing.T) {
 						e.Data[telemetry.Address] = ""
 					}
 				}
-				if tt.retry {
-					// Prevent cases where audit logs from previous calls are pushed after log is reset
-					spiretest.AssertLastLogs(t, test.logHook.AllEntries(), tt.expectLogs)
-				} else {
-					spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectLogs)
-				}
+
+				spiretest.AssertLogsAnyOrder(t, test.logHook.AllEntries(), tt.expectLogs)
 			}()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -3097,8 +3135,6 @@ func TestAttestAgent(t *testing.T) {
 				// make sure that the first request went well
 				require.NoError(t, err)
 				require.NotNil(t, result)
-				// clear entries from the previous run
-				test.logHook.Reset()
 
 				// attest once more
 				stream, err = test.client.AttestAgent(ctx)
@@ -3368,7 +3404,8 @@ func attest(t *testing.T, stream agentv1.Agent_AttestAgentClient, request *agent
 			request = &agentv1.AttestAgentRequest{
 				Step: &agentv1.AttestAgentRequest_ChallengeResponse{
 					ChallengeResponse: challenge,
-				}}
+				},
+			}
 
 			continue
 		}


### PR DESCRIPTION
There is some asynchrony to how gRPC handles Postprocess interceptor callbacks for bi-directional streaming APIs that results in race conditions around when audit log messages are emitted by the audit log middleware. This causes a lot of flakiness of ordering of log messages received and the sequencing of when those audit logs are received by the test logrus hook when the tests are run on CI. Resetting the entries received by the logger hook in-between calls to AttestAgent in the test is not enough to work around this asynchrony.

Rather than depending on the logs to come in a specific order and timeframe, instead match all the expected log messages from the gRPC server in any order rather than just the ones from the last call to AttestAgent.

Fixes #3716

