### PR TITLE
Pin docker/dockerfile:1.6.0 with multi-platform sha256

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.6.0@sha256:657fcc512c7369f4cb3d94ea329150f8daf626bc838b1a1e81f1834c73ecc77e
+# syntax = docker/dockerfile:1.6.0@sha256:ac85f380a63b13dfcefa89046420e1781752bab202122f8f50032edf31be0021
 
 # Build stage
 ARG goversion


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Docker build on platforms other than linux/amd64

**Description of change**
Set docker/dockerfile:1.6.0 sha256 to the multi-platform manifest instead of referencing the linux/amd64 version.
Cf. "crane digest docker/dockerfile:1.6.0" vs "crane digest --platform linux/amd64 docker/dockerfile:1.6.0"

**Which issue this PR fixes**
https://github.com/spiffe/spire/issues/4765
