### PR TITLE
oidc-discovery-provider support expose the serivce on https

### DIFF
--- a/conf/server/oidc-provider.conf
+++ b/conf/server/oidc-provider.conf
@@ -1,0 +1,11 @@
+log_level = "debug"
+log_path = "/tmp/oidc.log"
+
+domains = ["localhost"]
+listen_tls_addr = ":8188"
+svid_ttl = "24h"
+
+server_api {
+   address = "unix:///tmp/spire-server/private/api.sock"
+   spiffe_id = "spiffe://example.org/oidc-provider"
+}

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -203,6 +203,18 @@ workload_api {
 }
 ```
 
+#### Server API and Listen TLS address
+
+```hcl
+log_level = "debug"
+domains = ["mypublicdomain.test"]
+listen_tls_addr = ":8081"
+server_api {
+    address = "unix:///tmp/spire-server/private/api.sock"
+    spiffe_id = "spiffe://example.org/oidc-provider"
+}
+```
+
 #### Listening on a Unix Socket
 
 The following configuration has the OIDC Discovery Provider listen for requests

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -41,6 +41,7 @@ The configuration file is **required** by the provider. It contains
 | `insecure_addr`         | string  | optional\[3\]      | Exposes the service on http.                                           |          |
 | `set_key_use`           | bool    | optional           | If true, the `use` parameter on JWKs will be set to `sig`.             | `false`  |
 | `listen_socket_path`    | string  | required\[1\]\[3\] | Path on disk to listen with a Unix Domain Socket. Unix platforms only. |          |
+| `listen_tls_addr`       | string  | required\[1\]      | Exposee the service on https with certificates minted by ServerAPI.    |          |
 | `log_format`            | string  | optional           | Format of the logs (either `"TEXT"` or `"JSON"`)                       | `""`     |
 | `log_level`             | string  | required           | Log level (one of `"error"`,`"warn"`,`"info"`,`"debug"`)               | `"info"` |
 | `log_path`              | string  | optional           | Path on disk to write the log.                                         |          |
@@ -57,13 +58,13 @@ The configuration file is **required** by the provider. It contains
 
 #### Considerations for Unix platforms
 
-[1]: One of `acme`, `serving_cert_file` or `listen_socket_path` must be defined.
+[1]: One of `acme`, `listen_tls_addr`, `serving_cert_file` or `listen_socket_path` must be defined.
 
 [3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_socket_path`.
 
 #### Considerations for Windows platforms
 
