### PR TITLE
Fix racy spire upstreamauthority plugin tests

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/fake_handlers_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/fake_handlers_test.go
@@ -66,10 +66,10 @@ type testHandler struct {
 	sAPIServer *handler
 }
 
-func (h *testHandler) startTestServers(t *testing.T, ca *testca.CA, serverCert []*x509.Certificate, serverKey crypto.Signer,
+func (h *testHandler) startTestServers(t *testing.T, clk clock.Clock, ca *testca.CA, serverCert []*x509.Certificate, serverKey crypto.Signer,
 	svidCert []byte, svidKey []byte) {
 	h.wAPIServer = &whandler{cert: serverCert, key: serverKey, ca: ca, svidCert: svidCert, svidKey: svidKey}
-	h.sAPIServer = &handler{cert: serverCert, key: serverKey, ca: ca}
+	h.sAPIServer = &handler{clock: clk, cert: serverCert, key: serverKey, ca: ca}
 	h.sAPIServer.startServerAPITestServer(t)
 	h.wAPIServer.startWAPITestServer(t)
 }


### PR DESCRIPTION
The mock clock was not being threaded through everywhere causing sporadic NotAfter related assertions to fail.