### PR TITLE
Use cosign v2.2.3

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -17,16 +17,13 @@ jobs:
       id-token: write
       packages: write
 
-    env:
-      COSIGN_EXPERIMENTAL: 1
-
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
-          cosign-release: v1.13.1
+          cosign-release: v2.2.3
       - name: Install regctl
         uses: regclient/actions/regctl-installer@b6614f5f56245066b533343a85f4109bdc38c8cc # main
       - name: Build images

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -587,16 +587,13 @@ jobs:
       id-token: write
       packages: write
 
-    env:
-      COSIGN_EXPERIMENTAL: 1
-
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Install cosign
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
         with:
-          cosign-release: v1.13.1
+          cosign-release: v2.2.3
       - name: Install regctl
         uses: regclient/actions/regctl-installer@b6614f5f56245066b533343a85f4109bdc38c8cc # main
       - name: Download archived images

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -68,5 +68,5 @@ for img in "${OCI_IMAGES[@]}"; do
 
   image_digest="$(jq -r '.manifests[0].digest' "${ROOTDIR}oci/${img}/index.json")"
 
-  cosign sign "${registry}/${img}@${image_digest}"
+  cosign sign -y "${registry}/${img}@${image_digest}"
 done


### PR DESCRIPTION
Also, auto-accept cosign prompts for non-destructive actions needed to push to the transparency log when running from CI/CD.