### PR TITLE
reset timestamps claims to integer when composer plugins are invoked for compatibility with AWS

### DIFF
--- a/pkg/server/credtemplate/builder.go
+++ b/pkg/server/credtemplate/builder.go
@@ -345,6 +345,18 @@ func (b *Builder) BuildWorkloadJWTSVIDClaims(ctx context.Context, params Workloa
 		}
 	}
 
+	// AWS will otherwise reject validating timestamps serialized in scientific notation.
+	// Protobuf serializes large integers as float since Claims are represented as google.protobuf.Struct.
+	if len(b.config.CredentialComposers) > 0 {
+		if iat, ok := attributes.Claims["iat"].(float64); ok {
+			attributes.Claims["iat"] = int64(iat)
+		}
+
+		if exp, ok := attributes.Claims["exp"].(float64); ok {
+			attributes.Claims["exp"] = int64(exp)
+		}
+	}
+
 	return attributes.Claims, nil
 }
 


### PR DESCRIPTION
Using credentialcomposer plugins forces Claims to be translated as protobuf structs which serializes integers as floats (#4982). AWS rejects validating JWT issued by SPIRE with timestamps that are in scientific notation. AWS STS only accepts integer timestamps as valid. We've discussed this with AWS, and while they agree it's an issue in AWS STS, there's no recourse available with them. This fix helps reset value type for timestamps and also includes unit tests that proves the problem and the limited scope of the fix. This is the minimal change needed for SPIRE to produce verifiable JWT for AWS when using credentialcomposer plugin.

Signed-off-by: narora@indeed.com

**Pull Request check list**

- [Y] Commit conforms to CONTRIBUTING.md?
- [Y] Proper tests/regressions included?
- [N] Documentation updated?

**Affected functionality**
BuildWorkloadJWTSVIDClaims resets data type for certain claims.

**Description of change**
Minimal change needed for SPIRE to produce verifiable JWT for AWS when using credentialcomposer plugin.

**Which issue this PR fixes**
`fixes #4982`

