### PR TITLE
Add s390x support to PR checks and nightly builds

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -17,6 +17,9 @@ jobs:
       id-token: write
       packages: write
 
+    env:
+      PLATFORMS: linux/amd64,linux/arm64,linux/s390x
+
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -162,6 +162,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      PLATFORMS: linux/amd64,linux/arm64,linux/s390x
+
     steps:
       - name: Checkout
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Affects nightly and PR check workflows. 
<!-- Please provide a description of the affected functionality -->

**Description of change**
Added s390x support in nightly and PR check workflows. This change will allow building images on s390x during PR check and nightly builds. 
1. In PR build, s390x is added in the job which builds images.
2. In nightly build, s390x is added for build and publish along with other archs on ghcr, Please let us know if this change can be considered.
3. I have kept release workflow as is such that s390x image is not released as part of official releases.

And by default Makefile will have default archs i.e. linux/amd64,linux/arm64

**Which issue this PR fixes**
This issues refers to #4801.
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

