### PR TITLE
Doc: Fix typo in example JSON on plugin docs

### DIFF
--- a/doc/plugin_agent_svidstore_aws_secretsmanager.md
+++ b/doc/plugin_agent_svidstore_aws_secretsmanager.md
@@ -10,7 +10,7 @@ The format that is used to store in a secret the issued identity is the followin
 {
     "spiffeId": "spiffe://example.org",
     "x509Svid": "X509_CERT_CHAIN_PEM",
-    "x509SvidKey": "PRIVATE_KET_PEM",
+    "x509SvidKey": "PRIVATE_KEY_PEM",
     "bundle": "X509_BUNDLE_PEM",
     "federatedBundles": {
         "spiffe://federated.org": "X509_FEDERATED_BUNDLE_PEM"

--- a/doc/plugin_agent_svidstore_gcp_secretmanager.md
+++ b/doc/plugin_agent_svidstore_gcp_secretmanager.md
@@ -10,7 +10,7 @@ The format that is used to store in a secret the issued identity is the followin
 {
     "spiffeId": "spiffe://example.org",
     "x509Svid": "X509_CERT_CHAIN_PEM",
-    "x509SvidKey": "PRIVATE_KET_PEM",
+    "x509SvidKey": "PRIVATE_KEY_PEM",
     "bundle": "X509_BUNDLE_PEM",
     "federatedBundles": {
         "spiffe://federated.org": "X509_FEDERATED_BUNDLE_PEM"


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [X] Documentation updated?

**Description of change**
Fixes a typo in SVID Store documentation examples.


