### PR TITLE
Force rotation X.509 SVIDs in Agent side

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -142,7 +142,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 	}
 
-	svidStoreCache := a.newSVIDStoreCache()
+	svidStoreCache := a.newSVIDStoreCache(metrics)
 
 	manager, err := a.newManager(ctx, sto, cat, metrics, as, svidStoreCache, nodeAttestor)
 	if err != nil {
@@ -324,10 +324,11 @@ func (a *Agent) newManager(ctx context.Context, sto storage.Storage, cat catalog
 	}
 }
 
-func (a *Agent) newSVIDStoreCache() *storecache.Cache {
+func (a *Agent) newSVIDStoreCache(metrics telemetry.Metrics) *storecache.Cache {
 	config := &storecache.Config{
 		Log:         a.c.Log.WithField(telemetry.SubsystemName, "svid_store_cache"),
 		TrustDomain: a.c.TrustDomain,
+		Metrics:     metrics,
 	}
 
 	return storecache.New(config)

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"sort"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/backoff"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	agentmetrics "github.com/spiffe/spire/pkg/common/telemetry/agent"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/common"
 )
 
@@ -22,6 +24,13 @@ const (
 	SVIDCacheMaxSize = 1000
 	// SVIDSyncInterval is the interval at which SVIDs are synced with subscribers
 	SVIDSyncInterval = 500 * time.Millisecond
+	// Default batch size for processing tainted SVIDs
+	DefaultProcessingBatchSize = 100
+)
+
+var (
+	// Time interval between SVID batch processing
+	processingTaintedX509SVIDInterval = 5 * time.Second
 )
 
 // UpdateEntries holds information for an entries update to the cache.
@@ -125,6 +134,10 @@ type LRUCache struct {
 	svids map[string]*X509SVID
 
 	subscribeBackoffFn func() backoff.BackOff
+
+	processingBatchSize int
+	// used to debug scheduled batchs for tainted authorities
+	taintedBatchProcessedCh chan struct{}
 }
 
 func NewLRUCache(log logrus.FieldLogger, trustDomain spiffeid.TrustDomain, bundle *Bundle, metrics telemetry.Metrics, clk clock.Clock) *LRUCache {
@@ -146,6 +159,7 @@ func NewLRUCache(log logrus.FieldLogger, trustDomain spiffeid.TrustDomain, bundl
 		subscribeBackoffFn: func() backoff.BackOff {
 			return backoff.NewBackoff(clk, SVIDSyncInterval)
 		},
+		processingBatchSize: DefaultProcessingBatchSize,
 	}
 }
 
@@ -493,6 +507,34 @@ func (c *LRUCache) UpdateSVIDs(update *UpdateSVIDs) {
 	}
 }
 
