### PR TITLE
Do not use read-replicas for initial events-based cache load

### DIFF
--- a/pkg/server/endpoints/authorized_entryfetcher.go
+++ b/pkg/server/endpoints/authorized_entryfetcher.go
@@ -211,7 +211,7 @@ func buildRegistrationEntriesCache(ctx context.Context, ds datastore.DataStore, 
 	var token string
 	for {
 		resp, err := ds.ListRegistrationEntries(ctx, &datastore.ListRegistrationEntriesRequest{
-			DataConsistency: datastore.TolerateStale,
+			DataConsistency: datastore.RequireCurrent, // preliminary loading should not be done via read-replicas
 			Pagination: &datastore.Pagination{
 				Token:    token,
 				PageSize: pageSize,


### PR DESCRIPTION
For consistency sake, the initial state should be loaded from the main database instance and not from read replicas.