### PR TITLE
sdsv3: Don't log error when connection closes

### DIFF
--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -171,7 +171,9 @@ func (h *Handler) StreamSecrets(stream secret_v3.SecretDiscoveryService_StreamSe
 				continue
 			}
 		case err := <-errch:
-			log.WithError(err).Error("Received error from stream secrets server")
+			if err != nil {
+				log.WithError(err).Error("Received error from stream secrets server")
+			}
 			return err
 		}
 


### PR DESCRIPTION
If we receive a nil error on the `errch` it means that the connection has been closed cleanly. We shouldn't log an error in that case.

