### PR TITLE
Fix the clock skew calculation in auth tokens for IAM-based authentication with AWS RDS

### DIFF
--- a/pkg/server/datastore/sqldriver/awsrds/auth_token.go
+++ b/pkg/server/datastore/sqldriver/awsrds/auth_token.go
@@ -13,14 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 )
 
-const iso8601BasicFormat = "20060102T150405Z"
+const (
+	iso8601BasicFormat = "20060102T150405Z"
+	clockSkew          = time.Minute // Make sure that the authentication token is valid for one more minute.
+)
 
 type authTokenBuilder interface {
 	buildAuthToken(ctx context.Context, endpoint string, region string, dbUser string, creds aws.CredentialsProvider, optFns ...func(options *auth.BuildAuthTokenOptions)) (string, error)
-}
-
-type tokenGetter interface {
-	getAuthToken(ctx context.Context, params *Config, tokenBuilder authTokenBuilder) (string, error)
 }
 
 type authToken struct {
@@ -86,7 +85,7 @@ func (a *authToken) getAuthToken(ctx context.Context, config *Config, tokenBuild
 
 func (a *authToken) isExpired() bool {
 	clockSkew := time.Minute // Make sure that the authentication token is valid for one more minute.
-	return nowFunc().Add(-clockSkew).Sub(a.expiresAt) >= 0
+	return nowFunc().Add(clockSkew).Sub(a.expiresAt) >= 0
 }
 
 type awsTokenBuilder struct{}

--- a/pkg/server/datastore/sqldriver/awsrds/awsrds.go
+++ b/pkg/server/datastore/sqldriver/awsrds/awsrds.go
@@ -67,7 +67,7 @@ func (c *Config) getConnStringWithPassword(password string) (string, error) {
 	}
 }
 
-type tokens map[string]tokenGetter
+type tokens map[string]*authToken
 
 // sqlDriverWrapper is a wrapper for SQL drivers, adding IAM authentication.
 type sqlDriverWrapper struct {


### PR DESCRIPTION
The function isExpired() is used to know if the current cached token used in IAM-based authentication with AWS RDS backed databases is expired or not.
It's currently subtracting a clock skew to the current time, while it should be adding it so the comparison with the expiration time returns >= 0 to indicate that is expired within the skew.
This is done so it's considered expired some time before it really expires, to avoid using a cached token when it's very close to expiration.

I also took the opportunity to remove the tokenGetter interface that was not being used.