### PR TITLE
Fix the typo in the spire agent readme

### DIFF
--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -99,7 +99,7 @@ Only one of these three options may be set at a time.
 
 ### Profiling Names
 
-These are the available profiles that can be set in the `profiling_freq` configuration value:
+These are the available profiles that can be set in the `profiling_names` configuration value:
 
 - `goroutine`
 - `threadcreate`

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -109,7 +109,7 @@ This may be useful for templating configuration files, for example across differ
 
 ### Profiling Names
 
-These are the available profiles that can be set in the `profiling_freq` configuration value:
+These are the available profiles that can be set in the `profiling_names` configuration value:
 
 - `goroutine`
 - `threadcreate`


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

When I was trying to enable profiling for an investigation I realized this `profiling_names` session has a confusing statement. Hence I filed the issue https://github.com/spiffe/spire/issues/4884 and spin up this PR to get it fixed.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
https://github.com/spiffe/spire/issues/4884
