### PR TITLE
Ignore patch updates for GCP SDK modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     versions: ["2.x"]
   - dependency-name: "github.com/aws/aws-sdk-go-v2*"
     update-types: ["version-update:semver-patch"]
+  - dependency-name: "cloud.google.com/go/*"
+    update-types: ["version-update:semver-patch"]
   open-pull-requests-limit: 5
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
GCP SDK modules update quite frequently, but we don't usually make many changes to the GCP plugins that require SDK updates. We want to stay relatively up-to-date, but it is very rare that we need a specific feature/fix from a patch update. Updating to each new patch version is time consuming from a maintenance standpoint, with little to no benefit.

We already do this for AWS SDK modules, which have a similar cadence of updates.