### PR TITLE
Docker documentation was incorrectly referencing an invalid tag format

### DIFF
--- a/doc/docker_images.md
+++ b/doc/docker_images.md
@@ -30,7 +30,7 @@ $ docker run \
     --user 1000:1000 \
     -p 8081:8081 \
     -v /path/to/server/config:/etc/spire/server \
-    ghcr.io/spiffe/spire-server:v1.6.0 \
+    ghcr.io/spiffe/spire-server:1.6.1 \
     -config /etc/spire/server/server.conf
 ```
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
- N/A - Docker documentation incorrectly referenced an invalid tag format that does not exist in ghcr.

**Description of change**
- documentation changes:
  - Removing a 'v' at the beginning of a docker container label.
  - Updating minor version for the example.

**Which issue this PR fixes**
- N/A

