### PR TITLE
Clean up httpchallenge agent config

### DIFF
--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -28,12 +28,6 @@ func BuiltIn() catalog.BuiltIn {
 	return builtin(New())
 }
 
-func BuiltInWithHostname(hostname string) catalog.BuiltIn {
-	plugin := New()
-	plugin.hostname = hostname
-	return builtin(plugin)
-}
-
 func builtin(p *Plugin) catalog.BuiltIn {
 	return catalog.MakeBuiltIn(pluginName,
 		nodeattestorv1.NodeAttestorPluginServer(p),
@@ -59,11 +53,16 @@ type Plugin struct {
 	configv1.UnsafeConfigServer
 
 	m sync.Mutex
-	c *Config
+	c *configData
 
 	log hclog.Logger
 
-	hostname string
+	hooks struct {
+		// Controls which interface to bind to ("" in production, "localhost"
+		// in tests) and acts as the default HostName value when not provided
+		// via configuration.
+		bindHost string
+	}
 }
 
 func New() *Plugin {
@@ -71,7 +70,7 @@ func New() *Plugin {
 }
 
 func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestationServer) (err error) {
-	data, err := p.loadConfigData()
+	data, err := p.getConfig()
 	if err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func (p *Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_AidAttestatio
 
 	port := data.port
 
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", p.hooks.bindHost, port))
 	if err != nil {
 		return status.Errorf(codes.Internal, "could not listen on port %d: %v", port, err)
 	}
@@ -145,11 +144,12 @@ func (p *Plugin) Configure(_ context.Context, req *configv1.ConfigureRequest) (*
 	}
 
 	// Make sure the configuration produces valid data
-	if _, err := loadConfigData(p.hostname, config); err != nil {
+	configData, err := loadConfigData(p.hooks.bindHost, config)
+	if err != nil {
 		return nil, err
 	}
 
-	p.setConfig(config)
+	p.setConfig(configData)
 
 	return &configv1.ConfigureResponse{}, nil
 }
@@ -184,24 +184,19 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 	p.log = log
 }
 
-func (p *Plugin) getConfig() *Config {
+func (p *Plugin) getConfig() (*configData, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
-	return p.c
+	if p.c == nil {
+		return nil, status.Error(codes.FailedPrecondition, "not configured")
+	}
+	return p.c, nil
 }
 
-func (p *Plugin) setConfig(c *Config) {
+func (p *Plugin) setConfig(c *configData) {
 	p.m.Lock()
 	defer p.m.Unlock()
 	p.c = c
-}
-
-func (p *Plugin) loadConfigData() (*configData, error) {
-	config := p.getConfig()
-	if config == nil {
-		return nil, status.Error(codes.FailedPrecondition, "not configured")
-	}
-	return loadConfigData(p.hostname, config)
 }
 
 func loadConfigData(hostname string, config *Config) (*configData, error) {

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -52,7 +52,7 @@ type Plugin struct {
 	nodeattestorv1.UnsafeNodeAttestorServer
 	configv1.UnsafeConfigServer
 
-	m sync.Mutex
+	m sync.RWMutex
 	c *configData
 
 	log hclog.Logger
@@ -185,8 +185,8 @@ func (p *Plugin) SetLogger(log hclog.Logger) {
 }
 
 func (p *Plugin) getConfig() (*configData, error) {
-	p.m.Lock()
-	defer p.m.Unlock()
+	p.m.RLock()
+	defer p.m.RUnlock()
 	if p.c == nil {
 		return nil, status.Error(codes.FailedPrecondition, "not configured")
 	}

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -202,15 +202,9 @@ func (p *Plugin) setConfig(c *configData) {
 func (p *Plugin) loadConfigData(config *Config) (*configData, error) {
 	// Determine the host name to pass to the server. Values are preferred in
 	// this order:
-	// 1. HostName HCL configuration value
-	// 2. Test hook bind host (e.g. p.hooks.bindHost)
-	// 3. OS hostname value
-	//
-	// The test hook bind host value is only set during tests.
+	// 1. HCL HostName configuration value
+	// 2. OS hostname value
 	hostName := config.HostName
-	if hostName == "" {
-		hostName = p.hooks.bindHost
-	}
 	if hostName == "" {
 		var err error
 		hostName, err = os.Hostname()

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -1,5 +1,3 @@
-////go:build !darwin
-
 package httpchallenge
 
 import (

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -1,6 +1,6 @@
-//go:build !darwin
+////go:build !darwin
 
-package httpchallenge_test
+package httpchallenge
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
-	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/httpchallenge"
 	nodeattestortest "github.com/spiffe/spire/pkg/agent/plugin/nodeattestor/test"
 	common_httpchallenge "github.com/spiffe/spire/pkg/common/plugin/httpchallenge"
 	"github.com/spiffe/spire/test/plugintest"
@@ -40,7 +39,7 @@ func TestConfigureCommon(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			plugin := httpchallenge.New()
+			plugin := newPlugin()
 
 			resp, err := plugin.Configure(context.Background(), &configv1.ConfigureRequest{HclConfiguration: tt.hclConf})
 			if tt.expErr != "" {
@@ -206,6 +205,12 @@ func loadAndConfigurePlugin(t *testing.T, config string) nodeattestor.NodeAttest
 
 func loadPlugin(t *testing.T, options ...plugintest.Option) nodeattestor.NodeAttestor {
 	na := new(nodeattestor.V1)
-	plugintest.Load(t, httpchallenge.BuiltInWithHostname("localhost"), na, options...)
+	plugintest.Load(t, builtin(newPlugin()), na, options...)
 	return na
+}
+
+func newPlugin() *Plugin {
+	p := Newt()
+	p.hooks.bindAddress = "localhost"
+	return p
 }

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -210,7 +210,7 @@ func loadPlugin(t *testing.T, options ...plugintest.Option) nodeattestor.NodeAtt
 }
 
 func newPlugin() *Plugin {
-	p := Newt()
-	p.hooks.bindAddress = "localhost"
+	p := New()
+	p.hooks.bindHost = "localhost"
 	return p
 }


### PR DESCRIPTION
Has the plugin stash the fully determined configuration instead of redetermining it based on the parsed HCL values on each call.

Also enable testing on darwin.