### PR TITLE
[spire-agent] Added a jitter in spire agent svid renewal

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -442,7 +442,7 @@ func TestSVIDRotation(t *testing.T) {
 	// Now advance time enough that the cert is expiring soon enough that the
 	// manager will attempt to rotate, but be unable to since the read lock is
 	// held.
-	clk.Add(baseTTLSeconds / 2)
+	clk.Add(baseTTLSeconds)
 
 	closer := runManager(t, m)
 	defer closer()
@@ -1292,7 +1292,7 @@ func TestFetchJWTSVID(t *testing.T) {
 	require.Equal(t, expiresAtA, svid.ExpiresAt.Unix())
 
 	// expire the cached JWT soon and make sure new JWT is fetched
-	clk.Add(time.Second * 30)
+	clk.Add(time.Second * 45)
 	now = clk.Now()
 	tokenC := "C"
 	issuedAtC := now.Unix()

--- a/pkg/common/rotationutil/rotationutil_test.go
+++ b/pkg/common/rotationutil/rotationutil_test.go
@@ -29,6 +29,14 @@ func TestShouldRotateX509(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, ShouldRotateX509(mockClk.Now(), badCert))
+
+	// Cert that's already expired
+	temp.NotBefore = mockClk.Now().Add(-1 * time.Hour)
+	temp.NotAfter = mockClk.Now().Add(-1 * time.Minute)
+	badCert, _, err = util.SelfSign(temp)
+	require.NoError(t, err)
+
+	assert.True(t, ShouldRotateX509(mockClk.Now(), badCert))
 }
 
 func TestX509Expired(t *testing.T) {


### PR DESCRIPTION
Introduces a jitter to the renewal of SVIDs in spire-agent which will allow a more uniform distribution of requests to spire-server rather than thundering herds at the same time.

https://github.com/spiffe/spire/issues/4268 