### PR TITLE
Fix SyncAuthorizedEntries test race

### DIFF
--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -3190,7 +3190,6 @@ func TestSyncAuthorizedEntries(t *testing.T) {
 			name: "no caller id",
 			steps: []step{
 				{
-					req:  &entryv1.SyncAuthorizedEntriesRequest{},
 					err:  "caller ID missing from request context",
 					code: codes.Internal,
 				},
@@ -3217,7 +3216,6 @@ func TestSyncAuthorizedEntries(t *testing.T) {
 			name: "fetcher fails",
 			steps: []step{
 				{
-					req:  &entryv1.SyncAuthorizedEntriesRequest{},
 					err:  "failed to fetch entries",
 					code: codes.Internal,
 				},


### PR DESCRIPTION
The SyncAuthorizedEntries test is set up to optionally send a request, depending on the expectations of the test case. The "no caller ID" and "fetcher fails" test cases are currently set up to send the request on the stream. However, in these instances, the handler exits before reading the request off the stream due to the respective expected failures. Timing conditions still allowed the requests to be sent successfully most of the time but caused intermittent failures, particularly when being run in resource constrained environments (e.g. GH actions).

This change fixes the test cases by not attempting to send the request on the stream.

