### PR TITLE
Fix: only one of trust_bundle_path, trust_bundle_url, or insecure_bootstrap can be set

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -233,11 +233,21 @@ func (c *agentConfig) validate() error {
 		return errors.New("trust_domain must be configured")
 	}
 
+	// If insecure_bootstrap is set, trust_bundle_path or trust_bundle_url cannot be set
 	// If trust_bundle_url is set, download the trust bundle using HTTP and parse it from memory
 	// If trust_bundle_path is set, parse the trust bundle file on disk
 	// Both cannot be set
 	// The trust bundle URL must start with HTTPS
-	if c.TrustBundlePath == "" && c.TrustBundleURL == "" && !c.InsecureBootstrap {
+	if c.InsecureBootstrap {
+		switch {
+		case c.TrustBundleURL != "" && c.TrustBundlePath != "":
+			return errors.New("only one of insecure_bootstrap, trust_bundle_url, or trust_bundle_path can be specified, not the three options")
+		case c.TrustBundleURL != "":
+			return errors.New("only one of insecure_bootstrap or trust_bundle_url can be specified, not both")
+		case c.TrustBundlePath != "":
+			return errors.New("only one of insecure_bootstrap or trust_bundle_path can be specified, not both")
+		}
+	} else if c.TrustBundlePath == "" && c.TrustBundleURL == "" {
 		return errors.New("trust_bundle_path or trust_bundle_url must be configured unless insecure_bootstrap is set")
 	}
 


### PR DESCRIPTION
@mnp reported in issue #4530  that it was possible to set trust_bundle_url and insecure_bootstrap in the Agent configuration. There was a test for this case. However, the test was just checking if there was an error. There was an error but not the expected one. This commit also adds expectErrorContains to the test case struct so tests can check the expected error message. Also, more tests added.

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
SPIRE Agent config validation.

**Description of change**
Now, the validation code checks when the insecure bootstrap option is used with trust bundle config options and returns proper error messages. Tests were updated.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
#4530
