### PR TITLE
Fix Windows integration test to check for RUNNING service state also

### DIFF
--- a/test/integration/suites-windows/windows-service/common
+++ b/test/integration/suites-windows/windows-service/common
@@ -62,5 +62,5 @@ stop-service() {
 start-service(){
   log-info "starting $1 service..."
   docker-compose exec -T -u ContainerAdministrator "$1" \
-      sc start "$@" | grep -wq  "START_PENDING" || fail-now "failed to start $2 service"
+      sc start "$@" | grep -wq  "START_PENDING\|RUNNING" || fail-now "failed to start $2 service"
 }


### PR DESCRIPTION
We are checking for the `START_PENDING` status in the check, but maybe it started fast enough to be already in the `RUNNING` state. This is causing the integration test to fail intermittently.
Update the script to check for both states.