### PR TITLE
Fix broken link to SPIFFE bundle endpoint content

### DIFF
--- a/doc/scaling_spire.md
+++ b/doc/scaling_spire.md
@@ -62,7 +62,7 @@ Another use case is SPIFFE interoperability between organizations, such as betwe
 
 These multiple trust domain and interoperability use cases both require a well-defined, interoperable method for a Workload in one trust domain to authenticate a Workload in a different trust domain. Trust between the different trust domains is established by first authenticating the respective bundle endpoint, followed by retrieval of the foreign trust domain bundle via the authenticated endpoint.
 
-For additional detail on how this is achieved, refer to the following SPIFFE spec that describes the mechanism: <https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Trust_Domain_and_Bundle.md#5-spiffe-bundle-endpoint>
+For additional detail on how this is achieved, refer to the following SPIFFE spec that describes the mechanism: <https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md#4-spiffe-bundle-endpoint>
 
 For a tutorial on configuring Federated SPIRE, refer to: <https://github.com/spiffe/spire-tutorials/tree/main/docker-compose/federation>
 


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included? (N/A)
- [X] Documentation updated?

**Affected functionality**
None

**Description of change**
The docs on scaling SPIRE contain a link to the SPIFFE bundle endpoint docs, but that link is broken. (The relevant subsection was moved in [this pull request](https://github.com/spiffe/spiffe/pull/155) about 2-3 years ago.) This simple pull request simply fixes the link.

**Which issue this PR fixes**
None

