### PR TITLE
Use --silent for make go-bin-path invocation

### DIFF
--- a/test/integration/test-one.sh
+++ b/test/integration/test-one.sh
@@ -17,7 +17,7 @@ REPODIR=$(git rev-parse --show-toplevel)
 
 # Set and export the PATH to one that includes a go binary installed by the
 # Makefile, if necessary.
-PATH=$(cd "${REPODIR}" || exit; make go-bin-path)
+PATH=$(cd "${REPODIR}" || exit; make --silent go-bin-path)
 export PATH
 
 log-info "running \"${TESTNAME}\" test suite..."


### PR DESCRIPTION
Running integration tests is completely failing for me because PATH is overwritten to an invalid string (make[1] Entering ...).
