### PR TITLE
Remove the key_metadata_file and use_msi (azure_key_vault only) settings

### DIFF
--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -28,11 +28,11 @@ Consequently, if the file is lost, the plugin will not be able to identify keys
 that it has previously managed and will recreate new keys on demand.
 
 If you need more control over the identifier that's used for the server, the
-`key_identifier_value` setting can be used instead. This allows to specify a
-static identifier for the server instance, and is appropriate in situations
+`key_identifier_value` setting can be used to specify a
+static identifier for the server instance. This setting is appropriate in situations
 where a key identifier file can't be persisted.
 
-The plugin assigns [aliases](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html) to the Customer Master Keys that manages. The aliases are used to identify and name keys that are managed by the plugin.
+The plugin assigns [aliases](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html) to the Customer Master Keys that it manages. The aliases are used to identify and name keys that are managed by the plugin.
 
 Aliases managed by the plugin have the following form: `alias/SPIRE_SERVER/{TRUST_DOMAIN}/{SERVER_ID}/{KEY_ID}`. The `{SERVER_ID}` is the identifier handled by the `key_identifier_file` or `key_identifier_value` setting. This ID allows multiple servers in the same trust domain (e.g. servers in HA deployments) to manage keys with identical `{KEY_ID}`'s without collision. The `{KEY_ID}` in the alias name is encoded to use a [character set accepted by KMS](https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html#API_CreateAlias_RequestSyntax).
 

