### PR TITLE
Exclude dependabot author from new DCO check

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -20,4 +20,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pip3 install -U dco-check
-          dco-check
+          dco-check --exclude-pattern 'dependabot\[bot\]@users\.noreply\.github\.com'


### PR DESCRIPTION
Tested locally:
```
> git show HEAD
commit cf1f67f7e922d841eb353c39240078f3d43c795f (HEAD -> test-dependabot-dco)
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu Mar 28 17:00:52 2024 -0700

    Test commit resembling dependabot for DCO check

    Signed-off-by: dependabot[bot] <support@github.com>

diff --git a/README.md b/README.md
index c7022cb7..9f3a2d40 100644
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SPIRE (the [SPIFFE](https://github.com/spiffe/spiffe) Runtime Environment) is a

 SPIRE is a [graduated](https://www.cncf.io/projects/spire/) project of the [Cloud Native Computing Foundation](https://cncf.io/) (CNCF). If you are an organization that wants to help shape the evolution of technologies that are container-packaged, dynamically-scheduled and microservices-oriented, consider joining the CNCF.

-## Get SPIRE
+## Get SPIRE - foo

 - Pre-built releases of SPIRE can be found at [https://github.com/spiffe/spire/releases](https://github.com/spiffe/spire/releases). These releases contain both SPIRE Server and SPIRE Agent binaries.
 - Container images are published for [spire-server](https://ghcr.io/spiffe/spire-server), [spire-agent](https://ghcr.io/spiffe/spire-agent), and [oidc-discovery-provider](https://ghcr.io/spiffe/oidc-discovery-provider).

> python3 dco_check.py -b main
Detected: git (default)

Checking commits: 0727fa64f7af0330c3b4e1404d2e240bdd44cfe5..cf1f67f7e922d841eb353c39240078f3d43c795f

Missing sign-off(s):

	cf1f67f7e922d841eb353c39240078f3d43c795f
		sign-off not found for commit author: dependabot[bot] 49699333+dependabot[bot]@users.noreply.github.com; found: ['dependabot[bot] <support@github.com>']

> python3 dco_check.py -b main --exclude-pattern 'dependabot\[bot\]@users\.noreply\.github\.com'
Detected: git (default)

Checking commits: 0727fa64f7af0330c3b4e1404d2e240bdd44cfe5..cf1f67f7e922d841eb353c39240078f3d43c795f

All good!
```