### PR TITLE
Update Telemetry documentation for SPIRE DB Events

### DIFF
--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -6,55 +6,61 @@ The following metrics are emitted:
 
 ## SPIRE Server
 
-| Type         | Keys                                           | Labels                       | Description                                                                           |
-|--------------|------------------------------------------------|------------------------------|---------------------------------------------------------------------------------------|
-| Call Counter | `rpc`, `<service>`, `<method>`                 |                              | Call counters over the [SPIRE Server RPCs](https://github.com/spiffe/spire-api-sdk).  |
-| Counter      | `bundle_manager`, `update`, `federated_bundle` | `trust_domain_id`            | The bundle endpoint manager updated a federated bundle                                |
-| Call Counter | `bundle_manager`, `fetch`, `federated_bundle`  | `trust_domain_id`            | The bundle endpoint manager is fetching federated bundle.                             |
-| Call Counter | `ca`, `manager`, `bundle`, `prune`             |                              | The CA manager is pruning a bundle.                                                   |
-| Counter      | `ca`, `manager`, `bundle`, `pruned`            |                              | The CA manager has successfully pruned a bundle.                                      |
-| Call Counter | `ca`, `manager`, `jwt_key`, `prepare`          |                              | The CA manager is preparing a JWT Key.                                                |
-| Counter      | `ca`, `manager`, `x509_ca`, `activate`         |                              | The CA manager has successfully activated an X.509 CA.                                |
-| Call Counter | `ca`, `manager`, `x509_ca`, `prepare`          |                              | The CA manager is preparing an X.509 CA.                                              |
-| Call Counter | `datastore`, `bundle`, `append`                |                              | The Datastore is appending a bundle.                                                  |
-| Call Counter | `datastore`, `bundle`, `count`                 |                              | The Datastore is counting bundles.                                                    |
-| Call Counter | `datastore`, `bundle`, `create`                |                              | The Datastore is creating a bundle.                                                   |
-| Call Counter | `datastore`, `bundle`, `delete`                |                              | The Datastore is deleting a bundle.                                                   |
-| Call Counter | `datastore`, `bundle`, `fetch`                 |                              | The Datastore is fetching a bundle.                                                   |
-| Call Counter | `datastore`, `bundle`, `list`                  |                              | The Datastore is listing bundles.                                                     |
-| Call Counter | `datastore`, `bundle`, `prune`                 |                              | The Datastore is pruning a bundle.                                                    |
-| Call Counter | `datastore`, `bundle`, `set`                   |                              | The Datastore is setting a bundle.                                                    |
-| Call Counter | `datastore`, `bundle`, `update`                |                              | The Datastore is updating a bundle.                                                   |
-| Call Counter | `datastore`, `join_token`, `create`            |                              | The Datastore is creating a join token.                                               |
-| Call Counter | `datastore`, `join_token`, `delete`            |                              | The Datastore is deleting a join token.                                               |
-| Call Counter | `datastore`, `join_token`, `fetch`             |                              | The Datastore is fetching a join token.                                               |                                              |
-| Call Counter | `datastore`, `join_token`, `prune`             |                              | The Datastore is pruning join tokens.                                                 |                                               |
-| Call Counter | `datastore`, `node`, `count`                   |                              | The Datastore is counting nodes.                                                      |
-| Call Counter | `datastore`, `node`, `create`                  |                              | The Datastore  is creating a node.                                                    |
-| Call Counter | `datastore`, `node`, `delete`                  |                              | The Datastore is deleting a node.                                                     |
-| Call Counter | `datastore`, `node`, `fetch`                   |                              | The Datastore is fetching nodes.                                                      |
-| Call Counter | `datastore`, `node`, `list`                    |                              | The Datastore is listing nodes.                                                       |
-| Call Counter | `datastore`, `node`, `selectors`, `fetch`      |                              | The Datastore is fetching selectors for a node.                                       |
-| Call Counter | `datastore`, `node`, `selectors`, `list`       |                              | The Datastore is listing selectors for a node.                                        |
-| Call Counter | `datastore`, `node`, `selectors`, `set`        |                              | The Datastore is setting selectors for a node.                                        |
-| Call Counter | `datastore`, `node`, `update`                  |                              | The Datastore is updating a node.                                                     |
-| Call Counter | `datastore`, `registration_entry`, `count`     |                              | The Datastore is counting registration entries.                                       |
-| Call Counter | `datastore`, `registration_entry`, `create`    |                              | The Datastore is creating a registration entry.                                       |
-| Call Counter | `datastore`, `registration_entry`, `delete`    |                              | The Datastore is deleting a registration entry.                                       |
-| Call Counter | `datastore`, `registration_entry`, `fetch`     |                              | The Datastore is fetching registration entries.                                       |
-| Call Counter | `datastore`, `registration_entry`, `list`      |                              | The Datastore is listing registration entries.                                        |
-| Call Counter | `datastore`, `registration_entry`, `prune`     |                              | The Datastore is pruning registration entries.                                        |
-| Call Counter | `datastore`, `registration_entry`, `update`    |                              | The Datastore is updating a registration entry.                                       |
-| Call Counter | `entry`, `cache`, `reload`                     |                              | The Server is reloading its in-memory entry cache from the datastore.                 |
-| Counter      | `manager`, `jwt_key`, `activate`               |                              | The CA manager has successfully activated a JWT Key.                                  |
-| Gauge        | `manager`, `x509_ca`, `rotate`, `ttl`          | `trust_domain_id`            | The CA manager is rotating the X.509 CA with a given TTL for a specific Trust Domain. |
-| Call Counter | `registration_entry`, `manager`, `prune`       |                              | The Registration manager is pruning entries.                                          |
-| Counter      | `server_ca`, `sign`, `jwt_svid`                |                              | The CA has successfully signed a JWT SVID.                                            |
-| Counter      | `server_ca`, `sign`, `x509_ca_svid`            |                              | The CA has successfully signed an X.509 CA SVID.                                      |
-| Counter      | `server_ca`, `sign`, `x509_svid`               |                              | The CA has successfully signed an X.509 SVID.                                         |
-| Call Counter | `svid`, `rotate`                               |                              | The Server's SVID is being rotated.                                                   |
-| Gauge        | `started`                                      | `version`, `trust_domain_id` | Information about the Server.                                                         |
-| Gauge        | `uptime_in_ms`                                 |                              | The uptime of the Server in milliseconds.                                             |
+| Type         | Keys                                             | Labels                       | Description                                                                           |
+|--------------|--------------------------------------------------|------------------------------|---------------------------------------------------------------------------------------|
+| Call Counter | `rpc`, `<service>`, `<method>`                   |                              | Call counters over the [SPIRE Server RPCs](https://github.com/spiffe/spire-api-sdk).  |
+| Counter      | `bundle_manager`, `update`, `federated_bundle`   | `trust_domain_id`            | The bundle endpoint manager updated a federated bundle                                |
+| Call Counter | `bundle_manager`, `fetch`, `federated_bundle`    | `trust_domain_id`            | The bundle endpoint manager is fetching federated bundle.                             |
+| Call Counter | `ca`, `manager`, `bundle`, `prune`               |                              | The CA manager is pruning a bundle.                                                   |
+| Counter      | `ca`, `manager`, `bundle`, `pruned`              |                              | The CA manager has successfully pruned a bundle.                                      |
+| Call Counter | `ca`, `manager`, `jwt_key`, `prepare`            |                              | The CA manager is preparing a JWT Key.                                                |
+| Counter      | `ca`, `manager`, `x509_ca`, `activate`           |                              | The CA manager has successfully activated an X.509 CA.                                |
+| Call Counter | `ca`, `manager`, `x509_ca`, `prepare`            |                              | The CA manager is preparing an X.509 CA.                                              |
+| Call Counter | `datastore`, `bundle`, `append`                  |                              | The Datastore is appending a bundle.                                                  |
+| Call Counter | `datastore`, `bundle`, `count`                   |                              | The Datastore is counting bundles.                                                    |
+| Call Counter | `datastore`, `bundle`, `create`                  |                              | The Datastore is creating a bundle.                                                   |
+| Call Counter | `datastore`, `bundle`, `delete`                  |                              | The Datastore is deleting a bundle.                                                   |
+| Call Counter | `datastore`, `bundle`, `fetch`                   |                              | The Datastore is fetching a bundle.                                                   |
+| Call Counter | `datastore`, `bundle`, `list`                    |                              | The Datastore is listing bundles.                                                     |
+| Call Counter | `datastore`, `bundle`, `prune`                   |                              | The Datastore is pruning a bundle.                                                    |
+| Call Counter | `datastore`, `bundle`, `set`                     |                              | The Datastore is setting a bundle.                                                    |
+| Call Counter | `datastore`, `bundle`, `update`                  |                              | The Datastore is updating a bundle.                                                   |
+| Call Counter | `datastore`, `join_token`, `create`              |                              | The Datastore is creating a join token.                                               |
+| Call Counter | `datastore`, `join_token`, `delete`              |                              | The Datastore is deleting a join token.                                               |
+| Call Counter | `datastore`, `join_token`, `fetch`               |                              | The Datastore is fetching a join token.                                               |    
+| Call Counter | `datastore`, `join_token`, `prune`               |                              | The Datastore is pruning join tokens.                                                 |
+| Call Counter | `datastore`, `node`, `count`                     |                              | The Datastore is counting nodes.                                                      |
+| Call Counter | `datastore`, `node`, `create`                    |                              | The Datastore  is creating a node.                                                    |
+| Call Counter | `datastore`, `node`, `delete`                    |                              | The Datastore is deleting a node.                                                     |
+| Call Counter | `datastore`, `node`, `fetch`                     |                              | The Datastore is fetching nodes.                                                      |
+| Call Counter | `datastore`, `node`, `list`                      |                              | The Datastore is listing nodes.                                                       |
+| Call Counter | `datastore`, `node`, `selectors`, `fetch`        |                              | The Datastore is fetching selectors for a node.                                       |
+| Call Counter | `datastore`, `node`, `selectors`, `list`         |                              | The Datastore is listing selectors for a node.                                        |
+| Call Counter | `datastore`, `node`, `selectors`, `set`          |                              | The Datastore is setting selectors for a node.                                        |
+| Call Counter | `datastore`, `node`, `update`                    |                              | The Datastore is updating a node.                                                     |
+| Call Counter | `datastore`, `node_event`, `list`                |                              | The Datastore is listing node events.                                                 |
+| Call Counter | `datastore`, `node_event`, `prune`               |                              | The Datastore is pruning expired node events.                                         |
+| Call Counter | `datastore`, `node_event`, `fetch`               |                              | The Datastore is fetching a specific node event.                                      |
+| Call Counter | `datastore`, `registration_entry`, `count`       |                              | The Datastore is counting registration entries.                                       |
+| Call Counter | `datastore`, `registration_entry`, `create`      |                              | The Datastore is creating a registration entry.                                       |
+| Call Counter | `datastore`, `registration_entry`, `delete`      |                              | The Datastore is deleting a registration entry.                                       |
+| Call Counter | `datastore`, `registration_entry`, `fetch`       |                              | The Datastore is fetching registration entries.                                       |
+| Call Counter | `datastore`, `registration_entry`, `list`        |                              | The Datastore is listing registration entries.                                        |
+| Call Counter | `datastore`, `registration_entry`, `prune`       |                              | The Datastore is pruning registration entries.                                        |
+| Call Counter | `datastore`, `registration_entry`, `update`      |                              | The Datastore is updating a registration entry.                                       |
+| Call Counter | `datastore`, `registration_entry_event`, `list`  |                              | The Datastore is listing a registration entry events.                                 |
+| Call Counter | `datastore`, `registration_entry_event`, `prune` |                              | The Datastore is pruning expired registration entry events.                           |
+| Call Counter | `datastore`, `registration_entry_event`, `fetch` |                              | The Datastore is fetching a specific registration entry event.                        |
+| Call Counter | `entry`, `cache`, `reload`                       |                              | The Server is reloading its in-memory entry cache from the datastore.                 |
+| Counter      | `manager`, `jwt_key`, `activate`                 |                              | The CA manager has successfully activated a JWT Key.                                  |
+| Gauge        | `manager`, `x509_ca`, `rotate`, `ttl`            | `trust_domain_id`            | The CA manager is rotating the X.509 CA with a given TTL for a specific Trust Domain. |
+| Call Counter | `registration_entry`, `manager`, `prune`         |                              | The Registration manager is pruning entries.                                          |
+| Counter      | `server_ca`, `sign`, `jwt_svid`                  |                              | The CA has successfully signed a JWT SVID.                                            |
+| Counter      | `server_ca`, `sign`, `x509_ca_svid`              |                              | The CA has successfully signed an X.509 CA SVID.                                      |
+| Counter      | `server_ca`, `sign`, `x509_svid`                 |                              | The CA has successfully signed an X.509 SVID.                                         |
+| Call Counter | `svid`, `rotate`                                 |                              | The Server's SVID is being rotated.                                                   |
+| Gauge        | `started`                                        | `version`, `trust_domain_id` | Information about the Server.                                                         |
+| Gauge        | `uptime_in_ms`                                   |                              | The uptime of the Server in milliseconds.                                             |
 
 ## SPIRE Agent
 

--- a/doc/telemetry.md
+++ b/doc/telemetry.md
@@ -27,7 +27,7 @@ The following metrics are emitted:
 | Call Counter | `datastore`, `bundle`, `update`                  |                              | The Datastore is updating a bundle.                                                   |
 | Call Counter | `datastore`, `join_token`, `create`              |                              | The Datastore is creating a join token.                                               |
 | Call Counter | `datastore`, `join_token`, `delete`              |                              | The Datastore is deleting a join token.                                               |
-| Call Counter | `datastore`, `join_token`, `fetch`               |                              | The Datastore is fetching a join token.                                               |    
+| Call Counter | `datastore`, `join_token`, `fetch`               |                              | The Datastore is fetching a join token.                                               |
 | Call Counter | `datastore`, `join_token`, `prune`               |                              | The Datastore is pruning join tokens.                                                 |
 | Call Counter | `datastore`, `node`, `count`                     |                              | The Datastore is counting nodes.                                                      |
 | Call Counter | `datastore`, `node`, `create`                    |                              | The Datastore  is creating a node.                                                    |


### PR DESCRIPTION
Closes #4837

This covers the database interactions for both
registration entry events (list, prune, fetch)
and node events (list, prune, fetch)