--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -11,18 +11,30 @@ The plugin accepts the following configuration options:
 | access_key_id        | string | see [AWS KMS Access](#aws-kms-access)       | The Access Key Id used to authenticate to KMS                                                                               | Value of the AWS_ACCESS_KEY_ID environment variable     |
 | secret_access_key    | string | see [AWS KMS Access](#aws-kms-access)       | The Secret Access Key used to authenticate to KMS                                                                           | Value of the AWS_SECRET_ACCESS_KEY environment variable |
 | region               | string | yes                                         | The region where the keys will be stored                                                                                    |                                                         |
-| key_metadata_file    | string | no                                          | A file path location where information about generated keys will be persisted (deprecated, use key_identifier_file instead) |                                                         |
 | key_identifier_file  | string | Required if key_identifier_value is not set | A file path location where information about generated keys will be persisted                                               |                                                         |
-| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_metadata_file`)                                     |                                                         |
+| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                   |                                                         |
 | key_policy_file      | string | no                                          | A file path location to a custom key policy in JSON format                                                                  | ""                                                      |
 
 ### Alias and Key Management
 
+The plugin needs a way to identify the specific server instance where it's
+running. For that, either the `key_identifier_file` or `key_identifier_value`
+setting must be used. Setting a _Key Identifier File_ instructs the plugin to
+manage the identifier of the server automatically, storing the server ID in the
+specified file. This method should be appropriate for most situations.
+If a _Key Identifier File_ is configured and the file is not found during server
+startup, the file is recreated with a new auto-generated server ID.
+Consequently, if the file is lost, the plugin will not be able to identify keys
+that it has previously managed and will recreate new keys on demand.
+
+If you need more control over the identifier that's used for the server, the
+`key_identifier_value` setting can be used instead. This allows to specify a
+static identifier for the server instance, and is appropriate in situations
+where a key identifier file can't be persisted.
+
 The plugin assigns [aliases](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html) to the Customer Master Keys that manages. The aliases are used to identify and name keys that are managed by the plugin.
 
-Aliases managed by the plugin have the following form: `alias/SPIRE_SERVER/{TRUST_DOMAIN}/{SERVER_ID}/{KEY_ID}`. The `{SERVER_ID}` is an auto-generated ID unique to the server and is persisted in the _Key Metadata File_ (see the `key_metadata_file` configurable). This ID allows multiple servers in the same trust domain (e.g. servers in HA deployments) to manage keys with identical `{KEY_ID}`'s without collision. The `{KEY_ID}` in the alias name is encoded to use a [character set accepted by KMS](https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html#API_CreateAlias_RequestSyntax).
-
-If the _Key Metadata File_ is not found on server startup, the file is recreated, with a new auto-generated server ID. Consequently, if the file is lost, the plugin will not be able to identify keys that it has previously managed and will recreate new keys on demand.
+Aliases managed by the plugin have the following form: `alias/SPIRE_SERVER/{TRUST_DOMAIN}/{SERVER_ID}/{KEY_ID}`. The `{SERVER_ID}` is the identifier handled by the `key_identifier_file` or `key_identifier_value` setting. This ID allows multiple servers in the same trust domain (e.g. servers in HA deployments) to manage keys with identical `{KEY_ID}`'s without collision. The `{KEY_ID}` in the alias name is encoded to use a [character set accepted by KMS](https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html#API_CreateAlias_RequestSyntax).
 
 The plugin attempts to detect and prune stale aliases. To facilitate stale alias detection, the plugin actively updates the `LastUpdatedDate` field on all aliases every 6 hours. The plugin periodically scans aliases. Any alias encountered with a `LastUpdatedDate` older than two weeks is removed, along with its associated key.
 

--- a/doc/plugin_server_keymanager_azure_key_vault.md
+++ b/doc/plugin_server_keymanager_azure_key_vault.md
@@ -66,8 +66,8 @@ Consequently, if the file is lost, the plugin will not be able to identify keys
 that it has previously managed and will recreate new keys on demand.
 
 If you need more control over the identifier that's used for the server, the
-`key_identifier_value` setting can be used instead. This allows to specify a
-static identifier for the server instance, and is appropriate in situations
+`key_identifier_value` setting can be used to specify a
+static identifier for the server instance. This setting is appropriate in situations
 where a key identifier file can't be persisted.
 
 The plugin attempts to detect and delete stale keys. To facilitate stale

--- a/doc/plugin_server_keymanager_azure_key_vault.md
+++ b/doc/plugin_server_keymanager_azure_key_vault.md
@@ -12,11 +12,9 @@ The plugin accepts the following configuration options:
 
 | Key                  | Type    | Required                                    | Description                                                                                                                                                      | Default |
 |----------------------|---------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| key_metadata_file    | string  | no                                          | A file path location where key metadata used by the plugin will be persisted (deprecated). See "[Management of keys](#management-of-keys)" for more information. | ""      |
-| key_identifier_file  | string  | Required if key_identifier_value is not set | A file path location where key metadata used by the plugin will be persisted. See "[Management of keys](#management-of-keys)" for more information.              | ""      |
-| key_identifier_value | string  | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_metadata_file`)                                                                          | ""      |
+| key_identifier_file  | string  | Required if key_identifier_value is not set | A file path location where information about generated keys will be persisted. See "[Management of keys](#management-of-keys)" for more information.             | ""      |
+| key_identifier_value | string  | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`).                                                                       | ""      |
 | key_vault_uri        | string  | Yes                                         | The Key Vault URI where the keys managed by this plugin reside.                                                                                                  | ""      |
-| use_msi              | boolean | [Deprecated](#authenticating-to-azure)      | Whether or not to use MSI to authenticate to Azure Key Vault.                                                                                                    | false   |
 | subscription_id      | string  | [Optional](#authenticating-to-azure)        | The subscription id.                                                                                                                                             | ""      |
 | app_id               | string  | [Optional](#authenticating-to-azure)        | The application id.                                                                                                                                              | ""      |
 | app_secret           | string  | [Optional](#authenticating-to-azure)        | The application secret.                                                                                                                                          | ""      |
@@ -52,15 +50,25 @@ keys that it manages in order to keep track of them. All the tags are named with
 Users don't need to interact with the labels managed by the plugin. The
 following table is provided for informational purposes only:
 
-| Label           | Description                                                                                                                            |
-|-----------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| spire-server-td | A string representing the trust domain name of the server.                                                                             |
-| spire-server-id | Auto-generated ID that is unique to the server and is persisted in the _Key Metadata File_ (see the `key_metadata_file` configurable). |
+| Label           | Description                                                                                                                             |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| spire-server-td | A string representing the trust domain name of the server.                                                                              |
+| spire-server-id | An identifier that is unique to the server. This is handled by either the `key_identifier_file` or `key_identifier_value` configurable. |
 
-If the _Key Metadata File_ is not found during server startup, the file is
-recreated, with a new auto-generated server ID. Consequently, if the file is
-lost, the plugin will not be able to identify keys that it has previously
-managed and will recreate new keys on demand.
+The plugin needs a way to identify the specific server instance where it's
+running. For that, either the `key_identifier_file` or `key_identifier_value`
+setting must be used. Setting a _Key Identifier File_ instructs the plugin to
+manage the identifier of the server automatically, storing the server ID in the
+specified file. This method should be appropriate for most situations.
+If a _Key Identifier File_ is configured and the file is not found during server
+startup, the file is recreated with a new auto-generated server ID.
+Consequently, if the file is lost, the plugin will not be able to identify keys
+that it has previously managed and will recreate new keys on demand.
+
+If you need more control over the identifier that's used for the server, the
+`key_identifier_value` setting can be used instead. This allows to specify a
+static identifier for the server instance, and is appropriate in situations
+where a key identifier file can't be persisted.
 
 The plugin attempts to detect and delete stale keys. To facilitate stale
 keys detection, the plugin actively updates the `Updated` field of all keys managed by the server every 6 hours.

--- a/doc/plugin_server_keymanager_gcp_kms.md
+++ b/doc/plugin_server_keymanager_gcp_kms.md
@@ -68,8 +68,8 @@ Consequently, if the file is lost, the plugin will not be able to identify keys
 that it has previously managed and will recreate new keys on demand.
 
 If you need more control over the identifier that's used for the server, the
-`key_identifier_value` setting can be used instead. This allows to specify a
-static identifier for the server instance, and is appropriate in situations
+`key_identifier_value` setting can be used to specify a
+static identifier for the server instance. This setting is appropriate in situations
 where a key identifier file can't be persisted.
 
 The plugin attempts to detect and prune stale CryptoKeys. To facilitate stale

--- a/doc/plugin_server_keymanager_gcp_kms.md
+++ b/doc/plugin_server_keymanager_gcp_kms.md
@@ -13,9 +13,8 @@ The plugin accepts the following configuration options:
 | Key                  | Type   | Required                                    | Description                                                                                                                                                                                    | Default                                                         |
 |----------------------|--------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | key_policy_file      | string | no                                          | A file path location to a custom [IAM Policy (v3)](https://cloud.google.com/pubsub/docs/reference/rpc/google.iam.v1#google.iam.v1.Policy) in JSON format to be attached to created CryptoKeys. | ""                                                              |
-| key_metadata_file    | string | no                                          | A file path location where key metadata used by the plugin will be persisted (deprecated). See "[Management of keys](#management-of-keys)" for more information.                               | ""                                                              |
 | key_identifier_file  | string | Required if key_identifier_value is not set | A file path location where key metadata used by the plugin will be persisted. See "[Management of keys](#management-of-keys)" for more information.                                            | ""                                                              |
-| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_metadata_file`)                                                                                                        | ""                                                              |
+| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                                                                                        | ""                                                              |
 | key_ring             | string | yes                                         | Resource ID of the key ring where the keys managed by this plugin reside, in the format projects/\*/locations/\*/keyRings/\*                                                                   | ""                                                              |
 | service_account_file | string | no                                          | Path to the service account file used to authenticate with the Cloud KMS API.                                                                                                                  | Value of `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
 
@@ -51,17 +50,27 @@ the service. All the labels are named with the `spire-` prefix.
 Users don't need to interact with the labels managed by the plugin. The
 following table is provided for informational purposes only:
 
-| Label             | Description                                                                                                                            |
-|-------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| spire-server-td   | SHA-1 checksum of the trust domain name of the server.                                                                                 |
-| spire-server-id   | Auto-generated ID that is unique to the server and is persisted in the _Key Metadata File_ (see the `key_metadata_file` configurable). |
-| spire-last-update | Unix time of the last time that the plugin updated the CryptoKey to keep it active.                                                    |
-| spire-active      | Indicates if the CryptoKey is still in use by the plugin.                                                                              |
+| Label             | Description                                                                                                                             |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| spire-server-td   | SHA-1 checksum of the trust domain name of the server.                                                                                  |
+| spire-server-id   | An identifier that is unique to the server. This is handled by either the `key_identifier_file` or `key_identifier_value` configurable. |
+| spire-last-update | Unix time of the last time that the plugin updated the CryptoKey to keep it active.                                                     |
+| spire-active      | Indicates if the CryptoKey is still in use by the plugin.                                                                               |
 
-If the _Key Metadata File_ is not found during server startup, the file is
-recreated, with a new auto-generated server ID. Consequently, if the file is
-lost, the plugin will not be able to identify keys that it has previously
-managed and will recreate new keys on demand.
+The plugin needs a way to identify the specific server instance where it's
+running. For that, either the `key_identifier_file` or `key_identifier_value`
+setting must be used. Setting a _Key Identifier File_ instructs the plugin to
+manage the identifier of the server automatically, storing the server ID in the
+specified file. This method should be appropriate for most situations.
+If a _Key Identifier File_ is configured and the file is not found during server
+startup, the file is recreated with a new auto-generated server ID.
+Consequently, if the file is lost, the plugin will not be able to identify keys
+that it has previously managed and will recreate new keys on demand.
+
+If you need more control over the identifier that's used for the server, the
+`key_identifier_value` setting can be used instead. This allows to specify a
+static identifier for the server instance, and is appropriate in situations
+where a key identifier file can't be persisted.
 
 The plugin attempts to detect and prune stale CryptoKeys. To facilitate stale
 CryptoKey detection, the plugin actively updates the `spire-last-update` label


### PR DESCRIPTION
- Removed the deprecated setting `key_metadata_file` from the `aws_kms`, `azure_key_vault` and `gcp_kms` plugins.
- Updated the documentation describing how the `key_identifier_file` and `key_identifier_value` settings are used.
- Removed the deprecated `use_msi` setting from the `azure_key_vault` plugin. A separate PR removing that setting from the `azure_msi` plugin will be opened.