-[1]: One of `acme`, `serving_cert_file` or `listen_named_pipe_name` must be defined.
+[1]: One of `acme`, `listen_tls_addr`,`serving_cert_file` or `listen_named_pipe_name` must be defined.
 
 [3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
 

--- a/support/oidc-discovery-provider/config.go
+++ b/support/oidc-discovery-provider/config.go
@@ -50,6 +50,12 @@ type Config struct {
 	// going to be deployed behind an HTTPS proxy.
 	InsecureAddr string `hcl:"insecure_addr"`
 
+	// ListenTLSAddr is the HTTPS address. When set, the server does not
+	// perform ACME to obtain certificates. Instead, the server mint x509
+	// svid from ServerAPI and use certificates in x509 svid to serve.
+	// When ListenTLSAddr is set, ServerAPI must be set.
+	ListenTLSAddr string `hcl:"listen_tls_addr"`
+
 	// ListenSocketPath specifies a unix socket to listen for plaintext HTTP
 	// on, for when deployed behind another webserver or sidecar.
 	ListenSocketPath string `hcl:"listen_socket_path"`
@@ -216,6 +222,12 @@ func ParseConfig(hclConfig string) (_ *Config, err error) {
 			return nil, errs.New("tos_accepted must be set to true in the acme configuration section")
 		case c.ACME.Email == "":
 			return nil, errs.New("email must be configured in the acme configuration section")
+		}
+	}
+
+	if c.ListenTLSAddr != "" {
+		if c.ServerAPI == nil {
+			return nil, errs.New("listen_tls_addr require using server_api instead of workload_api")
 		}
 	}
 

--- a/support/oidc-discovery-provider/config_posix_test.go
+++ b/support/oidc-discovery-provider/config_posix_test.go
@@ -307,12 +307,12 @@ func parseConfigCasesOS() []parseConfigCase {
 		{
 			name: "both listen_tls_addr and insecure_addr configured",
 			in: `
-				spiffe_id = "spiffe://example.org/oidc-provider"
 				domains = ["domain.test"]
 				insecure_addr = ":8080"
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and insecure_addr are mutually exclusive",
@@ -320,12 +320,12 @@ func parseConfigCasesOS() []parseConfigCase {
 		{
 			name: "both listen_tls_addr and listen_socket_path configured",
 			in: `
-				spiffe_id = "spiffe://example.org/oidc-provider"
 				domains = ["domain.test"]
 				listen_socket_path = "test"
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and listen_socket_path are mutually exclusive",
@@ -341,6 +341,7 @@ func parseConfigCasesOS() []parseConfigCase {
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and serving_cert_file are mutually exclusive",
@@ -356,6 +357,7 @@ func parseConfigCasesOS() []parseConfigCase {
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and acme are mutually exclusive",
@@ -364,15 +366,23 @@ func parseConfigCasesOS() []parseConfigCase {
 			name: "listen_tls_addr with workload_api configured",
 			in: `
 				domains = ["domain.test"]
-				acme {
-					email = "admin@domain.test"
-					tos_accepted = true
-				}
 				listen_tls_addr = ":8081"
 
 				workload_api { socket_path = "/some/socket/path" trust_domain="foo.test" }
 			`,
 			err: "listen_tls_addr require using server_api instead of workload_api",
+		},
+		{
+			name: "listen_tls_addr and server_api configured without spiffe_id",
+			in: `
+				domains = ["domain.test"]
+				listen_tls_addr = ":8081"
+
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "spiffe_id must be set",
 		},
 		{
 			name: "with insecure addr and key use",

--- a/support/oidc-discovery-provider/config_posix_test.go
+++ b/support/oidc-discovery-provider/config_posix_test.go
@@ -50,7 +50,7 @@ func parseConfigCasesOS() []parseConfigCase {
 					socket_path = "/other/socket/path"
 				}
 			`,
-			err: "either acme, serving_cert_file, insecure_addr or listen_socket_path must be configured",
+			err: "either acme, listen_tls_addr, serving_cert_file, insecure_addr or listen_socket_path must be configured",
 		},
 		{
 			name: "ACME ToS not accepted",
@@ -303,6 +303,76 @@ func parseConfigCasesOS() []parseConfigCase {
 				}
 			`,
 			err: "serving_cert_file and listen_socket_path are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and insecure_addr configured",
+			in: `
+				spiffe_id = "spiffe://example.org/oidc-provider"
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and insecure_addr are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and listen_socket_path configured",
+			in: `
+				spiffe_id = "spiffe://example.org/oidc-provider"
+				domains = ["domain.test"]
+				listen_socket_path = "test"
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and listen_socket_path are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and serving_cert_file configured",
+			in: `
+				domains = ["domain.test"]
+				serving_cert_file {
+					cert_file_path = "test"
+					key_file_path = "test"
+				}
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and serving_cert_file are mutually exclusive",
+		},
+		{
+			name: "both acme and listen_tls_addr configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and acme are mutually exclusive",
+		},
+		{
+			name: "listen_tls_addr with workload_api configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				listen_tls_addr = ":8081"
+
+				workload_api { socket_path = "/some/socket/path" trust_domain="foo.test" }
+			`,
+			err: "listen_tls_addr require using server_api instead of workload_api",
 		},
 		{
 			name: "with insecure addr and key use",

--- a/support/oidc-discovery-provider/config_windows_test.go
+++ b/support/oidc-discovery-provider/config_windows_test.go
@@ -58,7 +58,7 @@ func parseConfigCasesOS() []parseConfigCase {
 					}					
 				}
 			`,
-			err: "either acme, serving_cert_file, insecure_addr or listen_named_pipe_name must be configured",
+			err: "either acme, listen_tls_addr, serving_cert_file, insecure_addr or listen_named_pipe_name must be configured",
 		},
 		{
 			name: "ACME ToS not accepted",
@@ -277,6 +277,64 @@ func parseConfigCasesOS() []parseConfigCase {
 				}
 			`,
 			err: "listen_named_pipe_name and the acme section are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and insecure_addr configured",
+			in: `
+				spiffe_id = "spiffe://example.org/oidc-provider"
+				domains = ["domain.test"]
+				insecure_addr = ":8080"
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and insecure_addr are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and listen_named_pipe_name configured",
+			in: `
+				spiffe_id = "spiffe://example.org/oidc-provider"
+				domains = ["domain.test"]
+				experimental {
+					listen_named_pipe_name = "test"
+				}
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and listen_named_pipe_name are mutually exclusive",
+		},
+		{
+			name: "both listen_tls_addr and serving_cert_file configured",
+			in: `
+				domains = ["domain.test"]
+				serving_cert_file {
+					cert_file_path = "test"
+					key_file_path = "test"
+				}
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and serving_cert_file are mutually exclusive",
+		},
+		{
+			name: "both acme and listen_tls_addr configured",
+			in: `
+				domains = ["domain.test"]
+				acme {
+					email = "admin@domain.test"
+					tos_accepted = true
+				}
+				listen_tls_addr = ":8081"
+				server_api {
+					socket_path = "/other/socket/path"
+				}
+			`,
+			err: "listen_tls_addr and acme are mutually exclusive",
 		},
 		{
 			name: "both acme and serving_cert_file configured",

--- a/support/oidc-discovery-provider/config_windows_test.go
+++ b/support/oidc-discovery-provider/config_windows_test.go
@@ -281,12 +281,12 @@ func parseConfigCasesOS() []parseConfigCase {
 		{
 			name: "both listen_tls_addr and insecure_addr configured",
 			in: `
-				spiffe_id = "spiffe://example.org/oidc-provider"
 				domains = ["domain.test"]
 				insecure_addr = ":8080"
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and insecure_addr are mutually exclusive",
@@ -294,7 +294,6 @@ func parseConfigCasesOS() []parseConfigCase {
 		{
 			name: "both listen_tls_addr and listen_named_pipe_name configured",
 			in: `
-				spiffe_id = "spiffe://example.org/oidc-provider"
 				domains = ["domain.test"]
 				experimental {
 					listen_named_pipe_name = "test"
@@ -302,6 +301,7 @@ func parseConfigCasesOS() []parseConfigCase {
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and listen_named_pipe_name are mutually exclusive",
@@ -317,6 +317,7 @@ func parseConfigCasesOS() []parseConfigCase {
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and serving_cert_file are mutually exclusive",
@@ -332,6 +333,7 @@ func parseConfigCasesOS() []parseConfigCase {
 				listen_tls_addr = ":8081"
 				server_api {
 					socket_path = "/other/socket/path"
+					spiffe_id = "spiffe://example.org/oidc-provider"
 				}
 			`,
 			err: "listen_tls_addr and acme are mutually exclusive",

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -175,6 +175,9 @@ func newSource(log logrus.FieldLogger, config *Config) (JWKSSource, error) {
 			Log:          log,
 			GRPCTarget:   config.getServerAPITargetName(),
 			PollInterval: config.ServerAPI.PollInterval,
+			DNSNames:     config.Domains,
+			SVIDTTL:      config.ServerAPI.SVIDTTL,
+			SPIFFEID:     config.ServerAPI.SPIFFEID,
 		})
 	case config.WorkloadAPI != nil:
 		workloadAPIAddr, err := config.getWorkloadAPIAddr()

--- a/support/oidc-discovery-provider/main_posix.go
+++ b/support/oidc-discovery-provider/main_posix.go
@@ -22,8 +22,8 @@ func (c *Config) getServerAPITargetName() string {
 // validateOS performs os specific validations of the configuration
 func (c *Config) validateOS() (err error) {
 	switch {
-	case c.ACME == nil && c.ListenSocketPath == "" && c.ServingCertFile == nil && c.InsecureAddr == "":
-		return errs.New("either acme, serving_cert_file, insecure_addr or listen_socket_path must be configured")
+	case c.ListenTLSAddr == "" && c.ACME == nil && c.ListenSocketPath == "" && c.ServingCertFile == nil && c.InsecureAddr == "":
+		return errs.New("either acme, listen_tls_addr, serving_cert_file, insecure_addr or listen_socket_path must be configured")
 	case c.ACME != nil && c.ServingCertFile != nil:
 		return errs.New("acme and serving_cert_file are mutually exclusive")
 	case c.ACME != nil && c.ListenSocketPath != "":
@@ -36,6 +36,14 @@ func (c *Config) validateOS() (err error) {
 		return errs.New("acme and insecure_addr are mutually exclusive")
 	case c.InsecureAddr != "" && c.ListenSocketPath != "":
 		return errs.New("insecure_addr and listen_socket_path are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.ACME != nil:
+		return errs.New("listen_tls_addr and acme are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.InsecureAddr != "":
+		return errs.New("listen_tls_addr and insecure_addr are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.ListenSocketPath != "":
+		return errs.New("listen_tls_addr and listen_socket_path are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.ServingCertFile != nil:
+		return errs.New("listen_tls_addr and serving_cert_file are mutually exclusive")
 	}
 
 	if c.ServerAPI != nil {

--- a/support/oidc-discovery-provider/main_windows.go
+++ b/support/oidc-discovery-provider/main_windows.go
@@ -24,8 +24,8 @@ func (c *Config) getServerAPITargetName() string {
 // validateOS performs os specific validations of the configuration
 func (c *Config) validateOS() (err error) {
 	switch {
-	case c.ACME == nil && c.Experimental.ListenNamedPipeName == "" && c.ServingCertFile == nil && c.InsecureAddr == "":
-		return errs.New("either acme, serving_cert_file, insecure_addr or listen_named_pipe_name must be configured")
+	case c.ListenTLSAddr == "" && c.ACME == nil && c.Experimental.ListenNamedPipeName == "" && c.ServingCertFile == nil && c.InsecureAddr == "":
+		return errs.New("either acme, listen_tls_addr, serving_cert_file, insecure_addr or listen_named_pipe_name must be configured")
 	case c.ACME != nil && c.ServingCertFile != nil:
 		return errs.New("acme and serving_cert_file are mutually exclusive")
 	case c.ACME != nil && c.Experimental.ListenNamedPipeName != "":
@@ -38,6 +38,14 @@ func (c *Config) validateOS() (err error) {
 		return errs.New("serving_cert_file and listen_named_pipe_name are mutually exclusive")
 	case c.InsecureAddr != "" && c.Experimental.ListenNamedPipeName != "":
 		return errs.New("insecure_addr and listen_named_pipe_name are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.ACME != nil:
+		return errs.New("listen_tls_addr and acme are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.InsecureAddr != "":
+		return errs.New("listen_tls_addr and insecure_addr are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.Experimental.ListenNamedPipeName != "":
+		return errs.New("listen_tls_addr and listen_named_pipe_name are mutually exclusive")
+	case c.ListenTLSAddr != "" && c.ServingCertFile != nil:
+		return errs.New("listen_tls_addr and serving_cert_file are mutually exclusive")
 	}
 	if c.ServerAPI != nil {
 		if c.ServerAPI.Experimental.NamedPipeName == "" {

--- a/support/oidc-discovery-provider/server_api.go
+++ b/support/oidc-discovery-provider/server_api.go
@@ -2,13 +2,23 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
+	"errors"
+	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	bundlev1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1"
+	svidv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/svid/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/util"
 	"github.com/zeebo/errs"
@@ -19,13 +29,25 @@ import (
 
 const (
 	DefaultServerAPIPollInterval = time.Second * 10
+	// DefaultServerSVIDTTL is zero indicates the default SVID TTL is determined
+	// by the Spire server instead of oidc-provider
+	DefaultServerSVIDTTL = 0
+)
+
+var (
+	_ JWKSSource        = &ServerAPISource{}
+	_ x509svid.Source   = &ServerAPISource{}
+	_ x509bundle.Source = &ServerAPISource{}
 )
 
 type ServerAPISourceConfig struct {
 	Log          logrus.FieldLogger
 	GRPCTarget   string
 	PollInterval time.Duration
+	SVIDTTL      time.Duration
 	Clock        clock.Clock
+	DNSNames     []string
+	SPIFFEID     string
 }
 
 type ServerAPISource struct {
@@ -33,17 +55,31 @@ type ServerAPISource struct {
 	clock  clock.Clock
 	cancel context.CancelFunc
 
-	mu       sync.RWMutex
-	wg       sync.WaitGroup
-	bundle   *types.Bundle
-	jwks     *jose.JSONWebKeySet
-	modTime  time.Time
-	pollTime time.Time
+	mu         sync.RWMutex
+	wg         sync.WaitGroup
+	conn       *grpc.ClientConn
+	bundle     *types.Bundle
+	x509bundle *x509bundle.Bundle
+	jwks       *jose.JSONWebKeySet
+	mint       *x509svid.SVID
+	modTime    time.Time
+	pollTime   time.Time
+	expireAt   time.Time
+	rotatedAt  time.Time
+
+	dnsNames []string
+	interval time.Duration
+	svidTTL  time.Duration
+	spiffeid spiffeid.ID
 }
 
 func NewServerAPISource(config ServerAPISourceConfig) (*ServerAPISource, error) {
+	var id spiffeid.ID
 	if config.PollInterval <= 0 {
 		config.PollInterval = DefaultServerAPIPollInterval
+	}
+	if config.SVIDTTL <= 0 {
+		config.SVIDTTL = DefaultServerSVIDTTL
 	}
 	if config.Clock == nil {
 		config.Clock = clock.New()
@@ -54,11 +90,23 @@ func NewServerAPISource(config ServerAPISourceConfig) (*ServerAPISource, error) 
 		return nil, errs.Wrap(err)
 	}
 
+	if config.SPIFFEID != "" {
+		id, err = spiffeid.FromString(config.SPIFFEID)
+		if err != nil {
+			return nil, errs.Wrap(err)
+		}
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &ServerAPISource{
-		log:    config.Log,
-		clock:  config.Clock,
-		cancel: cancel,
+		log:      config.Log,
+		clock:    config.Clock,
+		cancel:   cancel,
+		conn:     conn,
+		dnsNames: config.DNSNames,
+		interval: config.PollInterval,
+		svidTTL:  config.SVIDTTL,
+		spiffeid: id,
 	}
 
 	go s.pollEvery(ctx, conn, config.PollInterval)
@@ -68,6 +116,7 @@ func NewServerAPISource(config ServerAPISourceConfig) (*ServerAPISource, error) 
 func (s *ServerAPISource) Close() error {
 	s.cancel()
 	s.wg.Wait()
+	s.conn.Close()
 	return nil
 }
 
@@ -90,12 +139,12 @@ func (s *ServerAPISource) pollEvery(ctx context.Context, conn *grpc.ClientConn, 
 	s.wg.Add(1)
 	defer s.wg.Done()
 
-	defer conn.Close()
-	client := bundlev1.NewBundleClient(conn)
+	bundle := bundlev1.NewBundleClient(conn)
+	svid := svidv1.NewSVIDClient(conn)
 
 	s.log.WithField("interval", interval).Debug("Polling started")
 	for {
-		s.pollOnce(ctx, client)
+		s.pollOnce(ctx, bundle, svid)
 		select {
 		case <-ctx.Done():
 			s.log.WithError(ctx.Err()).Debug("Polling done")
@@ -105,14 +154,15 @@ func (s *ServerAPISource) pollEvery(ctx context.Context, conn *grpc.ClientConn, 
 	}
 }
 
-func (s *ServerAPISource) pollOnce(ctx context.Context, client bundlev1.BundleClient) {
+func (s *ServerAPISource) pollOnce(ctx context.Context, client bundlev1.BundleClient, svid svidv1.SVIDClient) {
 	// Ensure the stream gets cleaned up
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	bundle, err := client.GetBundle(ctx, &bundlev1.GetBundleRequest{
 		OutputMask: &types.BundleMask{
-			JwtAuthorities: true,
+			JwtAuthorities:  true,
+			X509Authorities: true,
 		},
 	})
 	if err != nil {
@@ -124,6 +174,14 @@ func (s *ServerAPISource) pollOnce(ctx context.Context, client bundlev1.BundleCl
 	s.mu.Lock()
 	s.pollTime = s.clock.Now()
 	s.mu.Unlock()
+
+	if s.needMintX509SVID() {
+		if err := s.mintX509SVID(ctx, svid, s.spiffeid, s.dnsNames, s.svidTTL); err != nil {
+			s.log.WithError(err).Warn("Failed to mint x509 svid")
+			return
+		}
+		s.log.WithField("id", s.spiffeid).WithField("dnsNames", s.dnsNames).WithField("ttl", s.svidTTL).Info("Minted x509 svid")
+	}
 }
 
 func (s *ServerAPISource) parseBundle(bundle *types.Bundle) {
@@ -149,9 +207,163 @@ func (s *ServerAPISource) parseBundle(bundle *types.Bundle) {
 		})
 	}
 
+	var x509b *x509bundle.Bundle
+	td, err := spiffeid.TrustDomainFromString(bundle.TrustDomain)
+	if err != nil {
+		s.log.WithError(err).WithField("trustdomain", bundle.TrustDomain).Warn("Malformed trustdomain in bundle")
+	} else {
+		x509b = x509bundle.New(td)
+		for _, au := range bundle.X509Authorities {
+			cert, err := x509.ParseCertificates(au.Asn1)
+			if err != nil {
+				s.log.WithError(err).WithField("trustdomain", bundle.TrustDomain).Warn("Malformed certificate in bundle")
+				continue
+			}
+
+			for _, c := range cert {
+				x509b.AddX509Authority(c)
+			}
+		}
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.bundle = bundle
+	s.x509bundle = x509b
 	s.jwks = jwks
 	s.modTime = s.clock.Now()
+}
+
+func (s *ServerAPISource) needMintX509SVID() bool {
+	var lifetime time.Duration
+	var expiresIn time.Duration
+
+	if s.spiffeid.IsZero() {
+		return false
+	}
+
+	if !s.rotatedAt.IsZero() {
+		lifetime = s.expireAt.Sub(s.rotatedAt)
+		expiresIn = s.expireAt.Sub(s.clock.Now())
+	}
+
+	var reason string
+	switch {
+	case s.mint == nil:
+		reason = "initializing"
+	case lifetime == 0:
+		reason = "initializing"
+	case expiresSoon(lifetime, expiresIn):
+		reason = "expires soon"
+	case expiresIn < 0:
+		reason = "has expired"
+	default:
+		return false
+	}
+
+	s.log.WithField("reason", reason).WithField("dnsNames", s.dnsNames).Info("Need mint x509 svid")
+	return true
+}
+
+func (s *ServerAPISource) mintX509SVID(ctx context.Context, client svidv1.SVIDClient, mintID spiffeid.ID, dnsNames []string, ttl time.Duration) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("failed to generate X509-SVID private key: %w", err)
+	}
+
+	csr, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		DNSNames: dnsNames,
+		URIs:     []*url.URL{mintID.URL()},
+	}, key)
+	if err != nil {
+		return fmt.Errorf("failed to create X509-SVID CSR: %w", err)
+	}
+
+	resp, err := client.MintX509SVID(ctx, &svidv1.MintX509SVIDRequest{
+		Csr: csr,
+		Ttl: int32(ttl.Seconds()),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to mint X509-SVID: %w", err)
+	}
+
+	if resp.Svid == nil {
+		return errors.New("no X509-SVID in response")
+	}
+
+	td, err := spiffeid.TrustDomainFromString(resp.Svid.Id.TrustDomain)
+	if err != nil {
+		return fmt.Errorf("invalid trust domain in response ID: %w", err)
+	}
+
+	id, err := spiffeid.FromPath(td, resp.Svid.Id.Path)
+	if err != nil {
+		return fmt.Errorf("invalid SPIFFE ID in response: %w", err)
+	}
+
+	var certChain []*x509.Certificate
+	for _, certDER := range resp.Svid.CertChain {
+		cert, err := x509.ParseCertificate(certDER)
+		if err != nil {
+			return fmt.Errorf("invalid certificate in response: %w", err)
+		}
+		certChain = append(certChain, cert)
+	}
+	if len(certChain) == 0 {
+		return errors.New("no certificates in response")
+	}
+
+	svid := &x509svid.SVID{
+		ID:           id,
+		PrivateKey:   key,
+		Certificates: certChain,
+	}
+	expireAt := certChain[0].NotAfter
+
+	for i, c := range certChain {
+		s.log.WithField("Subject", c.Subject.String()).WithField("Issuer", c.Issuer.String()).Debugf("Minted x509 svid cert %d", i)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mint = svid
+	s.expireAt = expireAt
+	s.rotatedAt = s.clock.Now()
+	return nil
+}
+
+func (s *ServerAPISource) GetX509SVID() (*x509svid.SVID, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.mint == nil {
+		return nil, errors.New("X509 SVID is not ready")
+	}
+	return s.mint, nil
+}
+
+func (s *ServerAPISource) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.x509bundle == nil {
+		return nil, errors.New("X509 Bundle is not ready")
+	}
+	return s.x509bundle, nil
+}
+
+func expiresSoon(lifetime, expiresIn time.Duration) bool {
+	const day = time.Hour * 24
+	const week = day * 7
+	const monthish = day * 30
+	switch {
+	case lifetime > monthish:
+		return expiresIn < week
+	case lifetime > week:
+		return expiresIn < (week / 2)
+	case lifetime > day:
+		return expiresIn < (day / 2)
+	case lifetime > time.Hour:
+		return expiresIn < (time.Hour / 2)
+	default:
+		return expiresIn < (lifetime / 2)
+	}
 }


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ *] Commit conforms to CONTRIBUTING.md?
- [ *] Proper tests/regressions included?
- [ *] Documentation updated?

**Affected functionality**
oidc-discovery-provider can expose the service on https. The service use certificates minted by ServerAPI to serve TLS connections.

**Description of change**
Add a new configuration option listen_tls_addr.
When  listen_tls_addr, use a x509svid to subscribe the minted x509 SVID and use the certificates in x509 SVID to serve TLS requests.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

**Quickstart example**

Start a local Spire server

```
./bin/spire-server run -config conf/server/server.conf
```

Start a local OIDC-provider to connect with Spire server and expose OIDC service.

```
./bin/oidc-discovery-provider  -config conf/server/oidc-provider.conf
```

Access the  OIDC service locally.
``` 
curl https://localhost:8188/.well-known/openid-configuration --cacert ./conf/server/dummy_upstream_ca.crt 
```

``` json
{
  "issuer": "https://localhost:8188",
  "jwks_uri": "https://localhost:8188/keys",
  "authorization_endpoint": "",
  "response_types_supported": [
    "id_token"
  ],
  "subject_types_supported": [],
  "id_token_signing_alg_values_supported": [
    "RS256",
    "ES256",
    "ES384"
  ]
}
```


