### PR TITLE
Move db event config items out of the experimental section.

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -62,28 +62,31 @@ type Config struct {
 }
 
 type serverConfig struct {
-	AdminIDs           []string           `hcl:"admin_ids"`
-	AgentTTL           string             `hcl:"agent_ttl"`
-	AuditLogEnabled    bool               `hcl:"audit_log_enabled"`
-	BindAddress        string             `hcl:"bind_address"`
-	BindPort           int                `hcl:"bind_port"`
-	CAKeyType          string             `hcl:"ca_key_type"`
-	CASubject          *caSubjectConfig   `hcl:"ca_subject"`
-	CATTL              string             `hcl:"ca_ttl"`
-	DataDir            string             `hcl:"data_dir"`
-	DefaultX509SVIDTTL string             `hcl:"default_x509_svid_ttl"`
-	DefaultJWTSVIDTTL  string             `hcl:"default_jwt_svid_ttl"`
-	Experimental       experimentalConfig `hcl:"experimental"`
-	Federation         *federationConfig  `hcl:"federation"`
-	JWTIssuer          string             `hcl:"jwt_issuer"`
-	JWTKeyType         string             `hcl:"jwt_key_type"`
-	LogFile            string             `hcl:"log_file"`
-	LogLevel           string             `hcl:"log_level"`
-	LogFormat          string             `hcl:"log_format"`
-	LogSourceLocation  bool               `hcl:"log_source_location"`
-	RateLimit          rateLimitConfig    `hcl:"ratelimit"`
-	SocketPath         string             `hcl:"socket_path"`
-	TrustDomain        string             `hcl:"trust_domain"`
+	AdminIDs             []string           `hcl:"admin_ids"`
+	AgentTTL             string             `hcl:"agent_ttl"`
+	AuditLogEnabled      bool               `hcl:"audit_log_enabled"`
+	BindAddress          string             `hcl:"bind_address"`
+	BindPort             int                `hcl:"bind_port"`
+	CacheReloadInterval  string             `hcl:"cache_reload_interval"`
+	CAKeyType            string             `hcl:"ca_key_type"`
+	CASubject            *caSubjectConfig   `hcl:"ca_subject"`
+	CATTL                string             `hcl:"ca_ttl"`
+	DataDir              string             `hcl:"data_dir"`
+	DefaultX509SVIDTTL   string             `hcl:"default_x509_svid_ttl"`
+	DefaultJWTSVIDTTL    string             `hcl:"default_jwt_svid_ttl"`
+	EventsBasedCache     bool               `hcl:"events_based_cache"`
+	Experimental         experimentalConfig `hcl:"experimental"`
+	Federation           *federationConfig  `hcl:"federation"`
+	JWTIssuer            string             `hcl:"jwt_issuer"`
+	JWTKeyType           string             `hcl:"jwt_key_type"`
+	LogFile              string             `hcl:"log_file"`
+	LogLevel             string             `hcl:"log_level"`
+	LogFormat            string             `hcl:"log_format"`
+	LogSourceLocation    bool               `hcl:"log_source_location"`
+	PruneEventsOlderThan string             `hcl:"prune_events_older_than"`
+	RateLimit            rateLimitConfig    `hcl:"ratelimit"`
+	SocketPath           string             `hcl:"socket_path"`
+	TrustDomain          string             `hcl:"trust_domain"`
 	// Temporary flag to allow disabling the inclusion of serial number in X509 CAs Subject field
 	ExcludeSNFromCASubject bool `hcl:"exclude_sn_from_ca_subject"`
 
@@ -100,10 +103,7 @@ type serverConfig struct {
 }
 
 type experimentalConfig struct {
-	AuthOpaPolicyEngine  *authpolicy.OpaEngineConfig `hcl:"auth_opa_policy_engine"`
-	CacheReloadInterval  string                      `hcl:"cache_reload_interval"`
-	EventsBasedCache     bool                        `hcl:"events_based_cache"`
-	PruneEventsOlderThan string                      `hcl:"prune_events_older_than"`
+	AuthOpaPolicyEngine *authpolicy.OpaEngineConfig `hcl:"auth_opa_policy_engine"`
 
 	Flags fflag.RawConfig `hcl:"feature_flags"`
 
@@ -660,27 +660,27 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		sc.Log.Warn("Experimental features have been enabled. Please see doc/upgrading.md for upgrade and compatibility considerations for experimental features.")
 	}
 
-	if c.Server.Experimental.CacheReloadInterval != "" {
-		interval, err := time.ParseDuration(c.Server.Experimental.CacheReloadInterval)
+	if c.Server.CacheReloadInterval != "" {
+		interval, err := time.ParseDuration(c.Server.CacheReloadInterval)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse cache reload interval: %w", err)
 		}
 		sc.CacheReloadInterval = interval
 	}
 
-	if c.Server.Experimental.PruneEventsOlderThan != "" {
-		interval, err := time.ParseDuration(c.Server.Experimental.PruneEventsOlderThan)
+	if c.Server.PruneEventsOlderThan != "" {
+		interval, err := time.ParseDuration(c.Server.PruneEventsOlderThan)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse prune events interval: %w", err)
 		}
 		sc.PruneEventsOlderThan = interval
 	}
 
-	if c.Server.Experimental.EventsBasedCache {
+	if c.Server.EventsBasedCache {
 		sc.Log.Info("Using events based cache")
 	}
 
-	sc.EventsBasedCache = c.Server.Experimental.EventsBasedCache
+	sc.EventsBasedCache = c.Server.EventsBasedCache
 	sc.AuthOpaPolicyEngineConfig = c.Server.Experimental.AuthOpaPolicyEngine
 
 	for _, f := range c.Server.Experimental.Flags {

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -1061,7 +1061,7 @@ func TestNewServerConfig(t *testing.T) {
 		{
 			msg: "cache_reload_interval is correctly parsed",
 			input: func(c *Config) {
-				c.Server.Experimental.CacheReloadInterval = "1m"
+				c.Server.CacheReloadInterval = "1m"
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Equal(t, time.Minute, c.CacheReloadInterval)
@@ -1071,7 +1071,7 @@ func TestNewServerConfig(t *testing.T) {
 			msg:         "invalid cache_reload_interval returns an error",
 			expectError: true,
 			input: func(c *Config) {
-				c.Server.Experimental.CacheReloadInterval = "b"
+				c.Server.CacheReloadInterval = "b"
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Nil(t, c)
@@ -1080,7 +1080,7 @@ func TestNewServerConfig(t *testing.T) {
 		{
 			msg: "prune_events_older_than is correctly parsed",
 			input: func(c *Config) {
-				c.Server.Experimental.PruneEventsOlderThan = "1m"
+				c.Server.PruneEventsOlderThan = "1m"
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Equal(t, time.Minute, c.PruneEventsOlderThan)
@@ -1090,7 +1090,7 @@ func TestNewServerConfig(t *testing.T) {
 			msg:         "invalid prune_events_older_than returns an error",
 			expectError: true,
 			input: func(c *Config) {
-				c.Server.Experimental.PruneEventsOlderThan = "b"
+				c.Server.PruneEventsOlderThan = "b"
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Nil(t, c)


### PR DESCRIPTION
Closes #4985

This commit makes the configuration elements like outside the experimental section.

If desired, this can be altered to also force the behavior to always be on with removal of the code supporting the non-db-entry-event logic.  Please indicate if this is desired, and if so, if you want the change in a follow up issue / PR or as part of this PR.
