### PR TITLE
Group k8s.io/* dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,15 +10,18 @@ updates:
     aws-sdk:
       patterns:
         - "github.com/aws/aws-sdk-go-v2/*"
-    google-cloud-sdk:
-      patterns:
-        - "cloud.google.com/go/*"
-    sigs.k8s.io:
-      patterns:
-        - "sig.k8s.io/*"
     azure-sdk:
       patterns:
         - "github.com/Azure/azure-sdk-for-go/*"
+    google-cloud-sdk:
+      patterns:
+        - "cloud.google.com/go/*"
+    k8s.io:
+      patterns:
+        - "k8s.io/*"
+    sigs.k8s.io:
+      patterns:
+        - "sig.k8s.io/*"
   ignore:
   - dependency-name: "github.com/spiffe/spire-api-sdk"
   - dependency-name: "github.com/spiffe/spire-plugin-sdk"


### PR DESCRIPTION
The Kubernetes client libraries prefixed by `k8s.io/*` follow the same versioning scheme. Have them be upgraded in unison to minimize overhead of merging each individual dep bump.

Also alphabetize the dependabot dependency groups.
