### PR TITLE
golangci-lint: add copyloopvar & update code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - intrange
     - whitespace
     - gocritic
+    - copyloopvar
     - wastedassign
     - nolintlint
 

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -123,8 +123,6 @@ func TestDownloadTrustBundle(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		t.Run(testCase.msg, func(t *testing.T) {
 			testServer := httptest.NewServer(http.HandlerFunc(
 				func(w http.ResponseWriter, r *http.Request) {
@@ -629,8 +627,6 @@ func TestMergeInput(t *testing.T) {
 	cases = append(cases, mergeInputCasesOS()...)
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		fileInput := &Config{Agent: &agentConfig{}}
 		cliInput := &agentConfig{}
 
@@ -1042,8 +1038,6 @@ func TestNewAgentConfig(t *testing.T) {
 	}
 	cases = append(cases, newAgentConfigCasesOS(t)...)
 	for _, testCase := range cases {
-		testCase := testCase
-
 		input := defaultValidConfig()
 
 		testCase.input(input)
@@ -1206,8 +1200,6 @@ func TestWarnOnUnknownConfig(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		c, err := ParseFile(filepath.Join(testFileDir, testCase.confFile), false)
 		require.NoError(t, err)
 

--- a/cmd/spire-server/cli/entry/util_test.go
+++ b/cmd/spire-server/cli/entry/util_test.go
@@ -45,7 +45,6 @@ func TestParseEntryJSON(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			p := testCase.testDataPath
 

--- a/cmd/spire-server/cli/logger/printers_test.go
+++ b/cmd/spire-server/cli/logger/printers_test.go
@@ -53,7 +53,6 @@ Launch Level : info
 			expectedError: errors.New("internal error: unexpected type *types.Entry returned; please report this as a bug"),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.env = &commoncli.Env{
 				Stdout: &tt.outWriter,

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -470,8 +470,6 @@ func TestMergeInput(t *testing.T) {
 	cases = append(cases, mergeInputCasesOS(t)...)
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		fileInput := &Config{Server: &serverConfig{}}
 
 		testCase.fileInput(fileInput)
@@ -1213,8 +1211,6 @@ func TestNewServerConfig(t *testing.T) {
 	cases = append(cases, newServerConfigCasesOS(t)...)
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		input := defaultValidConfig()
 
 		testCase.input(input)
@@ -1337,7 +1333,6 @@ func TestValidateConfig(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			conf := defaultValidConfig()
 			testCase.applyConf(conf)
@@ -1550,8 +1545,6 @@ func TestWarnOnUnknownConfig(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		c, err := ParseFile(filepath.Join(testFileDir, testCase.confFile), false)
 		require.NoError(t, err)
 
@@ -1759,7 +1752,6 @@ func TestHasCompatibleTTLs(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		testCase := testCase
 		if testCase.caTTL == 0 {
 			testCase.caTTL = credtemplate.DefaultX509CATTL
 		}

--- a/pkg/agent/api/debug/v1/service_test.go
+++ b/pkg/agent/api/debug/v1/service_test.go
@@ -189,7 +189,6 @@ func TestGetInfo(t *testing.T) {
 			err:  "failed to verify agent SVID: x509svid: could not get leaf SPIFFE ID: certificate contains no URI SAN",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()

--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -327,7 +327,6 @@ func TestSubscribeToX509SVIDs(t *testing.T) {
 			expectMetrics: generateSubscribeToX509SVIDMetrics(),
 		},
 	} {
-		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			metrics := fakemetrics.New()
 			params := testParams{
@@ -428,7 +427,6 @@ func TestSubscribeToX509Bundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			params := testParams{
 				CA:           ca,
@@ -668,7 +666,6 @@ func TestFetchJWTSVIDs(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			params := testParams{
 				CA:           ca,
@@ -768,7 +765,6 @@ func TestSubscribeToJWTBundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			params := testParams{
 				CA:           ca,

--- a/pkg/agent/api/health/v1/service_test.go
+++ b/pkg/agent/api/health/v1/service_test.go
@@ -82,7 +82,6 @@ func TestServiceCheck(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, logHook := test.NewNullLogger()
 

--- a/pkg/agent/attestor/node/node_test.go
+++ b/pkg/agent/attestor/node/node_test.go
@@ -281,8 +281,6 @@ func TestAttestor(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -527,7 +525,6 @@ func TestIsSVIDExpired(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Desc, func(t *testing.T) {
 			isExpired := attestor.IsSVIDExpired(tt.SVID, func() time.Time { return now })
 			require.Equal(t, tt.ExpectExpired, isExpired)

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -403,7 +403,6 @@ func TestRenewSVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			logHook.Reset()
 			tc.agentServer.err = tt.agentErr
@@ -757,7 +756,6 @@ func TestFetchUpdatesReleaseConnectionIfItFailsToFetch(t *testing.T) {
 			err: "failed to fetch bundle: rpc error: code = Unknown desc = an error",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client, tc := createClient(t)
 			tt.setupTest(tc)
@@ -921,7 +919,6 @@ func TestFetchJWTSVID(t *testing.T) {
 			fetchErr: status.Error(codes.Internal, "NewJWTSVID fails"),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupTest(tt.fetchErr)
 			resp, err := client.NewJWTSVID(ctx, "entry-id", []string{"myAud"})

--- a/pkg/agent/common/sigstore/sigstore_test.go
+++ b/pkg/agent/common/sigstore/sigstore_test.go
@@ -381,7 +381,6 @@ func TestVerify(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -163,7 +163,6 @@ func TestEndpoints(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, hook := test.NewNullLogger()
 			metrics := fakemetrics.New()

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -266,7 +266,6 @@ func TestFetchX509SVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			params := testParams{
 				CA:         ca,
@@ -425,7 +424,6 @@ func TestFetchX509Bundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.testName, func(t *testing.T) {
 			params := testParams{
 				CA:                            ca,
@@ -837,7 +835,6 @@ func TestFetchJWTSVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			params := testParams{
 				CA:         ca,
@@ -1042,7 +1039,6 @@ func TestFetchJWTBundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			params := testParams{
 				CA:                            ca,
@@ -1476,7 +1472,6 @@ func TestValidateJWTSVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			params := testParams{
 				Updates:                 tt.updates,

--- a/pkg/agent/manager/cache/jwt_cache_test.go
+++ b/pkg/agent/manager/cache/jwt_cache_test.go
@@ -201,7 +201,6 @@ func TestJWTSVIDCache(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cache := NewJWTSVIDCache(log, fakeMetrics, 8)
 			if tt.setJWTSVIDsCached != nil {

--- a/pkg/agent/manager/storecache/cache_test.go
+++ b/pkg/agent/manager/storecache/cache_test.go
@@ -523,8 +523,6 @@ func TestUpdateEntries(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			log, hook := test.NewNullLogger()
 			log.Level = logrus.DebugLevel

--- a/pkg/agent/plugin/keymanager/test/keymanagertest.go
+++ b/pkg/agent/plugin/keymanager/test/keymanagertest.go
@@ -263,7 +263,6 @@ func assertRSAKey(t *testing.T, key keymanager.Key, bits int) {
 
 func testSignCertificates(t *testing.T, key keymanager.Key, signatureAlgorithms []x509.SignatureAlgorithm) {
 	for _, signatureAlgorithm := range signatureAlgorithms {
-		signatureAlgorithm := signatureAlgorithm
 		t.Run("sign data "+signatureAlgorithm.String(), func(t *testing.T) {
 			assertSignCertificate(t, key, signatureAlgorithm)
 		})

--- a/pkg/agent/plugin/keymanager/v1_test.go
+++ b/pkg/agent/plugin/keymanager/v1_test.go
@@ -72,7 +72,6 @@ func TestV1GenerateKey(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				generateKeyResponse: &keymanagerv1.GenerateKeyResponse{
@@ -137,7 +136,6 @@ func TestV1GetKey(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				getPublicKeyResponse: &keymanagerv1.GetPublicKeyResponse{
@@ -194,7 +192,6 @@ func TestV1GetKeys(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			resp := &keymanagerv1.GetPublicKeysResponse{}
 			if tt.publicKey != nil {
@@ -291,7 +288,6 @@ func TestV1SignData(t *testing.T) {
 			expectCode:       codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				expectSignerOpts: tt.expectSignerOpts,

--- a/pkg/agent/plugin/nodeattestor/gcpiit/iit_test.go
+++ b/pkg/agent/plugin/nodeattestor/gcpiit/iit_test.go
@@ -160,7 +160,6 @@ func TestRetrieveIdentity(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.msg, func(t *testing.T) {
 			url := tt.url
 			if tt.handleFunc != nil {

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -39,7 +39,6 @@ func TestConfigureCommon(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := newPlugin()
 
@@ -85,7 +84,6 @@ func TestAidAttestationFailures(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			p := loadAndConfigurePlugin(t, tt.trustDomain, tt.config)
@@ -194,7 +192,6 @@ func TestAidAttestationSucceeds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 			expectPayload, err := json.Marshal(&tt.attestationData)

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -166,7 +166,6 @@ func TestConfigureCommon(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tpmdevid.AutoDetectTPMPath = func(string) (string, error) {
 				if isWindows {
@@ -265,7 +264,6 @@ func TestConfigurePosix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tpmdevid.AutoDetectTPMPath = func(string) (string, error) {
 				if tt.autoDetectTPMFails {
@@ -359,7 +357,6 @@ func TestConfigureWindows(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			tpmdevid.AutoDetectTPMPath = func(string) (string, error) {
 				return "", errors.New("autodetect is not supported on windows")
@@ -477,7 +474,6 @@ func TestAidAttestationFailures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			sim := setupSimulator(t)
 

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
@@ -153,7 +153,6 @@ func TestNewSession(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Run hook if exists, generally used to intentionally cause an error
 			// and test more code paths.
@@ -251,7 +250,6 @@ func TestSolveDevIDChallenge(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if isWindows {
 				tt.scfg.DevicePath = ""
@@ -325,7 +323,6 @@ func TestSolveCredActivationChallenge(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			nonce, err := tpm.SolveCredActivationChallenge(tt.credBlob, tt.encryptedSecret)
 			if tt.expErr != "" {
@@ -365,7 +362,6 @@ func TestCertifyDevIDKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var devicePath string
 			if !isWindows {
@@ -463,7 +459,6 @@ func TestGetEKCert(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.hook != nil {
 				tt.hook()
@@ -521,7 +516,6 @@ func TestGetEKPublic(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.hook != nil {
 				tt.hook()
@@ -595,7 +589,6 @@ func TestAutoDetectTPMPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Create devices
 			for _, fileName := range tt.deviceNames {

--- a/pkg/agent/plugin/nodeattestor/v1_test.go
+++ b/pkg/agent/plugin/nodeattestor/v1_test.go
@@ -107,7 +107,6 @@ func TestV1(t *testing.T) {
 			expectMessage: "nodeattestor(test): plugin response missing challenge response",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			nodeattestor := loadV1Plugin(t, tt.pluginImpl)
 			err := nodeattestor.Attest(context.Background(), tt.streamImpl)

--- a/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud_test.go
+++ b/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud_test.go
@@ -785,7 +785,6 @@ func TestPutX509SVID(t *testing.T) {
 			expectMsgPrefix: "svidstore(gcp_secretmanager): failed to add secret version: rpc error: code = DeadlineExceeded desc = some error",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()

--- a/pkg/agent/plugin/svidstore/utils_test.go
+++ b/pkg/agent/plugin/svidstore/utils_test.go
@@ -103,7 +103,6 @@ func TestParseMetadata(t *testing.T) {
 			expectErr:  `metadata does not contain a colon: "invalid"`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := svidstore.ParseMetadata(tt.secretData)
 			if tt.expectErr != "" {
@@ -249,7 +248,6 @@ func TestSecretFromProto(t *testing.T) {
 			err: "failed to parse FederatedBundle \"federated1\": x509: malformed certificate",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := svidstore.SecretFromProto(tt.req)
 			if tt.err != "" {

--- a/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/cgroup/dockerfinder_test.go
@@ -123,7 +123,6 @@ func TestContainerIDFinders(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.msg, func(t *testing.T) {
 			cf, err := NewContainerIDFinder(tt.matchers)
 			if tt.expectErr != "" {

--- a/pkg/agent/plugin/workloadattestor/docker/docker_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_posix_test.go
@@ -89,7 +89,6 @@ func TestContainerExtraction(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.desc, func(t *testing.T) {
 			withRootDirOpt := prepareRootDirOpt(t, tt.cgroups)
 			var d Docker = dockerError{}

--- a/pkg/agent/plugin/workloadattestor/docker/docker_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_test.go
@@ -76,7 +76,6 @@ func TestDockerSelectors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.desc, func(t *testing.T) {
 			d := fakeContainer{
 				Labels: tt.mockContainerLabels,

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_posix_test.go
@@ -307,7 +307,6 @@ func TestGetContainerIDFromCGroups(t *testing.T) {
 			expectMsg:         "multiple pod UIDs found in cgroups (11111111-b29f-11e7-9350-020968147796, 22222222-b29f-11e7-9350-020968147796)",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			podUID, containerID, err := getPodUIDAndContainerIDFromCGroups(makeCGroups(tt.cgroupPaths))
 			spiretest.RequireGRPCStatus(t, err, tt.expectCode, tt.expectMsg)
@@ -411,7 +410,6 @@ func TestGetPodUIDAndContainerIDFromCGroupPath(t *testing.T) {
 			cgroupPath: "/kubepods/pod2732ca68f6358eba7703fb6f82a25c94",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("cgroup path=%s", tt.cgroupPath)
 			podUID, containerID, ok := getPodUIDAndContainerIDFromCGroupPath(tt.cgroupPath)

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -579,7 +579,6 @@ func (s *Suite) TestConfigure() {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase // alias loop variable as it is used in the closure
 		s.T().Run(testCase.name, func(t *testing.T) {
 			p := s.newPlugin()
 
@@ -681,7 +680,6 @@ func (s *Suite) TestConfigureWithSigstore() {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		s.T().Run(tc.name, func(t *testing.T) {
 			p := s.newPlugin()
 

--- a/pkg/agent/plugin/workloadattestor/systemd/systemd_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/systemd/systemd_posix_test.go
@@ -44,7 +44,6 @@ func TestPlugin(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		log, logHook := test.NewNullLogger()
 		t.Run(testCase.name, func(t *testing.T) {
 			p := loadPlugin(t, log)

--- a/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
+++ b/pkg/agent/plugin/workloadattestor/unix/unix_posix_test.go
@@ -233,7 +233,6 @@ func (s *Suite) TestAttest() {
 	s.writeFile("exe", []byte("data"))
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		s.T().Run(testCase.name, func(t *testing.T) {
 			defer s.logHook.Reset()
 

--- a/pkg/agent/svid/store/service_test.go
+++ b/pkg/agent/svid/store/service_test.go
@@ -109,7 +109,6 @@ func TestRun(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
@@ -361,7 +360,6 @@ func TestRunDeleteSecrets(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()

--- a/pkg/common/api/middleware/metrics_test.go
+++ b/pkg/common/api/middleware/metrics_test.go
@@ -46,7 +46,6 @@ func TestWithMetrics(t *testing.T) {
 			statusLabelValue: codes.PermissionDenied.String(),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var expectedLabels []telemetry.Label
 

--- a/pkg/common/bundleutil/bundle_test.go
+++ b/pkg/common/bundleutil/bundle_test.go
@@ -88,7 +88,6 @@ func TestPruneBundle(t *testing.T) {
 			changed:    true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, _ := testlog.NewNullLogger()
 			newBundle, changed, err := PruneBundle(tt.bundle, tt.expiration, log)
@@ -217,7 +216,6 @@ func TestCommonBundleFromProto(t *testing.T) {
 			expectError: `bundle has an invalid trust domain "invalid TD": trust domain characters are limited to lowercase letters, numbers, dots, dashes, and underscores`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			bundle, err := CommonBundleFromProto(tt.bundle)
 

--- a/pkg/common/bundleutil/marshal_test.go
+++ b/pkg/common/bundleutil/marshal_test.go
@@ -141,7 +141,6 @@ func TestMarshal(t *testing.T) {
 	trustDomain := spiffeid.RequireTrustDomainFromString("domain.test")
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			bundle := spiffebundle.New(trustDomain)
 			bundle.SetRefreshHint(time.Minute)

--- a/pkg/common/bundleutil/unmarshal_test.go
+++ b/pkg/common/bundleutil/unmarshal_test.go
@@ -106,7 +106,6 @@ func TestUnmarshal(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			bundle, err := Unmarshal(trustDomain, []byte(testCase.doc))
 			if testCase.err != "" {

--- a/pkg/common/cli/trust_domain_test.go
+++ b/pkg/common/cli/trust_domain_test.go
@@ -38,7 +38,6 @@ func TestParseTrustDomain(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.msg, func(t *testing.T) {
 			logger, hook := logtest.NewNullLogger()
 			td, err := ParseTrustDomain(testCase.domain, logger)

--- a/pkg/common/diskutil/file_posix_test.go
+++ b/pkg/common/diskutil/file_posix_test.go
@@ -94,7 +94,6 @@ func TestWriteFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			file := filepath.Join(dir, "file")
 			err := tt.atomicWriteFunc(file, tt.data)

--- a/pkg/common/diskutil/file_windows_test.go
+++ b/pkg/common/diskutil/file_windows_test.go
@@ -96,7 +96,6 @@ func TestWriteFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			file := filepath.Join(dir, "file")
 			err := tt.atomicWriteFunc(file, tt.data)

--- a/pkg/common/hostservice/metricsservice/v1_test.go
+++ b/pkg/common/hostservice/metricsservice/v1_test.go
@@ -43,7 +43,6 @@ func TestV1SetGauge(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			expected := fakemetrics.New()
 			expected.SetGaugeWithLabels(tt.req.Key, tt.req.Val, v1ConvertToTelemetryLabels(tt.req.Labels))
@@ -89,7 +88,6 @@ func TestV1MeasureSince(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			expected := fakemetrics.New()
 			expected.MeasureSinceWithLabels(tt.req.Key, time.Unix(0, tt.req.Time), v1ConvertToTelemetryLabels(tt.req.Labels))
@@ -135,7 +133,6 @@ func TestV1IncrCounter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			expected := fakemetrics.New()
 			expected.IncrCounterWithLabels(tt.req.Key, tt.req.Val, v1ConvertToTelemetryLabels(tt.req.Labels))
@@ -181,7 +178,6 @@ func TestV1AddSample(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			expected := fakemetrics.New()
 			expected.AddSampleWithLabels(tt.req.Key, tt.req.Val, v1ConvertToTelemetryLabels(tt.req.Labels))
@@ -214,7 +210,6 @@ func TestV1EmitKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			expected := fakemetrics.New()
 			expected.EmitKey(tt.req.Key, tt.req.Val)
@@ -320,7 +315,6 @@ func TestV1ConvertToTelemetryLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			outLabels := v1ConvertToTelemetryLabels(tt.inLabels)
 
@@ -397,7 +391,6 @@ func TestV1ConvertToRPCLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			outLabels := v1ConvertToRPCLabels(tt.inLabels)
 

--- a/pkg/common/jwtsvid/validate_test.go
+++ b/pkg/common/jwtsvid/validate_test.go
@@ -76,7 +76,6 @@ func (s *TokenSuite) TestDifferentKeys() {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase // alias loop variable as it is used in the closure
 		s.T().Run(testCase.kid, func(t *testing.T) {
 			token := s.signJWTSVID(fakeSpiffeID, fakeAudience, time.Now().Add(time.Hour), testCase.key, testCase.kid)
 

--- a/pkg/common/plugin/sshpop/handshake_test.go
+++ b/pkg/common/plugin/sshpop/handshake_test.go
@@ -211,7 +211,6 @@ func TestVerifyAttestationData(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			s.state = stateServerInit
 			s.s.canonicalDomain = tt.serverCanonicalDomain
@@ -278,7 +277,6 @@ func TestRespondToChallenge(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			c.state = stateProvidedAttestationData
 			_, err := c.RespondToChallenge(tt.challengeReq)
@@ -339,7 +337,6 @@ func TestVerifyChallengeResponse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			s.state = stateAttestationDataVerified
 			s.cert = c.c.cert
@@ -393,7 +390,6 @@ func TestDecanonicalizeHostname(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			hostname, err := decanonicalizeHostname(tt.fqdn, tt.domain)
 			if tt.expectErr != "" {

--- a/pkg/common/plugin/sshpop/sshpop_test.go
+++ b/pkg/common/plugin/sshpop/sshpop_test.go
@@ -54,7 +54,6 @@ func TestNewClient(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			c, err := NewClient("example.org", tt.configString)
 			if tt.expectErr != "" {
@@ -139,7 +138,6 @@ func TestNewServer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			s, err := NewServer(tt.trustDomain, tt.configString)
 			if tt.expectErr != "" {
@@ -192,7 +190,6 @@ func TestPubkeysFromPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			pubkeys, err := pubkeysFromPath(tt.pubkeyPath)
 			if tt.expectErr != "" {

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -154,7 +154,6 @@ func TestMakeAgentID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			cert := &x509.Certificate{
 				Subject: pkix.Name{

--- a/pkg/common/selector/selector_test.go
+++ b/pkg/common/selector/selector_test.go
@@ -25,7 +25,6 @@ func TestValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test // alias loop variable as it is used in the closure
 		t.Run(test.name, func(t *testing.T) {
 			s := &common.Selector{
 				Type: test.selectorType,

--- a/pkg/common/telemetry/agent/keymanager/wrapper_test.go
+++ b/pkg/common/telemetry/agent/keymanager/wrapper_test.go
@@ -72,7 +72,6 @@ func TestWithMetrics(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		m.Reset()
 		require.NoError(t, tt.call())
 		key := strings.Split(tt.key, ".")

--- a/pkg/common/telemetry/sanitize_test.go
+++ b/pkg/common/telemetry/sanitize_test.go
@@ -37,7 +37,6 @@ func TestSanitize(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			out := sanitize(tt.in)
 
@@ -73,7 +72,6 @@ func TestSanitizeLabel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			out := sanitizeLabel(labelName, tt.in)
 
@@ -132,7 +130,6 @@ func TestGetSanitizedLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			out := SanitizeLabels(tt.in)
 

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -250,7 +250,6 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "ListCAJournalsForTesting",
 		},
 	} {
-		tt := tt
 		methodType, ok := wt.MethodByName(tt.methodName)
 		require.True(t, ok, "method %q does not exist on DataStore interface", tt.methodName)
 		methodValue := wv.Method(methodType.Index)

--- a/pkg/common/telemetry/server/keymanager/wrapper_test.go
+++ b/pkg/common/telemetry/server/keymanager/wrapper_test.go
@@ -81,7 +81,6 @@ func TestWithMetrics(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		m.Reset()
 		tt.call(t)
 

--- a/pkg/common/util/task.go
+++ b/pkg/common/util/task.go
@@ -37,7 +37,6 @@ func RunTasks(ctx context.Context, tasks ...func(context.Context) error) error {
 
 	wg.Add(len(tasks))
 	for _, task := range tasks {
-		task := task
 		go func() {
 			errch <- runTask(task)
 		}()

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -213,7 +213,6 @@ func TestCountAgents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, 0)
 			defer test.Cleanup()
@@ -906,7 +905,6 @@ func TestListAgents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			test.ds.SetNextError(tt.dsError)
@@ -1161,7 +1159,6 @@ func TestBanAgent(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, 0)
 			defer test.Cleanup()
@@ -1405,7 +1402,6 @@ func TestDeleteAgent(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, 0)
 			defer test.Cleanup()
@@ -1637,7 +1633,6 @@ func TestGetAgent(t *testing.T) {
 			dsError: errors.New("datastore error"),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, 0)
 			test.createTestNodes(ctx, t)
@@ -1981,7 +1976,6 @@ func TestRenewAgent(t *testing.T) {
 			expectDetail: &types.PermissionDeniedDetails{Reason: types.PermissionDeniedDetails_AGENT_MUST_REATTEST},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup test
 			test := setupServiceTest(t, tt.agentSVIDTTL)
@@ -2163,7 +2157,6 @@ func TestCreateJoinToken(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, 0)
 			test.ds.SetNextError(tt.dsError)
@@ -3133,7 +3126,6 @@ func TestAttestAgent(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			test := setupServiceTest(t, 0)

--- a/pkg/server/api/agent_test.go
+++ b/pkg/server/api/agent_test.go
@@ -67,7 +67,6 @@ func TestProtoFromAttestedNode(t *testing.T) {
 			expectErr: "scheme is missing or invalid",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			a, err := api.ProtoFromAttestedNode(tt.n)
 

--- a/pkg/server/api/audit/audit_test.go
+++ b/pkg/server/api/audit/audit_test.go
@@ -235,7 +235,6 @@ func TestAuditWitTypesStatus(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			auditLog := audit.New(log)
 			logHook.Reset()
@@ -322,7 +321,6 @@ func TestAuditWithError(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			auditLog := audit.New(log)
 			logHook.Reset()

--- a/pkg/server/api/bundle/v1/service_test.go
+++ b/pkg/server/api/bundle/v1/service_test.go
@@ -259,7 +259,6 @@ func TestGetFederatedBundle(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			test.isAdmin = tt.isAdmin
@@ -361,7 +360,6 @@ func TestGetBundle(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()
@@ -747,7 +745,6 @@ func TestAppendBundle(t *testing.T) {
 			noBundle: true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()
@@ -1107,7 +1104,6 @@ func TestBatchDeleteFederatedBundle(t *testing.T) {
 			dsError:         status.New(codes.Internal, "datasource fails").Err(),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()
@@ -1377,7 +1373,6 @@ func TestPublishJWTAuthority(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -1540,7 +1535,6 @@ func TestListFederatedBundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -1694,7 +1688,6 @@ func TestCountBundles(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()
@@ -2091,7 +2084,6 @@ func TestBatchCreateFederatedBundle(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			clearDSBundles(t, test.ds)
@@ -2507,7 +2499,6 @@ func TestBatchUpdateFederatedBundle(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()
@@ -2897,7 +2888,6 @@ func TestBatchSetFederatedBundle(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()

--- a/pkg/server/api/bundle_test.go
+++ b/pkg/server/api/bundle_test.go
@@ -90,7 +90,6 @@ func TestBundleToProto(t *testing.T) {
 			expectError: "invalid trust domain id: trust domain characters are limited to lowercase letters, numbers, dots, dashes, and underscores",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			bundle, err := api.BundleToProto(tt.bundle)
 
@@ -214,7 +213,6 @@ func TestProtoToBundle(t *testing.T) {
 			expectError: "invalid trust domain: trust domain characters are limited to lowercase letters, numbers, dots, dashes, and underscores",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			bundle, err := api.ProtoToBundle(tt.bundle)
 

--- a/pkg/server/api/debug/v1/service_test.go
+++ b/pkg/server/api/debug/v1/service_test.go
@@ -378,7 +378,6 @@ func TestGetInfo(t *testing.T) {
 			state: x509SVIDState,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t)
 			defer test.Cleanup()

--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -141,7 +141,6 @@ func TestCountEntries(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds := fakedatastore.New(t)
 			test := setupServiceTest(t, ds)
@@ -1194,7 +1193,6 @@ func TestListEntries(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			ds.SetNextError(tt.dsError)
@@ -1444,7 +1442,6 @@ func TestGetEntry(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			ds.SetNextError(tt.dsError)
@@ -2393,7 +2390,6 @@ func TestBatchCreateEntry(t *testing.T) {
 			}},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds := newFakeDS(t)
 
@@ -2654,7 +2650,6 @@ func TestBatchDeleteEntry(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds := fakedatastore.New(t)
 			test := setupServiceTest(t, ds)
@@ -2871,7 +2866,6 @@ func TestGetAuthorizedEntries(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, fakedatastore.New(t))
 			defer test.Cleanup()
@@ -3268,7 +3262,6 @@ func TestSyncAuthorizedEntries(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, fakedatastore.New(t))
 			defer func() {
@@ -4612,7 +4605,6 @@ func TestBatchUpdateEntry(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds := fakedatastore.New(t)
 			test := setupServiceTest(t, ds)

--- a/pkg/server/api/entry_test.go
+++ b/pkg/server/api/entry_test.go
@@ -95,7 +95,6 @@ func TestRegistrationEntryToProto(t *testing.T) {
 			err: "invalid SPIFFE ID: scheme is missing or invalid",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			entry, err := api.RegistrationEntryToProto(tt.entry)
 			if tt.err != "" {
@@ -464,7 +463,6 @@ func TestProtoToRegistrationEntryWithMask(t *testing.T) {
 			err:  "hint is too long, max length is 1024 characters",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			entry, err := api.ProtoToRegistrationEntryWithMask(context.Background(), td, tt.entry, tt.mask)
 			if tt.err != "" {
@@ -635,7 +633,6 @@ func TestProtoToRegistrationEntry(t *testing.T) {
 			err: "selector list is empty",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			entry, err := api.ProtoToRegistrationEntry(context.Background(), td, tt.entry)
 			if tt.err != "" {

--- a/pkg/server/api/health/v1/service_test.go
+++ b/pkg/server/api/health/v1/service_test.go
@@ -84,7 +84,6 @@ func TestServiceCheck(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, logHook := test.NewNullLogger()
 

--- a/pkg/server/api/id_test.go
+++ b/pkg/server/api/id_test.go
@@ -50,7 +50,6 @@ func TestIDFromProto(t *testing.T) {
 	// runTests exercises all the test cases against the given function
 	runTests := func(t *testing.T, fn func(ctx context.Context, td spiffeid.TrustDomain, protoID *types.SPIFFEID) (spiffeid.ID, error), testCases []testCase) {
 		for _, testCase := range append(baseCases, testCases...) {
-			testCase := testCase
 			t.Run(testCase.name, func(t *testing.T) {
 				log, logHook := test.NewNullLogger()
 
@@ -233,7 +232,6 @@ func TestAttestedNodeToProto(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			agent, err := api.AttestedNodeToProto(testCase.attNode, testCase.selectors)
 			if testCase.err != "" {

--- a/pkg/server/api/logger/v1/service_test.go
+++ b/pkg/server/api/logger/v1/service_test.go
@@ -141,7 +141,6 @@ func TestGetLogger(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, tt.launchLevel)
 			defer test.Cleanup()
@@ -390,7 +389,6 @@ func TestSetLoggerThenGetLogger(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, tt.launchLevel)
 			defer test.Cleanup()
@@ -638,7 +636,6 @@ func TestResetLogger(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, tt.launchLevel)
 			defer test.Cleanup()
@@ -729,7 +726,6 @@ func TestUnsetSetLogLevelRequest(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupServiceTest(t, tt.launchLevel)
 			defer test.Cleanup()

--- a/pkg/server/api/middleware/authorization_test.go
+++ b/pkg/server/api/middleware/authorization_test.go
@@ -321,7 +321,6 @@ func TestWithAuthorizationPreprocess(t *testing.T) {
 			expectMsg:  "failed to fetch caller entries: entry fetcher error",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			policyEngine, err := authpolicy.NewEngineFromRego(ctx, tt.rego, inmem.NewFromObject(map[string]any{}))

--- a/pkg/server/api/middleware/caller_test.go
+++ b/pkg/server/api/middleware/caller_test.go
@@ -165,7 +165,6 @@ func TestCallerContextFromContext(t *testing.T) {
 			expectMsg:  "client certificate has a malformed URI SAN: scheme is missing or invalid",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctxIn := context.Background()
 			if tt.peer != nil {

--- a/pkg/server/api/middleware/ratelimit_test.go
+++ b/pkg/server/api/middleware/ratelimit_test.go
@@ -264,7 +264,6 @@ func TestRateLimits(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, hook := test.NewNullLogger()
 			ctx := rpccontext.WithLogger(context.Background(), log)

--- a/pkg/server/api/selector_test.go
+++ b/pkg/server/api/selector_test.go
@@ -67,7 +67,6 @@ func TestSelectorsFromProto(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			selectors, err := api.SelectorsFromProto(testCase.proto)
 			if testCase.err != "" {

--- a/pkg/server/api/status_test.go
+++ b/pkg/server/api/status_test.go
@@ -138,7 +138,6 @@ func TestMakeErr(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			log, hook := test.NewNullLogger()
 			err := api.MakeErr(log, tt.code, tt.msg, tt.err)

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -528,7 +528,6 @@ func TestServiceMintX509SVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -788,7 +787,6 @@ func TestServiceMintJWTSVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -1089,7 +1087,6 @@ func TestServiceNewJWTSVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -1717,7 +1714,6 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 
@@ -2002,7 +1998,6 @@ func TestNewDownstreamX509CA(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 			test.ef.err = tt.fetcherErr

--- a/pkg/server/api/trustdomain/v1/service_test.go
+++ b/pkg/server/api/trustdomain/v1/service_test.go
@@ -195,7 +195,6 @@ func TestGetFederationRelationship(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ds := newFakeDS(t)
 			test := setupServiceTest(t, ds)
@@ -407,7 +406,6 @@ func TestListFederationRelationships(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test.logHook.Reset()
 

--- a/pkg/server/authpolicy/policy_test.go
+++ b/pkg/server/authpolicy/policy_test.go
@@ -209,7 +209,6 @@ func TestPolicy(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var json map[string]any
 			err := util.UnmarshalJSON([]byte(tt.jsonData), &json)
@@ -386,7 +385,6 @@ func TestNewEngineFromConfig(t *testing.T) {
 			success: false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 
@@ -425,7 +423,6 @@ func TestNewEngineFromRego(t *testing.T) {
 			success: false,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			// Just create arbitrary store since there isn't a way to create

--- a/pkg/server/bundle/client/client_test.go
+++ b/pkg/server/bundle/client/client_test.go
@@ -91,7 +91,6 @@ func TestClient(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			serverCert, serverKey := createServerCertificate(t, testCase.serverID)
 

--- a/pkg/server/bundle/client/manager_test.go
+++ b/pkg/server/bundle/client/manager_test.go
@@ -66,7 +66,6 @@ func TestManagerPeriodicBundleRefresh(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			test := newManagerTest(t, source,
 				func(spiffeid.TrustDomain) *spiffebundle.Bundle {

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -81,7 +81,6 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			ds := fakedatastore.New(t)
 

--- a/pkg/server/bundle/datastore/wrapper_test.go
+++ b/pkg/server/bundle/datastore/wrapper_test.go
@@ -78,7 +78,6 @@ func TestWithBundlePublisher(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			var ds datastore.DataStore = fakedatastore.New(t)

--- a/pkg/server/bundle/pubmanager/pubmanager.go
+++ b/pkg/server/bundle/pubmanager/pubmanager.go
@@ -110,7 +110,6 @@ func (m *Manager) publishBundle(ctx context.Context) (err error) {
 	var wg sync.WaitGroup
 	wg.Add(len(m.bundlePublishers))
 	for _, bp := range m.bundlePublishers {
-		bp := bp
 		go func() {
 			defer wg.Done()
 

--- a/pkg/server/ca/ca_test.go
+++ b/pkg/server/ca/ca_test.go
@@ -367,7 +367,6 @@ func (s *CATestSuite) TestSignWorkloadX509SVIDWithSubject() {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		s.T().Run(testCase.name, func(t *testing.T) {
 			params := s.createWorkloadX509SVIDParams()
 			params.Subject = testCase.subject

--- a/pkg/server/ca/manager/manager_test.go
+++ b/pkg/server/ca/manager/manager_test.go
@@ -934,7 +934,6 @@ func TestPruneCAJournals(t *testing.T) {
 
 	var expectedCAJournals []*datastore.CAJournal
 	for _, testCase := range testCases {
-		testCase := testCase
 		expectedCAJournals = []*datastore.CAJournal{}
 		t.Run(testCase.name, func(t *testing.T) {
 			// Have a fresh data store in each test case
@@ -1139,7 +1138,6 @@ func TestAlternateKeyTypes(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			ctx := context.Background()
 

--- a/pkg/server/ca/upstream_client_test.go
+++ b/pkg/server/ca/upstream_client_test.go
@@ -100,7 +100,6 @@ func TestUpstreamClientMintX509CA_FailsOnBadFirstResponse(t *testing.T) {
 			expectMsg:  "X509 CA minted by upstream authority is invalid: oh no",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			client, _, _ := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
 				TrustDomain:              trustDomain,

--- a/pkg/server/cache/dscache/cache_test.go
+++ b/pkg/server/cache/dscache/cache_test.go
@@ -147,7 +147,6 @@ func TestBundleInvalidations(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Create datastore and cache
 			ds := fakedatastore.New(t)

--- a/pkg/server/datastore/sqlstore/migration_test.go
+++ b/pkg/server/datastore/sqlstore/migration_test.go
@@ -95,7 +95,6 @@ func TestGetDBCodeVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.desc, func(t *testing.T) {
 			retVersion, err := getDBCodeVersion(tt.storedMigration)
 
@@ -157,7 +156,6 @@ func TestIsCompatibleCodeVersion(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.desc, func(t *testing.T) {
 			compatible := isCompatibleCodeVersion(tt.thisCodeVersion, tt.dbCodeVersion)
 
@@ -184,7 +182,6 @@ func TestIsDisabledMigrationAllowed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		t.Run(tt.desc, func(t *testing.T) {
 			err := isDisabledMigrationAllowed(codeVersion, tt.dbCodeVersion)
 

--- a/pkg/server/datastore/sqlstore/sqlite_test.go
+++ b/pkg/server/datastore/sqlstore/sqlite_test.go
@@ -65,7 +65,6 @@ func TestEmbellishSQLite3ConnString(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			actual, err := embellishSQLite3ConnString(testCase.in)
 			require.NoError(t, err)

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -1339,7 +1339,6 @@ func listBundles(tx *gorm.DB, req *datastore.ListBundlesRequest) (*datastore.Lis
 		Pagination: p,
 	}
 	for _, model := range bundles {
-		model := model // alias the loop variable since we pass it by reference below
 		bundle, err := modelToBundle(&model)
 		if err != nil {
 			return nil, err
@@ -4279,7 +4278,6 @@ func listFederationRelationships(tx *gorm.DB, req *datastore.ListFederationRelat
 		FederationRelationships: []*datastore.FederationRelationship{},
 	}
 	for _, model := range federationRelationships {
-		model := model // alias the loop variable since we pass it by reference below
 		federationRelationship, err := modelToFederationRelationship(tx, &model)
 		if err != nil {
 			return nil, err
@@ -4784,7 +4782,6 @@ func listCAJournalsForTesting(tx *gorm.DB) (caJournals []*datastore.CAJournal, e
 	}
 
 	for _, model := range caJournalsModel {
-		model := model // alias the loop variable since we pass it by reference below
 		caJournals = append(caJournals, modelToCAJournal(model))
 	}
 	return caJournals, nil

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -464,7 +464,6 @@ func (s *PluginSuite) TestListBundlesWithPagination() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			resp, err := s.ds.ListBundles(ctx, &datastore.ListBundlesRequest{
 				Pagination: test.pagination,
@@ -1181,7 +1180,6 @@ func (s *PluginSuite) TestListAttestedNodes() {
 			byCanReattest:       &canReattestFalse,
 		},
 	} {
-		tt := tt
 		for _, withPagination := range []bool{true, false} {
 			for _, withSelectors := range []bool{true, false} {
 				name := tt.test
@@ -1391,7 +1389,6 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 			},
 		},
 	} {
-		tt := tt
 		s.T().Run(tt.name, func(t *testing.T) {
 			s.ds = s.newPlugin()
 			defer s.ds.Close()
@@ -2077,7 +2074,6 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 			},
 		},
 	} {
-		tt := tt
 		s.T().Run(tt.name, func(t *testing.T) {
 			createdEntry, err := s.ds.CreateRegistrationEntry(ctx, tt.entry)
 			s.Require().NoError(err)
@@ -2150,7 +2146,6 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 			},
 		},
 	} {
-		tt := tt
 		s.T().Run(tt.name, func(t *testing.T) {
 			// Get latest event id
 			resp, err := s.ds.ListRegistrationEntryEvents(ctx, &datastore.ListRegistrationEntryEventsRequest{})
@@ -2813,7 +2808,6 @@ func (s *PluginSuite) testListRegistrationEntries(dataConsistency datastore.Data
 			expectPagedEntriesOut: [][]*common.RegistrationEntry{{foobarAD12}, {}},
 		},
 	} {
-		tt := tt
 		for _, withPagination := range []bool{true, false} {
 			name := tt.test
 			if withPagination {
@@ -3431,7 +3425,6 @@ func (s *PluginSuite) TestListParentIDEntries() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3481,7 +3474,6 @@ func (s *PluginSuite) TestListSelectorEntries() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3538,7 +3530,6 @@ func (s *PluginSuite) TestListEntriesBySelectorSubset() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3595,7 +3586,6 @@ func (s *PluginSuite) TestListSelectorEntriesSuperset() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3663,7 +3653,6 @@ func (s *PluginSuite) TestListEntriesBySelectorMatchAny() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3731,7 +3720,6 @@ func (s *PluginSuite) TestListEntriesByFederatesWithExact() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3799,7 +3787,6 @@ func (s *PluginSuite) TestListEntriesByFederatesWithSubset() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3872,7 +3859,6 @@ func (s *PluginSuite) TestListEntriesByFederatesWithMatchAny() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -3944,7 +3930,6 @@ func (s *PluginSuite) TestListEntriesByFederatesWithSuperset() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			ds := s.newPlugin()
 			defer ds.Close()
@@ -4737,7 +4722,6 @@ func (s *PluginSuite) TestListFederationRelationships() {
 		},
 	}
 	for _, test := range tests {
-		test := test
 		s.T().Run(test.name, func(t *testing.T) {
 			resp, err := s.ds.ListFederationRelationships(ctx, &datastore.ListFederationRelationshipsRequest{
 				Pagination: test.pagination,
@@ -5292,7 +5276,6 @@ func (s *PluginSuite) TestConfigure() {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		s.T().Run(tt.desc, func(t *testing.T) {
 			dbPath := filepath.ToSlash(filepath.Join(s.dir, "test-datastore-configure.sqlite3"))
 

--- a/pkg/server/endpoints/authorized_entryfetcher_attested_nodes_test.go
+++ b/pkg/server/endpoints/authorized_entryfetcher_attested_nodes_test.go
@@ -584,7 +584,6 @@ func TestSearchBeforeFirstNodeEvent(t *testing.T) {
 			expectedFetches:           []string{},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewNodeScenario(t, tt.setup)
 			attestedNodes, err := scenario.buildAttestedNodesCache()
@@ -812,7 +811,6 @@ func TestSelectedPolledNodeEvents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewNodeScenario(t, tt.setup)
 			attestedNodes, err := scenario.buildAttestedNodesCache()
@@ -1065,7 +1063,6 @@ func TestScanForNewNodeEvents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewNodeScenario(t, tt.setup)
 			attestedNodes, err := scenario.buildAttestedNodesCache()
@@ -1435,7 +1432,6 @@ func TestUpdateAttestedNodesCache(t *testing.T) {
 			expectedAuthorizedEntries: []string{},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewNodeScenario(t, tt.setup)
 			attestedNodes, err := scenario.buildAttestedNodesCache()

--- a/pkg/server/endpoints/authorized_entryfetcher_registration_entries_test.go
+++ b/pkg/server/endpoints/authorized_entryfetcher_registration_entries_test.go
@@ -782,7 +782,6 @@ func TestSearchBeforeFirstEntryEvent(t *testing.T) {
 			expectedFetches:           []string{},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewEntryScenario(t, tt.setup)
 			registrationEntries, err := scenario.buildRegistrationEntriesCache()
@@ -1015,7 +1014,6 @@ func TestSelectedPolledEntryEvents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewEntryScenario(t, tt.setup)
 			registrationEntries, err := scenario.buildRegistrationEntriesCache()
@@ -1279,7 +1277,6 @@ func TestScanForNewEntryEvents(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewEntryScenario(t, tt.setup)
 			attestedEntries, err := scenario.buildRegistrationEntriesCache()
@@ -1791,7 +1788,6 @@ func TestUpdateRegistrationEntriesCache(t *testing.T) {
 			expectedAuthorizedEntries: []string{},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			scenario := NewEntryScenario(t, tt.setup)
 			registeredEntries, err := scenario.buildRegistrationEntriesCache()

--- a/pkg/server/endpoints/bundle/server_test.go
+++ b/pkg/server/endpoints/bundle/server_test.go
@@ -146,7 +146,6 @@ func TestServer(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			addr, done := newTestServer(t,
 				testGetter(testCase.bundle),

--- a/pkg/server/hostservice/agentstore/agentstore_test.go
+++ b/pkg/server/hostservice/agentstore/agentstore_test.go
@@ -57,7 +57,6 @@ func TestAgentStore(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)

--- a/pkg/server/plugin/bundlepublisher/v1_test.go
+++ b/pkg/server/plugin/bundlepublisher/v1_test.go
@@ -49,7 +49,6 @@ func TestV1Publish(t *testing.T) {
 			expectMessage: "bundlepublisher(test): bundle is invalid: trust domain is missing",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			bundlepublisher := loadV1Plugin(t, &fakeV1Plugin{err: tt.pluginErr})
 			err := bundlepublisher.PublishBundle(context.Background(), tt.bundle)

--- a/pkg/server/plugin/credentialcomposer/v1_test.go
+++ b/pkg/server/plugin/credentialcomposer/v1_test.go
@@ -236,7 +236,6 @@ func TestV1ComposeServerX509CA(t *testing.T) {
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509CA attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := &fakeV1Plugin{err: tt.pluginErr, composeServerX509CAResponseOut: tt.responseOut}
 			cc := loadV1Plugin(t, plugin)
@@ -384,7 +383,6 @@ func TestV1ComposeServerX509SVID(t *testing.T) {
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := &fakeV1Plugin{err: tt.pluginErr, composeServerX509SVIDResponseOut: tt.responseOut}
 			cc := loadV1Plugin(t, plugin)
@@ -567,7 +565,6 @@ func TestV1ComposeAgentX509SVID(t *testing.T) {
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := &fakeV1Plugin{err: tt.pluginErr, composeAgentX509SVIDResponseOut: tt.responseOut}
 			cc := loadV1Plugin(t, plugin)
@@ -750,7 +747,6 @@ func TestV1ComposeWorkloadX509SVID(t *testing.T) {
 			expectMessage: `credentialcomposer(test): plugin returned invalid X509SVID attributes: extra extensions: invalid OID: non-integer part "NOT AN OID"`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := &fakeV1Plugin{err: tt.pluginErr, composeWorkloadX509SVIDResponseOut: tt.responseOut}
 			cc := loadV1Plugin(t, plugin)
@@ -847,7 +843,6 @@ func TestV1ComposeWorkloadJWTSVID(t *testing.T) {
 			expectAttributesOut: credentialcomposer.JWTSVIDAttributes{Claims: map[string]any{"NEW_KEY": "NEW_VALUE"}},
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := &fakeV1Plugin{err: tt.pluginErr, composeWorkloadJWTSVIDResponseOut: tt.responseOut}
 			cc := loadV1Plugin(t, plugin)

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -528,7 +528,6 @@ func (p *Plugin) refreshAliases(ctx context.Context) error {
 	defer p.mu.RUnlock()
 	var errs []string
 	for _, entry := range p.entries {
-		entry := entry
 		_, err := p.kmsClient.UpdateAlias(ctx, &kms.UpdateAliasInput{
 			AliasName:   &entry.AliasName,
 			TargetKeyId: &entry.Arn,

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -357,7 +357,6 @@ func TestConfigure(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -740,7 +739,6 @@ func TestGenerateKey(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1063,7 +1061,6 @@ func TestSignData(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1133,7 +1130,6 @@ func TestGetPublicKey(t *testing.T) {
 			code: codes.InvalidArgument,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1178,7 +1174,6 @@ func TestGetPublicKeys(t *testing.T) {
 			name: "non existing keys",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1350,7 +1345,6 @@ func TestRefreshAliases(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1582,7 +1576,6 @@ func TestDisposeAliases(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -1922,7 +1915,6 @@ func TestDisposeKeys(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
@@ -209,7 +209,6 @@ func TestConfigure(t *testing.T) {
 			getKeyErr: "get key error",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -316,7 +315,6 @@ func TestGenerateKey(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -633,7 +631,6 @@ func TestSignData(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -688,7 +685,6 @@ func TestGetPublicKey(t *testing.T) {
 			generatedKeyID: "some-id",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -730,7 +726,6 @@ func TestGetPublicKeys(t *testing.T) {
 			name: "non existing keys",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -796,7 +791,6 @@ func TestRefreshKeys(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)
@@ -891,7 +885,6 @@ func TestDisposeKeys(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// setup
 			ts := setupTest(t)

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -386,7 +386,6 @@ func TestConfigure(t *testing.T) {
 			getPublicKeyErrCount: getPublicKeyMaxAttempts + 1,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.putFakeCryptoKeys(tt.fakeCryptoKeys)
@@ -966,7 +965,6 @@ func TestGenerateKey(t *testing.T) {
 			getTokenInfoErr: errors.New("error getting token info"),
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.setDestroyTime(fakeTime)
@@ -1109,7 +1107,6 @@ func TestKeepActiveCryptoKeys(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.putFakeCryptoKeys(tt.fakeCryptoKeys)
@@ -1215,7 +1212,6 @@ func TestGetPublicKeys(t *testing.T) {
 			name: "non existing keys",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.putFakeCryptoKeys(tt.fakeCryptoKeys)
@@ -1317,7 +1313,6 @@ func TestGetPublicKey(t *testing.T) {
 			expectCodeGetPublicKey: codes.InvalidArgument,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.setPEMCrc32C(tt.pemCrc32C)
@@ -1413,7 +1408,6 @@ func TestSetIAMPolicy(t *testing.T) {
 			useCustomPolicy: true,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.fakeIAMHandle.setPolicyError(tt.policyErr)
@@ -1650,7 +1644,6 @@ func TestSignData(t *testing.T) {
 			signatureCrc32C: &wrapperspb.Int64Value{Value: 1},
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ts := setupTest(t)
 			ts.fakeKMSClient.setAsymmetricSignErr(tt.asymmetricSignErr)

--- a/pkg/server/plugin/keymanager/test/keymanagertest.go
+++ b/pkg/server/plugin/keymanager/test/keymanagertest.go
@@ -263,7 +263,6 @@ func assertRSAKey(t *testing.T, key keymanager.Key, bits int) {
 
 func testSignCertificates(t *testing.T, key keymanager.Key, signatureAlgorithms []x509.SignatureAlgorithm) {
 	for _, signatureAlgorithm := range signatureAlgorithms {
-		signatureAlgorithm := signatureAlgorithm
 		t.Run("sign data "+signatureAlgorithm.String(), func(t *testing.T) {
 			assertSignCertificate(t, key, signatureAlgorithm)
 		})

--- a/pkg/server/plugin/keymanager/v1_test.go
+++ b/pkg/server/plugin/keymanager/v1_test.go
@@ -71,7 +71,6 @@ func TestV1GenerateKey(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				generateKeyResponse: &keymanagerv1.GenerateKeyResponse{
@@ -136,7 +135,6 @@ func TestV1GetKey(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				getPublicKeyResponse: &keymanagerv1.GetPublicKeyResponse{
@@ -193,7 +191,6 @@ func TestV1GetKeys(t *testing.T) {
 			expectCode: codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			resp := &keymanagerv1.GetPublicKeysResponse{}
 			if tt.publicKey != nil {
@@ -290,7 +287,6 @@ func TestV1SignData(t *testing.T) {
 			expectCode:       codes.OK,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			plugin := fakeV1Plugin{
 				expectSignerOpts: tt.expectSignerOpts,

--- a/pkg/server/plugin/nodeattestor/awsiid/spiffeid_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/spiffeid_test.go
@@ -43,7 +43,6 @@ func TestMakeSpiffeID(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := makeAgentID(trustDomain, tt.agentPathTemplate, tt.doc, tt.tags)
 			require.NoError(t, err)

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -106,7 +106,6 @@ func TestConfigure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := httpchallenge.New()
 			resp, err := plugin.Configure(context.Background(), &configv1.ConfigureRequest{
@@ -323,7 +322,6 @@ func TestAttestFailures(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var testNonce string
 			if tt.tofu {
@@ -402,7 +400,6 @@ func TestAttestSucceeds(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			testNonce := "123456789abcdefghijklmnopqrstuvwxyz"
 			plugin := loadPlugin(t, tt.hclConf, !tt.tofu, client, testNonce)

--- a/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/server/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -138,7 +138,6 @@ func TestConfigure(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := tpmdevid.New()
 			resp, err := plugin.Configure(context.Background(), &configv1.ConfigureRequest{
@@ -494,7 +493,6 @@ func TestAttestFailiures(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			plugin := loadPlugin(t, tt.hclConf)
 			result, err := plugin.Attest(context.Background(), tt.payload, tt.challengeFn)
@@ -611,7 +609,6 @@ func TestAttestSucceeds(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a TPM session to generate payload and challenge response data
 			session, err := tpmutil.NewSession(&tpmutil.SessionConfig{

--- a/pkg/server/plugin/nodeattestor/v1_test.go
+++ b/pkg/server/plugin/nodeattestor/v1_test.go
@@ -129,7 +129,6 @@ func TestV1(t *testing.T) {
 			expectResult:  resultWithSelectorsAndCanReattest,
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			nodeattestor := loadV1Plugin(t, tt.plugin)
 			result, err := nodeattestor.Attest(context.Background(), []byte(tt.payload),

--- a/pkg/server/plugin/nodeattestor/x509pop/x509pop_test.go
+++ b/pkg/server/plugin/nodeattestor/x509pop/x509pop_test.go
@@ -129,7 +129,6 @@ func (s *Suite) TestAttestSuccess() {
 	}
 
 	for _, tt := range tests {
-		tt := tt // alias loop variable as it is used in the closure
 		s.T().Run(tt.desc, func(t *testing.T) {
 			attestor := s.loadPlugin(t, tt.giveConfig)
 

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
@@ -85,7 +85,6 @@ func TestConfigure(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			idp := fakeidentityprovider.New()
 
@@ -204,7 +203,6 @@ func testUpdateBundleObject(t *testing.T, notify func(notifier.Notifier) error) 
 			desc: "notifier(gcs_bundle): unable to update bundle object the-bucket/bundle.pem: googleapi: got HTTP response code 412 with body: ohno",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a raw instance so we can hook the bucket client creation,
 			// possibly overriding with a test specific hook.

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
@@ -693,7 +693,6 @@ func TestConfigure(t *testing.T) {
 			`,
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			test := setupTest(t, withNoConfigure())
 			_, err := test.rawPlugin.Configure(context.Background(), &configv1.ConfigureRequest{

--- a/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca_test.go
@@ -202,7 +202,6 @@ badjson
 			expectMsgPrefix:         "failed to create client: MissingEndpoint: 'Endpoint' configuration is required for this service",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			client := &pcaClientFake{t: t}
 			clock := clock.NewMock()
@@ -411,7 +410,6 @@ func TestMintX509CA(t *testing.T) {
 			expectMsgPrefix:         "upstreamauthority(aws_pca): failed to parse certificate chain from response: no PEM blocks",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			client := &pcaClientFake{t: t}
 			clk := clock.NewMock()

--- a/pkg/server/plugin/upstreamauthority/awssecret/awssecret_test.go
+++ b/pkg/server/plugin/upstreamauthority/awssecret/awssecret_test.go
@@ -197,7 +197,6 @@ func TestConfigure(t *testing.T) {
 			expectMsgPrefix: "unable to read missing_bundle: secret not found",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			var err error
 
@@ -328,7 +327,6 @@ func TestMintX509CA(t *testing.T) {
 			expectMsgPrefix: "upstreamauthority(awssecret): unable to sign CSR: unable to parse CSR",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			p := New()
 			p.hooks.clock = clk

--- a/pkg/server/plugin/upstreamauthority/disk/disk_test.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk_test.go
@@ -122,7 +122,6 @@ func TestMintX509CA(t *testing.T) {
 			expectedX509Authorities: []string{"spiffe://root"},
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			p := New()
 			p.clock = testData.Clock
@@ -307,7 +306,6 @@ func TestConfigure(t *testing.T) {
 			expectMsgPrefix:    "server core configuration must contain trust_domain",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			var err error
 

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -80,7 +80,6 @@ func TestConfigure(t *testing.T) {
 	}
 	cases = append(cases, configureCasesOS(t)...)
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 
@@ -261,7 +260,6 @@ func TestMintX509CA(t *testing.T) {
 
 	cases = append(cases, mintX509CACasesOS(t)...)
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			mockClock := clock.NewMock(t)
 

--- a/pkg/server/plugin/upstreamauthority/v1_test.go
+++ b/pkg/server/plugin/upstreamauthority/v1_test.go
@@ -199,7 +199,6 @@ func TestV1MintX509CA(t *testing.T) {
 			expectStreamMessage: "upstreamauthority(test): ohno",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			log, logHook := test.NewNullLogger()
 
@@ -364,7 +363,6 @@ func TestV1PublishJWTKey(t *testing.T) {
 			expectStreamMessage: "upstreamauthority(test): ohno",
 		},
 	} {
-		tt := tt
 		t.Run(tt.test, func(t *testing.T) {
 			log, logHook := test.NewNullLogger()
 

--- a/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
@@ -91,7 +91,6 @@ func TestNewAuthenticatedClientCertAuth(t *testing.T) {
 			namespace: "test-ns",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fakeVaultServer.CertAuthResponse = tt.response
 
@@ -176,7 +175,6 @@ func TestNewAuthenticatedClientTokenAuth(t *testing.T) {
 			expectMsgPrefix: "token is empty",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fakeVaultServer.LookupSelfResponse = tt.response
 
@@ -244,7 +242,6 @@ func TestNewAuthenticatedClientAppRoleAuth(t *testing.T) {
 			namespace: "test-ns",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fakeVaultServer.AppRoleAuthResponse = tt.response
 
@@ -308,7 +305,6 @@ func TestNewAuthenticatedClientK8sAuth(t *testing.T) {
 			namespace: "test-ns",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fakeVaultServer.K8sAuthResponse = tt.response
 

--- a/pkg/server/plugin/upstreamauthority/vault/vault_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_test.go
@@ -166,7 +166,6 @@ func TestConfigure(t *testing.T) {
 			expectMsgPrefix: "token_path is required",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			var err error
 
@@ -667,7 +666,6 @@ func TestMintX509CA(t *testing.T) {
 			expectMsgPrefix: "upstreamauthority(vault): failed to parse CSR data:",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fakeVaultServer := tt.fakeServer()
 

--- a/support/oidc-discovery-provider/config_test.go
+++ b/support/oidc-discovery-provider/config_test.go
@@ -85,7 +85,6 @@ func TestParseConfig(t *testing.T) {
 	testCases = append(testCases, parseConfigCasesOS()...)
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			actual, err := ParseConfig(testCase.in)
 			if testCase.err != "" {

--- a/support/oidc-discovery-provider/handler_test.go
+++ b/support/oidc-discovery-provider/handler_test.go
@@ -164,7 +164,6 @@ func TestHandlerHTTPS(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)
@@ -277,7 +276,6 @@ func TestHandlerHTTPInsecure(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)
@@ -442,7 +440,6 @@ func TestHandlerHTTP(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)
@@ -559,7 +556,6 @@ func TestHandlerProxied(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)
@@ -697,7 +693,6 @@ func TestHandlerJWTIssuer(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)

--- a/support/oidc-discovery-provider/healthchecks_handler_test.go
+++ b/support/oidc-discovery-provider/healthchecks_handler_test.go
@@ -105,7 +105,6 @@ func TestHealthCheckHandler(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			source := new(FakeKeySetSource)
 			source.SetKeySet(testCase.jwks, testCase.modTime, testCase.pollTime)


### PR DESCRIPTION
Add the `copyloopvar` linter, which enforces not creating explicit copies of the for loop iterator variable, which is no longer necessary as of Go 1.22.