### PR TITLE
agent: accept registration entries with RevisionNumber 0

### DIFF
--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -445,7 +445,7 @@ func (c *client) streamAndSyncEntries(ctx context.Context, entryClient entryv1.E
 	// on entry revisions.
 	processEntryRevisions := func(entryRevisions []*entryv1.EntryRevision) {
 		for _, entryRevision := range entryRevisions {
-			if entryRevision.Id == "" || entryRevision.RevisionNumber <= 0 {
+			if entryRevision.Id == "" || entryRevision.RevisionNumber < 0 {
 				c.c.Log.WithFields(logrus.Fields{
 					telemetry.RegistrationID: entryRevision.Id,
 					telemetry.RevisionNumber: entryRevision.RevisionNumber,


### PR DESCRIPTION
When using the SyncAuthorizedEntries API we verify that the RevisionNumber of the entries is at least 1. Unfortunately, the RevisionNumber as assigned by spire-server starts at 0, leading to the following error:
```
WARN[0004] Received malformed entry revision from SPIRE server; are the server and agent versions compatible?  entry_id=f1a26ecf-1043-4905-b5d9-789e60f88695 revision_number=0 subsystem_name=manager
````

I'm guessing the check is there in the unlikely case of a wrap-around, so I'm keeping it and verifying that the RevisionNumber is positive.

No tests here, but I'm working on adding some general tests for the feature in a follow-up PR.