### PR TITLE
Accelerate JSON processing in k8s workload attestation

### DIFF
--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -173,7 +173,6 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 }
 
 func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
-	starttime := time.Now()
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
@@ -206,20 +205,20 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 		}
 
 		var parser fastjson.Parser
-		podList, err := parser.Parse(string(list))
+		podList, err := parser.ParseBytes(*list)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to parse kubelet response: %v", err)
 		}
 
 		var attestResponse *workloadattestorv1.AttestResponse
-		for itemIndex, item := range podList.GetArray("items") {
-			uid := strings.Trim(fmt.Sprintf("%s", podList.Get("items", strconv.Itoa(itemIndex), "metadata", "uid")), "\"")
+		for itemIndex, _ := range podList.GetArray("items") {
+			uid := strings.Trim(string(podList.GetStringBytes("items", strconv.Itoa(itemIndex), "metadata", "uid")), "\"")
 			if podKnown && uid != string(podUID) {
 				// The pod holding the container is known. Skip unrelated pods.
 				continue
 			}
 			pod := new(corev1.Pod)
-			if err := json.Unmarshal([]byte(fmt.Sprintf("%s", item)), pod); err != nil {
+			if err := json.Unmarshal(podList.GetObject("items", strconv.Itoa(itemIndex)).MarshalTo(nil), &pod); err != nil {
 				return nil, status.Errorf(codes.Internal, "unable to decode pod info from kubelet response: %v", err)
 			}
 
@@ -252,8 +251,6 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 		}
 
 		if attestResponse != nil {
-			// fixme.ethsve Remove after test
-			fmt.Println("Duration of the successful attestation:", time.Since(starttime))
 			return attestResponse, nil
 		}
 
@@ -564,7 +561,7 @@ type kubeletClient struct {
 	Token     string
 }
 
-func (c *kubeletClient) GetPodList() ([]byte, error) {
+func (c *kubeletClient) GetPodList() (*[]byte, error) {
 	url := c.URL
 	url.Path = "/pods"
 	req, err := http.NewRequest("GET", url.String(), nil)
@@ -593,7 +590,7 @@ func (c *kubeletClient) GetPodList() ([]byte, error) {
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to read pods response: %v", err)
 	}
-	return out, nil
+	return &out, nil
 }
 
 func lookUpContainerInPod(containerID string, status corev1.PodStatus, log hclog.Logger) (*corev1.ContainerStatus, bool) {

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/valyala/fastjson"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -172,6 +173,7 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 }
 
 func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestRequest) (*workloadattestorv1.AttestResponse, error) {
+	starttime := time.Now()
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
@@ -203,23 +205,33 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 			return nil, err
 		}
 
+		var parser fastjson.Parser
+		podList, err := parser.Parse(string(list))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "unable to parse kubelet response: %v", err)
+		}
+
 		var attestResponse *workloadattestorv1.AttestResponse
-		for _, item := range list.Items {
-			item := item
-			if podKnown && item.UID != podUID {
+		for itemIndex, item := range podList.GetArray("items") {
+			uid := strings.Trim(fmt.Sprintf("%s", podList.Get("items", strconv.Itoa(itemIndex), "metadata", "uid")), "\"")
+			if podKnown && uid != string(podUID) {
 				// The pod holding the container is known. Skip unrelated pods.
 				continue
+			}
+			pod := new(corev1.Pod)
+			if err := json.Unmarshal([]byte(fmt.Sprintf("%s", item)), pod); err != nil {
+				return nil, status.Errorf(codes.Internal, "unable to decode pod info from kubelet response: %v", err)
 			}
 
 			var selectorValues []string
 
-			containerStatus, containerFound := lookUpContainerInPod(containerID, item.Status, log)
+			containerStatus, containerFound := lookUpContainerInPod(containerID, pod.Status, log)
 			switch {
 			case containerFound:
 				// The workload container was found in this pod. Add pod
 				// selectors. Only add workload container selectors if
 				// container selectors have not been disabled.
-				selectorValues = append(selectorValues, getSelectorValuesFromPodInfo(&item)...)
+				selectorValues = append(selectorValues, getSelectorValuesFromPodInfo(pod)...)
 				if !config.DisableContainerSelectors {
 					selectorValues = append(selectorValues, getSelectorValuesFromWorkloadContainerStatus(containerStatus)...)
 				}
@@ -227,7 +239,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 				// The workload container was not found (i.e. not ready yet?)
 				// but the pod is known. If container selectors have been
 				// disabled, then allow the pod selectors to be used.
-				selectorValues = append(selectorValues, getSelectorValuesFromPodInfo(&item)...)
+				selectorValues = append(selectorValues, getSelectorValuesFromPodInfo(pod)...)
 			}
 
 			if len(selectorValues) > 0 {
@@ -240,6 +252,8 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 		}
 
 		if attestResponse != nil {
+			// fixme.ethsve Remove after test
+			fmt.Println("Duration of the successful attestation:", time.Since(starttime))
 			return attestResponse, nil
 		}
 
@@ -550,7 +564,7 @@ type kubeletClient struct {
 	Token     string
 }
 
-func (c *kubeletClient) GetPodList() (*corev1.PodList, error) {
+func (c *kubeletClient) GetPodList() ([]byte, error) {
 	url := c.URL
 	url.Path = "/pods"
 	req, err := http.NewRequest("GET", url.String(), nil)
@@ -575,11 +589,10 @@ func (c *kubeletClient) GetPodList() (*corev1.PodList, error) {
 		return nil, status.Errorf(codes.Internal, "unexpected status code on pods response: %d %s", resp.StatusCode, tryRead(resp.Body))
 	}
 
-	out := new(corev1.PodList)
-	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to decode kubelet response: %v", err)
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to read pods response: %v", err)
 	}
-
 	return out, nil
 }
 


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
K8s workload attestation

**Description of change**
List of pods is read as an array of bytes from the kubelet's JSON response without decoding all to the PodList structure.
This is parsed by [fastjson](https://github.com/valyala/fastjson) which is way faster than the standard JSON library's function.
If the pod's UID is found in the parsed JSON then only that pod's data will be decoded into a pod structure instead of the whole pod list. For this reason the standard JSON library is used that helps to keep the changes as small as possible and most of the code untouched, however the improvement of the attestation speed is still significant.

According to my measurements the attestation with this change takes only 25-35% in average of the reference figures with the original k8s workload attestation.


**Which issue this PR fixes**
Fixes #3957