### PR TITLE
Clamp bundle refresh interval to a maximum

### DIFF
--- a/pkg/common/bundleutil/refreshhint.go
+++ b/pkg/common/bundleutil/refreshhint.go
@@ -13,6 +13,10 @@ const (
 	// MinimumRefreshHint is the smallest refresh hint the client allows.
 	// Anything smaller than the minimum will be reset to the minimum.
 	MinimumRefreshHint = time.Minute
+
+	// MaximumRefreshHint is the maximum refresh hint the client allows.
+	// Anything larger than the maximum will be reset to the maximum.
+	MaximumRefreshHint = 10 * time.Minute
 )
 
 // CalculateRefreshHint is used to calculate the refresh hint for a given
@@ -50,6 +54,9 @@ func CalculateRefreshHint(bundle *spiffebundle.Bundle) time.Duration {
 func safeRefreshHint(refreshHint time.Duration) time.Duration {
 	if refreshHint < MinimumRefreshHint {
 		return MinimumRefreshHint
+	}
+	if refreshHint > MaximumRefreshHint {
+		return MaximumRefreshHint
 	}
 	return refreshHint
 }


### PR DESCRIPTION
The refresh hint for a trust domain is useful to know when we expect to see updates to the bundle on a standard schedule, but there are situations where we get updates more often, for example when a spire-server doesn't have any available key (e.g. the first time it's started) and needs to create a new one and start using it immediately.

Because of this it's useful to clamp the refresh hint to a maxium so we can learn about those keys sooner rather than later.

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
fixes #4297

