### PR TITLE
Fix for TestRotator flaky test

### DIFF
--- a/pkg/agent/svid/rotator_test.go
+++ b/pkg/agent/svid/rotator_test.go
@@ -158,6 +158,7 @@ func TestRotator(t *testing.T) {
 				RotationStrategy: rotationutil.NewRotationStrategy(0),
 			})
 			rotator.client = mockClient
+			rotator.hooks.runRotatorSignal = make(chan struct{})
 
 			// Hook the rotation loop so we can determine when the rotator
 			// has finished a rotation evaluation (does not imply anything
@@ -178,6 +179,9 @@ func TestRotator(t *testing.T) {
 			go func() {
 				errCh <- rotator.Run(ctx)
 			}()
+
+			// Make sure that the rotator is running
+			<-rotator.hooks.runRotatorSignal
 
 			// All tests should get through one rotation loop or error
 			select {
@@ -513,7 +517,7 @@ func TestTaintedSVIDIsRotated(t *testing.T) {
 	})
 	rotator.client = mockClient
 	rotationFinishedCh := make(chan struct{}, 1)
-	rotator.rotationFinishedHook = func() {
+	rotator.hooks.rotationFinishedHook = func() {
 		close(rotationFinishedCh)
 	}
 


### PR DESCRIPTION
There is a race condition in the TestRotator test that can make it to fail:
https://github.com/spiffe/spire/actions/runs/11742647891/job/32713865973?pr=5642
```
--- FAIL: TestRotator (60.10s)
    --- FAIL: TestRotator/reattest_expires_after_startup (60.02s)
        rotator_test.go:211: timed out waiting for rotation check to finish
FAIL
FAIL	github.com/spiffe/spire/pkg/agent/svid	60.267s
```

For the "reattest expires after startup" test case, we advance the clock two minutes. But since the rotator is launched in a separated go routine, that may happen before the rotator is running.
Added a hook to make sure that we advance the clock after the rotator is running.