+// TaintX509SVIDs initiates the processing of all cached SVIDs, checking if they are tainted by the provided authorities.
+// It schedules the processing to run asynchronously in batches.
+func (c *LRUCache) TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x509.Certificate) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var entriesToProcess []string
+	for key, svid := range c.svids {
+		if svid != nil && len(svid.Chain) > 0 {
+			entriesToProcess = append(entriesToProcess, key)
+		}
+	}
+
+	// Check if there are any entries to process before scheduling
+	if len(entriesToProcess) == 0 {
+		c.log.Debug("No SVID entries to process for tainted X.509 authorities")
+		return
+	}
+
+	// Schedule the rotation process in a separate goroutine
+	go func() {
+		c.scheduleRotation(ctx, entriesToProcess, taintedX509Authorities)
+	}()
+
+	c.log.WithField(telemetry.Count, len(entriesToProcess)).
+		Debug("Scheduled rotation for SVID entries due to tainted X.509 authorities")
+}
+
 // GetStaleEntries obtains a list of stale entries
 func (c *LRUCache) GetStaleEntries() []*StaleEntry {
 	c.mu.Lock()
@@ -529,6 +571,87 @@ func (c *LRUCache) SyncSVIDsWithSubscribers() {
 	defer c.mu.Unlock()
 
 	c.syncSVIDsWithSubscribers()
+}
+
+// scheduleRotation processes SVID entries in batches, removing those tainted by X.509 authorities.
+// The process continues at regular intervals until all entries have been processed or the context is cancelled.
+func (c *LRUCache) scheduleRotation(ctx context.Context, entryIDs []string, taintedX509Authorities []*x509.Certificate) {
+	ticker := c.clk.Ticker(processingTaintedX509SVIDInterval)
+	defer ticker.Stop()
+
+	// Ensure consistent order for test cases if channel is used
+	if c.taintedBatchProcessedCh != nil {
+		sort.Strings(entryIDs)
+	}
+
+	for {
+		// Process batch of entries
+		batchSize := min(c.processingBatchSize, len(entryIDs))
+		processingEntries := entryIDs[:batchSize]
+
+		// TODO: this is for testing... REMOVE BEFORE MERGING!!!!
+		// start := time.Now()
+		c.processTaintedSVIDs(processingEntries, taintedX509Authorities)
+
+		// TODO: this is for testing... REMOVE BEFORE MERGING!!!!
+		// c.log.Debugf("******************************************************")
+		// c.log.Debugf("Processed %d SVIDs in %v", len(processingEntries), time.Since(start))
+		// c.log.Debugf("******************************************************")
+
+		// Remove processed entries from the list
+		entryIDs = entryIDs[batchSize:]
+
+		entriesLeftCount := len(entryIDs)
+		if entriesLeftCount == 0 {
+			c.log.Debug("Finished to process all tainted entries")
+			c.notifyTaintedBatchProcessed()
+			return
+		}
+		c.log.WithField(telemetry.Count, entriesLeftCount).Debug("Entries left to process")
+		c.notifyTaintedBatchProcessed()
+
+		select {
+		case <-ticker.C:
+		case <-ctx.Done():
+			c.log.Debug("Context cancelled, exiting rotation schedule")
+			return
+		}
+	}
+}
+
+func (c *LRUCache) notifyTaintedBatchProcessed() {
+	if c.taintedBatchProcessedCh != nil {
+		c.taintedBatchProcessedCh <- struct{}{}
+	}
+}
+
+// processTaintedSVIDs identifies and removes tainted SVIDs from the cache that have been signed by the given tainted authorities.
+func (c *LRUCache) processTaintedSVIDs(entryIDs []string, taintedX509Authorities []*x509.Certificate) {
+	counter := telemetry.StartCall(c.metrics, telemetry.CacheManager, "", telemetry.ProcessTaintedSVIDs)
+	defer counter.Done(nil)
+
+	// TODO: add metric fr time
+	taintedSVIDs := 0
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, entryID := range entryIDs {
+		svid, exists := c.svids[entryID]
+		if !exists || svid == nil {
+			// Skip if the SVID is not in cache or is nil
+			continue
+		}
+
+		// Check if the SVID is signed by any tainted authority
+		if x509util.IsSignedByRoot(svid.Chain, taintedX509Authorities) {
+			taintedSVIDs++
+			delete(c.svids, entryID)
+		}
+	}
+
+	agentmetrics.AddCacheManagerTaintedSVIDsSample(c.metrics, "", float32(taintedSVIDs))
+	c.log.WithField(telemetry.TaintedSVIDs, taintedSVIDs).Debug("Tainted X.509 SVIDs")
 }
 
 // Notify subscriber of selector set only if all SVIDs for corresponding selector set are cached

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -597,11 +597,11 @@ func (c *LRUCache) scheduleRotation(ctx context.Context, entryIDs []string, tain
 
 		entriesLeftCount := len(entryIDs)
 		if entriesLeftCount == 0 {
-			c.log.Debug("Finished processing all tainted entries")
+			c.log.Info("Finished processing all tainted entries")
 			c.notifyTaintedBatchProcessed()
 			return
 		}
-		c.log.WithField(telemetry.Count, entriesLeftCount).Debug("Tainted entries left to be processed")
+		c.log.WithField(telemetry.Count, entriesLeftCount).Info("There are tainted X.509 SVIDs left to be processed")
 		c.notifyTaintedBatchProcessed()
 
 		select {
@@ -651,7 +651,7 @@ func (c *LRUCache) processTaintedSVIDs(entryIDs []string, taintedX509Authorities
 	}
 
 	agentmetrics.AddCacheManagerTaintedSVIDsSample(c.metrics, "", float32(taintedSVIDs))
-	c.log.WithField(telemetry.TaintedSVIDs, taintedSVIDs).Debug("Tainted X.509 SVIDs")
+	c.log.WithField(telemetry.TaintedSVIDs, taintedSVIDs).Info("Tainted X.509 SVIDs")
 }
 
 // Notify subscriber of selector set only if all SVIDs for corresponding selector set are cached

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -38,6 +38,12 @@ type UpdateEntries struct {
 	// Bundles is a set of ALL trust bundles available to the agent, keyed by trust domain
 	Bundles map[spiffeid.TrustDomain]*spiffebundle.Bundle
 
+	// TaintedX509Authorities is a set of all tainted X.509 authorities notified by the server.
+	TaintedX509Authorities []string
+
+	// TaintedJWTAuthorities is a set of all tainted JWT authorities notified by the server.
+	TaintedJWTAuthorities []string
+
 	// RegistrationEntries is a set of all registration entries available to the
 	// agent, keyed by registration entry id.
 	RegistrationEntries map[string]*common.RegistrationEntry

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -1070,7 +1070,7 @@ func TestTaintX509SVIDs(t *testing.T) {
 		},
 		{
 			Level:   logrus.DebugLevel,
-			Message: "Entries left to process",
+			Message: "Tainted entries left to be processed",
 			Data:    logrus.Fields{telemetry.Count: "6"},
 		},
 	}
@@ -1091,7 +1091,7 @@ func TestTaintX509SVIDs(t *testing.T) {
 		},
 		{
 			Level:   logrus.DebugLevel,
-			Message: "Entries left to process",
+			Message: "Tainted entries left to be processed",
 			Data:    logrus.Fields{telemetry.Count: "2"},
 		},
 	}
@@ -1112,7 +1112,7 @@ func TestTaintX509SVIDs(t *testing.T) {
 		},
 		{
 			Level:   logrus.DebugLevel,
-			Message: "Finished to process all tainted entries",
+			Message: "Finished processing all tainted entries",
 		},
 	}
 	expectMetrics = append([]fakemetrics.MetricItem{

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -1064,13 +1064,13 @@ func TestTaintX509SVIDs(t *testing.T) {
 			Data:    logrus.Fields{telemetry.Count: "10"},
 		},
 		{
-			Level:   logrus.DebugLevel,
+			Level:   logrus.InfoLevel,
 			Message: "Tainted X.509 SVIDs",
 			Data:    logrus.Fields{telemetry.TaintedSVIDs: "3"},
 		},
 		{
-			Level:   logrus.DebugLevel,
-			Message: "Tainted entries left to be processed",
+			Level:   logrus.InfoLevel,
+			Message: "There are tainted X.509 SVIDs left to be processed",
 			Data:    logrus.Fields{telemetry.Count: "6"},
 		},
 	}
@@ -1085,13 +1085,13 @@ func TestTaintX509SVIDs(t *testing.T) {
 
 	expectLog = []spiretest.LogEntry{
 		{
-			Level:   logrus.DebugLevel,
+			Level:   logrus.InfoLevel,
 			Message: "Tainted X.509 SVIDs",
 			Data:    logrus.Fields{telemetry.TaintedSVIDs: "3"},
 		},
 		{
-			Level:   logrus.DebugLevel,
-			Message: "Tainted entries left to be processed",
+			Level:   logrus.InfoLevel,
+			Message: "There are tainted X.509 SVIDs left to be processed",
 			Data:    logrus.Fields{telemetry.Count: "2"},
 		},
 	}
@@ -1106,12 +1106,12 @@ func TestTaintX509SVIDs(t *testing.T) {
 
 	expectLog = []spiretest.LogEntry{
 		{
-			Level:   logrus.DebugLevel,
+			Level:   logrus.InfoLevel,
 			Message: "Tainted X.509 SVIDs",
 			Data:    logrus.Fields{telemetry.TaintedSVIDs: "2"},
 		},
 		{
-			Level:   logrus.DebugLevel,
+			Level:   logrus.InfoLevel,
 			Message: "Finished processing all tainted entries",
 		},
 	}

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -979,7 +979,7 @@ func TestTaintX509SVIDs(t *testing.T) {
 	batchProcessedCh := make(chan struct{}, 1)
 
 	// Initialize cache with configuration
-	cache := newTestLRUCacheWithConfig(10, clk)
+	cache := newTestLRUCacheWithConfig(clk)
 	cache.processingBatchSize = 4
 	cache.log = log
 	cache.taintedBatchProcessedCh = batchProcessedCh

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -15,6 +16,8 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/fakes/fakemetrics"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/spiffe/spire/test/testca"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -964,6 +967,196 @@ func TestSubscribeToLRUCacheChanges(t *testing.T) {
 	}
 }
 
+func TestTaintX509SVIDs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	clk := clock.NewMock(t)
+	fakeMetrics := fakemetrics.New()
+	log, logHook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+
+	batchProcessedCh := make(chan struct{}, 1)
+
+	// Initialize cache with configuration
+	cache := newTestLRUCacheWithConfig(10, clk)
+	cache.processingBatchSize = 4
+	cache.log = log
+	cache.taintedBatchProcessedCh = batchProcessedCh
+	cache.metrics = fakeMetrics
+
+	entries := createTestEntries(10)
+	updateEntries := &UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(entries...),
+	}
+
+	// Add entries to cache
+	cache.UpdateEntries(updateEntries, nil)
+
+	taintedCA := testca.New(t, trustDomain1)
+	newCA := testca.New(t, trustDomain1)
+	svids := makeX509SVIDs(entries...)
+
+	// Prepare SVIDs (some are signed by tainted authority, others are not)
+	prepareSVIDs(t, entries[:3], svids, taintedCA) // SVIDs for e0-e2 tainted
+	prepareSVIDs(t, entries[3:5], svids, newCA)    // SVIDs for e3-e4 not tainted
+	prepareSVIDs(t, entries[5:], svids, taintedCA) // SVIDs for e5-e9 tainted
+
+	cache.svids = svids
+	require.Equal(t, 10, cache.CountX509SVIDs())
+
+	waitForBatchFinished := func() {
+		select {
+		case <-cache.taintedBatchProcessedCh:
+		case <-ctx.Done():
+			require.Fail(t, "failed to process tainted authorities")
+		}
+	}
+
+	assertBatchProcess := func(expectLogs []spiretest.LogEntry, expectMetrics []fakemetrics.MetricItem, svidIDs ...string) {
+		waitForBatchFinished()
+		spiretest.AssertLogs(t, logHook.AllEntries(), expectLogs)
+		assert.Equal(t, expectMetrics, fakeMetrics.AllMetrics())
+
+		assert.Len(t, cache.svids, len(svidIDs))
+		for _, svidID := range svidIDs {
+			_, found := cache.svids[svidID]
+			assert.True(t, found, "svid not found: %q", svidID)
+		}
+	}
+
+	expectElapsedTimeMetric := []fakemetrics.MetricItem{
+		{
+			Type: fakemetrics.IncrCounterWithLabelsType,
+			Key:  []string{"cache_manager", "", "process_tainted_svids"},
+			Val:  1,
+			Labels: []telemetry.Label{
+				{
+					Name:  "status",
+					Value: "OK",
+				},
+			},
+		},
+		{
+			Type: fakemetrics.MeasureSinceWithLabelsType,
+			Key:  []string{"cache_manager", "", "process_tainted_svids", "elapsed_time"},
+			Val:  0,
+			Labels: []telemetry.Label{
+				{
+					Name:  "status",
+					Value: "OK",
+				},
+			},
+		},
+	}
+
+	// Reset logs and metrics before testing
+	resetLogsAndMetrics(logHook, fakeMetrics)
+
+	// Schedule taint and assert initial batch processing
+	cache.TaintX509SVIDs(ctx, taintedCA.X509Authorities())
+
+	expectLog := []spiretest.LogEntry{
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Scheduled rotation for SVID entries due to tainted X.509 authorities",
+			Data:    logrus.Fields{telemetry.Count: "10"},
+		},
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Tainted X.509 SVIDs",
+			Data:    logrus.Fields{telemetry.TaintedSVIDs: "3"},
+		},
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Entries left to process",
+			Data:    logrus.Fields{telemetry.Count: "6"},
+		},
+	}
+	expectMetrics := append([]fakemetrics.MetricItem{
+		{Type: fakemetrics.AddSampleType, Key: []string{telemetry.CacheManager, "", telemetry.TaintedSVIDs}, Val: 3}},
+		expectElapsedTimeMetric...)
+	assertBatchProcess(expectLog, expectMetrics, "e3", "e4", "e5", "e6", "e7", "e8", "e9")
+
+	// Advance clock, reset logs and metrics, and verify batch processing
+	resetLogsAndMetrics(logHook, fakeMetrics)
+	clk.Add(6 * time.Second)
+
+	expectLog = []spiretest.LogEntry{
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Tainted X.509 SVIDs",
+			Data:    logrus.Fields{telemetry.TaintedSVIDs: "3"},
+		},
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Entries left to process",
+			Data:    logrus.Fields{telemetry.Count: "2"},
+		},
+	}
+	expectMetrics = append([]fakemetrics.MetricItem{
+		{Type: fakemetrics.AddSampleType, Key: []string{telemetry.CacheManager, "", telemetry.TaintedSVIDs}, Val: 3}},
+		expectElapsedTimeMetric...)
+	assertBatchProcess(expectLog, expectMetrics, "e3", "e4", "e8", "e9")
+
+	// Advance clock again for the final batch
+	resetLogsAndMetrics(logHook, fakeMetrics)
+	clk.Add(6 * time.Second)
+
+	expectLog = []spiretest.LogEntry{
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Tainted X.509 SVIDs",
+			Data:    logrus.Fields{telemetry.TaintedSVIDs: "2"},
+		},
+		{
+			Level:   logrus.DebugLevel,
+			Message: "Finished to process all tainted entries",
+		},
+	}
+	expectMetrics = append([]fakemetrics.MetricItem{
+		{Type: fakemetrics.AddSampleType, Key: []string{telemetry.CacheManager, "", telemetry.TaintedSVIDs}, Val: 2}},
+		expectElapsedTimeMetric...)
+	assertBatchProcess(expectLog, expectMetrics, "e3", "e4")
+}
+
+func TestTaintX509SVIDsNoSVIDs(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	clk := clock.NewMock(t)
+	log, logHook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+
+	// Initialize cache with configuration
+	cache := newTestLRUCacheWithConfig(clk)
+	cache.log = log
+
+	entries := createTestEntries(10)
+	updateEntries := &UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(entries...),
+	}
+	// All entries has no chain...
+	cache.svids = makeX509SVIDs(entries...)
+
+	// Add entries to cache
+	cache.UpdateEntries(updateEntries, nil)
+	logHook.Reset()
+
+	fakeBundle := []*x509.Certificate{{Raw: []byte("foo")}}
+	cache.TaintX509SVIDs(ctx, fakeBundle)
+
+	expectLog := []spiretest.LogEntry{
+		{
+			Level:   logrus.DebugLevel,
+			Message: "No SVID entries to process for tainted X.509 authorities",
+		},
+	}
+	spiretest.AssertLogs(t, logHook.AllEntries(), expectLog)
+}
+
 func TestMetrics(t *testing.T) {
 	cache := newTestLRUCache(t)
 	fakeMetrics := fakemetrics.New()
@@ -1081,7 +1274,7 @@ func newTestLRUCache(t testing.TB) *LRUCache {
 
 func newTestLRUCacheWithConfig(clk clock.Clock) *LRUCache {
 	log, _ := test.NewNullLogger()
-	return NewLRUCache(log, spiffeid.RequireTrustDomainFromString("domain.test"), bundleV1, telemetry.Blackhole{}, clk)
+	return NewLRUCache(log, trustDomain1, bundleV1, telemetry.Blackhole{}, clk)
 }
 
 // numEntries should not be more than 12 digits
@@ -1224,4 +1417,32 @@ func makeFederatesWith(bundles ...*Bundle) []string {
 		out = append(out, bundle.TrustDomain().IDString())
 	}
 	return out
+}
+
+func createTestEntries(count int) []*common.RegistrationEntry {
+	var entries []*common.RegistrationEntry
+	for i := 0; i < count; i++ {
+		entry := makeRegistrationEntry(fmt.Sprintf("e%d", i), fmt.Sprintf("s%d", i))
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func prepareSVIDs(t *testing.T, entries []*common.RegistrationEntry, svids map[string]*X509SVID, ca *testca.CA) {
+	for _, entry := range entries {
+		svid, ok := svids[entry.EntryId]
+		require.True(t, ok)
+
+		chain, key := ca.CreateX509Certificate(
+			testca.WithID(spiffeid.RequireFromPath(trustDomain1, "/"+entry.EntryId)),
+		)
+
+		svid.Chain = chain
+		svid.PrivateKey = key
+	}
+}
+
+func resetLogsAndMetrics(logHook *test.Hook, fakeMetrics *fakemetrics.FakeMetrics) {
+	logHook.Reset()
+	fakeMetrics.Reset()
 }

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -94,6 +94,9 @@ func newManager(c *Config) *manager {
 		client:         client,
 		clk:            c.Clk,
 		svidStoreCache: c.SVIDStoreCache,
+
+		processedTaintedX509Authorities: make(map[string]struct{}),
+		processedTaintedJWTAuthorities:  make(map[string]struct{}),
 	}
 
 	return m

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -171,6 +171,14 @@ type manager struct {
 	// cache.
 	syncedEntries map[string]*common.RegistrationEntry
 	syncedBundles map[string]*common.Bundle
+
+	// processedTaintedX509Authorities holds all the already processed tainted X.509 Authorities
+	// to prevent processing them again.
+	processedTaintedX509Authorities map[string]struct{}
+
+	// processedTaintedJWTAuthorities holds all the already processed tainted JWT Authorities
+	// to prevent processing them again.
+	processedTaintedJWTAuthorities map[string]struct{}
 }
 
 func (m *manager) Initialize(ctx context.Context) error {

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/rotationutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/api/limits"
 	"github.com/spiffe/spire/proto/spire/common"
 )
@@ -324,7 +325,7 @@ func (m *manager) runSynchronizer(ctx context.Context) error {
 
 		err := m.synchronize(ctx)
 		switch {
-		case nodeutil.IsUnknownAuthorityError(err):
+		case x509util.IsUnknownAuthorityError(err):
 			m.c.Log.WithError(err).Info("Synchronize failed, non-recoverable error")
 			return fmt.Errorf("failed to sync with SPIRE Server: %w", err)
 		case err != nil && nodeutil.ShouldAgentReattest(err):

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -884,7 +884,7 @@ func TestForceRotation(t *testing.T) {
 	// Wait until tainted authorities are fully processed, then retry synchronization
 	assert.Eventually(t, func() bool {
 		for _, logEntry := range logHook.Entries {
-			if logEntry.Message == "Finished to process all tainted entries" {
+			if logEntry.Message == "Finished processing all tainted entries" {
 				return true
 			}
 		}

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -9,11 +9,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	testlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -770,6 +772,178 @@ func TestSynchronizationUpdatesRegistrationEntries(t *testing.T) {
 	compareRegistrationEntries(t,
 		regEntriesMap["resp3"],
 		m.cache.Entries())
+}
+
+func TestForceRotation(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	km := fakeagentkeymanager.New(t, dir)
+
+	clk := clock.NewMock(t)
+	// Big number to never get into regular rotation
+	ttl := 10000
+	api := newMockAPI(t, &mockAPIConfig{
+		km: km,
+		getAuthorizedEntries: func(*mockAPI, int32, *entryv1.GetAuthorizedEntriesRequest) (*entryv1.GetAuthorizedEntriesResponse, error) {
+			return makeGetAuthorizedEntriesResponse(t, "resp1", "resp2"), nil
+		},
+		batchNewX509SVIDEntries: func(*mockAPI, int32) []*common.RegistrationEntry {
+			return makeBatchNewX509SVIDEntries("resp1", "resp2")
+		},
+		svidTTL: ttl,
+		clk:     clk,
+	})
+
+	baseSVID, baseSVIDKey := api.newSVID(joinTokenID, 1*time.Hour)
+	cat := fakeagentcatalog.New()
+	cat.SetKeyManager(km)
+
+	log, logHook := testlog.NewNullLogger()
+	log.Level = logrus.DebugLevel
+
+	c := &Config{
+		ServerAddr:       api.addr,
+		SVID:             baseSVID,
+		SVIDKey:          baseSVIDKey,
+		Log:              log,
+		TrustDomain:      trustDomain,
+		Storage:          openStorage(t, dir),
+		Bundle:           api.bundle,
+		Metrics:          &telemetry.Blackhole{},
+		RotationInterval: time.Hour,
+		SyncInterval:     time.Hour,
+		Clk:              clk,
+		Catalog:          cat,
+		WorkloadKeyType:  workloadkey.ECP256,
+		SVIDStoreCache:   storecache.New(&storecache.Config{TrustDomain: trustDomain, Log: testLogger, Metrics: &telemetry.Blackhole{}}),
+		RotationStrategy: rotationutil.NewRotationStrategy(0),
+	}
+
+	m := newManager(c)
+
+	sub, err := m.SubscribeToCacheChanges(context.Background(), cache.Selectors{
+		{Type: "unix", Value: "uid:1111"},
+		{Type: "spiffe_id", Value: joinTokenID.String()},
+	})
+	require.NoError(t, err)
+	defer sub.Finish()
+
+	if err := m.Initialize(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, clk.Now(), m.GetLastSync())
+
+	// Before synchronization
+	identitiesBefore := identitiesByEntryID(m.cache.Identities())
+	if len(identitiesBefore) != 3 {
+		t.Fatalf("3 cached identities were expected; got %d", len(identitiesBefore))
+	}
+
+	// This is the initial update based on the selector set
+	u := <-sub.Updates()
+	if len(u.Identities) != 3 {
+		t.Fatalf("expected 3 identities, got: %d", len(u.Identities))
+	}
+
+	if len(u.Bundle.X509Authorities()) != 1 {
+		t.Fatal("expected 1 bundle root CA")
+	}
+
+	if !u.Bundle.Equal(api.bundle) {
+		t.Fatal("received bundle should be equals to the server bundle")
+	}
+
+	for key, eu := range identitiesByEntryID(u.Identities) {
+		eb, ok := identitiesBefore[key]
+		if !ok {
+			t.Fatalf("an update was received for an inexistent entry on the cache with EntryId=%v", key)
+		}
+		require.Equal(t, eb, eu, "identity received does not match identity on cache")
+	}
+
+	require.Equal(t, clk.Now(), m.GetLastSync())
+
+	// No ttl and bundle updates
+	clk.Add(time.Second)
+	require.NoError(t, m.synchronize(context.Background()))
+	select {
+	case <-sub.Updates():
+		t.Fatal("update unexpected after 1 second")
+	default:
+	}
+	assert.False(t, m.svid.IsTainted())
+
+	// Taint authority
+	api.taintCurrentX509Authority()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// Initial synchronization
+	require.NoError(t, m.synchronize(ctx))
+
+	// Wait until tainted authorities are fully processed, then retry synchronization
+	assert.Eventually(t, func() bool {
+		for _, logEntry := range logHook.Entries {
+			if logEntry.Message == "Finished to process all tainted entries" {
+				return true
+			}
+		}
+		return false
+	}, time.Minute, 50*time.Millisecond, "No tainted authority processed")
+
+	// Retry synchronization to handle potential edge case
+	require.NoError(t, m.synchronize(ctx))
+
+	select {
+	case u = <-sub.Updates():
+	case <-ctx.Done():
+		t.Fatal("Expected update after tainting authority, but none received")
+	}
+
+	// SVID is signed by a tainted authority, it must be tainted
+	assert.True(t, m.svid.IsTainted())
+	taintedSubjectKeyID := x509util.SubjectKeyIDToString(api.taintedX509Authority.SubjectKeyId)
+	expectProcessedTaintedX509Authorities := map[string]struct{}{
+		taintedSubjectKeyID: {},
+	}
+	assert.Equal(t, expectProcessedTaintedX509Authorities, m.processedTaintedX509Authorities)
+
+	// Make sure the update contains the updated entries and that the cache
+	// has a consistent view.
+	identitiesAfter := identitiesByEntryID(m.cache.Identities())
+	if len(identitiesAfter) != 3 {
+		t.Fatalf("expected 3 identities, got: %d", len(identitiesAfter))
+	}
+
+	for key, eb := range identitiesBefore {
+		ea, ok := identitiesAfter[key]
+		if !ok {
+			t.Fatalf("expected identity with EntryId=%v after synchronization", key)
+		}
+		require.NotEqual(t, eb, ea, "there is at least one identity that was not refreshed: %v", ea)
+	}
+
+	if len(u.Identities) != 3 {
+		t.Fatalf("expected 3 identities, got: %d", len(u.Identities))
+	}
+
+	if len(u.Bundle.X509Authorities()) != 2 {
+		t.Fatal("expected 1 bundle root CA")
+	}
+
+	if !u.Bundle.Equal(api.bundle) {
+		t.Fatal("received bundle should be equals to the server bundle")
+	}
+
+	for key, eu := range identitiesByEntryID(u.Identities) {
+		ea, ok := identitiesAfter[key]
+		if !ok {
+			t.Fatalf("an update was received for an inexistent entry on the cache with EntryId=%v", key)
+		}
+		require.Equal(t, eu, ea, "entry received does not match entry on cache")
+	}
+
+	require.Equal(t, clk.Now(), m.GetLastSync())
 }
 
 func TestSubscribersGetUpToDateBundle(t *testing.T) {
@@ -1597,6 +1771,8 @@ type mockAPI struct {
 	getAuthorizedEntriesCount int32
 	batchNewX509SVIDCount     int32
 
+	taintedX509Authority *x509.Certificate
+
 	clk clock.Clock
 
 	// Add latest's SVIDs per entry, to verify returned SVIDs are valid
@@ -1716,7 +1892,16 @@ func (h *mockAPI) NewJWTSVID(_ context.Context, req *svidv1.NewJWTSVIDRequest) (
 }
 
 func (h *mockAPI) GetBundle(context.Context, *bundlev1.GetBundleRequest) (*types.Bundle, error) {
-	return api.BundleToProto(bundleutil.BundleProtoFromRootCAs(h.bundle.TrustDomain().IDString(), h.bundle.X509Authorities()))
+	bundle := bundleutil.BundleProtoFromRootCAs(h.bundle.TrustDomain().IDString(), h.bundle.X509Authorities())
+	if h.taintedX509Authority != nil {
+		for _, eachRootCA := range bundle.RootCas {
+			if reflect.DeepEqual(eachRootCA.DerBytes, h.taintedX509Authority.Raw) {
+				eachRootCA.TaintedKey = true
+			}
+		}
+	}
+
+	return api.BundleToProto(bundle)
 }
 
 func (h *mockAPI) GetFederatedBundle(_ context.Context, req *bundlev1.GetFederatedBundleRequest) (*types.Bundle, error) {
@@ -1726,6 +1911,15 @@ func (h *mockAPI) GetFederatedBundle(_ context.Context, req *bundlev1.GetFederat
 			{Asn1: h.ca.Raw},
 		},
 	}, nil
+}
+
+// taintCurrentX509Authority create a new X.509 authority and taint old
+func (h *mockAPI) taintCurrentX509Authority() {
+	h.taintedX509Authority = h.ca
+	ca, caKey := createCA(h.t, h.clk)
+	h.ca = ca
+	h.caKey = caKey
+	h.bundle.AddX509Authority(ca)
 }
 
 func (h *mockAPI) rotateCA() {

--- a/pkg/agent/manager/storecache/cache.go
+++ b/pkg/agent/manager/storecache/cache.go
@@ -1,6 +1,8 @@
 package storecache
 
 import (
+	"context"
+	"crypto/x509"
 	"sort"
 	"sync"
 	"time"
@@ -10,6 +12,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	telemetry_agent "github.com/spiffe/spire/pkg/common/telemetry/agent"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/common"
 )
 
@@ -46,6 +50,7 @@ type cachedRecord struct {
 type Config struct {
 	Log         logrus.FieldLogger
 	TrustDomain spiffeid.TrustDomain
+	Metrics     telemetry.Metrics
 }
 
 type Cache struct {
@@ -217,6 +222,37 @@ func (c *Cache) UpdateSVIDs(update *cache.UpdateSVIDs) {
 		// Cache record is updated, remove it from stale map
 		delete(c.staleEntries, entryID)
 	}
+}
+
+func (c *Cache) TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x509.Certificate) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	counter := telemetry.StartCall(c.c.Metrics, telemetry.CacheManager, "svid_store", telemetry.ProcessTaintedSVIDs)
+	defer counter.Done(nil)
+
+	// start := time.Now()
+
+	taintedSVIDs := 0
+	for _, record := range c.records {
+		// Skip nil or already tainted SVIDs
+		if record.svid == nil {
+			continue
+		}
+
+		if x509util.IsSignedByRoot(record.svid.Chain, taintedX509Authorities) {
+			taintedSVIDs++
+			record.svid = nil // Mark SVID as tainted by setting it to nil
+		}
+	}
+
+	telemetry_agent.AddCacheManagerExpiredSVIDsSample(c.c.Metrics, "svid_store", float32(taintedSVIDs))
+	c.c.Log.WithField(telemetry.TaintedSVIDs, taintedSVIDs).Info("Tainted X.509 SVIDs")
+
+	// TODO: remove....
+	// c.c.Log.Debugf("******************************************************")
+	// c.c.Log.Debugf("Duration to process %d svids: %v", taintedSVIDs, time.Since(start))
+	// c.c.Log.Debugf("******************************************************")
 }
 
 // GetStaleEntries obtains a list of stale entries, that needs new SVIDs

--- a/pkg/agent/manager/storecache/cache.go
+++ b/pkg/agent/manager/storecache/cache.go
@@ -238,7 +238,15 @@ func (c *Cache) TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x5
 			continue
 		}
 
-		if x509util.IsSignedByRoot(record.svid.Chain, taintedX509Authorities) {
+		isTainted, err := x509util.IsSignedByRoot(record.svid.Chain, taintedX509Authorities)
+		if err != nil {
+			c.c.Log.WithError(err).
+				WithField(telemetry.RegistrationID, record.entry.EntryId).
+				Error("Failed to check if SVID is signed by tainted authority")
+			continue
+		}
+
+		if isTainted {
 			taintedSVIDs++
 			record.svid = nil // Mark SVID as tainted by setting it to nil
 		}

--- a/pkg/agent/manager/storecache/cache.go
+++ b/pkg/agent/manager/storecache/cache.go
@@ -231,8 +231,6 @@ func (c *Cache) TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x5
 	counter := telemetry.StartCall(c.c.Metrics, telemetry.CacheManager, "svid_store", telemetry.ProcessTaintedSVIDs)
 	defer counter.Done(nil)
 
-	// start := time.Now()
-
 	taintedSVIDs := 0
 	for _, record := range c.records {
 		// Skip nil or already tainted SVIDs
@@ -248,11 +246,6 @@ func (c *Cache) TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x5
 
 	telemetry_agent.AddCacheManagerExpiredSVIDsSample(c.c.Metrics, "svid_store", float32(taintedSVIDs))
 	c.c.Log.WithField(telemetry.TaintedSVIDs, taintedSVIDs).Info("Tainted X.509 SVIDs")
-
-	// TODO: remove....
-	// c.c.Log.Debugf("******************************************************")
-	// c.c.Log.Debugf("Duration to process %d svids: %v", taintedSVIDs, time.Since(start))
-	// c.c.Log.Debugf("******************************************************")
 }
 
 // GetStaleEntries obtains a list of stale entries, that needs new SVIDs

--- a/pkg/agent/manager/storecache/cache_test.go
+++ b/pkg/agent/manager/storecache/cache_test.go
@@ -1,11 +1,14 @@
 package storecache_test
 
 import (
+	"context"
 	"crypto/x509"
+	"fmt"
 	"net/url"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-metrics"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -14,7 +17,9 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager/storecache"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
 	"github.com/spiffe/spire/test/spiretest"
+	"github.com/spiffe/spire/test/testca"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -907,6 +912,141 @@ func TestUpdateEntriesCreatesNewEntriesOnCache(t *testing.T) {
 	spiretest.AssertLogsAnyOrder(t, hook.AllEntries(), expectedLogs)
 }
 
+func TestTaintX509SVIDs(t *testing.T) {
+	ctx := context.Background()
+	log, hook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+	fakeMetrics := fakemetrics.New()
+	taintedAuthority := testca.New(t, td)
+	newAuthority := testca.New(t, td)
+
+	c := storecache.New(&storecache.Config{
+		Log:         log,
+		TrustDomain: td,
+		Metrics:     fakeMetrics,
+	})
+
+	// Create initial entries
+	entries := makeEntries(td, "e1", "e2", "e3", "e4", "e5")
+	updateEntries := &cache.UpdateEntries{
+		Bundles: map[spiffeid.TrustDomain]*spiffebundle.Bundle{
+			td: tdBundle,
+		},
+		RegistrationEntries: entries,
+	}
+
+	// Set entries to cache
+	c.UpdateEntries(updateEntries, nil)
+
+	noTaintedSVID := createX509SVID(td, "e3", newAuthority)
+	updateSVIDs := &cache.UpdateSVIDs{
+		X509SVIDs: map[string]*cache.X509SVID{
+			"e1": createX509SVID(td, "e1", taintedAuthority),
+			"e2": createX509SVID(td, "e2", taintedAuthority),
+			"e3": noTaintedSVID,
+			"e5": createX509SVID(td, "e5", taintedAuthority),
+		},
+	}
+	c.UpdateSVIDs(updateSVIDs)
+
+	for _, tt := range []struct {
+		name               string
+		taintedAuthorities []*x509.Certificate
+		expectSVID         map[string]*cache.X509SVID
+		expectLogs         []spiretest.LogEntry
+		expectMetrics      []fakemetrics.MetricItem
+	}{
+		{
+			name:               "taint SVIDs",
+			taintedAuthorities: taintedAuthority.X509Authorities(),
+			expectSVID: map[string]*cache.X509SVID{
+				"e1": nil,
+				"e2": nil,
+				"e3": noTaintedSVID,
+				"e4": nil,
+				"e5": nil,
+			},
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "Tainted X.509 SVIDs",
+					Data: logrus.Fields{
+						telemetry.TaintedSVIDs: "3",
+					},
+				},
+			},
+			expectMetrics: []fakemetrics.MetricItem{
+				{
+					Type: fakemetrics.AddSampleType,
+					Key:  []string{"cache_manager", "svid_store", "expiring_svids", "svid_store"},
+					Val:  3,
+				},
+				{
+					Type:   fakemetrics.IncrCounterWithLabelsType,
+					Key:    []string{"cache_manager", "svid_store", "process_tainted_svids"},
+					Val:    1,
+					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
+				},
+				{
+					Type:   fakemetrics.MeasureSinceWithLabelsType,
+					Key:    []string{"cache_manager", "svid_store", "process_tainted_svids", "elapsed_time"},
+					Val:    0,
+					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
+				},
+			},
+		},
+		{
+			name:               "taint again",
+			taintedAuthorities: taintedAuthority.X509Authorities(),
+			expectSVID: map[string]*cache.X509SVID{
+				"e1": nil,
+				"e2": nil,
+				"e3": noTaintedSVID,
+				"e4": nil,
+				"e5": nil,
+			},
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "Tainted X.509 SVIDs",
+					Data: logrus.Fields{
+						telemetry.TaintedSVIDs: "0",
+					},
+				},
+			},
+			expectMetrics: []fakemetrics.MetricItem{
+				{
+					Type: fakemetrics.AddSampleType,
+					Key:  []string{"cache_manager", "svid_store", "expiring_svids", "svid_store"},
+					Val:  0,
+				},
+				{
+					Type:   fakemetrics.IncrCounterWithLabelsType,
+					Key:    []string{"cache_manager", "svid_store", "process_tainted_svids"},
+					Val:    1,
+					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
+				},
+				{
+					Type:   fakemetrics.MeasureSinceWithLabelsType,
+					Key:    []string{"cache_manager", "svid_store", "process_tainted_svids", "elapsed_time"},
+					Val:    0,
+					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			hook.Reset()
+			fakeMetrics.Reset()
+
+			c.TaintX509SVIDs(ctx, tt.taintedAuthorities)
+			assert.Equal(t, tt.expectSVID, svidMapFromRecords(c.Records()))
+			spiretest.AssertLogs(t, hook.AllEntries(), tt.expectLogs)
+			assert.Equal(t, tt.expectMetrics, fakeMetrics.AllMetrics())
+		})
+	}
+}
+
 func TestUpdateSVIDs(t *testing.T) {
 	log, hook := test.NewNullLogger()
 	log.Level = logrus.DebugLevel
@@ -1240,4 +1380,46 @@ func createTestEntry() *common.RegistrationEntry {
 		StoreSvid:      true,
 		RevisionNumber: 1,
 	}
+}
+
+func svidMapFromRecords(records []*storecache.Record) map[string]*cache.X509SVID {
+	recordsMap := make(map[string]*cache.X509SVID, len(records))
+	for _, eachRecord := range records {
+		recordsMap[eachRecord.ID] = eachRecord.Svid
+	}
+	return recordsMap
+}
+
+func createX509SVID(td spiffeid.TrustDomain, id string, ca *testca.CA) *cache.X509SVID {
+	chain, key := ca.CreateX509Certificate(
+		testca.WithID(spiffeid.RequireFromPath(td, "/"+id)),
+	)
+	return &cache.X509SVID{
+		Chain:      chain,
+		PrivateKey: key,
+	}
+}
+
+func makeEntries(td spiffeid.TrustDomain, ids ...string) map[string]*common.RegistrationEntry {
+	entries := make(map[string]*common.RegistrationEntry, len(ids))
+	for _, id := range ids {
+		entries[id] = &common.RegistrationEntry{
+			EntryId:   id,
+			SpiffeId:  spiffeid.RequireFromPath(td, "/"+id).String(),
+			Selectors: makeSelectors(id),
+			StoreSvid: true,
+		}
+	}
+	return entries
+}
+
+func makeSelectors(values ...string) []*common.Selector {
+	var selectors []*common.Selector
+	for _, value := range values {
+		selectors = append(selectors, &common.Selector{
+			Type:  "t",
+			Value: fmt.Sprintf("v:%s", value),
+		})
+	}
+	return selectors
 }

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -21,12 +21,17 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_agent "github.com/spiffe/spire/pkg/common/telemetry/agent"
 	"github.com/spiffe/spire/pkg/common/util"
+	"github.com/spiffe/spire/pkg/common/x509util"
 	"google.golang.org/grpc"
 )
 
 type Rotator interface {
 	Run(ctx context.Context) error
 	Reattest(ctx context.Context) error
+	// NotifyTaintedAuthorities processes new tainted authorities. If the current SVID is compromised,
+	// it is marked to force rotation.
+	NotifyTaintedAuthorities([]*x509.Certificate) error
+	IsTainted() bool
 
 	State() State
 	Subscribe() observer.Stream
@@ -58,6 +63,8 @@ type rotator struct {
 
 	// Hook that will be called when the SVID rotation finishes
 	rotationFinishedHook func()
+
+	tainted bool
 }
 
 type State struct {
@@ -130,6 +137,28 @@ func (r *rotator) Subscribe() observer.Stream {
 	return r.state.Observe()
 }
 
+func (r *rotator) IsTainted() bool {
+	return r.tainted
+}
+
+func (r *rotator) NotifyTaintedAuthorities(taintedAuthorities []*x509.Certificate) error {
+	state, ok := r.state.Value().(State)
+	if !ok {
+		return fmt.Errorf("unexpected state value type: %T", r.state.Value())
+	}
+
+	if r.tainted {
+		r.c.Log.Debug("Agent SVID already tainted")
+		return nil
+	}
+
+	r.tainted = x509util.IsSignedByRoot(state.SVID, taintedAuthorities)
+	if r.tainted {
+		r.c.Log.Debug("Agent SVID is tainted by a root authority, forcing rotation")
+	}
+	return nil
+}
+
 func (r *rotator) GetRotationMtx() *sync.RWMutex {
 	return r.rotMtx
 }
@@ -162,7 +191,7 @@ func (r *rotator) rotateSVIDIfNeeded(ctx context.Context) (err error) {
 		return fmt.Errorf("unexpected value type: %T", r.state.Value())
 	}
 
-	if r.c.RotationStrategy.ShouldRotateX509(r.clk.Now(), state.SVID[0]) {
+	if r.c.RotationStrategy.ShouldRotateX509(r.clk.Now(), state.SVID[0]) || r.tainted {
 		if state.Reattestable {
 			err = r.reattest(ctx)
 		} else {
@@ -222,6 +251,7 @@ func (r *rotator) reattest(ctx context.Context) (err error) {
 	}
 
 	r.state.Update(s)
+	r.tainted = false
 
 	// We must release the client because its underlaying connection is tied to an
 	// expired SVID, so next time the client is used, it will get a new connection with
@@ -269,6 +299,7 @@ func (r *rotator) rotateSVID(ctx context.Context) (err error) {
 	}
 
 	r.state.Update(s)
+	r.tainted = false
 
 	// We must release the client because its underlaying connection is tied to an
 	// expired SVID, so next time the client is used, it will get a new connection with

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -168,7 +168,7 @@ func (r *rotator) NotifyTaintedAuthorities(taintedAuthorities []*x509.Certificat
 	}
 
 	if tainted {
-		r.c.Log.Debug("Agent SVID is tainted by a root authority, forcing rotation")
+		r.c.Log.Info("Agent SVID is tainted by a root authority, forcing rotation")
 		r.setTainted(tainted)
 	}
 	return nil

--- a/pkg/agent/svid/rotator.go
+++ b/pkg/agent/svid/rotator.go
@@ -162,7 +162,11 @@ func (r *rotator) NotifyTaintedAuthorities(taintedAuthorities []*x509.Certificat
 		return nil
 	}
 
-	tainted := x509util.IsSignedByRoot(state.SVID, taintedAuthorities)
+	tainted, err := x509util.IsSignedByRoot(state.SVID, taintedAuthorities)
+	if err != nil {
+		return fmt.Errorf("failed to check if SVID is tainted: %w", err)
+	}
+
 	if tainted {
 		r.c.Log.Debug("Agent SVID is tainted by a root authority, forcing rotation")
 		r.setTainted(tainted)

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -120,7 +120,9 @@ func TestRotator(t *testing.T) {
 			// Create the starting SVID
 			svidKey, err := svidKM.GenerateKey(context.Background(), nil)
 			require.NoError(t, err)
+
 			svid, err := createTestSVID(svidKey.Public(), caCert, caKey, clk.Now(), clk.Now().Add(tt.notAfter))
+
 			require.NoError(t, err)
 
 			// Advance the clock by one second so SVID will always be expired
@@ -379,6 +381,163 @@ func TestRotationFails(t *testing.T) {
 			spiretest.RequireErrorPrefix(t, err, tt.expectErr)
 		})
 	}
+}
+
+func TestNotifyTaintedAuthority(t *testing.T) {
+	caCert, caKey := testca.CreateCACertificate(t, nil, nil)
+	anotherCert, _ := testca.CreateCACertificate(t, nil, nil)
+
+	svidKM := keymanager.ForSVID(fakeagentkeymanager.New(t, ""))
+	clk := clock.NewMock(t)
+	log, logHook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+
+	mockClient := &fakeClient{
+		clk:    clk,
+		caCert: caCert,
+		caKey:  caKey,
+	}
+
+	// Create the bundle
+	bundle := make(map[spiffeid.TrustDomain]*spiffebundle.Bundle)
+	bundle[trustDomain] = spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{caCert})
+
+	// Create the starting SVID
+	svidKey, err := svidKM.GenerateKey(context.Background(), nil)
+	require.NoError(t, err)
+
+	svid, err := createTestSVID(svidKey.Public(), caCert, caKey, clk.Now(), clk.Now().Add(time.Minute))
+	require.NoError(t, err)
+
+	// Initialize the rotator
+	rotator, _ := newRotator(&RotatorConfig{
+		SVIDKeyManager:   svidKM,
+		Log:              log,
+		Metrics:          telemetry.Blackhole{},
+		TrustDomain:      trustDomain,
+		BundleStream:     cache.NewBundleStream(observer.NewProperty(bundle).Observe()),
+		Clk:              clk,
+		SVID:             svid,
+		SVIDKey:          svidKey,
+		NodeAttestor:     fakeagentnodeattestor.New(t, fakeagentnodeattestor.Config{}),
+		RotationStrategy: rotationutil.NewRotationStrategy(0),
+	})
+	rotator.client = mockClient
+
+	// Ensure cert is not tainted initially
+	require.False(t, rotator.IsTainted())
+
+	for _, tt := range []struct {
+		name        string
+		authorities []*x509.Certificate
+
+		expectTainted bool
+		expectLogs    []spiretest.LogEntry
+	}{
+		{
+			name:          "no tainted",
+			authorities:   []*x509.Certificate{anotherCert},
+			expectTainted: false,
+		},
+		{
+			name:          "taint successfully",
+			authorities:   []*x509.Certificate{caCert},
+			expectTainted: true,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.DebugLevel,
+					Message: "Agent SVID is tainted by a root authority, forcing rotation",
+				},
+			},
+		},
+		{
+			name:          "already tainted",
+			authorities:   []*x509.Certificate{caCert},
+			expectTainted: true,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.DebugLevel,
+					Message: "Agent SVID already tainted",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logHook.Reset()
+
+			err := rotator.NotifyTaintedAuthorities(tt.authorities)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectTainted, rotator.IsTainted())
+			spiretest.AssertLogs(t, logHook.AllEntries(), tt.expectLogs)
+		})
+	}
+}
+
+func TestTaintedSVIDIsRotated(t *testing.T) {
+	caCert, caKey := testca.CreateCACertificate(t, nil, nil)
+
+	svidKM := keymanager.ForSVID(fakeagentkeymanager.New(t, ""))
+	clk := clock.NewMock(t)
+	log, _ := test.NewNullLogger()
+
+	mockClient := &fakeClient{
+		clk:    clk,
+		caCert: caCert,
+		caKey:  caKey,
+	}
+
+	// Create the bundle
+	bundle := make(map[spiffeid.TrustDomain]*spiffebundle.Bundle)
+	bundle[trustDomain] = spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{caCert})
+
+	// Create the starting SVID
+	svidKey, err := svidKM.GenerateKey(context.Background(), nil)
+	require.NoError(t, err)
+
+	svid, err := createTestSVID(svidKey.Public(), caCert, caKey, clk.Now(), clk.Now().Add(time.Minute))
+	require.NoError(t, err)
+
+	// Initialize the rotator
+	rotator, _ := newRotator(&RotatorConfig{
+		SVIDKeyManager:   svidKM,
+		Log:              log,
+		Metrics:          telemetry.Blackhole{},
+		TrustDomain:      trustDomain,
+		BundleStream:     cache.NewBundleStream(observer.NewProperty(bundle).Observe()),
+		Clk:              clk,
+		SVID:             svid,
+		SVIDKey:          svidKey,
+		NodeAttestor:     fakeagentnodeattestor.New(t, fakeagentnodeattestor.Config{}),
+		RotationStrategy: rotationutil.NewRotationStrategy(0),
+	})
+	rotator.client = mockClient
+	rotationFinishedCh := make(chan struct{}, 1)
+	rotator.rotationFinishedHook = func() {
+		close(rotationFinishedCh)
+	}
+
+	// Mark SVID as tainted
+	rotator.tainted = true
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- rotator.Run(ctx)
+	}()
+
+	select {
+	case err = <-errCh:
+		t.Fatalf("unexpected error during first rotation loop: %v", err)
+	case <-rotationFinishedCh:
+		// Rotation expected
+	case <-ctx.Done():
+		t.Fatal("expected rotation to finish before timeout")
+	}
+
+	require.False(t, rotator.IsTainted(), "SVID must not be tainted after rotation")
 }
 
 type fakeClient struct {

--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -445,7 +445,7 @@ func TestNotifyTaintedAuthority(t *testing.T) {
 			expectTainted: true,
 			expectLogs: []spiretest.LogEntry{
 				{
-					Level:   logrus.DebugLevel,
+					Level:   logrus.InfoLevel,
 					Message: "Agent SVID is tainted by a root authority, forcing rotation",
 				},
 			},

--- a/pkg/common/nodeutil/node.go
+++ b/pkg/common/nodeutil/node.go
@@ -2,7 +2,6 @@ package nodeutil
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -20,7 +19,6 @@ var (
 	shouldShutDown = map[types.PermissionDeniedDetails_Reason]struct{}{
 		types.PermissionDeniedDetails_AGENT_BANNED: {},
 	}
-	unknowAuthorityErr = "x509: certificate signed by unknown authority"
 )
 
 // IsAgentBanned determines if a given attested node is banned or not.
@@ -32,17 +30,6 @@ func IsAgentBanned(node *common.AttestedNode) bool {
 // ShouldAgentReattest returns true if the Server returned an error worth rebooting the Agent
 func ShouldAgentReattest(err error) bool {
 	return isExpectedPermissionDenied(err, shouldReattest)
-}
-
-// IsUnknownAuthorityError returns tru if the Server returned an unknow authority error when verifying
-// presented SVID
-func IsUnknownAuthorityError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Since it is an rpc error we are unable to use errors.As since it is not possible to unwrap
-	return strings.Contains(err.Error(), unknowAuthorityErr)
 }
 
 // ShouldAgentShutdown returns true if the Server returned an error worth shutting down the Agent

--- a/pkg/common/nodeutil/node_test.go
+++ b/pkg/common/nodeutil/node_test.go
@@ -1,16 +1,12 @@
 package nodeutil_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/nodeutil"
 	"github.com/spiffe/spire/proto/spire/common"
-	"github.com/spiffe/spire/test/testca"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -49,29 +45,6 @@ func TestShouldAgentReattest(t *testing.T) {
 
 	require.False(t, nodeutil.ShouldAgentReattest(getError(t, codes.PermissionDenied, &types.Status{})))
 	require.False(t, nodeutil.ShouldAgentReattest(getError(t, codes.PermissionDenied, nil)))
-}
-
-func TestIsUnknownAuthority(t *testing.T) {
-	t.Run("no error provided", func(t *testing.T) {
-		require.False(t, nodeutil.IsUnknownAuthorityError(nil))
-	})
-
-	t.Run("unexpected error", func(t *testing.T) {
-		require.False(t, nodeutil.IsUnknownAuthorityError(errors.New("oh no")))
-	})
-
-	t.Run("unknown authority err", func(t *testing.T) {
-		// Create two bundles with same TD and an SVID that is signed by one of them
-		ca := testca.New(t, spiffeid.RequireTrustDomainFromString("test.td"))
-		ca2 := testca.New(t, spiffeid.RequireTrustDomainFromString("test.td"))
-		svid := ca2.CreateX509SVID(spiffeid.RequireFromString("spiffe://test.td/w1"))
-
-		// Verify must fail
-		_, _, err := x509svid.Verify(svid.Certificates, ca.X509Bundle())
-		require.Error(t, err)
-
-		require.True(t, nodeutil.IsUnknownAuthorityError(err))
-	})
 }
 
 func TestShouldAgentShutdown(t *testing.T) {

--- a/pkg/common/telemetry/agent/manager.go
+++ b/pkg/common/telemetry/agent/manager.go
@@ -46,6 +46,16 @@ func AddCacheManagerOutdatedSVIDsSample(m telemetry.Metrics, cacheType string, c
 	m.AddSample(key, count)
 }
 
+// AddCacheManagerTaintedSVIDsSample count of tainted SVIDs according to
+// agent cache manager
+func AddCacheManagerTaintedSVIDsSample(m telemetry.Metrics, cacheType string, count float32) {
+	key := []string{telemetry.CacheManager, cacheType, telemetry.TaintedSVIDs}
+	if cacheType != "" {
+		key = append(key, cacheType)
+	}
+	m.AddSample(key, count)
+}
+
 // End Add Samples
 
 func SetSyncStats(m telemetry.Metrics, stats client.SyncStats) {

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -547,6 +547,9 @@ const (
 	// SubjectKeyID tags a certificate subject key ID
 	SubjectKeyID = "subject_key_id"
 
+	// SubjectKeyIDs tags a list of subject key ID
+	SubjectKeyIDs = "subject_key_ids"
+
 	// SVIDMapSize is the gauge key for the size of the LRU cache SVID map
 	SVIDMapSize = "lru_cache_svid_map_size"
 
@@ -777,6 +780,9 @@ const (
 	// RegistrationManager functionality related to a registration manager
 	RegistrationManager = "registration_manager"
 
+	// TaintedSVIDs tags tainted SVID count/list
+	TaintedSVIDs = "tainted_svids"
+
 	// Telemetry tags a telemetry module
 	Telemetry = "telemetry"
 
@@ -914,6 +920,9 @@ const (
 
 	// PushJWTKeyUpstream functionality related to pushing a public JWT Key to an upstream server.
 	PushJWTKeyUpstream = "push_jwtkey_upstream"
+
+	// ProcessTaintedSVIDs functionality related to processing tainted SVIDs.
+	ProcessTaintedSVIDs = "process_tainted_svids"
 
 	// SDSAPI functionality related to SDS; should be used with other tags
 	// to add clarity

--- a/pkg/common/x509util/cert.go
+++ b/pkg/common/x509util/cert.go
@@ -4,8 +4,14 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/x509"
+	"fmt"
+	"strings"
 
 	"github.com/spiffe/spire/pkg/common/cryptoutil"
+)
+
+const (
+	unknowAuthorityErr = "x509: certificate signed by unknown authority"
 )
 
 func CreateCertificate(template, parent *x509.Certificate, pub, priv any) (*x509.Certificate, error) {
@@ -73,10 +79,21 @@ func RawCertsFromCertificates(certs []*x509.Certificate) [][]byte {
 	return rawCerts
 }
 
-// IsSignedByRoot checks if the provided certificate chain is signed by one of the specified root CAs.
-func IsSignedByRoot(chain []*x509.Certificate, rootCAs []*x509.Certificate) bool {
-	if len(chain) == 0 {
+// IsUnknownAuthorityError returns tru if the Server returned an unknow authority error when verifying
+// presented SVID
+func IsUnknownAuthorityError(err error) bool {
+	if err == nil {
 		return false
+	}
+
+	// Since it is an rpc error we are unable to use errors.As since it is not possible to unwrap
+	return strings.Contains(err.Error(), unknowAuthorityErr)
+}
+
+// IsSignedByRoot checks if the provided certificate chain is signed by one of the specified root CAs.
+func IsSignedByRoot(chain []*x509.Certificate, rootCAs []*x509.Certificate) (bool, error) {
+	if len(chain) == 0 {
+		return false, nil
 	}
 	rootPool := x509.NewCertPool()
 	for _, x509Authority := range rootCAs {
@@ -93,7 +110,13 @@ func IsSignedByRoot(chain []*x509.Certificate, rootCAs []*x509.Certificate) bool
 		Intermediates: intermediatePool,
 		Roots:         rootPool,
 	})
+	if err == nil {
+		return true, nil
+	}
 
-	// TODO: may we verify if error is different to Signed by unknown authority?
-	return err == nil
+	if IsUnknownAuthorityError(err) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("failed to verify certificate chain: %w", err)
 }

--- a/pkg/common/x509util/cert_test.go
+++ b/pkg/common/x509util/cert_test.go
@@ -2,13 +2,39 @@ package x509util_test
 
 import (
 	"crypto/x509"
+	"errors"
 	"testing"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/test/testca"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestIsUnknownAuthority(t *testing.T) {
+	t.Run("no error provided", func(t *testing.T) {
+		require.False(t, x509util.IsUnknownAuthorityError(nil))
+	})
+
+	t.Run("unexpected error", func(t *testing.T) {
+		require.False(t, x509util.IsUnknownAuthorityError(errors.New("oh no")))
+	})
+
+	t.Run("unknown authority err", func(t *testing.T) {
+		// Create two bundles with same TD and an SVID that is signed by one of them
+		ca := testca.New(t, spiffeid.RequireTrustDomainFromString("test.td"))
+		ca2 := testca.New(t, spiffeid.RequireTrustDomainFromString("test.td"))
+		svid := ca2.CreateX509SVID(spiffeid.RequireFromString("spiffe://test.td/w1"))
+
+		// Verify must fail
+		_, _, err := x509svid.Verify(svid.Certificates, ca.X509Bundle())
+		require.Error(t, err)
+
+		require.True(t, x509util.IsUnknownAuthorityError(err))
+	})
+}
 
 func TestIsSignedByRoot(t *testing.T) {
 	td := spiffeid.RequireTrustDomainFromString("example.org")
@@ -19,19 +45,27 @@ func TestIsSignedByRoot(t *testing.T) {
 	ca2 := testca.New(t, td)
 	svid2 := ca2.CreateX509SVID(spiffeid.RequireFromPath(td, "/w2"))
 
-	testSignedByRoot := func(t *testing.T, chain []*x509.Certificate, rootCAs []*x509.Certificate, expect bool) {
-		isSigned := x509util.IsSignedByRoot(chain, rootCAs)
+	invalidCertificate := []*x509.Certificate{{Raw: []byte("invalid")}}
+
+	testSignedByRoot := func(t *testing.T, chain []*x509.Certificate, rootCAs []*x509.Certificate, expect bool, expectError string) {
+		isSigned, err := x509util.IsSignedByRoot(chain, rootCAs)
 		if expect {
 			assert.True(t, isSigned, "Expected chain to be signed by root")
 		} else {
 			assert.False(t, isSigned, "Expected chain NOT to be signed by root")
 		}
+		if expectError != "" {
+			assert.ErrorContains(t, err, expectError)
+		} else {
+			assert.NoError(t, err)
+		}
 	}
 
-	testSignedByRoot(t, svid1.Certificates, ca1.X509Authorities(), true)
-	testSignedByRoot(t, svid2.Certificates, ca2.X509Authorities(), true)
-	testSignedByRoot(t, svid2.Certificates, ca1.X509Authorities(), false)
-	testSignedByRoot(t, svid1.Certificates, ca2.X509Authorities(), false)
-	testSignedByRoot(t, nil, ca2.X509Authorities(), false)
-	testSignedByRoot(t, svid1.Certificates, nil, false)
+	testSignedByRoot(t, svid1.Certificates, ca1.X509Authorities(), true, "")
+	testSignedByRoot(t, svid2.Certificates, ca2.X509Authorities(), true, "")
+	testSignedByRoot(t, svid2.Certificates, ca1.X509Authorities(), false, "")
+	testSignedByRoot(t, svid1.Certificates, ca2.X509Authorities(), false, "")
+	testSignedByRoot(t, nil, ca2.X509Authorities(), false, "")
+	testSignedByRoot(t, svid1.Certificates, nil, false, "")
+	testSignedByRoot(t, invalidCertificate, ca1.X509Authorities(), false, "failed to verify certificate chain: x509: certificate has expired or is not yet valid")
 }

--- a/pkg/common/x509util/cert_test.go
+++ b/pkg/common/x509util/cert_test.go
@@ -1,0 +1,37 @@
+package x509util_test
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/x509util"
+	"github.com/spiffe/spire/test/testca"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSignedByRoot(t *testing.T) {
+	td := spiffeid.RequireTrustDomainFromString("example.org")
+	ca1 := testca.New(t, td)
+	intermediate := ca1.ChildCA(testca.WithID(td.ID()))
+	svid1 := intermediate.CreateX509SVID(spiffeid.RequireFromPath(td, "/w1"))
+
+	ca2 := testca.New(t, td)
+	svid2 := ca2.CreateX509SVID(spiffeid.RequireFromPath(td, "/w2"))
+
+	testSignedByRoot := func(t *testing.T, chain []*x509.Certificate, rootCAs []*x509.Certificate, expect bool) {
+		isSigned := x509util.IsSignedByRoot(chain, rootCAs)
+		if expect {
+			assert.True(t, isSigned, "Expected chain to be signed by root")
+		} else {
+			assert.False(t, isSigned, "Expected chain NOT to be signed by root")
+		}
+	}
+
+	testSignedByRoot(t, svid1.Certificates, ca1.X509Authorities(), true)
+	testSignedByRoot(t, svid2.Certificates, ca2.X509Authorities(), true)
+	testSignedByRoot(t, svid2.Certificates, ca1.X509Authorities(), false)
+	testSignedByRoot(t, svid1.Certificates, ca2.X509Authorities(), false)
+	testSignedByRoot(t, nil, ca2.X509Authorities(), false)
+	testSignedByRoot(t, svid1.Certificates, nil, false)
+}

--- a/pkg/server/api/localauthority/v1/service.go
+++ b/pkg/server/api/localauthority/v1/service.go
@@ -407,6 +407,10 @@ func (s *Service) TaintX509UpstreamAuthority(ctx context.Context, req *localauth
 		return nil, api.MakeErr(log, codes.Internal, "failed to taint upstream authority", err)
 	}
 
+	if err := s.ca.NotifyTaintedX509Authority(ctx, subjectKeyIDRequest); err != nil {
+		return nil, api.MakeErr(log, codes.Internal, "failed to notify tainted authority", err)
+	}
+
 	rpccontext.AuditRPC(ctx)
 	log.Info("X.509 upstream authority tainted successfully")
 

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -195,8 +195,8 @@ func (m *Manager) Close() {
 	}
 }
 
-func (m *Manager) NotifyTaintedX509Authority(ctx context.Context, authoirtyID string) error {
-	taintedAuthority, err := m.fetchRootCAByAuthorityID(ctx, authoirtyID)
+func (m *Manager) NotifyTaintedX509Authority(ctx context.Context, authorityID string) error {
+	taintedAuthority, err := m.fetchRootCAByAuthorityID(ctx, authorityID)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/svid/rotator.go
+++ b/pkg/server/svid/rotator.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
-	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/pkg/server/ca"
 )
 
@@ -70,7 +69,6 @@ func (r *Rotator) Run(ctx context.Context) error {
 			r.c.Log.Debug("Stopping SVID rotator")
 			return nil
 		case taintedAuthorities := <-r.c.ServerCA.TaintedAuthorities():
-			x509util.IsSignedByRoot()
 			isTainted := r.isX509AuthorityTainted(taintedAuthorities)
 			if isTainted {
 				r.triggerTaintedReceived(true)


### PR DESCRIPTION
* Force rotation of X.509 workload SVIDs in lru cache
* Force rotation of X.509 workload SVIDs in store SVID cache
* Force rotation of Agent SVID

**Which issue this PR fixes**
fixes #3907
fixes #3903


