### PR TITLE
Remove deprecated -ttl flag from spire server cli

### DIFF
--- a/cmd/spire-server/cli/entry/create.go
+++ b/cmd/spire-server/cli/entry/create.go
@@ -45,11 +45,6 @@ type createCommand struct {
 	// Entry hint, used to disambiguate entries with the same SPIFFE ID
 	hint string
 
-	// TTL for x509 and JWT SVIDs issued to this workload, unless type specific TTLs are set.
-	// This field is deprecated in favor of the x509SVIDTTL and jwtSVIDTTL fields and will be
-	// removed in a future release.
-	ttl int
-
 	// TTL for x509 SVIDs issued to this workload
 	x509SVIDTTL int
 
@@ -94,9 +89,8 @@ func (c *createCommand) AppendFlags(f *flag.FlagSet) {
 	f.StringVar(&c.entryID, "entryID", "", "A custom ID for this registration entry (optional). If not set, a new entry ID will be generated")
 	f.StringVar(&c.parentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.spiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.ttl, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version")
-	f.IntVar(&c.x509SVIDTTL, "x509SVIDTTL", 0, "The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag")
-	f.IntVar(&c.jwtSVIDTTL, "jwtSVIDTTL", 0, "The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag")
+	f.IntVar(&c.x509SVIDTTL, "x509SVIDTTL", 0, "The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.")
+	f.IntVar(&c.jwtSVIDTTL, "jwtSVIDTTL", 0, "The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.")
 	f.StringVar(&c.path, "data", "", "Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.")
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
@@ -158,20 +152,12 @@ func (c *createCommand) validate() (err error) {
 		return errors.New("a SPIFFE ID is required")
 	}
 
-	if c.ttl < 0 {
-		return errors.New("a positive TTL is required")
-	}
-
 	if c.x509SVIDTTL < 0 {
 		return errors.New("a positive x509-SVID TTL is required")
 	}
 
 	if c.jwtSVIDTTL < 0 {
 		return errors.New("a positive JWT-SVID TTL is required")
-	}
-
-	if c.ttl > 0 && (c.x509SVIDTTL > 0 || c.jwtSVIDTTL > 0) {
-		return errors.New("use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag")
 	}
 
 	return nil
@@ -200,18 +186,6 @@ func (c *createCommand) parseConfig() ([]*types.Entry, error) {
 		X509SvidTtl: int32(c.x509SVIDTTL),
 		JwtSvidTtl:  int32(c.jwtSVIDTTL),
 		Hint:        c.hint,
-	}
-
-	// c.ttl is deprecated but usable if the new c.x509Svid field is not used.
-	// c.ttl should not be used to set the jwtSVIDTTL value because the previous
-	// behavior was to have a hard-coded 5 minute JWT TTL no matter what the value
-	// of ttl was set to.
-	// validate(...) ensures that either the new fields or the deprecated field is
-	// used, but never a mixture.
-	//
-	// https://github.com/spiffe/spire/issues/2700
-	if e.X509SvidTtl == 0 {
-		e.X509SvidTtl = int32(c.ttl)
 	}
 
 	selectors := []*types.Selector{}

--- a/cmd/spire-server/cli/entry/create_test.go
+++ b/cmd/spire-server/cli/entry/create_test.go
@@ -54,7 +54,7 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	fakeRespOKFromCmd2 := &entryv1.BatchCreateEntryResponse{
+	fakeRespOKFromCmdWithoutJwtTtl := &entryv1.BatchCreateEntryResponse{
 		Results: []*entryv1.BatchCreateEntryResponse_Result{
 			{
 				Entry: &types.Entry{
@@ -186,28 +186,16 @@ func TestCreate(t *testing.T) {
 			expErrJSON:   "Error: selector \"unix\" must be formatted as type:value\n",
 		},
 		{
-			name:         "Negative TTL",
-			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "-10"},
-			expErrPretty: "Error: a positive TTL is required\n",
-			expErrJSON:   "Error: a positive TTL is required\n",
+			name:         "Negative X509SvidTtl",
+			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-x509SVIDTTL", "-10"},
+			expErrPretty: "Error: a positive x509-SVID TTL is required\n",
+			expErrJSON:   "Error: a positive x509-SVID TTL is required\n",
 		},
 		{
-			name:         "Invalid TTL and X509SvidTtl",
-			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-x509SVIDTTL", "20"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-		},
-		{
-			name:         "Invalid TTL and JwtSvidTtl",
-			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-jwtSVIDTTL", "20"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-		},
-		{
-			name:         "Invalid TTL and both X509SvidTtl and JwtSvidTtl",
-			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-x509SVIDTTL", "20", "-jwtSVIDTTL", "30"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
+			name:         "Negative jwtSVIDTTL",
+			args:         []string{"-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-jwtSVIDTTL", "-10"},
+			expErrPretty: "Error: a positive JWT-SVID TTL is required\n",
+			expErrJSON:   "Error: a positive JWT-SVID TTL is required\n",
 		},
 		{
 			name:         "Federated node entries",
@@ -346,7 +334,7 @@ StoreSvid        : true
 				"-parentID", "spiffe://example.org/parent",
 				"-selector", "zebra:zebra:2000",
 				"-selector", "alpha:alpha:2000",
-				"-ttl", "60",
+				"-x509SVIDTTL", "60",
 				"-federatesWith", "spiffe://domaina.test",
 				"-federatesWith", "spiffe://domainb.test",
 				"-admin",
@@ -376,111 +364,7 @@ StoreSvid        : true
 					},
 				},
 			},
-			fakeResp: fakeRespOKFromCmd2,
-			expOutPretty: fmt.Sprintf(`Entry ID         : entry-id
-SPIFFE ID        : spiffe://example.org/workload
-Parent ID        : spiffe://example.org/parent
-Revision         : 0
-Downstream       : true
-X509-SVID TTL    : 60
-JWT-SVID TTL     : default
-Expiration time  : %s
-Selector         : zebra:zebra:2000
-Selector         : alpha:alpha:2000
-FederatesWith    : spiffe://domaina.test
-FederatesWith    : spiffe://domainb.test
-DNS name         : unu1000
-DNS name         : ung1000
-Admin            : true
-StoreSvid        : true
-
-`, time.Unix(1552410266, 0).UTC()),
-			expOutJSON: `{
-  "results": [
-    {
-      "status": {
-        "code": 0,
-        "message": "OK"
-      },
-      "entry": {
-        "id": "entry-id",
-        "spiffe_id": {
-          "trust_domain": "example.org",
-          "path": "/workload"
-        },
-        "parent_id": {
-          "trust_domain": "example.org",
-          "path": "/parent"
-        },
-        "selectors": [
-          {
-            "type": "zebra",
-            "value": "zebra:2000"
-          },
-          {
-            "type": "alpha",
-            "value": "alpha:2000"
-          }
-        ],
-        "x509_svid_ttl": 60,
-        "federates_with": [
-          "spiffe://domaina.test",
-          "spiffe://domainb.test"
-        ],
-        "hint": "",
-        "admin": true,
-        "created_at": "1547583197",
-        "downstream": true,
-        "expires_at": "1552410266",
-        "dns_names": [
-          "unu1000",
-          "ung1000"
-        ],
-        "revision_number": "0",
-        "store_svid": true,
-        "jwt_svid_ttl": 0
-      }
-    }
-  ]
-}`,
-		},
-		{
-			name: "Create succeeds using deprecated command line arguments",
-			args: []string{
-				"-spiffeID", "spiffe://example.org/workload",
-				"-parentID", "spiffe://example.org/parent",
-				"-selector", "zebra:zebra:2000",
-				"-selector", "alpha:alpha:2000",
-				"-ttl", "60",
-				"-federatesWith", "spiffe://domaina.test",
-				"-federatesWith", "spiffe://domainb.test",
-				"-admin",
-				"-entryExpiry", "1552410266",
-				"-dns", "unu1000",
-				"-dns", "ung1000",
-				"-downstream",
-				"-storeSVID",
-			},
-			expReq: &entryv1.BatchCreateEntryRequest{
-				Entries: []*types.Entry{
-					{
-						SpiffeId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/workload"},
-						ParentId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/parent"},
-						Selectors: []*types.Selector{
-							{Type: "zebra", Value: "zebra:2000"},
-							{Type: "alpha", Value: "alpha:2000"},
-						},
-						X509SvidTtl:   60,
-						FederatesWith: []string{"spiffe://domaina.test", "spiffe://domainb.test"},
-						Admin:         true,
-						ExpiresAt:     1552410266,
-						DnsNames:      []string{"unu1000", "ung1000"},
-						Downstream:    true,
-						StoreSvid:     true,
-					},
-				},
-			},
-			fakeResp: fakeRespOKFromCmd2,
+			fakeResp: fakeRespOKFromCmdWithoutJwtTtl,
 			expOutPretty: fmt.Sprintf(`Entry ID         : entry-id
 SPIFFE ID        : spiffe://example.org/workload
 Parent ID        : spiffe://example.org/parent

--- a/cmd/spire-server/cli/entry/update.go
+++ b/cmd/spire-server/cli/entry/update.go
@@ -44,9 +44,6 @@ type updateCommand struct {
 	// Whether or not the entry is for a downstream SPIRE server
 	downstream bool
 
-	// TTL for certificates issued to this workload
-	ttl int
-
 	// TTL for x509 SVIDs issued to this workload
 	x509SvidTTL int
 
@@ -88,9 +85,8 @@ func (c *updateCommand) AppendFlags(f *flag.FlagSet) {
 	f.StringVar(&c.entryID, "entryID", "", "The Registration Entry ID of the record to update")
 	f.StringVar(&c.parentID, "parentID", "", "The SPIFFE ID of this record's parent")
 	f.StringVar(&c.spiffeID, "spiffeID", "", "The SPIFFE ID that this record represents")
-	f.IntVar(&c.ttl, "ttl", 0, "The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version")
-	f.IntVar(&c.x509SvidTTL, "x509SVIDTTL", 0, "The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag")
-	f.IntVar(&c.jwtSvidTTL, "jwtSVIDTTL", 0, "The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag")
+	f.IntVar(&c.x509SvidTTL, "x509SVIDTTL", 0, "The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.")
+	f.IntVar(&c.jwtSvidTTL, "jwtSVIDTTL", 0, "The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.")
 	f.StringVar(&c.path, "data", "", "Path to a file containing registration JSON (optional). If set to '-', read the JSON from stdin.")
 	f.Var(&c.selectors, "selector", "A colon-delimited type:value selector. Can be used more than once")
 	f.Var(&c.federatesWith, "federatesWith", "SPIFFE ID of a trust domain to federate with. Can be used more than once")
@@ -151,20 +147,12 @@ func (c *updateCommand) validate() (err error) {
 		return errors.New("a SPIFFE ID is required")
 	}
 
-	if c.ttl < 0 {
-		return errors.New("a positive TTL is required")
-	}
-
 	if c.x509SvidTTL < 0 {
 		return errors.New("a positive x509-SVID TTL is required")
 	}
 
 	if c.jwtSvidTTL < 0 {
 		return errors.New("a positive JWT-SVID TTL is required")
-	}
-
-	if c.ttl > 0 && (c.x509SvidTTL > 0 || c.jwtSvidTTL > 0) {
-		return errors.New("use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag")
 	}
 
 	return nil
@@ -191,18 +179,6 @@ func (c *updateCommand) parseConfig() ([]*types.Entry, error) {
 		X509SvidTtl: int32(c.x509SvidTTL),
 		JwtSvidTtl:  int32(c.jwtSvidTTL),
 		Hint:        c.hint,
-	}
-
-	// c.ttl is deprecated but usable if the new c.x509Svid field is not used.
-	// c.ttl should not be used to set the jwtSVIDTTL value because the previous
-	// behavior was to have a hard-coded 5 minute JWT TTL no matter what the value
-	// of ttl was set to.
-	// validate(...) ensures that either the new fields or the deprecated field is
-	// used, but never a mixture.
-	//
-	// https://github.com/spiffe/spire/issues/2700
-	if e.X509SvidTtl == 0 {
-		e.X509SvidTtl = int32(c.ttl)
 	}
 
 	selectors := []*types.Selector{}

--- a/cmd/spire-server/cli/entry/update_test.go
+++ b/cmd/spire-server/cli/entry/update_test.go
@@ -321,24 +321,6 @@ func TestUpdate(t *testing.T) {
 		JwtSvidTtl:  300,
 	}
 
-	entry5 := &types.Entry{
-		Id:       "entry-id",
-		SpiffeId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/workload"},
-		ParentId: &types.SPIFFEID{TrustDomain: "example.org", Path: "/parent"},
-		Selectors: []*types.Selector{
-			{Type: "zebra", Value: "zebra:2000"},
-			{Type: "alpha", Value: "alpha:2000"},
-		},
-		X509SvidTtl:   60,
-		JwtSvidTtl:    0,
-		FederatesWith: []string{"spiffe://domaina.test", "spiffe://domainb.test"},
-		Admin:         true,
-		ExpiresAt:     1552410266,
-		DnsNames:      []string{"unu1000", "ung1000"},
-		Downstream:    true,
-		Hint:          "external",
-	}
-
 	entry2Resp := proto.Clone(entry2).(*types.Entry)
 	entry2Resp.CreatedAt = 1547583197
 	entry3Resp := proto.Clone(entry3).(*types.Entry)
@@ -417,30 +399,6 @@ func TestUpdate(t *testing.T) {
 			expErrJSON:   "Error: selector \"unix\" must be formatted as type:value\n",
 		},
 		{
-			name:         "Negative TTL",
-			args:         []string{"-entryID", "entry-id", "-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "-10"},
-			expErrPretty: "Error: a positive TTL is required\n",
-			expErrJSON:   "Error: a positive TTL is required\n",
-		},
-		{
-			name:         "Invalid TTL and X509SvidTtl",
-			args:         []string{"-entryID", "entry-id", "-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-x509SVIDTTL", "20"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-		},
-		{
-			name:         "Invalid TTL and JwtSvidTtl",
-			args:         []string{"-entryID", "entry-id", "-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-jwtSVIDTTL", "20"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-		},
-		{
-			name:         "Invalid TTL and both X509SvidTtl and JwtSvidTtl",
-			args:         []string{"-entryID", "entry-id", "-selector", "unix", "-parentID", "spiffe://example.org/parent", "-spiffeID", "spiffe://example.org/workload", "-ttl", "10", "-x509SVIDTTL", "20", "-jwtSVIDTTL", "30"},
-			expErrPretty: "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-			expErrJSON:   "Error: use x509SVIDTTL and jwtSVIDTTL flags or the deprecated ttl flag\n",
-		},
-		{
 			name: "Server error",
 			args: []string{"-entryID", "entry-id", "-spiffeID", "spiffe://example.org/workload", "-parentID", "spiffe://example.org/parent", "-selector", "unix:uid:1"},
 			expReq: &entryv1.BatchUpdateEntryRequest{Entries: []*types.Entry{
@@ -476,58 +434,6 @@ func TestUpdate(t *testing.T) {
 			},
 			expReq: &entryv1.BatchUpdateEntryRequest{
 				Entries: []*types.Entry{entry1},
-			},
-			fakeResp: fakeRespOKFromCmd,
-			expOutPretty: fmt.Sprintf(`Entry ID         : entry-id
-SPIFFE ID        : spiffe://example.org/workload
-Parent ID        : spiffe://example.org/parent
-Revision         : 0
-Downstream       : true
-X509-SVID TTL    : 60
-JWT-SVID TTL     : 30
-Expiration time  : %s
-Selector         : zebra:zebra:2000
-Selector         : alpha:alpha:2000
-FederatesWith    : spiffe://domaina.test
-FederatesWith    : spiffe://domainb.test
-DNS name         : unu1000
-DNS name         : ung1000
-Admin            : true
-Hint             : external
-
-`, time.Unix(1552410266, 0).UTC()),
-			expOutJSON: fmt.Sprintf(`{
-  "results": [
-    {
-      "status": {
-        "code": 0,
-        "message": "OK"
-      },
-      "entry": %s
-    }
-  ]
-}`, entry0AdminJSON),
-		},
-		{
-			name: "Update succeeds using deprecated command line arguments",
-			args: []string{
-				"-entryID", "entry-id",
-				"-spiffeID", "spiffe://example.org/workload",
-				"-parentID", "spiffe://example.org/parent",
-				"-selector", "zebra:zebra:2000",
-				"-selector", "alpha:alpha:2000",
-				"-ttl", "60",
-				"-federatesWith", "spiffe://domaina.test",
-				"-federatesWith", "spiffe://domainb.test",
-				"-admin",
-				"-entryExpiry", "1552410266",
-				"-dns", "unu1000",
-				"-dns", "ung1000",
-				"-downstream",
-				"-hint", "external",
-			},
-			expReq: &entryv1.BatchUpdateEntryRequest{
-				Entries: []*types.Entry{entry5},
 			},
 			fakeResp: fakeRespOKFromCmd,
 			expOutPretty: fmt.Sprintf(`Entry ID         : entry-id

--- a/cmd/spire-server/cli/entry/util_posix_test.go
+++ b/cmd/spire-server/cli/entry/util_posix_test.go
@@ -21,7 +21,7 @@ const (
   -hint string
     	The entry hint, used to disambiguate entries with the same SPIFFE ID
   -jwtSVIDTTL int
-    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.
   -node
     	If set, this entry will be applied to matching nodes rather than workloads
   -output value
@@ -36,10 +36,8 @@ const (
     	The SPIFFE ID that this record represents
   -storeSVID
     	A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin
-  -ttl int
-    	The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version
   -x509SVIDTTL int
-    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.
 `
 	showUsage = `Usage of entry show:
   -downstream
@@ -83,7 +81,7 @@ const (
   -hint string
     	The entry hint, used to disambiguate entries with the same SPIFFE ID
   -jwtSVIDTTL int
-    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.
   -output value
     	Desired output format (pretty, json); default: pretty.
   -parentID string
@@ -96,10 +94,8 @@ const (
     	The SPIFFE ID that this record represents
   -storeSVID
     	A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin
-  -ttl int
-    	The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version
   -x509SVIDTTL int
-    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.
 `
 	deleteUsage = `Usage of entry delete:
   -entryID string

--- a/cmd/spire-server/cli/entry/util_windows_test.go
+++ b/cmd/spire-server/cli/entry/util_windows_test.go
@@ -21,7 +21,7 @@ const (
   -hint string
     	The entry hint, used to disambiguate entries with the same SPIFFE ID
   -jwtSVIDTTL int
-    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.
   -namedPipeName string
     	Pipe name of the SPIRE Server API named pipe (default "\\spire-server\\private\\api")
   -node
@@ -36,10 +36,8 @@ const (
     	The SPIFFE ID that this record represents
   -storeSVID
     	A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin
-  -ttl int
-    	The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version
   -x509SVIDTTL int
-    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.
 `
 	showUsage = `Usage of entry show:
   -downstream
@@ -83,7 +81,7 @@ const (
   -hint string
     	The entry hint, used to disambiguate entries with the same SPIFFE ID
   -jwtSVIDTTL int
-    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for JWT-SVIDs issued based on this registration entry.
   -namedPipeName string
     	Pipe name of the SPIRE Server API named pipe (default "\\spire-server\\private\\api")
   -output value
@@ -96,10 +94,8 @@ const (
     	The SPIFFE ID that this record represents
   -storeSVID
     	A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin
-  -ttl int
-    	The lifetime, in seconds, for SVIDs issued based on this registration entry. This flag is deprecated in favor of x509SVIDTTL and jwtSVIDTTL and will be removed in a future version
   -x509SVIDTTL int
-    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry. Overrides ttl flag
+    	The lifetime, in seconds, for x509-SVIDs issued based on this registration entry.
 `
 	deleteUsage = `Usage of entry delete:
   -entryID string

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -387,8 +387,8 @@ Creates registration entries.
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied.                                      |                                                 |
 | `-socketPath`    | Path to the SPIRE Server API socket                                                                                                                                                               | /tmp/spire-server/private/api.sock              |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued.                                                                                                                     |                                                 |
-| `-x509SVIDTTL`   | A TTL, in seconds, for any X509-SVID issued as a result of this record. Overrides `-ttl` value.                                                                                                   | The TTL configured with `default_x509_svid_ttl` |
-| `-jwtSVIDTTL`    | A TTL, in seconds, for any JWT-SVID issued as a result of this record. Overrides `-ttl` value.                                                                                                    | The TTL configured with `default_jwt_svid_ttl`  |
+| `-x509SVIDTTL`   | A TTL, in seconds, for any X509-SVID issued as a result of this record.                                                                                                                           | The TTL configured with `default_x509_svid_ttl` |
+| `-jwtSVIDTTL`    | A TTL, in seconds, for any JWT-SVID issued as a result of this record.                                                                                                                            | The TTL configured with `default_jwt_svid_ttl`  |
 | `-storeSVID`     | A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin                                                               |
 
 ### `spire-server entry update`
@@ -408,8 +408,8 @@ Updates registration entries.
 | `-selector`      | A colon-delimited type:value selector used for attestation. This parameter can be used more than once, to specify multiple selectors that must be satisfied.                              |                                                 |
 | `-socketPath`    | Path to the SPIRE Server API socket                                                                                                                                                       | /tmp/spire-server/private/api.sock              |
 | `-spiffeID`      | The SPIFFE ID that this record represents and will be set to the SVID issued.                                                                                                             |                                                 |
-| `-x509SVIDTTL`   | A TTL, in seconds, for any X509-SVID issued as a result of this record. Overrides `-ttl` value.                                                                                           | The TTL configured with `default_x509_svid_ttl` |
-| `-jwtSVIDTTL`    | A TTL, in seconds, for any JWT-SVID issued as a result of this record. Overrides `-ttl` value.                                                                                            | The TTL configured with `default_jwt_svid_ttl`  |
+| `-x509SVIDTTL`   | A TTL, in seconds, for any X509-SVID issued as a result of this record.                                                                                                                   | The TTL configured with `default_x509_svid_ttl` |
+| `-jwtSVIDTTL`    | A TTL, in seconds, for any JWT-SVID issued as a result of this record.                                                                                                                    | The TTL configured with `default_jwt_svid_ttl`  |
 | `storeSVID`      | A boolean value that, when set, indicates that the resulting issued SVID from this entry must be stored through an SVIDStore plugin                                                       |
 
 ### `spire-server entry count`

--- a/test/integration/suites-windows/windows-service/04-create-registration-entries
+++ b/test/integration/suites-windows/windows-service/04-create-registration-entries
@@ -7,6 +7,6 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "windows:user_name:User Manager\ContainerUser" \
-    -ttl 0
+    -x509SVIDTTL 0
 
 assert-synced-entry "spiffe://domain.test/workload"

--- a/test/integration/suites-windows/windows-workload-attestor/04-create-registration-entries
+++ b/test/integration/suites-windows/windows-workload-attestor/04-create-registration-entries
@@ -6,7 +6,7 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "windows:user_name:User Manager\ContainerUser" \
-    -ttl 0
+    -x509SVIDTTL 0
 
 check-synced-entry "spire-agent" "spiffe://domain.test/workload"
 

--- a/test/integration/suites/admin-endpoints/05-create-registration-entries
+++ b/test/integration/suites/admin-endpoints/05-create-registration-entries
@@ -7,7 +7,7 @@ docker compose exec -T spire-server-a \
     -spiffeID "spiffe://domain-a.test/admin" \
     -selector "unix:uid:1001" \
     -admin \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent-a" "spiffe://domain-a.test/admin"
 
 log-debug "creating foreign admin registration entry..."
@@ -17,7 +17,7 @@ docker compose exec -T spire-server-b \
     -spiffeID "spiffe://domain-b.test/admin" \
     -selector "unix:uid:1003" \
     -federatesWith "spiffe://domain-a.test" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent-b" "spiffe://domain-b.test/admin"
 
 log-debug "creating regular registration entry..."
@@ -26,5 +26,5 @@ docker compose exec -T spire-server-a \
     -parentID "spiffe://domain-a.test/spire/agent/x509pop/$(fingerprint conf/domain-a/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain-a.test/workload" \
     -selector "unix:uid:1002" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent-a" "spiffe://domain-a.test/workload"

--- a/test/integration/suites/agent-cli/07-check-api-watch
+++ b/test/integration/suites/agent-cli/07-check-api-watch
@@ -8,7 +8,7 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload-$m" \
     -selector "unix:uid:1001" \
-    -ttl 20 &
+    -x509SVIDTTL 20 &
 
 # Get the PID of the last background process
 API_WATCH_PID=$!

--- a/test/integration/suites/debug-endpoints/04-create-registration-entries
+++ b/test/integration/suites/debug-endpoints/04-create-registration-entries
@@ -7,7 +7,7 @@ docker compose exec -T spire-server \
     -spiffeID "spiffe://domain.test/admin" \
     -selector "unix:uid:1001" \
     -admin \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/admin"
 
 log-debug "creating regular registration entry..."
@@ -16,6 +16,6 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "unix:uid:1002" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/workload"
 

--- a/test/integration/suites/delegatedidentity/04-create-registration-entries
+++ b/test/integration/suites/delegatedidentity/04-create-registration-entries
@@ -6,7 +6,7 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/authorized_delegate" \
     -selector "unix:uid:1001" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/authorized_delegate"
 
 log-debug "creating registration entry for workload..."
@@ -15,5 +15,5 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "unix:uid:1002" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/workload"

--- a/test/integration/suites/downstream-endpoints/04-create-entries
+++ b/test/integration/suites/downstream-endpoints/04-create-entries
@@ -7,7 +7,7 @@ docker compose exec -T spire-server \
     -spiffeID "spiffe://domain.test/downstream" \
     -selector "unix:uid:1001" \
     -downstream \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/downstream"
 
 log-debug "creating workload registration entry..."
@@ -16,6 +16,6 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "unix:uid:1002" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/workload"
 

--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
@@ -59,7 +59,7 @@ setup-tests() {
         -spiffeID "spiffe://federated-domain.test/downstream-proxy" \
         -selector "unix:uid:0" \
         -federatesWith "spiffe://domain.test" \
-        -ttl 0
+        -x509SVIDTTL 0
     
     log-debug "creating registration entry for upstream proxy..."
     docker compose exec -T upstream-spire-server \
@@ -68,7 +68,7 @@ setup-tests() {
         -spiffeID "spiffe://domain.test/upstream-proxy" \
         -selector "unix:uid:0" \
         -federatesWith "spiffe://federated-domain.test" \
-        -ttl 0
+        -x509SVIDTTL 0
 
     log-debug "creating registration entry for downstream proxy..."
     docker compose exec -T upstream-spire-server \
@@ -76,7 +76,7 @@ setup-tests() {
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/downstream/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/downstream-proxy" \
         -selector "unix:uid:0" \
-        -ttl 0
+        -x509SVIDTTL 0
 }
 
 test-envoy() {

--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -20,7 +20,7 @@ setup-tests() {
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/upstream-agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/upstream-workload" \
         -selector "unix:uid:0" \
-        -ttl 0
+        -x509SVIDTTL 0
 
     log-debug "creating registration entry for downstream workload..."
     docker compose exec -T spire-server \
@@ -28,7 +28,7 @@ setup-tests() {
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/downstream-agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/downstream-workload" \
         -selector "unix:uid:0" \
-        -ttl 0
+        -x509SVIDTTL 0
 }
 
 test-envoy() {

--- a/test/integration/suites/fetch-x509-svids/04-create-registration-entries
+++ b/test/integration/suites/fetch-x509-svids/04-create-registration-entries
@@ -10,7 +10,7 @@ for ((m=1;m<=$SIZE;m++)); do
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload-$m" \
     -selector "unix:uid:1001" \
-    -ttl 0 &
+    -x509SVIDTTL 0 &
 done
 
 for ((m=1;m<=$SIZE;m++)); do

--- a/test/integration/suites/fetch-x509-svids/06-create-registration-entries
+++ b/test/integration/suites/fetch-x509-svids/06-create-registration-entries
@@ -10,7 +10,7 @@ for ((m=1;m<=$SIZE;m++)); do
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload/$m" \
     -selector "unix:uid:1002" \
-    -ttl 0 &
+    -x509SVIDTTL 0 &
 done
 
 for ((m=1;m<=$SIZE;m++)); do

--- a/test/integration/suites/ghostunnel-federation/04-create-workload-entries
+++ b/test/integration/suites/ghostunnel-federation/04-create-workload-entries
@@ -9,7 +9,7 @@ docker compose exec -T downstream-spire-server \
     -spiffeID "spiffe://downstream-domain.test/downstream-workload" \
     -selector "unix:uid:0" \
     -federatesWith "spiffe://upstream-domain.test" \
-    -ttl 0
+    -x509SVIDTTL 0
 
 log-debug "creating registration entry for upstream workload..."
 docker compose exec -T upstream-spire-server \
@@ -18,4 +18,4 @@ docker compose exec -T upstream-spire-server \
     -spiffeID "spiffe://upstream-domain.test/upstream-workload" \
     -selector "unix:uid:0" \
     -federatesWith "spiffe://downstream-domain.test" \
-    -ttl 0
+    -x509SVIDTTL 0

--- a/test/integration/suites/join-token/04-create-workload-entry
+++ b/test/integration/suites/join-token/04-create-workload-entry
@@ -6,7 +6,9 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/node" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "unix:uid:0" \
-    -ttl 0
+    -x509SVIDTTL 0 \
+    -jwtSVIDTTL 0
+
 
 # Check at most 30 times (with one second in between) that the agent has
 # successfully synced down the workload entry.

--- a/test/integration/suites/nested-rotation/02-create-intermediate-downstream-entries
+++ b/test/integration/suites/nested-rotation/02-create-intermediate-downstream-entries
@@ -7,7 +7,7 @@ docker compose exec -T root-server \
     -spiffeID "spiffe://domain.test/intermediateA" \
     -selector "docker:label:org.integration.name:intermediateA" \
     -downstream \
-    -ttl 3600
+    -x509SVIDTTL 3600
 check-synced-entry "root-agent" "spiffe://domain.test/intermediateA"
 
 log-debug "creating intermediateB downstream registration entry..."
@@ -17,5 +17,5 @@ docker compose exec -T root-server \
     -spiffeID "spiffe://domain.test/intermediateB" \
     -selector "docker:label:org.integration.name:intermediateB" \
     -downstream \
-    -ttl 3600
+    -x509SVIDTTL 3600
 check-synced-entry "root-agent" "spiffe://domain.test/intermediateB"

--- a/test/integration/suites/nested-rotation/04-create-leafA-downstream-entry
+++ b/test/integration/suites/nested-rotation/04-create-leafA-downstream-entry
@@ -8,6 +8,6 @@ docker compose exec -T intermediateA-server \
     -spiffeID "spiffe://domain.test/leafA" \
     -selector "docker:label:org.integration.name:leafA" \
     -downstream \
-    -ttl 90
+    -x509SVIDTTL 90
 
 check-synced-entry "intermediateA-agent" "spiffe://domain.test/leafA"

--- a/test/integration/suites/nested-rotation/07-create-leafB-downstream-entry
+++ b/test/integration/suites/nested-rotation/07-create-leafB-downstream-entry
@@ -8,6 +8,6 @@ docker compose exec -T intermediateB-server \
     -spiffeID "spiffe://domain.test/leafB" \
     -selector "docker:label:org.integration.name:leafB" \
     -downstream \
-    -ttl 90
+    -x509SVIDTTL 90
 
 check-synced-entry "intermediateB-agent" "spiffe://domain.test/leafB"

--- a/test/integration/suites/nested-rotation/09-create-workload-entries
+++ b/test/integration/suites/nested-rotation/09-create-workload-entries
@@ -6,7 +6,7 @@ docker compose exec -T intermediateA-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateA/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateA/workload" \
     -selector "unix:uid:1001" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "intermediateA-agent" "spiffe://domain.test/intermediateA/workload"
 
 log-debug "creating leafA workload registration entry..."
@@ -15,7 +15,7 @@ docker compose exec -T leafA-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint leafA/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafA/workload" \
     -selector "unix:uid:1001" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "leafA-agent" "spiffe://domain.test/leafA/workload"
 
 log-debug "creating intermediateB workload registration entry..."
@@ -24,7 +24,7 @@ docker compose exec -T intermediateB-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint intermediateB/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/intermediateB/workload" \
     -selector "unix:uid:1001" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "intermediateB-agent" "spiffe://domain.test/intermediateB/workload"
 
 log-debug "creating leafB workload registration entry..."
@@ -33,5 +33,5 @@ docker compose exec -T leafB-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint leafB/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/leafB/workload" \
     -selector "unix:uid:1001" \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "leafB-agent" "spiffe://domain.test/leafB/workload"

--- a/test/integration/suites/node-attestation/04-test-x509pop-attestation
+++ b/test/integration/suites/node-attestation/04-test-x509pop-attestation
@@ -7,7 +7,7 @@ docker compose exec -T spire-server \
     -spiffeID "spiffe://domain.test/admin" \
     -selector "unix:uid:1000" \
     -admin \
-    -ttl 0
+    -x509SVIDTTL 0
 check-synced-entry "spire-agent" "spiffe://domain.test/admin"
 
 log-debug "running x509pop test..."

--- a/test/integration/suites/oidc-discovery-provider/04-assert-jwks-using-workload-api
+++ b/test/integration/suites/oidc-discovery-provider/04-assert-jwks-using-workload-api
@@ -10,7 +10,8 @@ docker compose exec -T spire-server \
   -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
   -spiffeID "spiffe://domain.test/oidc-provider" \
   -selector "docker:label:org.integration.name:oidc-discovery-provider" \
-  -ttl 0
+  -x509SVIDTTL 0 \
+  -jwtSVIDTTL 0
 
 check-synced-entry "spire-agent" "spiffe://domain.test/oidc-provider"
 

--- a/test/integration/suites/rotation/04-create-workload-entry
+++ b/test/integration/suites/rotation/04-create-workload-entry
@@ -6,7 +6,7 @@ docker compose exec -T spire-server \
     -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
     -spiffeID "spiffe://domain.test/workload" \
     -selector "unix:uid:0" \
-    -ttl 0
+    -x509SVIDTTL 0
 
 # Check at most 30 times (with one second in between) that the agent has
 # successfully synced down the workload entry.

--- a/test/integration/suites/spire-server-cli/03-entry
+++ b/test/integration/suites/spire-server-cli/03-entry
@@ -33,7 +33,7 @@ docker compose exec -T spire-server \
         -spiffeID spiffe://domain.test/otherChild \
         -node \
         -dns dnsname1 \
-        -ttl 123 || fail-now "failed to create entry 3"
+        -x509SVIDTTL 123 || fail-now "failed to create entry 3"
 
 # Verify entry count correctly indicates three entries
 docker compose exec -T spire-server /opt/spire/bin/spire-server entry count | grep 3 || fail-now "failed to count 3 entries"
@@ -139,7 +139,7 @@ docker compose exec -T spire-server \
         -parentID spiffe://domain.test/parent \
         -spiffeID spiffe://domain.test/child1 \
         -federatesWith spiffe://federated1.test \
-        -ttl 456 || fail-now "failed to update entry 1"
+        -x509SVIDTTL 456 || fail-now "failed to update entry 1"
 
 docker compose exec -T spire-server \
 	/opt/spire/bin/spire-server entry update \

--- a/test/integration/suites/upgrade/01-run-upgrade-tests
+++ b/test/integration/suites/upgrade/01-run-upgrade-tests
@@ -41,7 +41,7 @@ create-registration-entry() {
         -parentID "spiffe://domain.test/spire/agent/x509pop/$(fingerprint conf/agent/agent.crt.pem)" \
         -spiffeID "spiffe://domain.test/workload" \
         -selector "unix:uid:${UID}" \
-        -ttl 0
+        -x509SVIDTTL 0
 
     # Check at most 30 times (with one second in between) that the agent has
     # successfully synced down the workload entry.


### PR DESCRIPTION
This commit removes the deprecated `-ttl` flag from `spire entry create` and `spire entry update`. 
See discussion in [issue #5254.](https://github.com/spiffe/spire/issues/5254)


**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
This commit removes the deprecated `-ttl` flag from `spire entry create` and `spire entry update`. 

**Description of change**
As per the issue referenced above:
> The CLI has long since deprecated the -ttl flag in favor of the SVID specific flags -x509SVIDTTL and -jwtSVIDTTL. The deprecated flag should be removed.

**Which issue this PR fixes**
fixes#5254

