### PR TITLE
Fix racy tests that test streaming RPCs

### DIFF
--- a/test/spiretest/apiserver.go
+++ b/test/spiretest/apiserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -52,6 +53,39 @@ func newAPIServer(tb testing.TB, registerFn func(s *grpc.Server), server *grpc.S
 		}
 	}
 	return conn, done
+}
+
+type DrainHandlerMiddleware struct {
+	wg sync.WaitGroup
+}
+
+func NewDrainHandlerMiddleware() *DrainHandlerMiddleware {
+	return &DrainHandlerMiddleware{}
+}
+
+func (m *DrainHandlerMiddleware) Wait() {
+	m.wg.Wait()
+}
+
+func (m *DrainHandlerMiddleware) Preprocess(ctx context.Context, fullMethod string, req any) (context.Context, error) {
+	m.wg.Add(1)
+	return ctx, nil
+}
+
+func (m *DrainHandlerMiddleware) Postprocess(ctx context.Context, fullMethod string, handlerInvoked bool, rpcErr error) {
+	m.wg.Done()
+}
+
+func (m *DrainHandlerMiddleware) UnaryServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+	m.wg.Add(1)
+	defer m.wg.Done()
+	return handler(ctx, req)
+}
+
+func (m *DrainHandlerMiddleware) StreamServerInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	m.wg.Add(1)
+	defer m.wg.Done()
+	return handler(srv, ss)
 }
 
 func unaryInterceptor(fn func(ctx context.Context) context.Context) func(context.Context, any, *grpc.UnaryServerInfo, grpc.UnaryHandler) (any, error) {

--- a/test/spiretest/apiserver.go
+++ b/test/spiretest/apiserver.go
@@ -67,22 +67,22 @@ func (m *DrainHandlerMiddleware) Wait() {
 	m.wg.Wait()
 }
 
-func (m *DrainHandlerMiddleware) Preprocess(ctx context.Context, fullMethod string, req any) (context.Context, error) {
+func (m *DrainHandlerMiddleware) Preprocess(ctx context.Context, _ string, _ any) (context.Context, error) {
 	m.wg.Add(1)
 	return ctx, nil
 }
 
-func (m *DrainHandlerMiddleware) Postprocess(ctx context.Context, fullMethod string, handlerInvoked bool, rpcErr error) {
+func (m *DrainHandlerMiddleware) Postprocess(ctx context.Context, _ string, _ bool, _ error) {
 	m.wg.Done()
 }
 
-func (m *DrainHandlerMiddleware) UnaryServerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+func (m *DrainHandlerMiddleware) UnaryServerInterceptor(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	m.wg.Add(1)
 	defer m.wg.Done()
 	return handler(ctx, req)
 }
 
-func (m *DrainHandlerMiddleware) StreamServerInterceptor(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func (m *DrainHandlerMiddleware) StreamServerInterceptor(srv any, ss grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	m.wg.Add(1)
 	defer m.wg.Done()
 	return handler(srv, ss)

--- a/test/spiretest/apiserver.go
+++ b/test/spiretest/apiserver.go
@@ -72,7 +72,7 @@ func (m *DrainHandlerMiddleware) Preprocess(ctx context.Context, _ string, _ any
 	return ctx, nil
 }
 
-func (m *DrainHandlerMiddleware) Postprocess(ctx context.Context, _ string, _ bool, _ error) {
+func (m *DrainHandlerMiddleware) Postprocess(context.Context, string, bool, error) {
 	m.wg.Done()
 }
 


### PR DESCRIPTION
Adds middleware to tests that ensures that all handlers have finished before the test asserts properties about the stream.