### PR TITLE
Build the SPIRE Agent Docker image to run as root by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,13 @@ RUN mkdir -p /spireroot/opt/spire/bin \
     /spireroot/tmp/spire-agent/public \
     /spireroot/var/lib/spire/agent
 
-# For users that wish to run SPIRE containers as a non-root user,
-# a default unprivileged user is provided such that the default paths
-# that SPIRE will try to read from, write to, and create at runtime
-# can be given the correct file ownership/permissions at build time.
-# This is done through the spireuid and spiregid arguments that the
-# spire-server, spire-agent, and oidc-discovery-provider build stages use.
+# For users that wish to run SPIRE containers with a specific uid and gid, the
+# spireuid and spiregid arguments are provided. The default paths that SPIRE
+# will try to read from, write to, and create at runtime are given the
+# corresponding file ownership/permissions at build time.
+# A default non-root user is defined for SPIRE Server and the OIDC Discovery
+# Provider. The SPIRE Agent image runs as root by default to facilitate the
+# sharing of the agent socket in Kubernetes environments.
 
 # SPIRE Server
 FROM spire-base AS spire-server
@@ -69,8 +70,8 @@ COPY --link --from=builder --chown=${spireuid}:${spiregid} --chmod=755 /spire/bi
 
 # SPIRE Agent
 FROM spire-base AS spire-agent
-ARG spireuid=1000
-ARG spiregid=1000
+ARG spireuid=0
+ARG spiregid=0
 USER ${spireuid}:${spiregid}
 ENTRYPOINT ["/opt/spire/bin/spire-agent", "run"]
 COPY --link --from=prep-spire-agent --chown=${spireuid}:${spiregid} --chmod=755 /spireroot /

--- a/doc/docker_images.md
+++ b/doc/docker_images.md
@@ -47,6 +47,12 @@ If you want to use configure SPIRE to use paths that are not used by the example
 
 If you want to run SPIRE as a non-root user that is not uid `1000`, you will need to build your own custom container images that set up permissions correctly for your dedicated user.
 
+### Kubernetes environments
+
+In Kubernetes, SPIRE Agent is normally deployed as DaemonSet to run one Workload API server instance per host, and it is necessary to inject the Workload API socket into each pod.
+The [SPIFFE CSI Driver](https://github.com/spiffe/spiffe-csi) can be used to avoid the use of hostPath volumes in workload containers, but the use of a hostPath volume in the SPIRE Agent container is still needed.
+For that reason, the SPIRE Agent container image is built to run as root by default.
+
 ## Directories available in release images
 
 To address the previously mentioned limitations with scratch-based images, the SPIRE release images come with some commonly used directories pre-installed with correct permissions for a user with uid `1000` and group with gid `1000`.

--- a/test/integration/suites/delegatedidentity/05-test-endpoints
+++ b/test/integration/suites/delegatedidentity/05-test-endpoints
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 log-info "Test Delegated Identity API (for success)"
-docker-compose exec -u 1001:1000 -T spire-agent \
+docker-compose exec -u 1001 -T spire-agent \
 	/opt/spire/conf/agent/delegatedidentityclient -expectedID spiffe://domain.test/workload || fail-now "Failed to check Delegated Identity API"
 
 log-info "Test Delegated Identity API (expecting permission denied)"
-docker-compose exec -u 1002:1000 -T spire-agent \
+docker-compose exec -u 1002 -T spire-agent \
 	/opt/spire/conf/agent/delegatedidentityclient || fail-now "Failed to check Delegated Identity API"

--- a/test/integration/suites/join-token/04-create-workload-entry
+++ b/test/integration/suites/join-token/04-create-workload-entry
@@ -5,7 +5,7 @@ docker-compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/node" \
     -spiffeID "spiffe://domain.test/workload" \
-    -selector "unix:uid:1000" \
+    -selector "unix:uid:0" \
     -ttl 0
 
 # Check at most 30 times (with one second in between) that the agent has

--- a/test/integration/suites/k8s/conf/agent/spire-agent.yaml
+++ b/test/integration/suites/k8s/conf/agent/spire-agent.yaml
@@ -112,12 +112,6 @@ spec:
       serviceAccountName: spire-agent
       containers:
         - name: spire-agent
-          # Make sure that we can create the directory for the socket in the host,
-          # this is needed because we use a hostPath volume to share the socket
-          # for the Workload API.
-          securityContext:
-            runAsUser: 0
-            runAsGroup: 0
           image: spire-agent:latest-local
           imagePullPolicy: Never
           args: ["-config", "/run/spire/config/agent.conf"]

--- a/test/integration/suites/rotation/04-create-workload-entry
+++ b/test/integration/suites/rotation/04-create-workload-entry
@@ -5,7 +5,7 @@ docker-compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
-    -selector "unix:uid:1000" \
+    -selector "unix:uid:0" \
     -ttl 0
 
 # Check at most 30 times (with one second in between) that the agent has


### PR DESCRIPTION
Build the SPIRE Agent Docker image to run as root by default as we have been doing in previous releases.
Running it as a non-root user would be pretty disruptive for users running SPIRE in Kubernetes environments, where the use of a hostPath volume is needed for the SPIRE Agent container to share the agent socket.