### PR TITLE
Fix documentation for agent KeyManager "disk"

### DIFF
--- a/doc/plugin_agent_keymanager_disk.md
+++ b/doc/plugin_agent_keymanager_disk.md
@@ -13,7 +13,7 @@ A sample configuration:
 ```hcl
     KeyManager "disk" {
         plugin_data = {
-            keys_path = "/opt/spire/data/server/keys.json"
+            directory = "/opt/spire/data/agent"
         }
     }
 ```


### PR DESCRIPTION
Text of the documentation was correct, but the example was for the server KeyManager "disk".