### PR TITLE
SPIFFE_ENDPOINT_SOCKET env support for spire-agent

### DIFF
--- a/cmd/spire-agent/cli/common/defaults_posix.go
+++ b/cmd/spire-agent/cli/common/defaults_posix.go
@@ -2,9 +2,24 @@
 
 package common
 
+import (
+	"os"
+)
+
 const (
-	// DefaultSocketPath is the SPIRE agent's default socket path
-	DefaultSocketPath = "/tmp/spire-agent/public/api.sock"
+	// DefaultRunSocketPath is the SPIRE agent's default socket path
+	DefaultRunSocketPath = "/tmp/spire-agent/public/api.sock"
 	// DefaultAdminSocketPath is the SPIRE agent's default admin socket path
 	DefaultAdminSocketPath = "/tmp/spire-agent/private/admin.sock"
 )
+
+// DefaultSocketPath is the SPIRE agent's default socket path
+var DefaultSocketPath string
+
+func init() {
+	DefaultSocketPath = DefaultRunSocketPath
+	ses := os.Getenv("SPIFFE_ENDPOINT_SOCKET")
+	if ses != "" {
+		DefaultSocketPath = ses
+	}
+}

--- a/cmd/spire-agent/cli/common/defaults_windows.go
+++ b/cmd/spire-agent/cli/common/defaults_windows.go
@@ -2,9 +2,24 @@
 
 package common
 
+import (
+	"os"
+)
+
 const (
-	// DefaultNamedPipeName is the SPIRE agent's default named pipe name
-	DefaultNamedPipeName = "\\spire-agent\\public\\api"
+	// DefaultRunNamedPipeName is the SPIRE agent's default named pipe name
+	DefaultRunNamedPipeName = "\\spire-agent\\public\\api"
 	// DefaultAdminNamedPipeName is the SPIRE agent's default admin named pipe name
 	DefaultAdminNamedPipeName = "\\spire-agent\\private\\admin"
 )
+
+// DefaultNamedPipeName is the SPIRE agent's default named pipe name
+var DefaultNamedPipeName string
+
+func init() {
+	DefaultNamedPipeName = DefaultRunNamedPipeName
+	ses := os.Getenv("SPIFFE_ENDPOINT_SOCKET")
+	if ses != "" {
+		DefaultNamedPipeName = ses
+	}
+}

--- a/cmd/spire-agent/cli/run/run_posix.go
+++ b/cmd/spire-agent/cli/run/run_posix.go
@@ -22,7 +22,7 @@ func (c *agentConfig) addOSFlags(flags *flag.FlagSet) {
 }
 
 func (c *agentConfig) setPlatformDefaults() {
-	c.SocketPath = common.DefaultSocketPath
+	c.SocketPath = common.DefaultRunSocketPath
 }
 
 func (c *agentConfig) getAddr() (net.Addr, error) {

--- a/cmd/spire-agent/cli/run/run_windows.go
+++ b/cmd/spire-agent/cli/run/run_windows.go
@@ -17,7 +17,7 @@ func (c *agentConfig) addOSFlags(flags *flag.FlagSet) {
 }
 
 func (c *agentConfig) setPlatformDefaults() {
-	c.Experimental.NamedPipeName = common.DefaultNamedPipeName
+	c.Experimental.NamedPipeName = common.DefaultRunNamedPipeName
 }
 
 func (c *agentConfig) getAddr() (net.Addr, error) {


### PR DESCRIPTION
Enables specifying SPIFFE_ENDPOINT_SOCKET to the non run subcommands to the spire-agent

partially-fixes: https://github.com/spiffe/spire/issues/5770