### PR TITLE
Print prometheus address and port in logs and name it "exporter listen" instead of "server"

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -447,10 +447,10 @@ plugins {
 # available metrics collectors.
 # telemetry {
 #     Prometheus {
-#         # host: Prometheus server host.
+#         # host: Prometheus exporter listen address.
 #         # host = ""
 
-#         # port: Prometheus server port.
+#         # port: Prometheus exporter listen port.
 #         port = 9988
 #     }
 

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -955,10 +955,10 @@ plugins {
 # available metrics collectors.
 # telemetry {
 #     Prometheus {
-#         # host: Prometheus server host.
+#         # host: Prometheus exporter listen address.
 #         # host = ""
 
-#         # port: Prometheus server port.
+#         # port: Prometheus exporter listen port.
 #         port = 9988
 #     }
 

--- a/doc/telemetry/telemetry_config.md
+++ b/doc/telemetry/telemetry_config.md
@@ -33,10 +33,10 @@ You may use all, some, or none of the collectors. The following collectors suppo
 
 ### `Prometheus`
 
-| Configuration | Type     | Description            |
-|---------------|----------|------------------------|
-| `host`        | `string` | Prometheus server host |
-| `port`        | `int`    | Prometheus server port |
+| Configuration | Type     | Description               |
+|---------------|----------|---------------------------|
+| `host`        | `string` | Prometheus exporter listen address |
+| `port`        | `int`    | Prometheus exporter listen port    |
 
 ### `DogStatsd`
 

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -49,6 +49,7 @@ func newPrometheusRunner(c *MetricsConfig) (sinkRunner, error) {
 	if runner.c.Host != "localhost" {
 		runner.log.Warnf("Agent is now configured to accept remote network connections for Prometheus stats collection. Please ensure access to this port is tightly controlled")
 	}
+	runner.log.Debug("Starting prometheus listener on %s:%d", runner.c.Host, runner.c.Port)
 
 	runner.server = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", runner.c.Host, runner.c.Port),

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -52,7 +52,7 @@ func newPrometheusRunner(c *MetricsConfig) (sinkRunner, error) {
 	runner.log.WithFields(logrus.Fields{
 		"host": runner.c.Host,
 		"port": runner.c.Port,
-  }).Debug("Starting prometheus exporter")
+	}).Info("Starting prometheus exporter")
 
 	runner.server = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", runner.c.Host, runner.c.Port),

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -49,7 +49,10 @@ func newPrometheusRunner(c *MetricsConfig) (sinkRunner, error) {
 	if runner.c.Host != "localhost" {
 		runner.log.Warnf("Agent is now configured to accept remote network connections for Prometheus stats collection. Please ensure access to this port is tightly controlled")
 	}
-	runner.log.Debug("Starting prometheus listener on %s:%d", runner.c.Host, runner.c.Port)
+	runner.log.WithFields(logrus.Fields{
+		"host": runner.c.Host,
+		"port": runner.c.Port,
+  }).Debug("Starting prometheus exporter")
 
 	runner.server = &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", runner.c.Host, runner.c.Port),


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
One more string in logs.

**Description of change**
<!-- Please provide a description of the change -->
It's common in prometheus infrastructure to call client-side metrics server "exporter", not server. "Server" in configuration option is a bit confusing.
Also, it's useful to log where it listens on.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
I didn't create issue
