### PR TITLE
Use a temporary file for the fakedatastore

### DIFF
--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -3,8 +3,9 @@ package fakedatastore
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"path/filepath"
 	"sort"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,8 +22,6 @@ import (
 
 var (
 	ctx = context.Background()
-
-	nextID uint32
 )
 
 type DataStore struct {
@@ -38,10 +37,14 @@ func New(tb testing.TB) *DataStore {
 	ds := sql.New(log)
 	ds.SetUseServerTimestamps(true)
 
+	tmpDir := tb.TempDir()
+	dbPath := filepath.Join(tmpDir, "spire.db")
+	dbPath = url.PathEscape(dbPath)
+
 	err := ds.Configure(ctx, fmt.Sprintf(`
 		database_type = "sqlite3"
-		connection_string = "file:memdb%d?mode=memory&cache=shared"
-	`, atomic.AddUint32(&nextID, 1)))
+		connection_string = "file:%s"
+	`, dbPath))
 	require.NoError(tb, err)
 
 	tb.Cleanup(func() {


### PR DESCRIPTION
With a in memory sqlite datastore the database gets cleaned up when all connections to it get closed. If that happens, the next connection to be opened will see an empty database and usually error out.

I've noticed this in tests ocassionally and this seems to make running the db using  not fail. For example this seems to fix #5789 and #5774 . I think it's worth testing it out for a while to see if those issues resurface.