### PR TITLE
unix attestor: fix discover_workload_path on mac os

### DIFF
--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -45,6 +46,10 @@ func (s *Suite) SetupTest() {
 }
 
 func (s *Suite) TestAttest() {
+	unreadableExePath := "/proc/10/unreadable-exe"
+	if runtime.GOOS != "linux" {
+		unreadableExePath = filepath.Join(s.dir, "unreadable-exe")
+	}
 	testCases := []struct {
 		name           string
 		pid            int
@@ -131,7 +136,7 @@ func (s *Suite) TestAttest() {
 			pid:        10,
 			config:     "discover_workload_path = true",
 			expectCode: codes.Internal,
-			expectMsg:  "workloadattestor(unix): SHA256 digest: open /proc/10/unreadable-exe: no such file or directory",
+			expectMsg:  fmt.Sprintf("workloadattestor(unix): SHA256 digest: open %s: no such file or directory", unreadableExePath),
 		},
 		{
 			name:       "process binary exceeds size limits",


### PR DESCRIPTION
When enabling 'discover_workload_path' on mac os the agent fails to attest any workload due to it trying to access a procfs path:
```
ERRO[0068] Failed to collect all selectors for PID       error="workload attestor \"unix\" failed: rpc error: code = Internal desc = workloadattestor(unix): SHA256 digest: open /proc/16470/exe: no such file or directory" pid=16470 subsystem_name=workload_attestor
DEBU[0068] PID attested to have selectors                pid=16470 selectors="[]" subsystem_name=workload_attestor
ERRO[0068] No identity issued                            method=FetchX509SVID pid=16470 registered=false service=WorkloadAPI subsystem_name=endpoints
```

I assume this is needed to be able to get a path that is accessible by the spire-agent, for example if it runs in a different namespace. I assume it's mostly intended for Linux, for most other OSes `proc.Exe()` would be better. Either way, it's likely to be wrong on various OSes since they either have no procfs, they have no link to the executable in procfs, or they link is named differently (e.g. `a.out` or `file`).
