### PR TITLE
Do not save the CA journal file anymore

### DIFF
--- a/pkg/server/ca/manager/manager_test.go
+++ b/pkg/server/ca/manager/manager_test.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
-	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -1062,7 +1060,6 @@ func (m *managerTest) selfSignedConfigWithKeyTypes(x509CAKeyType, jwtKeyType key
 		TrustDomain:   testTrustDomain,
 		X509CAKeyType: x509CAKeyType,
 		JWTKeyType:    jwtKeyType,
-		Dir:           m.dir,
 		Metrics:       m.metrics,
 		Log:           m.log,
 		Clock:         m.clock,
@@ -1206,10 +1203,6 @@ func (m *managerTest) addTimeAndPrune(d time.Duration) {
 }
 
 func (m *managerTest) wipeJournal(t *testing.T) {
-	// TODO: journal saved on this will no longer be supported in v1.10. Remove
-	// this.
-	require.NoError(t, os.Remove(filepath.Join(m.m.c.Dir, "journal.pem")))
-
 	// Have a clean datastore.
 	m.ds = fakedatastore.New(t)
 	m.cat.SetDataStore(m.ds)

--- a/pkg/server/ca/manager/slot.go
+++ b/pkg/server/ca/manager/slot.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -57,9 +58,8 @@ func (s *SlotLoader) load(ctx context.Context) (*Journal, map[SlotPosition]Slot,
 	log := s.Log
 
 	jc := &journalConfig{
-		cat:      s.Catalog,
-		log:      log,
-		filePath: s.journalPath(),
+		cat: s.Catalog,
+		log: log,
 	}
 
 	// Load the journal and see if we can figure out the next and current
@@ -109,6 +109,10 @@ func (s *SlotLoader) load(ctx context.Context) (*Journal, map[SlotPosition]Slot,
 		slots[NextJWTKeySlot] = nextJWTKey
 	}
 
+	// TODO: Remove after 1.11.0 release.
+	// No point in checking for errors here, we're just trying to clean up the
+	// CA journal file that was used before 1.9.0.
+	os.Remove(s.journalPath())
 	return loadedJournal, slots, nil
 }
 

--- a/pkg/server/ca/manager/slot_test.go
+++ b/pkg/server/ca/manager/slot_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -181,8 +180,7 @@ func TestJournalLoad(t *testing.T) {
 	jwtKeyBPKIX, err := x509.MarshalPKIXPublicKey(jwtKeyB.Public())
 	require.NoError(t, err)
 
-	tempDir := t.TempDir()
-	journalFile := filepath.Join(tempDir, "journal.pem")
+	activeX509AuthorityID := getOneX509AuthorityID(ctx, t, km)
 
 	// Dates
 	firstIssuedAtUnix := now.Add(-3 * time.Minute).Unix()
@@ -776,18 +774,17 @@ func TestJournalLoad(t *testing.T) {
 			loghook.Reset()
 			journal := new(Journal)
 			journal.config = &journalConfig{
-				cat:      cat,
-				filePath: journalFile,
-				log:      log,
+				cat: cat,
+				log: log,
 			}
 			journal.setEntries(tt.entries)
+			journal.activeX509AuthorityID = activeX509AuthorityID
 			err = journal.save(ctx)
 			require.NoError(t, err)
 
 			loader := &SlotLoader{
 				TrustDomain: td,
 				Log:         log,
-				Dir:         tempDir,
 				Catalog:     cat,
 			}
 


### PR DESCRIPTION
SPIRE saves the CA journal in the datastore since 1.9.0, and the journal file is not needed since then.
The CA journal file was kept in sync with the datastore only to allow downgrades, but starting with 1.10.0 SPIRE can only be downgraded to 1.9.0 (as the oldest), that stores the CA journal in the datastore.
Stop saving the CA journal on disk and remove the file in case it's still there.