### PR TITLE
Fix test breaking when a proxy is configured on the host

### DIFF
--- a/pkg/common/plugin/httpchallenge/httpchallenge_test.go
+++ b/pkg/common/plugin/httpchallenge/httpchallenge_test.go
@@ -79,13 +79,14 @@ func TestValidateChallenge(t *testing.T) {
 			}))
 			defer func() { testServer.Close() }()
 
-			transport := http.DefaultTransport.(*http.Transport).Clone()
-			transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-				if addr == "foo.bar:80" {
-					addr = strings.TrimPrefix(testServer.URL, "http://")
-				}
-				dialer := &net.Dialer{}
-				return dialer.DialContext(ctx, network, addr)
+			transport := &http.Transport{
+				DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+					if addr == "foo.bar:80" {
+						addr = strings.TrimPrefix(testServer.URL, "http://")
+					}
+					dialer := &net.Dialer{}
+					return dialer.DialContext(ctx, network, addr)
+				},
 			}
 
 			err := VerifyChallenge(context.Background(), &http.Client{Transport: transport}, ad, c)


### PR DESCRIPTION
When the host has HTTP_PROXY settings defined, one of the new http_challege node agent tests will forward the request to the proxy from the local environment, which can't handle the request, rather then redirecting back to the test fixture properly. This patch changes the test to function like the rest of the http_challenge tests and calls back to the test fixture directly.