### PR TITLE
Update ITs to use docker  v2

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -38,6 +38,7 @@ docker-up() {
         log-debug "bringing up $*..."
     fi
     docker compose up -d "$@" || fail-now "failed to bring up services."
+
 }
 
 docker-wait-for-healthy() {
@@ -88,6 +89,23 @@ fingerprint() {
 	# "coreutils" output format (`-r`) to provide uniform output from
 	# `openssl sha1` on macOS and linux.
 	openssl x509 -in "$1" -outform DER | openssl sha1 -r | awk '{print $1}'
+}
+
+check-server-started() {
+  # Check at most 20 times (with one second in between) that the server has
+  # successfully started.
+  MAXCHECKS=20
+  CHECKINTERVAL=1
+  for ((i=1;i<=MAXCHECKS;i++)); do
+      log-info "checking for starting server APIs ($i of $MAXCHECKS max)..."
+      docker compose logs "$1"
+      if docker compose logs "$1" | grep "Starting Server APIs"; then
+          return 0
+      fi
+      sleep "${CHECKINTERVAL}"
+  done
+
+  fail-now "timed out waiting for server to start"
 }
 
 check-synced-entry() {

--- a/test/integration/common
+++ b/test/integration/common
@@ -37,7 +37,7 @@ docker-up() {
     else
         log-debug "bringing up $*..."
     fi
-    docker-compose up -d "$@" || fail-now "failed to bring up services."
+    docker compose up -d "$@" || fail-now "failed to bring up services."
 }
 
 docker-wait-for-healthy() {
@@ -70,17 +70,17 @@ docker-stop() {
     else
         log-debug "stopping $*..."
     fi
-    docker-compose stop "$@"
+    docker compose stop "$@"
 }
 
 docker-down() {
     log-debug "bringing down services..."
-    docker-compose down
+    docker compose down
 }
 
 docker-cleanup() {
     log-debug "cleaning up services..."
-    docker-compose down -v --remove-orphans
+    docker compose down -v --remove-orphans
 }
 
 fingerprint() {
@@ -97,8 +97,8 @@ check-synced-entry() {
   CHECKINTERVAL=1
   for ((i=1;i<=MAXCHECKS;i++)); do
       log-info "checking for synced entry ($i of $MAXCHECKS max)..."
-      docker-compose logs "$1"
-      if docker-compose logs "$1" | grep "$2"; then
+      docker compose logs "$1"
+      if docker compose logs "$1" | grep "$2"; then
           return 0
       fi
       sleep "${CHECKINTERVAL}"
@@ -113,7 +113,7 @@ check-x509-svid-count() {
 
   for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "check X.509-SVID count on agent debug endpoint ($((i)) of $MAXCHECKS max)..."
-    COUNT=$(docker-compose exec -T "$1" /opt/spire/conf/agent/debugclient -testCase "printDebugPage" | jq '.svidsCount')
+    COUNT=$(docker compose exec -T "$1" /opt/spire/conf/agent/debugclient -testCase "printDebugPage" | jq '.svidsCount')
     log-info "X.509-SVID Count: ${COUNT}"
     if [ "$COUNT" -eq "$2" ]; then
       log-info "X.509-SVID count of $COUNT from cache matches the expected count of $2"

--- a/test/integration/common
+++ b/test/integration/common
@@ -38,7 +38,6 @@ docker-up() {
         log-debug "bringing up $*..."
     fi
     docker compose up -d "$@" || fail-now "failed to bring up services."
-
 }
 
 docker-wait-for-healthy() {

--- a/test/integration/suites-windows/windows-service/02-bootstrap-agent
+++ b/test/integration/suites-windows/windows-service/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     c:/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt || fail-now "failed to bootstrap agent"

--- a/test/integration/suites-windows/windows-service/04-create-registration-entries
+++ b/test/integration/suites-windows/windows-service/04-create-registration-entries
@@ -2,7 +2,7 @@
 source ./common
 
 log-debug "creating regular registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     c:/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \

--- a/test/integration/suites-windows/windows-service/05-test-fetch-svid
+++ b/test/integration/suites-windows/windows-service/05-test-fetch-svid
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 log-debug "test fetch x509 SVID..."
-docker-compose exec -T -u ContainerUser spire-agent  \
+docker compose exec -T -u ContainerUser spire-agent  \
     c:/spire/bin/spire-agent api fetch x509 || fail-now "failed to fetch x509"
 
 log-debug "test fetch JWT SVID..."
-docker-compose exec -T -u ContainerUser spire-agent \
+docker compose exec -T -u ContainerUser spire-agent \
     c:/spire/bin/spire-agent api fetch jwt -audience mydb || fail-now "failed to fetch JWT"

--- a/test/integration/suites-windows/windows-service/common
+++ b/test/integration/suites-windows/windows-service/common
@@ -22,7 +22,7 @@ assert-service-status() {
   for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for $1 service $2 ($i of $MAXCHECKS max)..."
     scCommand=$([ "$2" == "STOPPED" ] && echo "query" || echo "interrogate")
-    if docker-compose exec -T -u ContainerAdministrator "$1" sc "$scCommand" "$1" | grep -wq "$2"; then
+    if docker compose exec -T -u ContainerAdministrator "$1" sc "$scCommand" "$1" | grep -wq "$2"; then
       log-info "$1 is in $2 state"
       return 0
     fi
@@ -49,18 +49,18 @@ assert-graceful-shutdown() {
 
 create-service() {
   log-info "creating $1 service..."
-  docker-compose exec -T -u ContainerAdministrator "$1" \
+  docker compose exec -T -u ContainerAdministrator "$1" \
       sc create "$1" binPath="$2" ||  grep "STOPPED" fail-now "failed to create $1 service"
 }
 
 stop-service() {
   log-info "stopping $1 service..."
-  docker-compose exec -T -u ContainerAdministrator "$1" \
+  docker compose exec -T -u ContainerAdministrator "$1" \
       sc stop "$1" || fail-now "failed to stop $1 service"
 }
 
 start-service(){
   log-info "starting $1 service..."
-  docker-compose exec -T -u ContainerAdministrator "$1" \
+  docker compose exec -T -u ContainerAdministrator "$1" \
       sc start "$@" | grep -wq  "START_PENDING\|RUNNING" || fail-now "failed to start $2 service"
 }

--- a/test/integration/suites-windows/windows-service/docker-compose.yaml
+++ b/test/integration/suites-windows/windows-service/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   spire-server:
     image: spire-server-windows:latest-local

--- a/test/integration/suites-windows/windows-service/teardown
+++ b/test/integration/suites-windows/windows-service/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites-windows/windows-workload-attestor/02-bootstrap-agent
+++ b/test/integration/suites-windows/windows-workload-attestor/02-bootstrap-agent
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     c:/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
 

--- a/test/integration/suites-windows/windows-workload-attestor/04-create-registration-entries
+++ b/test/integration/suites-windows/windows-workload-attestor/04-create-registration-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating regular registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     c:/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \

--- a/test/integration/suites-windows/windows-workload-attestor/05-test-fetch-svid
+++ b/test/integration/suites-windows/windows-workload-attestor/05-test-fetch-svid
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 log-debug "test fetch x509 SVID..."
-docker-compose exec -T spire-agent  \
+docker compose exec -T spire-agent  \
     c:/spire/bin/spire-agent api fetch x509 || fail-now "failed to fetch x509"
 
 log-debug "test fetch JWT SVID..."
-docker-compose exec -T spire-agent \
+docker compose exec -T spire-agent \
     c:/spire/bin/spire-agent api fetch jwt -audience mydb || fail-now "failed to fetch jwt"
 

--- a/test/integration/suites-windows/windows-workload-attestor/docker-compose.yaml
+++ b/test/integration/suites-windows/windows-workload-attestor/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server-windows:latest-local

--- a/test/integration/suites-windows/windows-workload-attestor/teardown
+++ b/test/integration/suites-windows/windows-workload-attestor/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/admin-endpoints/02-bootstrap-federation-bundles
+++ b/test/integration/suites/admin-endpoints/02-bootstrap-federation-bundles
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 log-debug "bootstrapping bundle from server b to server a..."
-docker-compose exec -T spire-server-b \
+docker compose exec -T spire-server-b \
     /opt/spire/bin/spire-server bundle show -format spiffe \
-| docker-compose exec -T spire-server-a \
+| docker compose exec -T spire-server-a \
     /opt/spire/bin/spire-server bundle set -format spiffe -id spiffe://domain-b.test
 
 log-debug "bootstrapping bundle from server a to server b..."
-docker-compose exec -T spire-server-a \
+docker compose exec -T spire-server-a \
     /opt/spire/bin/spire-server bundle show -format spiffe \
-| docker-compose exec -T spire-server-b \
+| docker compose exec -T spire-server-b \
     /opt/spire/bin/spire-server bundle set -format spiffe -id spiffe://domain-a.test

--- a/test/integration/suites/admin-endpoints/03-bootstrap-agent
+++ b/test/integration/suites/admin-endpoints/03-bootstrap-agent
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent a..."
-docker-compose exec -T spire-server-a \
+docker compose exec -T spire-server-a \
     /opt/spire/bin/spire-server bundle show > conf/domain-a/agent/bootstrap.crt
 
 log-debug "bootstrapping agent b..."
-docker-compose exec -T spire-server-b \
+docker compose exec -T spire-server-b \
     /opt/spire/bin/spire-server bundle show > conf/domain-b/agent/bootstrap.crt

--- a/test/integration/suites/admin-endpoints/05-create-registration-entries
+++ b/test/integration/suites/admin-endpoints/05-create-registration-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating admin registration entry on server a..."
-docker-compose exec -T spire-server-a \
+docker compose exec -T spire-server-a \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain-a.test/spire/agent/x509pop/$(fingerprint conf/domain-a/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain-a.test/admin" \
@@ -11,7 +11,7 @@ docker-compose exec -T spire-server-a \
 check-synced-entry "spire-agent-a" "spiffe://domain-a.test/admin"
 
 log-debug "creating foreign admin registration entry..."
-docker-compose exec -T spire-server-b \
+docker compose exec -T spire-server-b \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain-b.test/spire/agent/x509pop/$(fingerprint conf/domain-b/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain-b.test/admin" \
@@ -21,7 +21,7 @@ docker-compose exec -T spire-server-b \
 check-synced-entry "spire-agent-b" "spiffe://domain-b.test/admin"
 
 log-debug "creating regular registration entry..."
-docker-compose exec -T spire-server-a \
+docker compose exec -T spire-server-a \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain-a.test/spire/agent/x509pop/$(fingerprint conf/domain-a/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain-a.test/workload" \

--- a/test/integration/suites/admin-endpoints/06-test-endpoints
+++ b/test/integration/suites/admin-endpoints/06-test-endpoints
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 log-debug "test admin workload..."
-docker-compose exec -u 1001 -T spire-agent-a \
+docker compose exec -u 1001 -T spire-agent-a \
 	/opt/spire/conf/agent/adminclient -trustDomain domain-a.test -serverAddr spire-server-a:8081 || fail-now "failed to check admin endpoints"
 
 log-debug "test foreign admin workload..."
-docker-compose exec -u 1003 -T spire-agent-b \
+docker compose exec -u 1003 -T spire-agent-b \
   /opt/spire/conf/agent/adminclient -trustDomain domain-a.test -serverAddr spire-server-a:8081 || fail-now "failed to check admin foreign td endpoints"
 
 log-debug "test regular workload..."
-docker-compose exec -u 1002 -T spire-agent-a \
+docker compose exec -u 1002 -T spire-agent-a \
 	/opt/spire/conf/agent/adminclient -trustDomain domain-a.test -serverAddr spire-server-a:8081 -expectErrors || fail-now "failed to check admin endpoints"

--- a/test/integration/suites/admin-endpoints/docker-compose.yaml
+++ b/test/integration/suites/admin-endpoints/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server-a:
     image: spire-server:latest-local

--- a/test/integration/suites/admin-endpoints/teardown
+++ b/test/integration/suites/admin-endpoints/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/agent-cli/02-bootstrap-agent
+++ b/test/integration/suites/agent-cli/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/agent-cli/04-check-healthy
+++ b/test/integration/suites/agent-cli/04-check-healthy
@@ -7,7 +7,7 @@ HEALTHCHECK_FAIL=0
 
 for ((m=1;m<=$RETRIES;m++)); do
 
-    AGENTS=$(docker-compose exec -T spire-server /opt/spire/bin/spire-server agent list)
+    AGENTS=$(docker compose exec -T spire-server /opt/spire/bin/spire-server agent list)
     if [ "$AGENTS" != "No attested agents found" ]; then
         AGENT_FOUND=1  
         break
@@ -15,8 +15,8 @@ for ((m=1;m<=$RETRIES;m++)); do
 
 done
 
-HEALTH=$(docker-compose exec -T spire-agent /opt/spire/bin/spire-agent healthcheck)
-HEALTH_FAIL=$(docker-compose exec -T spire-agent /opt/spire/bin/spire-agent healthcheck -socketPath invalid/path 2>&1 &)
+HEALTH=$(docker compose exec -T spire-agent /opt/spire/bin/spire-agent healthcheck)
+HEALTH_FAIL=$(docker compose exec -T spire-agent /opt/spire/bin/spire-agent healthcheck -socketPath invalid/path 2>&1 &)
 
 if [[ "$HEALTH" =~ "Agent is healthy." ]]; then
     HEALTHCHECK=1

--- a/test/integration/suites/agent-cli/05-check-valid-config
+++ b/test/integration/suites/agent-cli/05-check-valid-config
@@ -4,10 +4,10 @@ VALID_CONFIG=0
 INVALID_CONFIG=0
 
 # Assert that 'validate' command works
-VALIDATE=$(docker-compose exec -T spire-agent /opt/spire/bin/spire-agent validate)
+VALIDATE=$(docker compose exec -T spire-agent /opt/spire/bin/spire-agent validate)
 
 # Assert that 'validate' command fails with an invalid path
-VALIDATE_FAIL=$(docker-compose exec -T spire-agent /opt/spire/bin/spire-agent validate -config invalid/path 2>&1 &)
+VALIDATE_FAIL=$(docker compose exec -T spire-agent /opt/spire/bin/spire-agent validate -config invalid/path 2>&1 &)
 
 if [[ "$VALIDATE" =~ "SPIRE agent configuration file is valid." ]]; then
     VALID_CONFIG=1

--- a/test/integration/suites/agent-cli/06-check-api-watch-fail
+++ b/test/integration/suites/agent-cli/06-check-api-watch-fail
@@ -4,7 +4,7 @@ SVID_RECEIVED=1
 TIMEOUT_REACHED=0
 
 # Run the background process and store its output in a temporary file
-(docker-compose exec -u 1001 -T spire-agent /opt/spire/bin/spire-agent api watch < /dev/null > api_watch_output.txt) &
+(docker compose exec -u 1001 -T spire-agent /opt/spire/bin/spire-agent api watch < /dev/null > api_watch_output.txt) &
 
 # Get the PID of the last background process
 API_WATCH_PID=$!

--- a/test/integration/suites/agent-cli/07-check-api-watch
+++ b/test/integration/suites/agent-cli/07-check-api-watch
@@ -3,7 +3,7 @@
 TIMEOUT_REACHED=0
 RETRIES=3
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload-$m" \
@@ -14,7 +14,7 @@ docker-compose exec -T spire-server \
 API_WATCH_PID=$!
 
 # Run the background process and store its output in a temporary file
-(docker-compose exec -u 1001 -T spire-agent /opt/spire/bin/spire-agent api watch < /dev/null > api_watch_output.txt) &
+(docker compose exec -u 1001 -T spire-agent /opt/spire/bin/spire-agent api watch < /dev/null > api_watch_output.txt) &
 
 # Wait for the background process to complete
 wait $API_WATCH_PID

--- a/test/integration/suites/agent-cli/docker-compose.yaml
+++ b/test/integration/suites/agent-cli/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/agent-cli/teardown
+++ b/test/integration/suites/agent-cli/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/datastore-mysql-replication/01-test-variants
+++ b/test/integration/suites/datastore-mysql-replication/01-test-variants
@@ -17,7 +17,7 @@ wait-mysql-container-initialized() {
     local init_check_interval=3
     for ((i = 1; i <= max_init_checks; i++)); do
         log-info "waiting for ${service} database initialization (${i} of ${max_init_checks} max)..."
-        if docker-compose logs "${service}" | grep "${init_msg}"; then
+        if docker compose logs "${service}" | grep "${init_msg}"; then
             return 1
         fi
         sleep "${init_check_interval}"
@@ -34,7 +34,7 @@ wait-mysql-container-ready() {
     local ready_check_interval=3
     for ((i = 1; i <= max_ready_checks; i++)); do
         log-info "waiting for ${service} to be ready (${i} of ${max_ready_checks} max)..."
-        if docker-compose exec -T "${service}" mysql -uspire -ptest -e "show databases;" >/dev/null; then
+        if docker compose exec -T "${service}" mysql -uspire -ptest -e "show databases;" >/dev/null; then
             return 1
             break
         fi
@@ -83,7 +83,7 @@ START GROUP_REPLICATION;
 SET @@GLOBAL.group_replication_bootstrap_group=0;
 SELECT * FROM performance_schema.replication_group_members;
 "
-    docker-compose exec -T "${service}" mysql -uroot "-p$mysql_root_password" -e "${replication_script}" 
+    docker compose exec -T "${service}" mysql -uroot "-p$mysql_root_password" -e "${replication_script}" 
 }
 
 # Setup a replica server with group replication. It is compatible with MySQL 5.7 and above.
@@ -95,7 +95,7 @@ configure-readonly-group-replication() {
 CHANGE MASTER TO MASTER_USER='${replication_user}' FOR CHANNEL '${replication_channel}';
 START GROUP_REPLICATION;
 "
-    docker-compose exec -T "${service}" mysql -uroot "-p$mysql_root_password" -e "${replication_script}" 
+    docker compose exec -T "${service}" mysql -uroot "-p$mysql_root_password" -e "${replication_script}" 
 }
 
 test-mysql-replication() {

--- a/test/integration/suites/datastore-mysql/01-test-variants
+++ b/test/integration/suites/datastore-mysql/01-test-variants
@@ -16,7 +16,7 @@ test-mysql() {
     INIT=
     for ((i=1;i<=MAXINITCHECKS;i++)); do
         log-info "waiting for ${SERVICE} database initialization ($i of $MAXINITCHECKS max)..."
-        if docker-compose logs "${SERVICE}" | grep "$INITMSG"; then
+        if docker compose logs "${SERVICE}" | grep "$INITMSG"; then
             INIT=1
             break
         fi
@@ -35,7 +35,7 @@ test-mysql() {
     READY=
     for ((i=1;i<=MAXREADYCHECKS;i++)); do
         log-info "waiting for ${SERVICE} to be ready ($i of $MAXREADYCHECKS max)..."
-        if docker-compose exec -T "${SERVICE}" mysql -uspire -ptest -e "show databases;" > /dev/null; then
+        if docker compose exec -T "${SERVICE}" mysql -uspire -ptest -e "show databases;" > /dev/null; then
             READY=1
             break
         fi

--- a/test/integration/suites/datastore-mysql/docker-compose.yaml
+++ b/test/integration/suites/datastore-mysql/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mysql-5-7:
     image: mysql:5.7

--- a/test/integration/suites/datastore-postgres-replication/01-test-variants
+++ b/test/integration/suites/datastore-postgres-replication/01-test-variants
@@ -10,7 +10,7 @@ wait-container-ready() {
     local ready=
     for ((i=1;i<=max_checks;i++)); do
         log-info "waiting for ${service} ($i of $max_checks max)..."
-        if docker-compose exec -T "${service}" pg_isready -h localhost -U postgres >/dev/null; then
+        if docker compose exec -T "${service}" pg_isready -h localhost -U postgres >/dev/null; then
 	    return 1
         fi
         sleep "${check_interval}"

--- a/test/integration/suites/datastore-postgres-replication/docker-compose.yaml
+++ b/test/integration/suites/datastore-postgres-replication/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres-10-readwrite:
     image: postgres:10

--- a/test/integration/suites/datastore-postgres/01-test-variants
+++ b/test/integration/suites/datastore-postgres/01-test-variants
@@ -12,7 +12,7 @@ test-postgres() {
     READY=
     for ((i=1;i<=MAXCHECKS;i++)); do
         log-info "waiting for ${SERVICE} ($i of $MAXCHECKS max)..."
-        if docker-compose exec -T "${SERVICE}" pg_isready -h localhost -U postgres >/dev/null; then
+        if docker compose exec -T "${SERVICE}" pg_isready -h localhost -U postgres >/dev/null; then
             READY=1
             break
         fi

--- a/test/integration/suites/datastore-postgres/docker-compose.yaml
+++ b/test/integration/suites/datastore-postgres/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   postgres-10:
     image: postgres:10

--- a/test/integration/suites/debug-endpoints/02-bootstrap-agent
+++ b/test/integration/suites/debug-endpoints/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/debug-endpoints/04-create-registration-entries
+++ b/test/integration/suites/debug-endpoints/04-create-registration-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating admin registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/admin" \
@@ -11,7 +11,7 @@ docker-compose exec -T spire-server \
 check-synced-entry "spire-agent" "spiffe://domain.test/admin"
 
 log-debug "creating regular registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \

--- a/test/integration/suites/debug-endpoints/05-test-endpoints
+++ b/test/integration/suites/debug-endpoints/05-test-endpoints
@@ -5,21 +5,21 @@ CHECKINTERVAL=1
 # Call debug endpoints every 1s for 30s
 for ((i=1; i<=MAXCHECKS;i++)); do
 	log-info "test server debug endpoints ($i of $MAXCHECKS max)..."
-	docker-compose exec -T spire-server \
+	docker compose exec -T spire-server \
 		/opt/spire/conf/server/debugclient || fail-now "failed to check server debug endpoints"
 
 	log-info "test agent debug endpoints ($i of $MAXCHECKS max)..."
-	docker-compose exec -T spire-agent \
+	docker compose exec -T spire-agent \
 		/opt/spire/conf/agent/debugclient || fail-now "failed to check agent debug endpoints"
 	 sleep $CHECKINTERVAL
 done
 
 # Verify server TCP server does not implements Debug endpoint
-docker-compose exec -u 1001 -T spire-agent \
+docker compose exec -u 1001 -T spire-agent \
 	/opt/spire/conf/agent/debugclient -testCase "serverWithWorkload" || fail-now "failed to check server debug endpoints using admin workload"
 
-docker-compose exec -u 1002 -T spire-agent \
+docker compose exec -u 1002 -T spire-agent \
 	/opt/spire/conf/agent/debugclient -testCase "serverWithWorkload" || fail-now "failed to check server debug endpoints using regular workload"
 
-docker-compose exec -T spire-agent \
+docker compose exec -T spire-agent \
 	/opt/spire/conf/agent/debugclient -testCase "serverWithInsecure" || fail-now "failed to check server debug endpoints using insecure connection"

--- a/test/integration/suites/debug-endpoints/docker-compose.yaml
+++ b/test/integration/suites/debug-endpoints/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/debug-endpoints/teardown
+++ b/test/integration/suites/debug-endpoints/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/delegatedidentity/02-bootstrap-agent
+++ b/test/integration/suites/delegatedidentity/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/delegatedidentity/04-create-registration-entries
+++ b/test/integration/suites/delegatedidentity/04-create-registration-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating registration entry for authorized client..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/authorized_delegate" \
@@ -10,7 +10,7 @@ docker-compose exec -T spire-server \
 check-synced-entry "spire-agent" "spiffe://domain.test/authorized_delegate"
 
 log-debug "creating registration entry for workload..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \

--- a/test/integration/suites/delegatedidentity/05-test-endpoints
+++ b/test/integration/suites/delegatedidentity/05-test-endpoints
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 log-info "Test Delegated Identity API (for success)"
-docker-compose exec -u 1001 -T spire-agent \
+docker compose exec -u 1001 -T spire-agent \
 	/opt/spire/conf/agent/delegatedidentityclient -expectedID spiffe://domain.test/workload || fail-now "Failed to check Delegated Identity API"
 
 log-info "Test Delegated Identity API (expecting permission denied)"
-docker-compose exec -u 1002 -T spire-agent \
+docker compose exec -u 1002 -T spire-agent \
 	/opt/spire/conf/agent/delegatedidentityclient || fail-now "Failed to check Delegated Identity API"

--- a/test/integration/suites/delegatedidentity/docker-compose.yaml
+++ b/test/integration/suites/delegatedidentity/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/delegatedidentity/teardown
+++ b/test/integration/suites/delegatedidentity/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/downstream-endpoints/02-bootstrap-agent
+++ b/test/integration/suites/downstream-endpoints/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/downstream-endpoints/04-create-entries
+++ b/test/integration/suites/downstream-endpoints/04-create-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating downstream registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/downstream" \
@@ -11,7 +11,7 @@ docker-compose exec -T spire-server \
 check-synced-entry "spire-agent" "spiffe://domain.test/downstream"
 
 log-debug "creating workload registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \

--- a/test/integration/suites/downstream-endpoints/05-test-endpoints
+++ b/test/integration/suites/downstream-endpoints/05-test-endpoints
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 log-debug "test downstream workload..."
-docker-compose exec -u 1001 -T spire-agent \
+docker compose exec -u 1001 -T spire-agent \
 	/opt/spire/conf/agent/downstreamclient || fail-now "failed to check downstream endpoints"
 
 log-debug "Test regular workload..."
-docker-compose exec -u 1002 -T spire-agent \
+docker compose exec -u 1002 -T spire-agent \
 	/opt/spire/conf/agent/downstreamclient -expectErrors || fail-now "failed to check permission errors on downstream endpoints"

--- a/test/integration/suites/downstream-endpoints/docker-compose.yaml
+++ b/test/integration/suites/downstream-endpoints/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/downstream-endpoints/teardown
+++ b/test/integration/suites/downstream-endpoints/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
@@ -7,24 +7,24 @@ setup-tests() {
 
     # Bootstrap agents
     log-debug "bootstrapping downstream federated agent..."
-    docker-compose exec -T downstream-federated-spire-server \
+    docker compose exec -T downstream-federated-spire-server \
         /opt/spire/bin/spire-server bundle show > conf/downstream-federated/agent/bootstrap.crt
     
     log-debug "bootstrapping upstream agent..."
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server bundle show > conf/upstream/agent/bootstrap.crt
 
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server bundle show > conf/downstream/agent/bootstrap.crt
     
     log-debug "creating federation relationship from downstream federated to upstream server and set bundle in same command..."
-    docker-compose exec -T downstream-federated-spire-server \
+    docker compose exec -T downstream-federated-spire-server \
         /opt/spire/bin/spire-server bundle show -format spiffe > conf/upstream/server/federated-domain.test.bundle
 
     # On macOS, there can be a delay propagating the file on the bind mount to the other container
     sleep 1
 
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server federation create \
         -bundleEndpointProfile "https_spiffe" \
         -bundleEndpointURL "https://downstream-federated-spire-server:8443" \
@@ -34,17 +34,17 @@ setup-tests() {
         -trustDomainBundlePath "/opt/spire/conf/server/federated-domain.test.bundle"
     
     log-debug "bootstrapping bundle from upstream to downstream federated server..."
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server bundle show -format spiffe > conf/downstream-federated/server/domain.test.bundle
 
     # On macOS, there can be a delay propagating the file on the bind mount to the other container
     sleep 1
 
-    docker-compose exec -T downstream-federated-spire-server \
+    docker compose exec -T downstream-federated-spire-server \
         /opt/spire/bin/spire-server bundle set -format spiffe -id spiffe://domain.test -path /opt/spire/conf/server/domain.test.bundle
 
     log-debug "creating federation relationship from upstream to downstream federated server..."
-    docker-compose exec -T downstream-federated-spire-server \
+    docker compose exec -T downstream-federated-spire-server \
         /opt/spire/bin/spire-server federation create \
         -bundleEndpointProfile "https_spiffe" \
         -bundleEndpointURL "https://upstream-spire-server" \
@@ -53,7 +53,7 @@ setup-tests() {
 
     # Register workloads
     log-debug "creating registration entry for downstream federated proxy..."
-    docker-compose exec -T downstream-federated-spire-server \
+    docker compose exec -T downstream-federated-spire-server \
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://federated-domain.test/spire/agent/x509pop/$(fingerprint conf/downstream-federated/agent/agent.crt.pem)" \
         -spiffeID "spiffe://federated-domain.test/downstream-proxy" \
@@ -62,7 +62,7 @@ setup-tests() {
         -ttl 0
     
     log-debug "creating registration entry for upstream proxy..."
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/upstream/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/upstream-proxy" \
@@ -71,7 +71,7 @@ setup-tests() {
         -ttl 0
 
     log-debug "creating registration entry for downstream proxy..."
-    docker-compose exec -T upstream-spire-server \
+    docker compose exec -T upstream-spire-server \
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/downstream/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/downstream-proxy" \
@@ -87,11 +87,11 @@ test-envoy() {
     local check_interval=1
 	
     # Remove howdy, it i necessary for VERIFY to get again messages
-    docker-compose exec -T upstream-socat rm -f /tmp/howdy
+    docker compose exec -T upstream-socat rm -f /tmp/howdy
     
     log-debug "Checking mTLS: ${mTLSSocat}"
-    TRY() { docker-compose exec -T ${mTLSSocat} /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
-    VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
+    TRY() { docker compose exec -T ${mTLSSocat} /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
+    VERIFY() { docker compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
     
     local mtls_federated_ok=
     for ((i=1;i<=max_checks_per_port;i++)); do
@@ -105,8 +105,8 @@ test-envoy() {
     done
     
     log-debug "Checking TLS: ${tlsSocat}"
-    TRY() { docker-compose exec -T ${tlsSocat} /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
-    VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
+    TRY() { docker compose exec -T ${tlsSocat} /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
+    VERIFY() { docker compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
     
     tls_federated_ok=
     for ((i=1;i<=max_checks_per_port;i++)); do
@@ -160,7 +160,7 @@ for release in "${ENVOY_RELEASES_TO_TEST[@]}"; do
     test-envoy "downstream-federated-socat-mtls" "downstream-federated-socat-tls"
 
     # stop and clear everything but the server container
-    docker-compose stop \
+    docker compose stop \
         upstream-proxy \
         downstream-proxy \
         downstream-federated-proxy \
@@ -170,5 +170,5 @@ for release in "${ENVOY_RELEASES_TO_TEST[@]}"; do
         downstream-federated-socat-mtls \
         downstream-federated-socat-tls
 
-    docker-compose rm -f
+    docker compose rm -f
 done

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/docker-compose.yaml
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   upstream-spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/teardown
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -6,16 +6,16 @@ setup-tests() {
 
     # Bootstrap the agent
     log-debug "bootstrapping downstream agent..."
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server bundle show > conf/downstream-agent/bootstrap.crt
 
     log-debug "bootstrapping upstream agent..."
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server bundle show > conf/upstream-agent/bootstrap.crt
 
     # Register the workload
     log-debug "creating registration entry for upstream workload..."
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/upstream-agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/upstream-workload" \
@@ -23,7 +23,7 @@ setup-tests() {
         -ttl 0
 
     log-debug "creating registration entry for downstream workload..."
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry create \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/downstream-agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/downstream-workload" \
@@ -37,8 +37,8 @@ test-envoy() {
     MAXCHECKSPERPORT=15
     CHECKINTERVAL=1
 
-    TRY() { docker-compose exec -T downstream-socat-mtls /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
-    VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
+    TRY() { docker compose exec -T downstream-socat-mtls /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }
+    VERIFY() { docker compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_MTLS; }
 
     MTLS_OK=
     for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
@@ -51,8 +51,8 @@ test-envoy() {
         sleep "${CHECKINTERVAL}"
     done
 
-    TRY() { docker-compose exec -T downstream-socat-tls /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
-    VERIFY() { docker-compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
+    TRY() { docker compose exec -T downstream-socat-tls /bin/sh -c 'echo HELLO_TLS | socat -u STDIN TCP:localhost:8002'; }
+    VERIFY() { docker compose exec -T upstream-socat cat /tmp/howdy | grep -q HELLO_TLS; }
 
     TLS_OK=
     for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
@@ -104,12 +104,12 @@ for release in "${ENVOY_RELEASES_TO_TEST[@]}"; do
     test-envoy
 
     # stop and clear everything but the server container
-    docker-compose stop \
+    docker compose stop \
         upstream-proxy \
         downstream-proxy \
         upstream-socat \
         downstream-socat-mtls \
         downstream-socat-tls
 
-    docker-compose rm -f
+    docker compose rm -f
 done

--- a/test/integration/suites/envoy-sds-v3/docker-compose.yaml
+++ b/test/integration/suites/envoy-sds-v3/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/envoy-sds-v3/teardown
+++ b/test/integration/suites/envoy-sds-v3/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/evict-agent/02-bootstrap-agent
+++ b/test/integration/suites/evict-agent/02-bootstrap-agent
@@ -6,8 +6,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "trying to bootstrap agent ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose exec -T spire-server \
+    docker compose logs spire-agent
+    if docker compose exec -T spire-server \
         /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt; then
 	    exit 0
     fi

--- a/test/integration/suites/evict-agent/04-ban-agent
+++ b/test/integration/suites/evict-agent/04-ban-agent
@@ -2,7 +2,7 @@
 
 log-debug "banning agent..."
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent ban \
     -spiffeID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"
 
@@ -12,8 +12,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for agent is shutting down ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "Agent is banned: removing SVID and shutting down"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "Agent is banned: removing SVID and shutting down"; then
 	exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/evict-agent/05-agent-failed-to-start
+++ b/test/integration/suites/evict-agent/05-agent-failed-to-start
@@ -9,8 +9,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking that the agent is not able to start ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "failed to fetch authorized entries:"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "failed to fetch authorized entries:"; then
 	exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/evict-agent/06-delete-agent
+++ b/test/integration/suites/evict-agent/06-delete-agent
@@ -2,6 +2,6 @@
 
 log-debug "deleting agent to enable reattestation..."
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent evict \
     -spiffeID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"

--- a/test/integration/suites/evict-agent/07-start-agent
+++ b/test/integration/suites/evict-agent/07-start-agent
@@ -9,8 +9,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking that the agent is back up ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "Starting Workload and SDS APIs"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "Starting Workload and SDS APIs"; then
 	    exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/evict-agent/08-evict-agent
+++ b/test/integration/suites/evict-agent/08-evict-agent
@@ -7,7 +7,7 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "attempting to evict agent ($i of $MAXCHECKS max)..."
-    if docker-compose exec -T spire-server \
+    if docker compose exec -T spire-server \
         /opt/spire/bin/spire-server agent evict \
         -spiffeID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"; then
 	    exit 0
@@ -21,8 +21,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for agent to get notification and try to reattest ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "Agent needs to re-attest; will attempt to re-attest"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "Agent needs to re-attest; will attempt to re-attest"; then
 	    exit 0
     fi
     sleep "${CHECKINTERVAL}"
@@ -33,8 +33,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for agent to get notification and try to reattest ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "Successfully reattested node"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "Successfully reattested node"; then
 	    exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/evict-agent/docker-compose.yaml
+++ b/test/integration/suites/evict-agent/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/evict-agent/teardown
+++ b/test/integration/suites/evict-agent/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/fetch-x509-svids/02-bootstrap-agent
+++ b/test/integration/suites/fetch-x509-svids/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/fetch-x509-svids/04-create-registration-entries
+++ b/test/integration/suites/fetch-x509-svids/04-create-registration-entries
@@ -5,7 +5,7 @@ SIZE=10
 # Create entries for uid 1001
 for ((m=1;m<=$SIZE;m++)); do
   log-debug "creating registration entry: $m"
-  docker-compose exec -T spire-server \
+  docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload-$m" \

--- a/test/integration/suites/fetch-x509-svids/05-fetch-x509-svids
+++ b/test/integration/suites/fetch-x509-svids/05-fetch-x509-svids
@@ -3,7 +3,7 @@
 ENTRYCOUNT=10
 CACHESIZE=8
 
-X509SVIDCOUNT=$(docker-compose exec -u 1001 -T spire-agent \
+X509SVIDCOUNT=$(docker compose exec -u 1001 -T spire-agent \
   /opt/spire/bin/spire-agent api fetch x509 \
   -socketPath /opt/spire/sockets/workload_api.sock | grep -i "spiffe://domain.test" | wc -l || fail-now "X.509-SVID check failed")
 

--- a/test/integration/suites/fetch-x509-svids/06-create-registration-entries
+++ b/test/integration/suites/fetch-x509-svids/06-create-registration-entries
@@ -5,7 +5,7 @@ SIZE=10
 # Create entries for uid 1002
 for ((m=1;m<=$SIZE;m++)); do
   log-debug "creating registration entry...($m)"
-  docker-compose exec -T spire-server \
+  docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload/$m" \

--- a/test/integration/suites/fetch-x509-svids/07-fetch-x509-svids
+++ b/test/integration/suites/fetch-x509-svids/07-fetch-x509-svids
@@ -3,7 +3,7 @@
 CACHESIZE=8
 ENTRYCOUNT=10
 
-X509SVIDCOUNT=$(docker-compose exec -u 1002 -T spire-agent \
+X509SVIDCOUNT=$(docker compose exec -u 1002 -T spire-agent \
   /opt/spire/bin/spire-agent api fetch x509 \
   -socketPath /opt/spire/sockets/workload_api.sock | grep -i "spiffe://domain.test" | wc -l || fail-now "X.509-SVID check failed")
 
@@ -13,7 +13,7 @@ else
   log-info "Expected $ENTRYCOUNT X.509-SVIDs and received $X509SVIDCOUNT for uid 1002";
 fi
 
-X509SVIDCOUNT=$(docker-compose exec -u 1001 -T spire-agent \
+X509SVIDCOUNT=$(docker compose exec -u 1001 -T spire-agent \
   /opt/spire/bin/spire-agent api fetch x509 \
   -socketPath /opt/spire/sockets/workload_api.sock | grep -i "spiffe://domain.test" | wc -l || fail-now "X.509-SVID check failed")
 

--- a/test/integration/suites/fetch-x509-svids/docker-compose.yaml
+++ b/test/integration/suites/fetch-x509-svids/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/fetch-x509-svids/teardown
+++ b/test/integration/suites/fetch-x509-svids/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/ghostunnel-federation/02-bootstrap-federation-and-agents
+++ b/test/integration/suites/ghostunnel-federation/02-bootstrap-federation-and-agents
@@ -3,29 +3,29 @@
 set -e
 
 log-debug "bootstrapping downstream agent..."
-docker-compose exec -T downstream-spire-server \
+docker compose exec -T downstream-spire-server \
     /opt/spire/bin/spire-server bundle show > conf/downstream/agent/bootstrap.crt
 
 log-debug "bootstrapping upstream agent..."
-docker-compose exec -T upstream-spire-server \
+docker compose exec -T upstream-spire-server \
     /opt/spire/bin/spire-server bundle show > conf/upstream/agent/bootstrap.crt
 
 log-debug "bootstrapping bundle from downstream to upstream server..."
-docker-compose exec -T downstream-spire-server \
+docker compose exec -T downstream-spire-server \
     /opt/spire/bin/spire-server bundle show -format spiffe > conf/upstream/server/downstream-domain.test.bundle
 
 # On macOS, there can be a delay propagating the file on the bind mount to the other container
 sleep 1
 
-docker-compose exec -T upstream-spire-server \
+docker compose exec -T upstream-spire-server \
     /opt/spire/bin/spire-server bundle set -format spiffe -id spiffe://downstream-domain.test -path /opt/spire/conf/server/downstream-domain.test.bundle
 
 log-debug "bootstrapping bundle from upstream to downstream server..."
-docker-compose exec -T upstream-spire-server \
+docker compose exec -T upstream-spire-server \
     /opt/spire/bin/spire-server bundle show -format spiffe > conf/downstream/server/upstream-domain.test.bundle
 
 # On macOS, there can be a delay propagating the file on the bind mount to the other container
 sleep 1
 
-docker-compose exec -T downstream-spire-server \
+docker compose exec -T downstream-spire-server \
     /opt/spire/bin/spire-server bundle set -format spiffe -id spiffe://upstream-domain.test -path /opt/spire/conf/server/upstream-domain.test.bundle

--- a/test/integration/suites/ghostunnel-federation/04-create-workload-entries
+++ b/test/integration/suites/ghostunnel-federation/04-create-workload-entries
@@ -3,7 +3,7 @@
 set -o pipefail
 
 log-debug "creating registration entry for downstream workload..."
-docker-compose exec -T downstream-spire-server \
+docker compose exec -T downstream-spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://downstream-domain.test/spire/agent/x509pop/$(fingerprint conf/downstream/agent/agent.crt.pem)" \
     -spiffeID "spiffe://downstream-domain.test/downstream-workload" \
@@ -12,7 +12,7 @@ docker-compose exec -T downstream-spire-server \
     -ttl 0
 
 log-debug "creating registration entry for upstream workload..."
-docker-compose exec -T upstream-spire-server \
+docker compose exec -T upstream-spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://upstream-domain.test/spire/agent/x509pop/$(fingerprint conf/upstream/agent/agent.crt.pem)" \
     -spiffeID "spiffe://upstream-domain.test/upstream-workload" \

--- a/test/integration/suites/ghostunnel-federation/05-check-workload-connectivity
+++ b/test/integration/suites/ghostunnel-federation/05-check-workload-connectivity
@@ -3,14 +3,14 @@
 MAXCHECKSPERPORT=15
 CHECKINTERVAL=1
 
-TRY() { docker-compose exec -T downstream-workload /bin/sh -c 'echo HELLO | socat -u STDIN TCP:localhost:8000'; }
-VERIFY() { docker-compose exec -T upstream-workload cat /tmp/howdy | grep -q HELLO; }
+TRY() { docker compose exec -T downstream-workload /bin/sh -c 'echo HELLO | socat -u STDIN TCP:localhost:8000'; }
+VERIFY() { docker compose exec -T upstream-workload cat /tmp/howdy | grep -q HELLO; }
 
 for ((i=1;i<=MAXCHECKSPERPORT;i++)); do
     log-debug "Checking proxy ($i of $MAXCHECKSPERPORT max)..."
     if TRY && VERIFY; then
         log-info "Proxy OK"
-        docker-compose exec -T upstream-workload rm /tmp/howdy
+        docker compose exec -T upstream-workload rm /tmp/howdy
         exit 0
     fi
 

--- a/test/integration/suites/ghostunnel-federation/10-stop-agents
+++ b/test/integration/suites/ghostunnel-federation/10-stop-agents
@@ -3,7 +3,7 @@
 set -e
 
 log-debug "stopping downstream agent"
-docker-compose exec -T downstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf stop spire-agent
+docker compose exec -T downstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf stop spire-agent
 
 log-debug "stopping upstream agent"
-docker-compose exec -T upstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf stop spire-agent
+docker compose exec -T upstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf stop spire-agent

--- a/test/integration/suites/ghostunnel-federation/12-start-agents
+++ b/test/integration/suites/ghostunnel-federation/12-start-agents
@@ -3,7 +3,7 @@
 set -e
 
 log-debug "starting downstream agent"
-docker-compose exec -T downstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf start spire-agent
+docker compose exec -T downstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf start spire-agent
 
 log-debug "starting upstream agent"
-docker-compose exec -T upstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf start spire-agent
+docker compose exec -T upstream-workload supervisorctl --configuration /opt/supervisord/supervisord.conf start spire-agent

--- a/test/integration/suites/ghostunnel-federation/docker-compose.yaml
+++ b/test/integration/suites/ghostunnel-federation/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   upstream-spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/ghostunnel-federation/teardown
+++ b/test/integration/suites/ghostunnel-federation/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "${SUCCESS}" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/join-token/02-bootstrap-agents
+++ b/test/integration/suites/join-token/02-bootstrap-agents
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
 
 log-info "generating join token..."
-TOKEN=$(docker-compose exec -T spire-server \
+TOKEN=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server token generate -spiffeID spiffe://domain.test/node | awk '{print $2}' | tr -d '\r')
 
 # Inserts the join token into the agent configuration

--- a/test/integration/suites/join-token/04-create-workload-entry
+++ b/test/integration/suites/join-token/04-create-workload-entry
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/node" \
     -spiffeID "spiffe://domain.test/workload" \
@@ -14,8 +14,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for synced workload entry ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "spiffe://domain.test/workload"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "spiffe://domain.test/workload"; then
         exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/join-token/05-check-svid
+++ b/test/integration/suites/join-token/05-check-svid
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-info "checking X509-SVID..."
-docker-compose exec -T spire-agent \
+docker compose exec -T spire-agent \
     /opt/spire/bin/spire-agent api fetch x509 || fail-now "SVID check failed"

--- a/test/integration/suites/join-token/06-start-bad-agent
+++ b/test/integration/suites/join-token/06-start-bad-agent
@@ -5,7 +5,7 @@ docker-up bad-spire-agent
 MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
-    docker-compose logs bad-spire-agent | tee bad-agent-logs
+    docker compose logs bad-spire-agent | tee bad-agent-logs
     if grep -sq "failed to attest: join token does not exist or has already been used" bad-agent-logs; then
         exit 0
     fi

--- a/test/integration/suites/join-token/docker-compose.yaml
+++ b/test/integration/suites/join-token/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/join-token/teardown
+++ b/test/integration/suites/join-token/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/nested-rotation/01-start-root
+++ b/test/integration/suites/nested-rotation/01-start-root
@@ -2,6 +2,7 @@
 
 log-debug "Starting root-server..."
 docker-up root-server
+check-server-started "root-server"
 
 log-debug "bootstrapping root-agent..."
 docker compose exec -T root-server \

--- a/test/integration/suites/nested-rotation/01-start-root
+++ b/test/integration/suites/nested-rotation/01-start-root
@@ -4,7 +4,7 @@ log-debug "Starting root-server..."
 docker-up root-server
 
 log-debug "bootstrapping root-agent..."
-docker-compose exec -T root-server \
+docker compose exec -T root-server \
     /opt/spire/bin/spire-server bundle show > root/agent/bootstrap.crt
 
 log-debug "Starting root-agent..."

--- a/test/integration/suites/nested-rotation/02-create-intermediate-downstream-entries
+++ b/test/integration/suites/nested-rotation/02-create-intermediate-downstream-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating intermediateA downstream registration entry..."
-docker-compose exec -T root-server \
+docker compose exec -T root-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint root/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateA" \
@@ -11,7 +11,7 @@ docker-compose exec -T root-server \
 check-synced-entry "root-agent" "spiffe://domain.test/intermediateA"
 
 log-debug "creating intermediateB downstream registration entry..."
-docker-compose exec -T root-server \
+docker compose exec -T root-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint root/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateB" \

--- a/test/integration/suites/nested-rotation/03-start-intermediateA
+++ b/test/integration/suites/nested-rotation/03-start-intermediateA
@@ -4,7 +4,7 @@ log-debug "Starting intermediateA-server.."
 docker-up intermediateA-server
 
 log-debug "bootstrapping intermediateA agent..."
-docker-compose exec -T intermediateA-server \
+docker compose exec -T intermediateA-server \
     /opt/spire/bin/spire-server bundle show > intermediateA/agent/bootstrap.crt
 
 log-debug "Starting intermediateA-agent..."

--- a/test/integration/suites/nested-rotation/03-start-intermediateA
+++ b/test/integration/suites/nested-rotation/03-start-intermediateA
@@ -2,6 +2,7 @@
 
 log-debug "Starting intermediateA-server.."
 docker-up intermediateA-server
+check-server-started "intermediateA-server"
 
 log-debug "bootstrapping intermediateA agent..."
 docker compose exec -T intermediateA-server \

--- a/test/integration/suites/nested-rotation/04-create-leafA-downstream-entry
+++ b/test/integration/suites/nested-rotation/04-create-leafA-downstream-entry
@@ -2,7 +2,7 @@
 
 log-debug "creating leafA downstream registration entry..."
 # Create downstream registation entry on intermediateA-server for `leafA-server`
-docker-compose exec -T intermediateA-server \
+docker compose exec -T intermediateA-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateA/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafA" \

--- a/test/integration/suites/nested-rotation/05-start-leafA
+++ b/test/integration/suites/nested-rotation/05-start-leafA
@@ -4,7 +4,7 @@ log-debug "Starting leafA-server.."
 docker-up leafA-server
 
 log-debug "bootstrapping leafA agent..."
-docker-compose exec -T leafA-server \
+docker compose exec -T leafA-server \
     /opt/spire/bin/spire-server bundle show > leafA/agent/bootstrap.crt
 
 log-debug "Starting leafA-agent..."

--- a/test/integration/suites/nested-rotation/05-start-leafA
+++ b/test/integration/suites/nested-rotation/05-start-leafA
@@ -2,6 +2,7 @@
 
 log-debug "Starting leafA-server.."
 docker-up leafA-server
+check-server-started "leafA-server"
 
 log-debug "bootstrapping leafA agent..."
 docker compose exec -T leafA-server \

--- a/test/integration/suites/nested-rotation/06-start-intermediateB
+++ b/test/integration/suites/nested-rotation/06-start-intermediateB
@@ -2,6 +2,7 @@
 
 log-debug "Starting intermediateB-server.."
 docker-up intermediateB-server
+check-server-started "intermediateB-server"
 
 log-debug "bootstrapping intermediateB downstream agent..."
 docker compose exec -T intermediateB-server \

--- a/test/integration/suites/nested-rotation/06-start-intermediateB
+++ b/test/integration/suites/nested-rotation/06-start-intermediateB
@@ -4,7 +4,7 @@ log-debug "Starting intermediateB-server.."
 docker-up intermediateB-server
 
 log-debug "bootstrapping intermediateB downstream agent..."
-docker-compose exec -T intermediateB-server \
+docker compose exec -T intermediateB-server \
     /opt/spire/bin/spire-server bundle show > intermediateB/agent/bootstrap.crt
 
 log-debug "Starting intermediateB-agent..."

--- a/test/integration/suites/nested-rotation/07-create-leafB-downstream-entry
+++ b/test/integration/suites/nested-rotation/07-create-leafB-downstream-entry
@@ -2,7 +2,7 @@
 
 log-debug "creating leafB downstream registration entry..."
 # Create downstream registration entry on itermediateB for leafB-server
-docker-compose exec -T intermediateB-server \
+docker compose exec -T intermediateB-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateB/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafB" \

--- a/test/integration/suites/nested-rotation/08-start-leafB
+++ b/test/integration/suites/nested-rotation/08-start-leafB
@@ -2,6 +2,7 @@
 
 log-debug "Starting leafB-server.."
 docker-up leafB-server
+check-server-started "leafB-server"
 
 log-debug "bootstrapping leafB agent..."
 docker compose exec -T leafB-server \

--- a/test/integration/suites/nested-rotation/08-start-leafB
+++ b/test/integration/suites/nested-rotation/08-start-leafB
@@ -4,7 +4,7 @@ log-debug "Starting leafB-server.."
 docker-up leafB-server
 
 log-debug "bootstrapping leafB agent..."
-docker-compose exec -T leafB-server \
+docker compose exec -T leafB-server \
     /opt/spire/bin/spire-server bundle show > leafB/agent/bootstrap.crt
 
 log-debug "Starting leafB-agent..."

--- a/test/integration/suites/nested-rotation/09-create-workload-entries
+++ b/test/integration/suites/nested-rotation/09-create-workload-entries
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating intermediateA workload registration entry..."
-docker-compose exec -T intermediateA-server \
+docker compose exec -T intermediateA-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateA/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateA/workload" \
@@ -10,7 +10,7 @@ docker-compose exec -T intermediateA-server \
 check-synced-entry "intermediateA-agent" "spiffe://domain.test/intermediateA/workload"
 
 log-debug "creating leafA workload registration entry..."
-docker-compose exec -T leafA-server \
+docker compose exec -T leafA-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint leafA/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafA/workload" \
@@ -19,7 +19,7 @@ docker-compose exec -T leafA-server \
 check-synced-entry "leafA-agent" "spiffe://domain.test/leafA/workload"
 
 log-debug "creating intermediateB workload registration entry..."
-docker-compose exec -T intermediateB-server \
+docker compose exec -T intermediateB-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateB/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateB/workload" \
@@ -28,7 +28,7 @@ docker-compose exec -T intermediateB-server \
 check-synced-entry "intermediateB-agent" "spiffe://domain.test/intermediateB/workload"
 
 log-debug "creating leafB workload registration entry..."
-docker-compose exec -T leafB-server \
+docker compose exec -T leafB-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint leafB/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafB/workload" \

--- a/test/integration/suites/nested-rotation/10-check-svids
+++ b/test/integration/suites/nested-rotation/10-check-svids
@@ -5,29 +5,29 @@ CHECKINTERVAL=6
 
 validateX509SVID() {
   # Write svid on disk
-  docker-compose exec -u 1001 -T $1 \
+  docker compose exec -u 1001 -T $1 \
       /opt/spire/bin/spire-agent api fetch x509 \
       -socketPath /opt/spire/sockets/workload_api.sock \
       -write /tmp || fail-now "x509-SVID check failed"
 
   # Copy SVID
-  docker cp $(docker-compose ps -q $1):/tmp/svid.0.pem - | docker cp - $(docker-compose ps -q $2):/opt/
+  docker cp $(docker compose ps -q $1):/tmp/svid.0.pem - | docker cp - $(docker compose ps -q $2):/opt/
 
-  docker-compose exec -u 1001 -T $2 \
+  docker compose exec -u 1001 -T $2 \
       /opt/spire/bin/spire-agent api fetch x509 \
       -socketPath /opt/spire/sockets/workload_api.sock \
       -write /tmp || fail-now "x509-SVID check failed"
 
-  docker-compose exec -T $2 openssl verify -verbose -CAfile /tmp/bundle.0.pem -untrusted /opt/svid.0.pem /opt/svid.0.pem
+  docker compose exec -T $2 openssl verify -verbose -CAfile /tmp/bundle.0.pem -untrusted /opt/svid.0.pem /opt/svid.0.pem
 }
 
 validateJWTSVID() {
    # Fetch JWT-SVID and extract token
-  token=$(docker-compose exec -u 1001 -T $1 \
+  token=$(docker compose exec -u 1001 -T $1 \
       /opt/spire/bin/spire-agent api fetch jwt -audience testIt -socketPath /opt/spire/sockets/workload_api.sock -output json | jq -r '.[0].svids[0].svid') || fail-now "JWT-SVID check failed"
 
   # Validate token
-  docker-compose exec -u 1001 -T $2 \
+  docker compose exec -u 1001 -T $2 \
       /opt/spire/bin/spire-agent api validate jwt -audience testIt  -svid "${token}" \
         -socketPath /opt/spire/sockets/workload_api.sock
 }

--- a/test/integration/suites/nested-rotation/docker-compose.yaml
+++ b/test/integration/suites/nested-rotation/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   # Root
   root-server:

--- a/test/integration/suites/nested-rotation/teardown
+++ b/test/integration/suites/nested-rotation/teardown
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 
 docker-down

--- a/test/integration/suites/node-attestation/02-start-agent
+++ b/test/integration/suites/node-attestation/02-start-agent
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
 
 log-debug "starting agent..."
-docker-compose up -d "spire-agent" || fail-now "failed to bring up services."
+docker compose up -d "spire-agent" || fail-now "failed to bring up services."

--- a/test/integration/suites/node-attestation/03-test-node-attestation
+++ b/test/integration/suites/node-attestation/03-test-node-attestation
@@ -1,31 +1,31 @@
 #!/bin/bash
 
 # Test node attestation api
-jointoken=`docker-compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep jointoken`
+jointoken=`docker compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep jointoken`
 echo "Created Join Token" $jointoken
 
-svid1=`docker-compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep jointokenattest -tokenName $jointoken`
+svid1=`docker compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep jointokenattest -tokenName $jointoken`
 if [[ $? -ne 0 ]];
 then
 	fail-now "Failed to do initial join token attestation"
 fi
 echo "Received initial SVID:" $svid1
 
-svid2=`docker-compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep renew -certificate "${svid1}"`
+svid2=`docker compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep renew -certificate "${svid1}"`
 if [[ $? -ne 0 ]];
 then
 	fail-now "Failed to do SVID renewal"
 fi
 echo "Received renewed SVID:" $svid2
 
-docker-compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep ban -tokenName ${jointoken} 
+docker compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep ban -tokenName ${jointoken} 
 if [[ $? -ne 0 ]];
 then
 	fail-now "Failed to do initial join token attestation"
 fi
 echo "Agent banned"
 
-if docker-compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep renew -certificate "${svid2}" 
+if docker compose exec -u 1000 -T spire-server /opt/spire/conf/server/node-attestation -testStep renew -certificate "${svid2}" 
 then
 	fail-now "Expected agent to be banned"
 fi

--- a/test/integration/suites/node-attestation/04-test-x509pop-attestation
+++ b/test/integration/suites/node-attestation/04-test-x509pop-attestation
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating admin registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/admin" \
@@ -11,4 +11,4 @@ docker-compose exec -T spire-server \
 check-synced-entry "spire-agent" "spiffe://domain.test/admin"
 
 log-debug "running x509pop test..."
-docker-compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep x509pop || fail-now "failed to check x509pop attestion"
+docker compose exec -u 1000 -T spire-agent /opt/spire/conf/agent/node-attestation -testStep x509pop || fail-now "failed to check x509pop attestion"

--- a/test/integration/suites/node-attestation/docker-compose.yaml
+++ b/test/integration/suites/node-attestation/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/node-attestation/teardown
+++ b/test/integration/suites/node-attestation/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/node-re-attestation/02-start-agent
+++ b/test/integration/suites/node-re-attestation/02-start-agent
@@ -2,11 +2,11 @@
 source ./common
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
 
 log-info "generating join token..."
-TOKEN=$(docker-compose exec -T spire-server \
+TOKEN=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server token generate -spiffeID spiffe://domain.test/node -output json | jq -r ".value")
 
 # Inserts the join token into the agent configuration
@@ -14,10 +14,10 @@ log-debug "using join token ${TOKEN}..."
 sed -i.bak "s#TOKEN#${TOKEN}#g" conf/agent/agent_jointoken.conf
 
 log-debug "starting agent a..."
-docker-compose up -d "spire-agent-a" || fail-now "failed to bring up services."
+docker compose up -d "spire-agent-a" || fail-now "failed to bring up services."
 
 log-debug "starting agent b..."
-docker-compose up -d "spire-agent-b" || fail-now "failed to bring up services."
+docker compose up -d "spire-agent-b" || fail-now "failed to bring up services."
 
 AGENT_A_SPIFFE_ID_PATH="/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"
 AGENT_B_SPIFFE_ID_PATH="/spire/agent/join_token/$(grep -oP '(?<=join_token = ")[^"]*' conf/agent/agent_jointoken.conf)"

--- a/test/integration/suites/node-re-attestation/03-evict-agents
+++ b/test/integration/suites/node-re-attestation/03-evict-agents
@@ -5,10 +5,10 @@ AGENT_A_SPIFFE_ID="spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/a
 AGENT_B_SPIFFE_ID="spiffe://domain.test/spire/agent/join_token/$(grep -oP '(?<=join_token = ")[^"]*' conf/agent/agent_jointoken.conf)"
 
 log-debug "evicting agents..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent evict -spiffeID $AGENT_A_SPIFFE_ID || fail-now "failed to evict agent a."
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent evict -spiffeID $AGENT_B_SPIFFE_ID || fail-now "failed to evict agent b."
 
 check-evict-agents $AGENT_A_SPIFFE_ID $AGENT_B_SPIFFE_ID

--- a/test/integration/suites/node-re-attestation/04-check-re-attest
+++ b/test/integration/suites/node-re-attestation/04-check-re-attest
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./common
 
-docker-compose restart "spire-agent-a" "spire-agent-b" || fail-now "failed to stop services."
+docker compose restart "spire-agent-a" "spire-agent-b" || fail-now "failed to stop services."
 
 # spire-agent-b can't re-attest because join_token implements trust on first use model.
 AGENT_A_SPIFFE_ID_PATH="/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"

--- a/test/integration/suites/node-re-attestation/common
+++ b/test/integration/suites/node-re-attestation/common
@@ -8,7 +8,7 @@ check-attested-agents () {
   for ((i=1;i<=MAXCHECKS;i++)); do
     log-debug "checking attested agents ($i of $MAXCHECKS max)......"
     MATCHING_COUNT=0
-    AGENTS=$(docker-compose exec -T spire-server /opt/spire/bin/spire-server agent list -output json)
+    AGENTS=$(docker compose exec -T spire-server /opt/spire/bin/spire-server agent list -output json)
     AGENTS_COUNT=$(jq -r '.agents | length' <<< "$AGENTS")
 
     for spiffe_id_path in "$@"; do
@@ -34,7 +34,7 @@ check-evict-agents() {
     MATCHING_COUNT=0
     log-info "checking for evicted agent ($i of $MAXCHECKS max)..."
     for spiffe_id in "$@"; do
-      if docker-compose logs "spire-server" | grep "Agent is not attested" | grep "caller_id=\"$spiffe_id\""; then
+      if docker compose logs "spire-server" | grep "Agent is not attested" | grep "caller_id=\"$spiffe_id\""; then
         MATCHING_COUNT=$((MATCHING_COUNT+1))
       fi
     done

--- a/test/integration/suites/node-re-attestation/docker-compose.yaml
+++ b/test/integration/suites/node-re-attestation/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/node-re-attestation/teardown
+++ b/test/integration/suites/node-re-attestation/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/oidc-discovery-provider/02-bootstrap-agent
+++ b/test/integration/suites/oidc-discovery-provider/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
   /opt/spire/bin/spire-server bundle show -socketPath /opt/spire/conf/server/api.sock >conf/agent/bootstrap.crt

--- a/test/integration/suites/oidc-discovery-provider/04-assert-jwks-using-workload-api
+++ b/test/integration/suites/oidc-discovery-provider/04-assert-jwks-using-workload-api
@@ -5,7 +5,7 @@ source common
 docker-up spire-agent
 
 log-debug "creating registration entry for oidc-provider"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
   /opt/spire/bin/spire-server entry create -socketPath /opt/spire/conf/server/api.sock \
   -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
   -spiffeID "spiffe://domain.test/oidc-provider" \

--- a/test/integration/suites/oidc-discovery-provider/common
+++ b/test/integration/suites/oidc-discovery-provider/common
@@ -4,7 +4,7 @@ check-equal-keys() {
   PROVIDER_SOCKET_PATH=$1
 
   JWK=$(curl --unix-socket $PROVIDER_SOCKET_PATH http://localhost/keys | jq ".keys[0]" || fail-now "Failed to fetch JWK from provider")
-  BUNDLE=$(docker-compose exec -T spire-server /opt/spire/bin/spire-server bundle show -socketPath /opt/spire/conf/server/api.sock -output json | jq ".jwt_authorities[0]" || fail-now "Failed to fetch JWT bundle from SPIRE server")
+  BUNDLE=$(docker compose exec -T spire-server /opt/spire/bin/spire-server bundle show -socketPath /opt/spire/conf/server/api.sock -output json | jq ".jwt_authorities[0]" || fail-now "Failed to fetch JWT bundle from SPIRE server")
 
   PROVIDER_KEY_ID=$(echo ${JWK} | jq -r ".kid")
   BUNDLE_KEY_ID=$(echo ${BUNDLE} | jq -r ".key_id")

--- a/test/integration/suites/oidc-discovery-provider/docker-compose.yaml
+++ b/test/integration/suites/oidc-discovery-provider/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/oidc-discovery-provider/teardown
+++ b/test/integration/suites/oidc-discovery-provider/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/rotation/02-bootstrap-agent
+++ b/test/integration/suites/rotation/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/rotation/04-create-workload-entry
+++ b/test/integration/suites/rotation/04-create-workload-entry
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "creating registration entry..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
@@ -14,8 +14,8 @@ MAXCHECKS=30
 CHECKINTERVAL=1
 for ((i=1;i<=MAXCHECKS;i++)); do
     log-info "checking for synced workload entry ($i of $MAXCHECKS max)..."
-    docker-compose logs spire-agent
-    if docker-compose logs spire-agent | grep "spiffe://domain.test/workload"; then
+    docker compose logs spire-agent
+    if docker compose logs spire-agent | grep "spiffe://domain.test/workload"; then
         exit 0
     fi
     sleep "${CHECKINTERVAL}"

--- a/test/integration/suites/rotation/05-check-svids
+++ b/test/integration/suites/rotation/05-check-svids
@@ -7,7 +7,7 @@ NUMCHECKS=15
 CHECKINTERVAL=3
 for ((i=1;i<=NUMCHECKS;i++)); do
     log-info "checking X509-SVID ($i of $NUMCHECKS)..."
-    docker-compose exec -T spire-agent \
+    docker compose exec -T spire-agent \
         /opt/spire/bin/spire-agent api fetch x509 || fail-now "SVID check failed"
     sleep "${CHECKINTERVAL}"
 done

--- a/test/integration/suites/rotation/docker-compose.yaml
+++ b/test/integration/suites/rotation/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/rotation/teardown
+++ b/test/integration/suites/rotation/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/spire-server-cli/02-bundle
+++ b/test/integration/suites/spire-server-cli/02-bundle
@@ -1,67 +1,67 @@
 #!/bin/bash
 
 # Verify 'bundle count' correctly indicates a single bundle (the server bundle)
-docker-compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 1 || fail-now "failed to count 1 bundle"
+docker compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 1 || fail-now "failed to count 1 bundle"
 
 # Verify 'bundle show'
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
      /opt/spire/bin/spire-server bundle show | openssl x509 -text -noout | grep URI:spiffe://domain.test || fail-now "failed to show bundle (pem)"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server bundle show -format spiffe || fail-now "failed to show bundle (spiffe)"
 
 # Verify federated bundle can be created (pem)
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 cat /opt/spire/conf/fixture/ca.pem | 
     /opt/spire/bin/spire-server bundle set -id spiffe://federated.td" || fail-now "failed to create bundle (pem)"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list -id spiffe://federated.td |
     grep 'makw2ekuHKWC4hBhCkpr5qY4bI8YUcXfxg/1AiEA67kMyH7bQnr7OVLUrL+b9ylA'" || fail-now "federated bundle not found"
 
 # Verify federated bundle can be updated (pem)
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle set -id spiffe://federated.td -path /opt/spire/conf/fixture/ca2.pem || fail-now "failed to set bundle with path (pem)"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list -id spiffe://federated.td |
     grep 'q+2ZoNyl4udPj7IMYIGX8yuCNRmh7m3d9tvoDgIgbS26wSwDjngGqdiHHL8fTcg'" || fail-now "federated bundle was not updated"
 
 # Verify federated bundle can be created (spiffe)
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 cat /opt/spire/conf/fixture/ca.spiffe | 
     /opt/spire/bin/spire-server bundle set -id spiffe://federated2.td -format spiffe" || fail-now "failed to create bundle (spiffe)"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list -id spiffe://federated2.td -format spiffe |
     grep 'fK-wKTnKL7KFLM27lqq5DC-bxrVaH6rDV-IcCSEOeL4'" || fail-now "federated bundle not found"
 
 # Verify 'bundle count' correctly indicates two bundles
-docker-compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 3 || fail-now "failed to count 3 bundles"
+docker compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 3 || fail-now "failed to count 3 bundles"
 
 # Verify federated bundle can be updated (pem)
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle set -id spiffe://federated2.td -path /opt/spire/conf/fixture/ca2.spiffe -format spiffe || fail-now "failed to set bundle with path (spiffe)"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list -id spiffe://federated2.td -format spiffe | 
     grep 'HxVuaUnxgi431G5D3g9hqeaQhEbsyQZXmaas7qsUC_c'" || fail-now "federated bundle was not updated"
 
 # Verify 'bundle list' contains both federated bundles
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list | 
     grep -E 'federated.td|federated2.td' -c | grep 2" || fail-now "Unexpected amout of federated bundles"
 
 # Verify delete
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle delete -id spiffe://federated.td || fail-now "failed to delete federated bundle"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 /opt/spire/bin/spire-server bundle list | 
     grep -E 'federated.td|federated2.td' -c | grep 1" || fail-now "Unexpected amout of federated bundles"
 
 # Verify 'bundle count' correctly indicates two bundles (server bundle and one federated bundle)
-docker-compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 2 || fail-now "failed to count 2 bundles"
+docker compose exec -T spire-server /opt/spire/bin/spire-server bundle count | grep 2 || fail-now "failed to count 2 bundles"

--- a/test/integration/suites/spire-server-cli/03-entry
+++ b/test/integration/suites/spire-server-cli/03-entry
@@ -1,18 +1,18 @@
 #!/bin/bash
 
 # Create bundles of federated trust domains to be used by other commands
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 cat /opt/spire/conf/fixture/ca.pem | 
     /opt/spire/bin/spire-server bundle set -id spiffe://federated1.test" || fail-now "failed to create federated bundle 1"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     ash -c "
 cat /opt/spire/conf/fixture/ca.pem | 
     /opt/spire/bin/spire-server bundle set -id spiffe://federated2.test" || fail-now "failed to create federated bundle 2"
 
 # Verify entry create
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry create \
         -selector s1:v1 \
         -parentID spiffe://domain.test/parent \
@@ -20,14 +20,14 @@ docker-compose exec -T spire-server \
         -federatesWith spiffe://federated1.test \
         -admin || fail-now "failed to create entry 1"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry create \
         -selector notUpdated:notUpdated \
         -parentID spiffe://domain.test/parentNotUpdated \
         -spiffeID spiffe://domain.test/child2NotUpdated \
         -downstream || fail-now "failed to create entry 2"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
         -selector otherS:otherV \
         -spiffeID spiffe://domain.test/otherChild \
@@ -36,11 +36,11 @@ docker-compose exec -T spire-server \
         -ttl 123 || fail-now "failed to create entry 3"
 
 # Verify entry count correctly indicates three entries
-docker-compose exec -T spire-server /opt/spire/bin/spire-server entry count | grep 3 || fail-now "failed to count 3 entries"
+docker compose exec -T spire-server /opt/spire/bin/spire-server entry count | grep 3 || fail-now "failed to count 3 entries"
 
 # Verify entry show and set variables entryID1, entryID2 and entryID3
 # Entry 1
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/child1)"
 
@@ -70,7 +70,7 @@ entryID1="$(echo "$showResult" | grep "Entry ID")" || fail-now "failed to show e
 entryID1="${entryID1#*: }"
 
 # Entry 2
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/child2NotUpdated)"
 
@@ -101,7 +101,7 @@ entryID2="$(echo "$showResult" | grep "Entry ID")" || fail-now "failed to show e
 entryID2="${entryID2#*: }"
 
 # Entry 3
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/otherChild)"
 
@@ -132,7 +132,7 @@ entryID3="$(echo "$showResult" | grep "Entry ID")" || fail-now "failed to show e
 entryID3="${entryID3#*: }"
 
 # Verify entry update
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry update \
         -entryID ${entryID1} \
         -selector s1:v1 \
@@ -141,7 +141,7 @@ docker-compose exec -T spire-server \
         -federatesWith spiffe://federated1.test \
         -ttl 456 || fail-now "failed to update entry 1"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry update \
         -entryID ${entryID2} \
         -selector s1:v1 -selector s2:v2 \
@@ -150,7 +150,7 @@ docker-compose exec -T spire-server \
         -federatesWith spiffe://federated1.test -federatesWith spiffe://federated2.test \
         -dns dnsname2 || fail-now "failed to update entry 2"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry update \
         -entryID ${entryID3} \
         -selector otherS:otherV \
@@ -161,7 +161,7 @@ docker-compose exec -T spire-server \
 
 # Verify entry show after updates
 # Entry 1
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/child1)"
 
@@ -191,7 +191,7 @@ echo $(echo "$showResult" | grep "Admin" || echo "Failed when expected") \
         | grep "Failed when expected" || fail-now "failed to show entry 1 after update, 'grep Admin' should fail"
 
 # Entry 2
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/child2)"
 
@@ -224,7 +224,7 @@ echo $(echo "$showResult" | grep "Admin" || echo "Failed when expected") \
         | grep "Failed when expected" || fail-now "failed to show entry 2 after update, 'grep Admin' should fail"
 
 # Entry 3
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
         -spiffeID spiffe://domain.test/child3)"
 
@@ -254,7 +254,7 @@ echo "$showResult" | grep "Admin" | grep "true" || fail-now "failed to show entr
 
 # Verify entry show using filters
 # By parent
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry show \
         -parentID spiffe://domain.test/parent)"
 
@@ -263,7 +263,7 @@ echo "$showResult" | grep "Entry ID" | grep ${entryID1} || fail-now "failed to s
 echo "$showResult" | grep "Entry ID" | grep ${entryID2} || fail-now "failed to show entries by parentID, expected Entry ID 2 not found"
 
 # By selectors (default matcher, SUPERSET)
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry show \
         -selector s1:v1)"
 
@@ -271,7 +271,7 @@ echo "$showResult" | grep "Found 2 entries" || fail-now "failed to show entry 1 
 echo "$showResult" | grep ${entryID1} || fail-now "failed to show entry 1 by selector, unexpected Entry ID"
 echo "$showResult" | grep ${entryID2} || fail-now "failed to show entry 1 by selector, unexpected Entry ID"
 
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry show \
         -selector s1:v1 -selector s2:v2)"
 
@@ -279,7 +279,7 @@ echo "$showResult" | grep "Found 1 entry" || fail-now "failed to show entry 2 by
 echo "$showResult" | grep ${entryID2} || fail-now "failed to show entry 2 by selector, unexpected Entry ID"
 
 # By selectors (change matcher)
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
 	-selector s1:v1 \
 	-matchSelectorsOn exact)"
@@ -288,7 +288,7 @@ echo "$showResult" | grep "Found 1 entry" || fail-now "failed to show entry 1 by
 echo "$showResult" | grep ${entryID1} || fail-now "failed to show entry 1 by selector, unexpected Entry ID"
 
 # Verify entry delete
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry show)"
 
 echo "$showResult" | grep "Found 3 entries" || fail-now "failed to show entries before delete"
@@ -296,11 +296,11 @@ echo "$showResult" | grep "Entry ID" | grep ${entryID1} || fail-now "failed to s
 echo "$showResult" | grep "Entry ID" | grep ${entryID2} || fail-now "failed to show entries before delete, expected Entry ID 2 not found"
 echo "$showResult" | grep "Entry ID" | grep ${entryID3} || fail-now "failed to show entries before delete, expected Entry ID 3 not found"
 
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry delete \
         -entryID ${entryID1} || fail-now "failed to delete entry 1"
 
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry show)"
 
 echo "$showResult" | grep "Found 2 entries" || fail-now "failed to show entries after delete"
@@ -308,4 +308,4 @@ echo "$showResult" | grep "Entry ID" | grep ${entryID2} || fail-now "failed to s
 echo "$showResult" | grep "Entry ID" | grep ${entryID3} || fail-now "failed to show entries after delete, expected Entry ID 3 not found"
 
 # Verify entry count correctly indicates two entries
-docker-compose exec -T spire-server /opt/spire/bin/spire-server entry count | grep 2 || fail-now "failed to count 2 entries"
+docker compose exec -T spire-server /opt/spire/bin/spire-server entry count | grep 2 || fail-now "failed to count 2 entries"

--- a/test/integration/suites/spire-server-cli/04-bootstrap-agents
+++ b/test/integration/suites/spire-server-cli/04-bootstrap-agents
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
 
 # Set conf files for each agent
@@ -12,7 +12,7 @@ cp -R conf/agent/ conf/agent-3
 # Set a different join token for each agent
 # Agent 1
 log-info "generating join token for agent 1..."
-TOKEN=$(docker-compose exec -T spire-server \
+TOKEN=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server token generate -spiffeID spiffe://domain.test/node1 | awk '{print $2}' | tr -d '\r')
 
 log-debug "using join token ${TOKEN} for agent 1..."
@@ -20,7 +20,7 @@ sed -i.bak "s#TOKEN#${TOKEN}#g" conf/agent-1/agent.conf
 
 # Agent 2
 log-info "generating join token for agent 2..."
-TOKEN=$(docker-compose exec -T spire-server \
+TOKEN=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server token generate -spiffeID spiffe://domain.test/node2 | awk '{print $2}' | tr -d '\r')
 
 log-debug "using join token ${TOKEN} for agent 2..."
@@ -28,7 +28,7 @@ sed -i.bak "s#TOKEN#${TOKEN}#g" conf/agent-2/agent.conf
 
 # Agent 3
 log-info "generating join token for agent 3..."
-TOKEN=$(docker-compose exec -T spire-server \
+TOKEN=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server token generate -spiffeID spiffe://domain.test/node3 | awk '{print $2}' | tr -d '\r')
 
 log-debug "using join token ${TOKEN} for agent 3..."

--- a/test/integration/suites/spire-server-cli/06-agent
+++ b/test/integration/suites/spire-server-cli/06-agent
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Verify agent count correctly indicates three agents
-docker-compose exec -T spire-server /opt/spire/bin/spire-server agent count | grep 3 || fail-now "failed to count 3 agents"
+docker compose exec -T spire-server /opt/spire/bin/spire-server agent count | grep 3 || fail-now "failed to count 3 agents"
 
 # Verify 3 agents were created
-listResult="$(docker-compose exec -T spire-server \
+listResult="$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent list)"
 
 echo "$listResult" | grep "Found 3 attested agents" || fail-now "failed to list the 3 agents initially"
@@ -12,21 +12,21 @@ echo "$listResult" | grep "Attestation type" | grep "join_token" || fail-now "un
 
 # Get agent SPIFFE IDs from entries, knowing they were attested using join-token
 # Agent 1
-agentID1="$(docker-compose exec -T spire-server \
+agentID1="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://domain.test/node1)"
 agentID1="$(echo "$agentID1" | grep "Parent ID")" || fail-now "failed to extract agentID1"
 agentID1="${agentID1#*: }"
 
 # Agent 2
-agentID2="$(docker-compose exec -T spire-server \
+agentID2="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://domain.test/node2)"
 agentID2="$(echo "$agentID2" | grep "Parent ID")" || fail-now "failed to extract agentID2"
 agentID2="${agentID2#*: }"
 
 # Agent 3
-agentID3="$(docker-compose exec -T spire-server \
+agentID3="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry show \
     -spiffeID spiffe://domain.test/node3)"
 agentID3="$(echo "$agentID3" | grep "Parent ID")" || fail-now "failed to extract agentID3"
@@ -39,7 +39,7 @@ echo "$listResult" | grep "$agentID3" || fail-now "agentID3=$agentID3 not found 
 
 # Verify agent show
 # Agent 1
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID1)"
 
 echo "$showResult" | grep "Found an attested agent given its SPIFFE ID" || fail-now "failed to show agent 1"
@@ -47,7 +47,7 @@ echo "$showResult" | grep "SPIFFE ID" | grep "$agentID1" || fail-now "unexpected
 echo "$showResult" | grep "Attestation type" | grep "join_token" || fail-now "unexpected attestation type for agent 1"
 
 # Agent 2
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID2)"
 
 echo "$showResult" | grep "Found an attested agent given its SPIFFE ID" || fail-now "failed to show agent 2"
@@ -55,7 +55,7 @@ echo "$showResult" | grep "SPIFFE ID" | grep "$agentID2" || fail-now "unexpected
 echo "$showResult" | grep "Attestation type" | grep "join_token" || fail-now "unexpected attestation type for agent 2"
 
 # Agent 3
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID3)"
 
 echo "$showResult" | grep "Found an attested agent given its SPIFFE ID" || fail-now "failed to show agent 3"
@@ -63,33 +63,33 @@ echo "$showResult" | grep "SPIFFE ID" | grep "$agentID3" || fail-now "unexpected
 echo "$showResult" | grep "Attestation type" | grep "join_token" || fail-now "unexpected attestation type for agent 3"
 
 # Verify agent ban
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent ban -spiffeID "$agentID1" | grep "Agent banned successfully" || fail-now "failed to ban agent 1"
 
 # Verify agent list after ban
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent list | grep "Found 3 attested agents" || fail-now "failed to list the agents after ban"
 
 # Verify agent show after ban Agent 1
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID1 | grep "Banned            : true" || fail-now "agent 1 was not banned"
 
 # Verify agent evict
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent evict -spiffeID "$agentID1" | grep "Agent evicted successfully" || fail-now "failed to evict agent 1"
 
 # Verify agent list after evict
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server agent list | grep "Found 2 attested agents" || fail-now "failed to list the agents after evict"
 
 # Verify agent show after evict
 # Agent 1
-echo "$(docker-compose exec -T spire-server \
+echo "$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID1 || echo "OK: agent 1 not found")" \
     | grep "OK: agent 1 not found" || fail-now "agent 1 was found after evict"
 
 # Agent 2
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID2)"
 
 echo "$showResult" | grep "Found an attested agent given its SPIFFE ID" || fail-now "failed to show agent 2 after evict"
@@ -97,7 +97,7 @@ echo "$showResult" | grep "SPIFFE ID" | grep "$agentID2" || fail-now "unexpected
 echo "$showResult" | grep "Attestation type" | grep "join_token" || fail-now "unexpected attestation type for agent 2 after evict"
 
 # Agent 3
-showResult="$(docker-compose exec -T spire-server \
+showResult="$(docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server agent show -spiffeID $agentID3)"
 
 echo "$showResult" | grep "Found an attested agent given its SPIFFE ID" || fail-now "failed to show agent 3 after evict"

--- a/test/integration/suites/spire-server-cli/docker-compose.yaml
+++ b/test/integration/suites/spire-server-cli/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server-alpine

--- a/test/integration/suites/spire-server-cli/teardown
+++ b/test/integration/suites/spire-server-cli/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/svidstore/02-bootstrap-agent
+++ b/test/integration/suites/svidstore/02-bootstrap-agent
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 log-debug "bootstrapping agent..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt

--- a/test/integration/suites/svidstore/04-create-entries
+++ b/test/integration/suites/svidstore/04-create-entries
@@ -3,19 +3,19 @@
 source ./common
 
 log-debug "creating registration entries that must have it's SVIDs stored ..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/stored-1" \
     -selector "disk:name:stored-1" \
     -storeSVID true
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/stored-2" \
     -selector "disk:name:stored-2" \
     -storeSVID true
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/stored-3" \
@@ -27,12 +27,12 @@ check-synced-entry "spire-agent" "spiffe://domain.test/stored-2"
 check-synced-entry "spire-agent" "spiffe://domain.test/stored-3"
 
 log-debug "creating registration entries that should not have the SVID stored..."
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/not-stored-1" \
     -selector "disk:name:not-stored-1"
-docker-compose exec -T spire-server \
+docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry create \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/not-stored-2" \

--- a/test/integration/suites/svidstore/05-update-entries
+++ b/test/integration/suites/svidstore/05-update-entries
@@ -3,9 +3,9 @@
 source ./common
 
 log-debug "updating registration entries that has stored SVIDs..."
-ids=$(docker-compose exec -T spire-server /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.store_svid == true) | .id')
+ids=$(docker compose exec -T spire-server /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.store_svid == true) | .id')
 for id in $ids; do
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry update \
         -entryID $id \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
@@ -14,10 +14,10 @@ for id in $ids; do
 done
 
 log-debug "updating registration entries that don't have stored SVIDs..."
-ids=$(docker-compose exec -T spire-server \
+ids=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.spiffe_id.path | contains("not-stored")) | .id')
 for id in $ids; do
-    docker-compose exec -T spire-server \
+    docker compose exec -T spire-server \
         /opt/spire/bin/spire-server entry update \
         -entryID "$id" \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \

--- a/test/integration/suites/svidstore/06-delete-entries
+++ b/test/integration/suites/svidstore/06-delete-entries
@@ -3,9 +3,9 @@
 source ./common
 
 log-debug "deleting all registration entries..."
-ids=$(docker-compose exec -T spire-server /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | .id')
+ids=$(docker compose exec -T spire-server /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | .id')
 for id in $ids; do
-    docker-compose exec -T spire-server /opt/spire/bin/spire-server entry delete -entryID $id
+    docker compose exec -T spire-server /opt/spire/bin/spire-server entry delete -entryID $id
 done
 
 check-deleted-svids

--- a/test/integration/suites/svidstore/common
+++ b/test/integration/suites/svidstore/common
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check-stored-svids() {
-    stored_ids=$(docker-compose exec -T spire-server \
+    stored_ids=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.store_svid == true) | .id')
 
     for id in $stored_ids; do
@@ -10,8 +10,8 @@ check-stored-svids() {
       CHECKINTERVAL=1
       for ((i=1;i<=MAXCHECKS;i++)); do
           log-info "checking for stored entry ($i of $MAXCHECKS max)..."
-          docker-compose logs "spire-agent"
-          if docker-compose logs "spire-agent" | grep '"SVID stored successfully" entry='"$id"''; then
+          docker compose logs "spire-agent"
+          if docker compose logs "spire-agent" | grep '"SVID stored successfully" entry='"$id"''; then
               found=1
               break
           fi
@@ -23,20 +23,20 @@ check-stored-svids() {
       fi
     done
 
-    docker-compose exec -u 1000 -T spire-server \
+    docker compose exec -u 1000 -T spire-server \
       /opt/spire/conf/server/checkstoredsvids /opt/spire/conf/agent/svids.json  || fail-now "failed to check stored svids"
 }
 
 
 check-deleted-svids() {
-    stored_ids=$(docker-compose exec -T spire-server \
+    stored_ids=$(docker compose exec -T spire-server \
     /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.store_svid == true) | .id')
 
     no_entries=0
     MAXCHECKS=10
     CHECKINTERVAL=1
     for ((i=1;i<=MAXCHECKS;i++)); do
-      stored_ids=$(docker-compose exec -T spire-server \
+      stored_ids=$(docker compose exec -T spire-server \
       /opt/spire/bin/spire-server entry show -output json | jq -r '.entries[] | select(.store_svid == true) | .id')
       if [ -z "$stored_ids" ]; then
         no_entries=1
@@ -48,6 +48,6 @@ check-deleted-svids() {
       fail-now "timed out waiting for agent to delete all svids"
     fi
 
-    docker-compose exec -u 1000 -T spire-server \
+    docker compose exec -u 1000 -T spire-server \
       /opt/spire/conf/server/checkstoredsvids /opt/spire/conf/agent/svids.json  || fail-now "failed to check stored svids"
 }

--- a/test/integration/suites/svidstore/docker-compose.yaml
+++ b/test/integration/suites/svidstore/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   spire-server:
     image: spire-server:latest-local

--- a/test/integration/suites/svidstore/teardown
+++ b/test/integration/suites/svidstore/teardown
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/suites/upgrade/00-setup
+++ b/test/integration/suites/upgrade/00-setup
@@ -11,7 +11,7 @@ mkdir -p test/after-agent-upgrade
 make-service() {
     local _registry=$1
     local _version=$2
-cat <<EOF >> docker-compose.yaml
+cat <<EOF >> docker compose.yaml
   spire-server-${_version}:
     container_name: spire-server-${_version}
     image: ${_registry}spire-server:${_version}
@@ -53,10 +53,10 @@ EOF
 }
 
 #
-# Create the docker-compose.yaml with a spire-server and spire-agent for each
+# Create the docker compose.yaml with a spire-server and spire-agent for each
 # version we want to test against the latest
 #
-cat <<EOF > docker-compose.yaml
+cat <<EOF > docker compose.yaml
 version: '3'
 networks:
   our-network: {}

--- a/test/integration/suites/upgrade/00-setup
+++ b/test/integration/suites/upgrade/00-setup
@@ -57,7 +57,6 @@ EOF
 # version we want to test against the latest
 #
 cat <<EOF > docker compose.yaml
-version: '3'
 networks:
   our-network: {}
 services:

--- a/test/integration/suites/upgrade/00-setup
+++ b/test/integration/suites/upgrade/00-setup
@@ -11,7 +11,7 @@ mkdir -p test/after-agent-upgrade
 make-service() {
     local _registry=$1
     local _version=$2
-cat <<EOF >> docker compose.yaml
+cat <<EOF >> docker-compose.yaml
   spire-server-${_version}:
     container_name: spire-server-${_version}
     image: ${_registry}spire-server:${_version}
@@ -53,10 +53,10 @@ EOF
 }
 
 #
-# Create the docker compose.yaml with a spire-server and spire-agent for each
+# Create the docker-compose.yaml with a spire-server and spire-agent for each
 # version we want to test against the latest
 #
-cat <<EOF > docker compose.yaml
+cat <<EOF > docker-compose.yaml
 networks:
   our-network: {}
 services:

--- a/test/integration/suites/upgrade/01-run-upgrade-tests
+++ b/test/integration/suites/upgrade/01-run-upgrade-tests
@@ -18,7 +18,7 @@ start-old-server() {
 
 bootstrap-agent() {
     # TODO: Remove -socketPath argument in 1.7.0 and rely on the default socket path
-    docker-compose exec -T "spire-server-$1" \
+    docker compose exec -T "spire-server-$1" \
         /opt/spire/bin/spire-server bundle show \
         -socketPath /opt/spire/data/server/socket/api.sock > conf/agent/bootstrap.crt
 }
@@ -35,7 +35,7 @@ start-old-agent() {
 create-registration-entry() {
     log-debug "creating registration entry..."
     # TODO: Remove -socketPath argument in 1.7.0 and rely on the default socket path
-    docker-compose exec -T "spire-server-$1" \
+    docker compose exec -T "spire-server-$1" \
         /opt/spire/bin/spire-server entry create \
         -socketPath /opt/spire/data/server/socket/api.sock \
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
@@ -49,8 +49,8 @@ create-registration-entry() {
     local _checkinterval=1
     for ((i=1;i<=_maxchecks;i++)); do
         log-info "checking for synced workload entry ($i of $_maxchecks max)..."
-        docker-compose logs "spire-agent-$1"
-        if docker-compose logs "spire-agent-$1" | grep "spiffe://domain.test/workload"; then
+        docker compose logs "spire-agent-$1"
+        if docker compose logs "spire-agent-$1" | grep "spiffe://domain.test/workload"; then
             return
         fi
         sleep "${_checkinterval}"
@@ -60,7 +60,7 @@ create-registration-entry() {
 
 check-old-agent-svid() {
     log-info "checking X509-SVID on $1 agent..."
-        docker-compose exec -T "spire-agent-$1" \
+        docker compose exec -T "spire-agent-$1" \
             /opt/spire/bin/spire-agent api fetch x509 \
             -socketPath /opt/spire/data/agent/socket/api.sock \
             -write /opt/test/before-server-upgrade || fail-now "SVID check failed"
@@ -80,7 +80,7 @@ upgrade-server() {
 # Validates that the current version of the codebase is ahead of the version
 # being updated.
 check-codebase-version-is-ahead() {
-    _current_version=$(docker-compose exec -T spire-server-latest-local  \
+    _current_version=$(docker compose exec -T spire-server-latest-local  \
             /opt/spire/bin/spire-server --version 2>&1 | cut -d'-' -f 1)
 
     if [ "$_current_version" = "$1" ]; then
@@ -99,7 +99,7 @@ check-old-agent-svid-after-upgrade() {
     for ((i=1;i<=_maxchecks;i++)); do
         log-info "checking X509-SVID after server upgrade ($i of $_maxchecks max)..."
         # TODO: Remove -socketPath argument in 1.7.0 and rely on the default socket path
-        docker-compose exec -T "spire-agent-$1" \
+        docker compose exec -T "spire-agent-$1" \
             /opt/spire/bin/spire-agent api fetch x509 \
             -socketPath /opt/spire/data/agent/socket/api.sock \
             -write /opt/test/after-server-upgrade || fail-now "SVID check failed"
@@ -128,7 +128,7 @@ stop-and-evict-agent() {
 
     log-info "evicting agent..."
     # TODO: Remove -socketPath argument in 1.7.0 and rely on the default socket path
-    docker-compose exec -T "spire-server-$1" \
+    docker compose exec -T "spire-server-$1" \
         /opt/spire/bin/spire-server agent evict \
         -socketPath /opt/spire/data/server/socket/api.sock \
         -spiffeID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)"
@@ -139,7 +139,7 @@ stop-and-evict-agent() {
 check-new-agent-svid-after-upgrade() {
     log-info "checking X509-SVID after agent upgrade..."
     # TODO: Remove -socketPath argument in 1.7.0 and rely on the default socket path
-    docker-compose exec -T spire-agent-latest-local \
+    docker compose exec -T spire-agent-latest-local \
         /opt/spire/bin/spire-agent api fetch x509 \
         -socketPath /opt/spire/data/agent/socket/api.sock \
         -write /opt/test/after-agent-upgrade || fail-now "SVID check failed"

--- a/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
+++ b/test/integration/suites/upgrade/02-verify-codebase-version-is-updated
@@ -47,7 +47,7 @@ check-version-against-latest-release() {
 
 # Get current version from latest local image
 docker-up spire-server-latest-local
-_commit_version=$(docker-compose exec -T spire-server-latest-local \
+_commit_version=$(docker compose exec -T spire-server-latest-local \
             /opt/spire/bin/spire-server --version 2>&1 | cut -d'-' -f 1)
 docker-down
 

--- a/test/integration/suites/upgrade/teardown
+++ b/test/integration/suites/upgrade/teardown
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ -z "$SUCCESS" ]; then
-    docker-compose logs
+    docker compose logs
 fi
 docker-down

--- a/test/integration/test-one.sh
+++ b/test/integration/test-one.sh
@@ -50,9 +50,9 @@ cleanup() {
         fail-now "\"${TESTNAME}\" failed to tear down."
     fi
 
-    # double check that if docker-compose was used that we clean everything up.
+    # double check that if docker compose was used that we clean everything up.
     # this helps us to not pollute the local docker state.
-    if [ -f "${RUNDIR}/docker-compose.yaml" ]; then
+    if [ -f "${RUNDIR}/docker compose.yaml" ]; then
         docker-cleanup
     fi
 

--- a/test/integration/test-one.sh
+++ b/test/integration/test-one.sh
@@ -52,7 +52,7 @@ cleanup() {
 
     # double check that if docker compose was used that we clean everything up.
     # this helps us to not pollute the local docker state.
-    if [ -f "${RUNDIR}/docker compose.yaml" ]; then
+    if [ -f "${RUNDIR}/docker-compose.yaml" ]; then
         docker-cleanup
     fi
 


### PR DESCRIPTION
github runners [latest version](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240730.2) remove the deprecated docker compose v1.
Upgrade all unit tests scripts to start using docker v2