### PR TITLE
spire-server: improve entry lookup for NewJWTSvid and BatchX509SVID requests

### DIFF
--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -13,7 +13,7 @@ import (
 
 // AuthorizedEntryFetcher is the interface to fetch authorized entries
 type AuthorizedEntryFetcher interface {
-	// LookupAuthorizedEntries fetches the entries in entrIDs that the
+	// LookupAuthorizedEntries fetches the entries in entryIDs that the
 	// specified SPIFFE ID is authorized for
 	LookupAuthorizedEntries(ctx context.Context, id spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error)
 	// FetchAuthorizedEntries fetches the entries that the specified

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -13,6 +13,9 @@ import (
 
 // AuthorizedEntryFetcher is the interface to fetch authorized entries
 type AuthorizedEntryFetcher interface {
+	// LookupAuthorizedEntries fetches the entries in entrIDs that the
+	// specified SPIFFE ID is authorized for
+	LookupAuthorizedEntries(ctx context.Context, id spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error)
 	// FetchAuthorizedEntries fetches the entries that the specified
 	// SPIFFE ID is authorized for
 	FetchAuthorizedEntries(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error)

--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -4841,6 +4841,20 @@ type entryFetcher struct {
 	entries []*types.Entry
 }
 
+func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]*types.Entry, error) {
+	entries, err := f.FetchAuthorizedEntries(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	entriesMap := make(map[string]*types.Entry)
+	for _, entry := range entries {
+		entriesMap[entry.GetId()] = entry
+	}
+
+	return entriesMap, nil
+}
+
 func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
 	if f.err != "" {
 		return nil, status.Error(codes.Internal, f.err)

--- a/pkg/server/api/svid/v1/service.go
+++ b/pkg/server/api/svid/v1/service.go
@@ -168,8 +168,13 @@ func (s *Service) BatchNewX509SVID(ctx context.Context, req *svidv1.BatchNewX509
 		return nil, api.MakeErr(log, status.Code(err), "rejecting request due to certificate signing rate limiting", err)
 	}
 
+	requestedEntries := make(map[string]struct{})
+	for _, svidParam := range req.Params {
+		requestedEntries[svidParam.GetEntryId()] = struct{}{}
+	}
+
 	// Fetch authorized entries
-	entriesMap, err := s.fetchEntries(ctx, log)
+	entriesMap, err := s.findEntries(ctx, log, requestedEntries)
 	if err != nil {
 		return nil, err
 	}
@@ -205,24 +210,17 @@ func (s *Service) BatchNewX509SVID(ctx context.Context, req *svidv1.BatchNewX509
 	return &svidv1.BatchNewX509SVIDResponse{Results: results}, nil
 }
 
-// fetchEntries fetches authorized entries using caller ID from context
-func (s *Service) fetchEntries(ctx context.Context, log logrus.FieldLogger) (map[string]*types.Entry, error) {
+func (s *Service) findEntries(ctx context.Context, log logrus.FieldLogger, entries map[string]struct{}) (map[string]*types.Entry, error) {
 	callerID, ok := rpccontext.CallerID(ctx)
 	if !ok {
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)
 	}
 
-	entries, err := s.ef.FetchAuthorizedEntries(ctx, callerID)
+	foundEntries, err := s.ef.LookupAuthorizedEntries(ctx, callerID, entries)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.Internal, "failed to fetch registration entries", err)
 	}
-
-	entriesMap := make(map[string]*types.Entry, len(entries))
-	for _, entry := range entries {
-		entriesMap[entry.Id] = entry
-	}
-
-	return entriesMap, nil
+	return foundEntries, nil
 }
 
 // newX509SVID creates an X509-SVID using data from registration entry and key from CSR
@@ -262,7 +260,7 @@ func (s *Service) newX509SVID(ctx context.Context, param *svidv1.NewX509SVIDPara
 		}
 	}
 
-	spiffeID, err := api.TrustDomainMemberIDFromProto(ctx, s.td, entry.SpiffeId)
+	spiffeID, err := api.TrustDomainMemberIDFromProto(ctx, s.td, entry.GetSpiffeId())
 	if err != nil {
 		// This shouldn't be the case unless there is invalid data in the datastore
 		return &svidv1.BatchNewX509SVIDResponse_Result{
@@ -274,8 +272,8 @@ func (s *Service) newX509SVID(ctx context.Context, param *svidv1.NewX509SVIDPara
 	x509Svid, err := s.ca.SignWorkloadX509SVID(ctx, ca.WorkloadX509SVIDParams{
 		SPIFFEID:  spiffeID,
 		PublicKey: csr.PublicKey,
-		DNSNames:  entry.DnsNames,
-		TTL:       time.Duration(entry.X509SvidTtl) * time.Second,
+		DNSNames:  entry.GetDnsNames(),
+		TTL:       time.Duration(entry.GetX509SvidTtl()) * time.Second,
 	})
 	if err != nil {
 		return &svidv1.BatchNewX509SVIDResponse_Result{
@@ -285,12 +283,12 @@ func (s *Service) newX509SVID(ctx context.Context, param *svidv1.NewX509SVIDPara
 
 	log.WithField(telemetry.Expiration, x509Svid[0].NotAfter.Format(time.RFC3339)).
 		WithField(telemetry.SerialNumber, x509Svid[0].SerialNumber.String()).
-		WithField(telemetry.RevisionNumber, entry.RevisionNumber).
+		WithField(telemetry.RevisionNumber, entry.GetRevisionNumber()).
 		Debug("Signed X509 SVID")
 
 	return &svidv1.BatchNewX509SVIDResponse_Result{
 		Svid: &types.X509SVID{
-			Id:        entry.SpiffeId,
+			Id:        entry.GetSpiffeId(),
 			CertChain: x509util.RawCertsFromCertificates(x509Svid),
 			ExpiresAt: x509Svid[0].NotAfter.Unix(),
 		},
@@ -350,8 +348,12 @@ func (s *Service) NewJWTSVID(ctx context.Context, req *svidv1.NewJWTSVIDRequest)
 		return nil, api.MakeErr(log, status.Code(err), "rejecting request due to JWT signing request rate limiting", err)
 	}
 
+	entries := map[string]struct{}{
+		req.EntryId: {},
+	}
+
 	// Fetch authorized entries
-	entriesMap, err := s.fetchEntries(ctx, log)
+	entriesMap, err := s.findEntries(ctx, log, entries)
 	if err != nil {
 		return nil, err
 	}
@@ -361,12 +363,12 @@ func (s *Service) NewJWTSVID(ctx context.Context, req *svidv1.NewJWTSVIDRequest)
 		return nil, api.MakeErr(log, codes.NotFound, "entry not found or not authorized", nil)
 	}
 
-	jwtsvid, err := s.mintJWTSVID(ctx, entry.SpiffeId, req.Audience, entry.JwtSvidTtl)
+	jwtsvid, err := s.mintJWTSVID(ctx, entry.GetSpiffeId(), req.Audience, entry.GetJwtSvidTtl())
 	if err != nil {
 		return nil, err
 	}
 	rpccontext.AuditRPCWithFields(ctx, logrus.Fields{
-		telemetry.TTL: entry.JwtSvidTtl,
+		telemetry.TTL: entry.GetJwtSvidTtl(),
 	})
 
 	return &svidv1.NewJWTSVIDResponse{

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -2173,6 +2173,20 @@ type entryFetcher struct {
 	entries []*types.Entry
 }
 
+func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]*types.Entry, error) {
+	entries, err := f.FetchAuthorizedEntries(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+
+	entriesMap := make(map[string]*types.Entry)
+	for _, entry := range entries {
+		entriesMap[entry.GetId()] = entry
+	}
+
+	return entriesMap, nil
+}
+
 func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
 	if f.err != "" {
 		return nil, status.Error(codes.Internal, f.err)

--- a/pkg/server/authorizedentries/cache.go
+++ b/pkg/server/authorizedentries/cache.go
@@ -59,6 +59,34 @@ func NewCache(clk clock.Clock) *Cache {
 	}
 }
 
+func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries map[string]struct{}) map[string]*types.Entry {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Load up the agent selectors. If the agent info does not exist, it is
+	// likely that the cache is still catching up to a recent attestation.
+	// Since the calling agent has already been authorized and authenticated,
+	// it is safe to continue with the authorized entry crawl to obtain entries
+	// that are directly parented against the agent. Any entries that would be
+	// obtained via node aliasing will not be returned until the cache is
+	// updated with the node selectors for the agent.
+	agent, _ := c.agentsByID.Get(agentRecord{ID: agentID.String()})
+
+	foundEntries := make(map[string]*types.Entry)
+
+	parentSeen := allocStringSet()
+	defer freeStringSet(parentSeen)
+
+	c.findDescendents(foundEntries, agentID.String(), requestedEntries, parentSeen)
+
+	agentAliases := c.getAgentAliases(agent.Selectors)
+	for _, alias := range agentAliases {
+		c.findDescendents(foundEntries, alias.AliasID, requestedEntries, parentSeen)
+	}
+
+	return foundEntries
+}
+
 func (c *Cache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -162,6 +190,26 @@ func (c *Cache) appendDescendents(records []entryRecord, parentID string, parent
 		records = c.appendDescendents(records, entry.SPIFFEID, parentSeen)
 	}
 	return records
+}
+
+func (c *Cache) findDescendents(foundEntries map[string]*types.Entry, parentID string, requestedEntries map[string]struct{}, parentSeen stringSet) {
+	if _, ok := parentSeen[parentID]; ok {
+		return
+	}
+	parentSeen[parentID] = struct{}{}
+
+	pivot := entryRecord{ParentID: parentID}
+	c.entriesByParentID.AscendGreaterOrEqual(pivot, func(record entryRecord) bool {
+		if record.ParentID != parentID {
+			return false
+		}
+
+		if _, ok := requestedEntries[record.EntryID]; ok {
+			foundEntries[record.EntryID] = cloneEntry(record.EntryCloneOnly)
+		}
+		c.findDescendents(foundEntries, record.SPIFFEID, requestedEntries, parentSeen)
+		return true
+	})
 }
 
 func (c *Cache) appendEntryRecordsForParentID(records []entryRecord, parentID string) []entryRecord {

--- a/pkg/server/authorizedentries/cache.go
+++ b/pkg/server/authorizedentries/cache.go
@@ -77,11 +77,11 @@ func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries ma
 	parentSeen := allocStringSet()
 	defer freeStringSet(parentSeen)
 
-	c.findDescendents(foundEntries, agentID.String(), requestedEntries, parentSeen)
+	c.addDescendants(foundEntries, agentID.String(), requestedEntries, parentSeen)
 
 	agentAliases := c.getAgentAliases(agent.Selectors)
 	for _, alias := range agentAliases {
-		c.findDescendents(foundEntries, alias.AliasID, requestedEntries, parentSeen)
+		c.addDescendants(foundEntries, alias.AliasID, requestedEntries, parentSeen)
 	}
 
 	return foundEntries
@@ -192,7 +192,7 @@ func (c *Cache) appendDescendents(records []entryRecord, parentID string, parent
 	return records
 }
 
-func (c *Cache) findDescendents(foundEntries map[string]*types.Entry, parentID string, requestedEntries map[string]struct{}, parentSeen stringSet) {
+func (c *Cache) addDescendants(foundEntries map[string]*types.Entry, parentID string, requestedEntries map[string]struct{}, parentSeen stringSet) {
 	if _, ok := parentSeen[parentID]; ok {
 		return
 	}
@@ -207,7 +207,7 @@ func (c *Cache) findDescendents(foundEntries map[string]*types.Entry, parentID s
 		if _, ok := requestedEntries[record.EntryID]; ok {
 			foundEntries[record.EntryID] = cloneEntry(record.EntryCloneOnly)
 		}
-		c.findDescendents(foundEntries, record.SPIFFEID, requestedEntries, parentSeen)
+		c.addDescendants(foundEntries, record.SPIFFEID, requestedEntries, parentSeen)
 		return true
 	})
 }

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -933,7 +933,7 @@ func BenchmarkEntryLookup(b *testing.B) {
 				id:            {},
 				id + "/child": {},
 			})
-			require.Len(b, entries, 2)
+			require.Len(b, entries, 1)
 		}
 	}
 }

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -29,6 +29,7 @@ const (
 	spiffeScheme     = "spiffe"
 	trustDomain      = "example.org"
 	testNodeAttestor = "test-nodeattestor"
+	serverID         = "spiffe://example.org/spire/server"
 )
 
 var (
@@ -50,7 +51,6 @@ func TestCache(t *testing.T) {
 
 	rootID := spiffeid.RequireFromString("spiffe://example.org/root")
 
-	const serverID = "spiffe://example.org/spire/server"
 	const numEntries = 5
 	entryIDs := make([]string, numEntries)
 	for i := range numEntries {
@@ -128,7 +128,7 @@ func TestCache(t *testing.T) {
 
 	expected := entries[:3]
 	expected = append(expected, entries[4])
-	assertAuthorizedEntries(t, cache, rootID, expected...)
+	assertAuthorizedEntries(t, cache, rootID, entries, expected...)
 }
 
 func TestCacheReturnsClonedEntries(t *testing.T) {
@@ -232,9 +232,9 @@ func TestFullCacheNodeAliasing(t *testing.T) {
 	cache, err := BuildFromDataStore(context.Background(), ds)
 	assert.NoError(t, err)
 
-	assertAuthorizedEntries(t, cache, agentIDs[0], workloadEntries[:2]...)
-	assertAuthorizedEntries(t, cache, agentIDs[1], workloadEntries[1])
-	assertAuthorizedEntries(t, cache, agentIDs[2], workloadEntries[2])
+	assertAuthorizedEntries(t, cache, agentIDs[0], workloadEntries, workloadEntries[:2]...)
+	assertAuthorizedEntries(t, cache, agentIDs[1], workloadEntries, workloadEntries[1])
+	assertAuthorizedEntries(t, cache, agentIDs[2], workloadEntries, workloadEntries[2])
 }
 
 func TestFullCacheExcludesNodeSelectorMappedEntriesForExpiredAgents(t *testing.T) {
@@ -795,7 +795,7 @@ func newSQLPlugin(ctx context.Context, tb testing.TB) datastore.DataStore {
 	return p
 }
 
-func assertAuthorizedEntries(tb testing.TB, cache Cache, agentID spiffeid.ID, entries ...*common.RegistrationEntry) {
+func assertAuthorizedEntries(tb testing.TB, cache Cache, agentID spiffeid.ID, allEntries []*common.RegistrationEntry, entries ...*common.RegistrationEntry) {
 	tb.Helper()
 	expected, err := api.RegistrationEntriesToProto(entries)
 	require.NoError(tb, err)
@@ -806,10 +806,134 @@ func assertAuthorizedEntries(tb testing.TB, cache Cache, agentID spiffeid.ID, en
 	sortEntries(authorizedEntries)
 
 	spiretest.AssertProtoListEqual(tb, expected, authorizedEntries)
+
+	assertLookupEntries(tb, cache, agentID, allEntries, entries...)
+}
+
+func assertLookupEntries(tb testing.TB, cache Cache, agentID spiffeid.ID, lookup []*common.RegistrationEntry, entries ...*common.RegistrationEntry) {
+	tb.Helper()
+	expected, err := api.RegistrationEntriesToProto(entries)
+	require.NoError(tb, err)
+	sortEntries(expected)
+
+	lookupEntries := make(map[string]struct{})
+	for _, entry := range lookup {
+		lookupEntries[entry.EntryId] = struct{}{}
+	}
+	foundEntries := cache.LookupAuthorizedEntries(agentID, lookupEntries)
+	require.Len(tb, foundEntries, len(entries))
 }
 
 func sortEntries(es []*types.Entry) {
 	sort.Slice(es, func(a, b int) bool {
 		return es[a].Id < es[b].Id
 	})
+}
+
+func setupLookupTest(tb testing.TB, count int) (*FullEntryCache, []string) {
+	ds := fakedatastore.New(tb)
+	ctx := context.Background()
+
+	// Create an attested agent
+	agentID := spiffeid.RequireFromString("spiffe://example.org/spire/agent/1")
+	node := &common.AttestedNode{
+		SpiffeId:            agentID.String(),
+		AttestationDataType: testNodeAttestor,
+		CertSerialNumber:    "1",
+		CertNotAfter:        time.Now().Add(24 * time.Hour).Unix(),
+	}
+	createAttestedNode(tb, ds, node)
+	setNodeSelectors(ctx, tb, ds, agentID.String(), &common.Selector{
+		Type:  "alias",
+		Value: "root",
+	})
+
+	// Create root alias
+	createRegistrationEntry(ctx, tb, ds, &common.RegistrationEntry{
+		ParentId: serverID,
+		SpiffeId: "spiffe://example.org/root",
+		Selectors: []*common.Selector{
+			{
+				Type:  "alias",
+				Value: "root",
+			},
+		},
+	})
+
+	entries := []string{}
+	for id := range count {
+		idStr := strconv.Itoa(id)
+		// Create one entry parented to the alias
+		entry := createRegistrationEntry(ctx, tb, ds, &common.RegistrationEntry{
+			ParentId: "spiffe://example.org/root",
+			SpiffeId: "spiffe://example.org/workload/" + idStr,
+			Selectors: []*common.Selector{
+				{
+					Type:  "workload",
+					Value: "id:" + strconv.Itoa(id),
+				},
+			},
+		})
+		entries = append(entries, entry.EntryId)
+
+		// And another one to parented to the workload to verify
+		// the lookup recurses.
+		entry = createRegistrationEntry(ctx, tb, ds, &common.RegistrationEntry{
+			ParentId: "spiffe://example.org/workload/" + idStr,
+			SpiffeId: "spiffe://example.org/workload/" + idStr + "/child",
+			Selectors: []*common.Selector{
+				{
+					Type:  "workload",
+					Value: "id:" + strconv.Itoa(id),
+				},
+			},
+		})
+		entries = append(entries, entry.EntryId)
+	}
+
+	cache, err := BuildFromDataStore(ctx, ds)
+	assert.NoError(tb, err)
+
+	return cache, entries
+}
+
+func TestLookupEntries(t *testing.T) {
+	agentID := spiffeid.RequireFromString("spiffe://example.org/spire/agent/1")
+	cache, entries := setupLookupTest(t, 8)
+
+	found := cache.LookupAuthorizedEntries(agentID, make(map[string]struct{}))
+	require.Len(t, found, 0)
+
+	found = cache.LookupAuthorizedEntries(agentID, map[string]struct{}{
+		"does-not-exist": {},
+	})
+	require.Len(t, found, 0)
+
+	found = cache.LookupAuthorizedEntries(agentID, map[string]struct{}{
+		"does-not-exist": {},
+		entries[1]:       {},
+		entries[7]:       {},
+		entries[15]:      {},
+	})
+	require.Contains(t, found, entries[1])
+	require.Contains(t, found, entries[7])
+	require.Contains(t, found, entries[15])
+}
+
+func BenchmarkEntryLookup(b *testing.B) {
+	agentID := spiffeid.RequireFromString("spiffe://example.org/spire/agent/1")
+	cache, entries := setupLookupTest(b, 256)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		for _, id := range entries {
+			entries := cache.LookupAuthorizedEntries(agentID, map[string]struct{}{
+				id:            {},
+				id + "/child": {},
+			})
+			require.Len(b, entries, 2)
+		}
+	}
 }

--- a/pkg/server/endpoints/authorized_entryfetcher.go
+++ b/pkg/server/endpoints/authorized_entryfetcher.go
@@ -56,6 +56,10 @@ func NewAuthorizedEntryFetcherWithEventsBasedCache(ctx context.Context, log logr
 	}, nil
 }
 
+func (a *AuthorizedEntryFetcherWithEventsBasedCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error) {
+	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil
+}
+
 func (a *AuthorizedEntryFetcherWithEventsBasedCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
 	return a.cache.GetAuthorizedEntries(agentID), nil
 }

--- a/pkg/server/endpoints/entryfetcher.go
+++ b/pkg/server/endpoints/entryfetcher.go
@@ -49,6 +49,12 @@ func NewAuthorizedEntryFetcherWithFullCache(ctx context.Context, buildCache entr
 	}, nil
 }
 
+func (a *AuthorizedEntryFetcherWithFullCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil
+}
+
 func (a *AuthorizedEntryFetcherWithFullCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/pkg/server/endpoints/entryfetcher_test.go
+++ b/pkg/server/endpoints/entryfetcher_test.go
@@ -28,6 +28,17 @@ type staticEntryCache struct {
 	entries map[spiffeid.ID][]*types.Entry
 }
 
+func (f *staticEntryCache) LookupAuthorizedEntries(agentID spiffeid.ID, _ map[string]struct{}) map[string]*types.Entry {
+	entries := f.entries[agentID]
+
+	entriesMap := make(map[string]*types.Entry)
+	for _, entry := range entries {
+		entriesMap[entry.GetId()] = entry
+	}
+
+	return entriesMap
+}
+
 func (sef *staticEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
 	return sef.entries[agentID]
 }


### PR DESCRIPTION
When signing SVIDs we need to verify that the agent is authorized for the entry it has requested. This is currently done by fetching all authorized entries and then seeing if the entry the agent requests a SVID for is part of them. This can be quite wasteful, since for a lot of operations we only require a small subset of the entries.

Speed up this operation by adding a new cache API for looking up a set of entries.

<img width="2236" alt="image" src="https://github.com/user-attachments/assets/d78b68e4-c0bc-423c-8c27-2571fc5f7c8f" />


**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
NewJWTSVID and BatchX509SVID server APIs.

**Description of change**
Instead of fetching all authorized entries for a new SVID signing requests, only fetch the ones required. In the case of signign JWT-SVIDs, it's only one so there's a big improvement. In the case of X509-SVID, this is usually done in a batch so improvements will depend on batch size and the number of entries the agent is authorized for.

**Which issue this PR fixes**
fixes #5801

