### PR TITLE
Bump generated test certificate TTLs to 1 hour

### DIFF
--- a/test/integration/setup/x509pop/gencerts.go
+++ b/test/integration/setup/x509pop/gencerts.go
@@ -22,7 +22,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	notAfter := time.Now().Add(time.Minute * 10)
+	notAfter := time.Now().Add(time.Hour)
 
 	caKey := generateKey()
 	caCert := createRootCertificate(caKey, &x509.Certificate{
@@ -74,7 +74,7 @@ func writeKey(path string, key crypto.Signer) {
 		Type:  "PRIVATE KEY",
 		Bytes: keyBytes,
 	})
-	writeFile(path, pemBytes, 0600)
+	writeFile(path, pemBytes, 0o600)
 }
 
 func writeCerts(path string, certs ...*x509.Certificate) {
@@ -86,7 +86,7 @@ func writeCerts(path string, certs ...*x509.Certificate) {
 		})
 		checkErr(err)
 	}
-	writeFile(path, data.Bytes(), 0644)
+	writeFile(path, data.Bytes(), 0o644)
 }
 
 func writeFile(path string, data []byte, mode os.FileMode) {


### PR DESCRIPTION
Tests relying on these certs have been seen to fail due to the certs expiring during the test run when run in GitHub infrastructure. Increase the cert TTL to be more accommodating to longer-running tests and test environments where there may be larger clock skew out of our control.