### PR TITLE
Fix data race in agent manager tests

### DIFF
--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -883,7 +883,7 @@ func TestForceRotation(t *testing.T) {
 
 	// Wait until tainted authorities are fully processed, then retry synchronization
 	assert.Eventually(t, func() bool {
-		for _, logEntry := range logHook.Entries {
+		for _, logEntry := range logHook.AllEntries() {
 			if logEntry.Message == "Finished processing all tainted entries" {
 				return true
 			}


### PR DESCRIPTION
`Entries` is not safe to access concurrently while logs are being written by another goroutine. This is causing failures in CI/CD. Using `AllEntries()` instead, which is internally protected by a mutex.