### PR TITLE
Run upgrade integration test on arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,9 +308,6 @@ endif
 integration:
 ifeq ($(os1), windows)
 	$(error Integration tests are not supported on windows)
-else ifeq (,$(filter $(arch2),arm64,aarch64))
-	# TODO: Remove this special handling of arm64 in 1.7.0
-	$(E)(export IGNORE_SUITES=suites/upgrade && $(go_path) ./test/integration/test.sh $(SUITES))
 else
 	$(E)$(go_path) ./test/integration/test.sh $(SUITES)
 endif


### PR DESCRIPTION
The upgrade test couldn't run on arm64 until v1.7.0 because it relies on the release Docker images from the previous minor release series to all be available for arm64. The project started publishing Docker release images for arm64 starting in v1.6.0, so this test can be re-enabled for arm64 architecture now.