### PR TITLE
server/plugins/azure: use the default credentials API

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -313,7 +313,8 @@ plugins {
     #         # plugin reside.
     #         # key_vault_uri = "https://spire-server.vault.azure.net/"
     #
-    #         # use_msi: Whether or not to use MSI to authenticate to
+    #         # use_msi: Deprecated and will be removed in a future release; will be used implicitly if other mechanisms to authenticate fail.
+    #         # Whether or not to use MSI to authenticate to
     #         # Azure Key Vault. Mutually exclusive with
     #         # tenant_id, subscription_id, app_id, and app_secret.
     #         # use_msi = false
@@ -379,7 +380,8 @@ plugins {
     #                 # ID are rejected. Default: https://management.azure.com/
     #                 # resource_id = "https://management.azure.com/"
 
-    #                 # use_msi: Whether or not to use MSI to authenticate to
+    #                 # use_msi: Deprecated and will be removed in a future release; will be used implicitly if other mechanisms to authenticate fail.
+    #                 # Whether or not to use MSI to authenticate to
     #                 # Azure services. Mutually exclusive with
     #                 # subscription_id, app_id, and app_secret.
     #                 # use_msi = false

--- a/doc/plugin_server_keymanager_azure_key_vault.md
+++ b/doc/plugin_server_keymanager_azure_key_vault.md
@@ -14,7 +14,7 @@ The plugin accepts the following configuration options:
 |-------------------|---------|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | key_metadata_file | string  | yes                                         | A file path location where key metadata used by the plugin will be persisted. See "[Management of keys](#management-of-keys)" for more information. | ""      |
 | key_vault_uri     | string  | Yes                                         | The Key Vault URI where the keys managed by this plugin reside.                                                                                     | ""      |
-| use_msi           | boolean | [Optional](#authenticating-to-azure)        | Whether or not to use MSI to authenticate to Azure Key Vault.                                                                                       | false   |
+| use_msi           | boolean | [Deprecated](#authenticating-to-azure)        | Whether or not to use MSI to authenticate to Azure Key Vault.                                                                                       | false   |
 | subscription_id   | string  | [Optional](#authenticating-to-azure)        | The subscription id.                                                                                                                                | ""      |
 | app_id            | string  | [Optional](#authenticating-to-azure)        | The application id.                                                                                                                                 | ""      |
 | app_secret        | string  | [Optional](#authenticating-to-azure)        | The application secret.                                                                                                                             | ""      |
@@ -22,10 +22,15 @@ The plugin accepts the following configuration options:
 
 ### Authenticating to Azure
 
-This plugin can be configured to either authenticate with an MSI token
-(`use_msi`) or credentials for an application registered within the tenant
-(`tenant_id`,`subscription_id`, `app_id`, and `app_secret`). The SPIRE Server must be running
-in an Azure VM when authenticating with an MSI token.
+By default, the plugin will attempt to use the application default credential by
+using the [DefaultAzureCredential API](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#section-readme).
+The `DefaultAzureCredential API` attempts to authenticate via the following mechanisms in order -
+environment variables, Workload Identity, and Managed Identity; stopping when once succeeds.
+When using Workload Identity or Managed Identity, the plugin must be able to fetch the credential for the configured
+tenant ID, or else the attestation of nodes using this attestor will fail.
+
+Alternatively, the plugin can be configured to use static credentials for an application
+registered within the tenant (`subscription_id`, `app_id`, and `app_secret`).
 
 ### Use of key versions
 

--- a/doc/plugin_server_nodeattestor_azure_msi.md
+++ b/doc/plugin_server_nodeattestor_azure_msi.md
@@ -27,7 +27,7 @@ Each tenant in the main configuration supports the following
 | Configuration     | Required                             | Description                                                                                               | Default                         |
 |-------------------|--------------------------------------|-----------------------------------------------------------------------------------------------------------|---------------------------------|
 | `resource_id`     | Optional                             | The resource ID (or audience) for the tenant's MSI token. Tokens for a different resource ID are rejected | <https://management.azure.com/> |
-| `use_msi`         | [Optional](#authenticating-to-azure) | Whether or not to use MSI to authenticate to Azure services for selector resolution.                      | false                           |
+| `use_msi`         | [Deprecated](#authenticating-to-azure) | Whether or not to use MSI to authenticate to Azure services for selector resolution.                      | false                           |
 | `subscription_id` | [Optional](#authenticating-to-azure) | The subscription the tenant resides in                                                                    |                                 |
 | `app_id`          | [Optional](#authenticating-to-azure) | The application id                                                                                        |                                 |
 | `app_secret`      | [Optional](#authenticating-to-azure) | The application secret                                                                                    |                                 |
@@ -41,10 +41,15 @@ MSI token for resources it does not know about.
 This plugin requires credentials to authenticate with Azure in order to inquire
 about properties of the attesting node and produce selectors.
 
-Each tenant can be configured to either authenticate with an MSI token
-(`use_msi`) or credentials for an application registered within the tenant
-(`subscription_id`, `app_id`, and `app_secret`). The SPIRE Server must reside
-in the same tenant when authenticating with an MSI token.
+By default, the plugin will attempt to use the application default credential by
+using the [DefaultAzureCredential API](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/azidentity#section-readme).
+The `DefaultAzureCredential API` attempts to authenticate via the following mechanisms in order -
+environment variables, Workload Identity, and Managed Identity; stopping when once succeeds.
+When using Workload Identity or Managed Identity, the plugin must be able to fetch the credential for the configured
+tenant ID, or else the attestation of nodes using this attestor will fail.
+
+Alternatively, the plugin can be configured to use static credentials for an application
+registered within the tenant (`subscription_id`, `app_id`, and `app_secret`).
 
 For backwards compatibility reasons the authentication configuration is *NOT*
 required, however, it will be in a future release.

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
@@ -79,11 +79,14 @@ type pluginHooks struct {
 type Config struct {
 	KeyMetadataFile string `hcl:"key_metadata_file" json:"key_metadata_file"`
 	KeyVaultURI     string `hcl:"key_vault_uri" json:"key_vault_uri"`
-	UseMSI          bool   `hcl:"use_msi" json:"use_msi"`
 	TenantID        string `hcl:"tenant_id" json:"tenant_id"`
 	SubscriptionID  string `hcl:"subscription_id" json:"subscription_id"`
 	AppID           string `hcl:"app_id" json:"app_id"`
 	AppSecret       string `hcl:"app_secret" json:"app_secret"`
+
+	// Deprecated: use_msi is deprecated and will be removed in a future release.
+	// Will be used implicitly if other mechanisms to authenticate fail.
+	UseMSI bool `hcl:"use_msi" json:"use_msi"`
 }
 
 // Plugin is the main representation of this keymanager plugin

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
@@ -121,8 +121,6 @@ func TestConfigure(t *testing.T) {
 		{
 			name:             "missing client authentication config",
 			configureRequest: configureRequestWithVars(createKeyMetadataFile(t), validKeyVaultURI, "", "", "", "", "false"),
-			err:              "either MSI (use_msi) must be set to true or app authentication (tenant_id, subscription_id, app_id and app_secret) must be set",
-			code:             codes.InvalidArgument,
 		},
 		{
 			name:             "use MSI while app secret is set",
@@ -998,7 +996,7 @@ func configureRequestWithString(config string) *configv1.ConfigureRequest {
 func createKeyMetadataFile(t *testing.T) string {
 	tempDir := t.TempDir()
 	tempFilePath := filepath.ToSlash(filepath.Join(tempDir, validServerIDFile))
-	err := os.WriteFile(tempFilePath, []byte(validServerID), 0600)
+	err := os.WriteFile(tempFilePath, []byte(validServerID), 0o600)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/server/plugin/nodeattestor/azuremsi/msi.go
+++ b/pkg/server/plugin/nodeattestor/azuremsi/msi.go
@@ -100,7 +100,7 @@ type MSIAttestorPlugin struct {
 		keySetProvider        jwtutil.KeySetProvider
 		newClient             func(string, azcore.TokenCredential) (apiClient, error)
 		fetchInstanceMetadata func(azure.HTTPClient) (*azure.InstanceMetadata, error)
-		msiCredential         func() (azcore.TokenCredential, error)
+		fetchCredential       func(string) (azcore.TokenCredential, error)
 	}
 }
 
@@ -112,9 +112,14 @@ func New() *MSIAttestorPlugin {
 	p.hooks.keySetProvider = jwtutil.NewCachingKeySetProvider(jwtutil.OIDCIssuer(azureOIDCIssuer), keySetRefreshInterval)
 	p.hooks.newClient = newAzureClient
 	p.hooks.fetchInstanceMetadata = azure.FetchInstanceMetadata
-	p.hooks.msiCredential = func() (azcore.TokenCredential, error) {
-		return azidentity.NewManagedIdentityCredential(nil)
+	p.hooks.fetchCredential = func(tenantID string) (azcore.TokenCredential, error) {
+		return azidentity.NewDefaultAzureCredential(
+			&azidentity.DefaultAzureCredentialOptions{
+				TenantID: tenantID,
+			},
+		)
 	}
+
 	return p
 }
 
@@ -203,11 +208,9 @@ func (p *MSIAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 	}
 
 	var selectorValues []string
-	if tenant.client != nil {
-		selectorValues, err = p.resolve(stream.Context(), tenant.client, claims.PrincipalID)
-		if err != nil {
-			return err
-		}
+	selectorValues, err = p.resolve(stream.Context(), tenant.client, claims.PrincipalID)
+	if err != nil {
+		return err
 	}
 
 	return stream.Send(&nodeattestorv1.AttestResponse{
@@ -277,26 +280,29 @@ func (p *MSIAttestorPlugin) Configure(_ context.Context, req *configv1.Configure
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "unable to create client for tenant %q: %v", tenantID, err)
 			}
+
 		case tenant.UseMSI:
+			p.log.Warn("use_msi is deprecated and will be removed in a future release")
+			fallthrough // use default credential which attempts to fetch credentials using MSI
+
+		default:
 			instanceMetadata, err := p.hooks.fetchInstanceMetadata(http.DefaultClient)
 			if err != nil {
 				return nil, err
 			}
-			cred, err := p.hooks.msiCredential()
+			cred, err := p.hooks.fetchCredential(tenantID)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "unable to get MSI credential: %v", err)
+				return nil, status.Errorf(codes.Internal, "unable to fetch client credential: %v", err)
 			}
 			client, err = p.hooks.newClient(instanceMetadata.Compute.SubscriptionID, cred)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "unable to create client with MSI credential: %v", err)
+				return nil, status.Errorf(codes.Internal, "unable to create client with default credential: %v", err)
 			}
 		}
 
 		// If credentials are not configured then selectors won't be gathered.
-		// TODO: make this an error condition in a future release
 		if client == nil {
-			p.log.Warn("No client credentials available for tenant. Selectors will not be produced by the node attestor for this node. This will be an error in a future release.",
-				"tenant", tenantID)
+			return nil, status.Errorf(codes.Internal, "no client credentials available for tenant %q", tenantID)
 		}
 
 		tenants[tenantID] = &tenantConfig{

--- a/pkg/server/plugin/nodeattestor/azuremsi/msi.go
+++ b/pkg/server/plugin/nodeattestor/azuremsi/msi.go
@@ -63,10 +63,13 @@ func builtin(p *MSIAttestorPlugin) catalog.BuiltIn {
 
 type TenantConfig struct {
 	ResourceID     string `hcl:"resource_id" json:"resource_id"`
-	UseMSI         bool   `hcl:"use_msi" json:"use_msi"`
 	SubscriptionID string `hcl:"subscription_id" json:"subscription_id"`
 	AppID          string `hcl:"app_id" json:"app_id"`
 	AppSecret      string `hcl:"app_secret" json:"app_secret"`
+
+	// Deprecated: use_msi is deprecated and will be removed in a future release.
+	// Will be used implicitly if other mechanisms to authenticate fail.
+	UseMSI bool `hcl:"use_msi" json:"use_msi"`
 }
 
 type MSIAttestorConfig struct {


### PR DESCRIPTION
Uses the NewDefaultAzureCredential API to fetch
client credentials. This API wraps different
mechanisms to obtain credentials using a chained
token credential mechanism. By doing so, the Azure plugins are able to obtain a token using any of the supported mechanisms: env vars, MSI, workload identity, without needing separate config input for each.

This is a part of #4485 to enable obtaining API tokens using Azure workload identity.

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?


