### PR TITLE
Apply gopls modernize pass

### DIFF
--- a/cmd/spire-server/cli/logger/printers_test.go
+++ b/cmd/spire-server/cli/logger/printers_test.go
@@ -14,7 +14,7 @@ import (
 func TestPrettyPrintLogger(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
-		logger         interface{}
+		logger         any
 		outWriter      errorWriter
 		errWriter      errorWriter
 		env            *commoncli.Env

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -571,10 +571,7 @@ func (c *client) streamAndSyncEntries(ctx context.Context, entryClient entryv1.E
 	// time using the assumed page size.
 	for len(needFull) > 0 {
 		// Request up to a page full of full entries
-		n := len(needFull)
-		if n > pageSize {
-			n = pageSize
-		}
+		n := min(len(needFull), pageSize)
 		if err := stream.Send(&entryv1.SyncAuthorizedEntriesRequest{Ids: needFull[:n]}); err != nil {
 			return SyncEntriesStats{}, err
 		}

--- a/pkg/agent/common/sigstore/sigstore_test.go
+++ b/pkg/agent/common/sigstore/sigstore_test.go
@@ -710,7 +710,7 @@ func createTestCert() *x509.Certificate {
 
 func createFakePayload() []byte {
 	signaturePayload := payload.SimpleContainerImage{
-		Optional: map[string]interface{}{
+		Optional: map[string]any{
 			"subject": "test-subject",
 		},
 	}

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"sort"
 	"strconv"
 
@@ -356,9 +357,7 @@ type validationContextBuilder interface {
 
 func (h *Handler) getValidationContextBuilder(req *discovery_v3.DiscoveryRequest, upd *cache.WorkloadUpdate) (validationContextBuilder, error) {
 	federatedBundles := make(map[spiffeid.TrustDomain]*spiffebundle.Bundle)
-	for td, federatedBundle := range upd.FederatedBundles {
-		federatedBundles[td] = federatedBundle
-	}
+	maps.Copy(federatedBundles, upd.FederatedBundles)
 	if !h.isSPIFFECertValidationDisabled(req) && supportsSPIFFEAuthExtension(req) {
 		return newSpiffeBuilder(upd.Bundle, federatedBundles)
 	}
@@ -423,9 +422,7 @@ func newSpiffeBuilder(tdBundle *spiffebundle.Bundle, federatedBundles map[spiffe
 	}
 
 	// Add all federated bundles
-	for td, bundle := range federatedBundles {
-		bundles[td] = bundle
-	}
+	maps.Copy(bundles, federatedBundles)
 
 	return &spiffeBuilder{
 		bundles: bundles,

--- a/pkg/agent/manager/cache/bundle_cache.go
+++ b/pkg/agent/manager/cache/bundle_cache.go
@@ -1,6 +1,8 @@
 package cache
 
 import (
+	"maps"
+
 	"github.com/imkira/go-observer"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -98,8 +100,6 @@ func copyBundleMap(bundles map[spiffeid.TrustDomain]*Bundle) map[spiffeid.TrustD
 	}
 
 	out := make(map[spiffeid.TrustDomain]*Bundle, len(bundles))
-	for key, bundle := range bundles {
-		out[key] = bundle
-	}
+	maps.Copy(out, bundles)
 	return out
 }

--- a/pkg/agent/manager/cache/jwt_cache.go
+++ b/pkg/agent/manager/cache/jwt_cache.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"sync"
 
@@ -166,7 +167,7 @@ func jwtSVIDKey(spiffeID spiffeid.ID, audience []string) string {
 	// item.
 
 	// duplicate and sort the audience slice
-	audience = append([]string(nil), audience...)
+	audience = slices.Clone(audience)
 	sort.Strings(audience)
 
 	_, _ = io.WriteString(h, spiffeID.String())

--- a/pkg/agent/plugin/nodeattestor/azuremsi/msi_test.go
+++ b/pkg/agent/plugin/nodeattestor/azuremsi/msi_test.go
@@ -64,7 +64,7 @@ func (s *MSIAttestorSuite) TestAidAttestationFailedToObtainToken() {
 func (s *MSIAttestorSuite) TestAidAttestationSuccess() {
 	s.token = s.makeAccessToken("PRINCIPALID", "TENANTID")
 
-	expectPayload := []byte(fmt.Sprintf(`{"token":%q}`, s.token))
+	expectPayload := fmt.Appendf(nil, `{"token":%q}`, s.token)
 
 	attestor := s.loadAttestor(
 		plugintest.CoreConfig(catalog.CoreConfig{

--- a/pkg/agent/plugin/nodeattestor/k8spsat/psat_test.go
+++ b/pkg/agent/plugin/nodeattestor/k8spsat/psat_test.go
@@ -64,7 +64,7 @@ func (s *AttestorSuite) TestAttestSuccess() {
 
 	na := s.loadPluginWithTokenPath(s.writeValue("token", token))
 
-	err = na.Attest(context.Background(), streamBuilder.ExpectAndBuild([]byte(fmt.Sprintf(`{"cluster":"production","token":"%s"}`, token))))
+	err = na.Attest(context.Background(), streamBuilder.ExpectAndBuild(fmt.Appendf(nil, `{"cluster":"production","token":"%s"}`, token)))
 	s.Require().NoError(err)
 }
 

--- a/pkg/agent/plugin/nodeattestor/test/serverstream.go
+++ b/pkg/agent/plugin/nodeattestor/test/serverstream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spiffe/spire/pkg/agent/plugin/nodeattestor"
 	"google.golang.org/grpc/codes"
@@ -82,7 +83,7 @@ func (b *ServerStreamBuilder) FailAndBuild(err error) nodeattestor.ServerStream 
 }
 
 func (b *ServerStreamBuilder) addHandler(handler ServerStreamHandler) *ServerStreamBuilder {
-	handlers := append([]ServerStreamHandler(nil), b.handlers...)
+	handlers := slices.Clone(b.handlers)
 	handlers = append(handlers, handler)
 	return &ServerStreamBuilder{
 		pluginName: b.pluginName,

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -74,7 +74,7 @@ type dockerPluginConfig struct {
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 
-	Experimental experimentalConfig `hcl:"experimental,omitempty" json:"experimental,omitempty"`
+	Experimental experimentalConfig `hcl:"experimental,omitempty" json:"experimental"`
 
 	containerHelper *containerHelper
 	dockerOpts      []dockerclient.Opt

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -651,7 +651,7 @@ func (p *Plugin) getPodList(ctx context.Context, client *kubeletClient, cacheFor
 		return result, nil
 	}
 
-	podList, err, _ := p.singleflight.Do("podList", func() (interface{}, error) {
+	podList, err, _ := p.singleflight.Do("podList", func() (any, error) {
 		result := p.getPodListCache()
 		if result != nil {
 			return result, nil

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -951,8 +952,8 @@ func (s *Suite) requireAttestFailure(p workloadattestor.WorkloadAttestor, code c
 
 func (s *Suite) requireSelectorsEqual(expected, actual []*common.Selector) {
 	// assert the selectors (non-destructively sorting for consistency)
-	actual = append([]*common.Selector(nil), actual...)
-	expected = append([]*common.Selector(nil), expected...)
+	actual = slices.Clone(actual)
+	expected = slices.Clone(expected)
 	util.SortSelectors(actual)
 	util.SortSelectors(expected)
 	s.RequireProtoListEqual(expected, actual)

--- a/pkg/common/backoff/size_backoff.go
+++ b/pkg/common/backoff/size_backoff.go
@@ -31,19 +31,11 @@ func (r *sizeLimitedBackOff) NextBackOff() int {
 }
 
 func (r *sizeLimitedBackOff) Success() {
-	newSize := r.currentSize * 2
-	if newSize > r.maxSize {
-		newSize = r.maxSize
-	}
-	r.currentSize = newSize
+	r.currentSize = min(r.currentSize*2, r.maxSize)
 }
 
 func (r *sizeLimitedBackOff) Failure() {
-	newSize := r.currentSize / 2
-	if newSize < 1 {
-		newSize = 1
-	}
-	r.currentSize = newSize
+	r.currentSize = max(r.currentSize/2, 1)
 }
 
 func (r *sizeLimitedBackOff) Reset() {

--- a/pkg/common/pemutil/block.go
+++ b/pkg/common/pemutil/block.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 )
 
 var (
@@ -70,14 +71,7 @@ func parseBlocks(pemBytes []byte, expectedCount int, expectedTypes ...string) (b
 		}
 
 		if len(expectedTypes) > 0 {
-			found := false
-			for _, expectedType := range expectedTypes {
-				if expectedType == pemBlock.Type {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !slices.Contains(expectedTypes, pemBlock.Type) {
 				var expectedTypeList any = expectedTypes
 				if len(expectedTypes) == 1 {
 					expectedTypeList = expectedTypes[0]

--- a/pkg/common/plugin/k8s/apiserver/client_test.go
+++ b/pkg/common/plugin/k8s/apiserver/client_test.go
@@ -374,7 +374,7 @@ func (s *ClientSuite) createSampleKubeConfigFile(kubeConfigPath string) {
 	err = os.WriteFile(clientKeyPath, kubeConfigClientKey, 0600)
 	s.Require().NoError(err)
 
-	kubeConfigContent := []byte(fmt.Sprintf(kubeConfig, caPath, clientCrtPath, clientKeyPath))
+	kubeConfigContent := fmt.Appendf(nil, kubeConfig, caPath, clientCrtPath, clientKeyPath)
 	err = os.WriteFile(kubeConfigPath, kubeConfigContent, 0600)
 	s.Require().NoError(err)
 }

--- a/pkg/common/telemetry/metrics_benchmark_test.go
+++ b/pkg/common/telemetry/metrics_benchmark_test.go
@@ -63,55 +63,55 @@ func BenchmarkStatsd(b *testing.B) {
 
 func benchmarkMetricImpl(b *testing.B, m Metrics) {
 	b.Run("SetGauge", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.SetGauge(key, valf)
 		}
 	})
 
 	b.Run("SetGaugeWithLabels", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.SetGaugeWithLabels(key, valf, labels)
 		}
 	})
 
 	b.Run("EmitKey", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.EmitKey(key, valf)
 		}
 	})
 
 	b.Run("IncrCounter", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.IncrCounter(key, valf)
 		}
 	})
 
 	b.Run("IncrCounterWithLabels", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.IncrCounterWithLabels(key, valf, labels)
 		}
 	})
 
 	b.Run("AddSample", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.AddSample(key, valf)
 		}
 	})
 
 	b.Run("AddSampleWithLabels", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.AddSampleWithLabels(key, valf, labels)
 		}
 	})
 
 	b.Run("MeasureSince", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.MeasureSince(key, valt)
 		}
 	})
 
 	b.Run("MeasureSinceWithLabels", func(b *testing.B) {
-		for range b.N {
+		for b.Loop() {
 			m.MeasureSinceWithLabels(key, valt, labels)
 		}
 	})

--- a/pkg/common/util/sort_test.go
+++ b/pkg/common/util/sort_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"math/rand"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
@@ -98,7 +99,7 @@ func TestSortRegistrationEntries(t *testing.T) {
 }
 
 func shuffleRegistrationEntries(rs []*common.RegistrationEntry) []*common.RegistrationEntry {
-	shuffled := append([]*common.RegistrationEntry{}, rs...)
+	shuffled := slices.Clone(rs)
 	rand.Shuffle(len(shuffled), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})
@@ -194,7 +195,7 @@ func TestSortTypesEntries(t *testing.T) {
 }
 
 func shuffleTypesEntries(rs []*types.Entry) []*types.Entry {
-	shuffled := append([]*types.Entry{}, rs...)
+	shuffled := slices.Clone(rs)
 	rand.Shuffle(len(rs), func(i, j int) {
 		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
 	})

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -3148,8 +3148,7 @@ func TestAttestAgent(t *testing.T) {
 				spiretest.AssertLogsAnyOrder(t, test.logHook.AllEntries(), tt.expectLogs)
 			}()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			test.setupAttestor(t)
 			test.setupJoinTokens(ctx, t)

--- a/pkg/server/api/audit/audit.go
+++ b/pkg/server/api/audit/audit.go
@@ -1,6 +1,8 @@
 package audit
 
 import (
+	"maps"
+
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -38,9 +40,7 @@ func New(l logrus.FieldLogger) Logger {
 }
 
 func (l *logger) AddFields(fields logrus.Fields) {
-	for key, value := range fields {
-		l.fields[key] = value
-	}
+	maps.Copy(l.fields, fields)
 }
 
 func (l *logger) Audit() {

--- a/pkg/server/api/bundle.go
+++ b/pkg/server/api/bundle.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -160,15 +161,11 @@ func FieldsFromBundleProto(proto *types.Bundle, inputMask *types.BundleMask) log
 	}
 
 	if inputMask == nil || inputMask.JwtAuthorities {
-		for k, v := range FieldsFromJwtAuthoritiesProto(proto.JwtAuthorities) {
-			fields[k] = v
-		}
+		maps.Copy(fields, FieldsFromJwtAuthoritiesProto(proto.JwtAuthorities))
 	}
 
 	if inputMask == nil || inputMask.X509Authorities {
-		for k, v := range FieldsFromX509AuthoritiesProto(proto.X509Authorities) {
-			fields[k] = v
-		}
+		maps.Copy(fields, FieldsFromX509AuthoritiesProto(proto.X509Authorities))
 	}
 	return fields
 }

--- a/pkg/server/api/bundle/v1/service.go
+++ b/pkg/server/api/bundle/v1/service.go
@@ -3,6 +3,7 @@ package bundle
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -102,13 +103,9 @@ func (s *Service) GetBundle(ctx context.Context, req *bundlev1.GetBundleRequest)
 func (s *Service) AppendBundle(ctx context.Context, req *bundlev1.AppendBundleRequest) (*types.Bundle, error) {
 	parseRequest := func() logrus.Fields {
 		fields := logrus.Fields{}
-		for k, v := range api.FieldsFromJwtAuthoritiesProto(req.JwtAuthorities) {
-			fields[k] = v
-		}
+		maps.Copy(fields, api.FieldsFromJwtAuthoritiesProto(req.JwtAuthorities))
 
-		for k, v := range api.FieldsFromX509AuthoritiesProto(req.X509Authorities) {
-			fields[k] = v
-		}
+		maps.Copy(fields, api.FieldsFromX509AuthoritiesProto(req.X509Authorities))
 
 		return fields
 	}

--- a/pkg/server/api/bundle/v1/service_test.go
+++ b/pkg/server/api/bundle/v1/service_test.go
@@ -1719,12 +1719,12 @@ func createBundle(t *testing.T, test *serviceTest, td string) *common.Bundle {
 		TrustDomainId:  td,
 		RefreshHint:    60,
 		SequenceNumber: 42,
-		RootCas:        []*common.Certificate{{DerBytes: []byte(fmt.Sprintf("cert-bytes-%s", td))}},
+		RootCas:        []*common.Certificate{{DerBytes: fmt.Appendf(nil, "cert-bytes-%s", td)}},
 		JwtSigningKeys: []*common.PublicKey{
 			{
 				Kid:       fmt.Sprintf("key-id-%s", td),
 				NotAfter:  time.Now().Add(time.Minute).Unix(),
-				PkixBytes: []byte(fmt.Sprintf("key-bytes-%s", td)),
+				PkixBytes: fmt.Appendf(nil, "key-bytes-%s", td),
 			},
 		},
 	}

--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
@@ -70,7 +71,7 @@ func RegistrationEntryToProto(e *common.RegistrationEntry) (*types.Entry, error)
 		Admin:          e.Admin,
 		Downstream:     e.Downstream,
 		ExpiresAt:      e.EntryExpiry,
-		DnsNames:       append([]string(nil), e.DnsNames...),
+		DnsNames:       slices.Clone(e.DnsNames),
 		RevisionNumber: e.RevisionNumber,
 		StoreSvid:      e.StoreSvid,
 		JwtSvidTtl:     e.JwtSvidTtl,

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -350,8 +351,6 @@ func calculateNextUpdate(b *spiffebundle.Bundle) time.Duration {
 
 func cloneTrustDomainConfigs(configs map[spiffeid.TrustDomain]TrustDomainConfig) map[spiffeid.TrustDomain]TrustDomainConfig {
 	clone := make(map[spiffeid.TrustDomain]TrustDomainConfig, len(configs))
-	for k, v := range configs {
-		clone[k] = v
-	}
+	maps.Copy(clone, configs)
 	return clone
 }

--- a/pkg/server/bundle/client/sources.go
+++ b/pkg/server/bundle/client/sources.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -55,9 +56,7 @@ func (s *TrustDomainConfigSet) GetTrustDomainConfigs(context.Context) (map[spiff
 
 func duplicateTrustDomainConfigMap(in TrustDomainConfigMap) TrustDomainConfigMap {
 	out := make(TrustDomainConfigMap, len(in))
-	for td, config := range in {
-		out[td] = config
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -70,9 +69,7 @@ func MergeTrustDomainConfigSources(sources ...TrustDomainConfigSource) TrustDoma
 			if err != nil {
 				return nil, err
 			}
-			for td, config := range configs {
-				merged[td] = config
-			}
+			maps.Copy(merged, configs)
 		}
 		return merged, nil
 	})

--- a/pkg/server/bundle/client/sources_test.go
+++ b/pkg/server/bundle/client/sources_test.go
@@ -32,8 +32,7 @@ func TestMergedTrustDomainConfigSource(t *testing.T) {
 	})
 
 	t.Run("context is passed through and error returned", func(t *testing.T) {
-		expectedCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		expectedCtx := t.Context()
 
 		var actualCtx context.Context
 		source := client.MergeTrustDomainConfigSources(client.TrustDomainConfigSourceFunc(

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -873,12 +873,7 @@ func MaxSVIDTTL() time.Duration {
 // TTL that is guaranteed to not be cut artificially short by a scheduled
 // rotation?
 func MaxSVIDTTLForCATTL(caTTL time.Duration) time.Duration {
-	maxTTL := caTTL / activationThresholdDivisor
-	if maxTTL > activationThresholdCap {
-		maxTTL = activationThresholdCap
-	}
-
-	return maxTTL
+	return min(caTTL/activationThresholdDivisor, activationThresholdCap)
 }
 
 // MinCATTLForSVIDTTL returns the minimum CA TTL necessary to guarantee an SVID

--- a/pkg/server/ca/manager/slot.go
+++ b/pkg/server/ca/manager/slot.go
@@ -518,19 +518,13 @@ func otherSlotID(id string) string {
 
 func preparationThreshold(issuedAt, notAfter time.Time) time.Time {
 	lifetime := notAfter.Sub(issuedAt)
-	threshold := lifetime / preparationThresholdDivisor
-	if threshold > preparationThresholdCap {
-		threshold = preparationThresholdCap
-	}
+	threshold := min(lifetime/preparationThresholdDivisor, preparationThresholdCap)
 	return notAfter.Add(-threshold)
 }
 
 func keyActivationThreshold(issuedAt, notAfter time.Time) time.Time {
 	lifetime := notAfter.Sub(issuedAt)
-	threshold := lifetime / activationThresholdDivisor
-	if threshold > activationThresholdCap {
-		threshold = activationThresholdCap
-	}
+	threshold := min(lifetime/activationThresholdDivisor, activationThresholdCap)
 	return notAfter.Add(-threshold)
 }
 

--- a/pkg/server/cache/entrycache/fullcache.go
+++ b/pkg/server/cache/entrycache/fullcache.go
@@ -2,6 +2,7 @@ package entrycache
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -223,7 +224,7 @@ func (c *FullEntryCache) crawl(parentID spiffeID, seen map[spiffeID]struct{}) []
 	seen[parentID] = struct{}{}
 
 	// Make a copy so that the entries aren't aliasing the backing array
-	entries := append([]*types.Entry(nil), c.entries[parentID]...)
+	entries := slices.Clone(c.entries[parentID])
 	for _, entry := range entries {
 		entries = append(entries, c.crawl(spiffeIDFromProto(entry.SpiffeId), seen)...)
 	}

--- a/pkg/server/cache/entrycache/fullcache_test.go
+++ b/pkg/server/cache/entrycache/fullcache_test.go
@@ -469,8 +469,8 @@ func TestBuildIteratorError(t *testing.T) {
 
 func BenchmarkBuildInMemory(b *testing.B) {
 	allEntries, agents := buildBenchmarkData()
-	b.ResetTimer()
-	for range b.N {
+
+	for b.Loop() {
 		_, err := Build(context.Background(), makeEntryIterator(allEntries), makeAgentIterator(agents))
 		if err != nil {
 			b.Fatal(err)
@@ -517,8 +517,7 @@ func BenchmarkBuildSQL(b *testing.B) {
 		setNodeSelectors(ctx, b, ds, agentIDStr, ss...)
 	}
 
-	b.ResetTimer()
-	for range b.N {
+	for b.Loop() {
 		_, err := BuildFromDataStore(ctx, ds)
 		if err != nil {
 			b.Fatal(err)
@@ -925,9 +924,8 @@ func BenchmarkEntryLookup(b *testing.B) {
 	cache, entries := setupLookupTest(b, 256)
 
 	b.ReportAllocs()
-	b.ResetTimer()
 
-	for range b.N {
+	for b.Loop() {
 		for _, id := range entries {
 			entries := cache.LookupAuthorizedEntries(agentID, map[string]struct{}{
 				id:            {},

--- a/pkg/server/credtemplate/builder_test.go
+++ b/pkg/server/credtemplate/builder_test.go
@@ -1158,7 +1158,7 @@ func TestBuildWorkloadJWTSVIDClaims(t *testing.T) {
 				config.CredentialComposers = []credentialcomposer.CredentialComposer{loadGrpcPlugin(t)}
 			},
 			overrideExpected: func(expected map[string]any) {
-				expected["aud"] = []interface{}{"AUDIENCE"}
+				expected["aud"] = []any{"AUDIENCE"}
 				expected["iat"] = now.Unix()
 				expected["exp"] = jwtSVIDNotAfter.Unix()
 			},
@@ -1169,7 +1169,7 @@ func TestBuildWorkloadJWTSVIDClaims(t *testing.T) {
 				config.CredentialComposers = []credentialcomposer.CredentialComposer{fakeCC{id: 1, onlyFoo: true, addInt64: true}, loadGrpcPlugin(t)}
 			},
 			overrideExpected: func(expected map[string]any) {
-				expected["aud"] = []interface{}{"AUDIENCE"}
+				expected["aud"] = []any{"AUDIENCE"}
 				expected["iat"] = now.Unix()
 				expected["exp"] = jwtSVIDNotAfter.Unix()
 				expected["foo"] = "VALUE-1"
@@ -1182,7 +1182,7 @@ func TestBuildWorkloadJWTSVIDClaims(t *testing.T) {
 				config.CredentialComposers = []credentialcomposer.CredentialComposer{loadGrpcPlugin(t), fakeCC{id: 1, onlyFoo: true, addInt64: true}}
 			},
 			overrideExpected: func(expected map[string]any) {
-				expected["aud"] = []interface{}{"AUDIENCE"}
+				expected["aud"] = []any{"AUDIENCE"}
 				expected["iat"] = now.Unix()
 				expected["exp"] = jwtSVIDNotAfter.Unix()
 				expected["foo"] = "VALUE-1"

--- a/pkg/server/credvalidator/validator.go
+++ b/pkg/server/credvalidator/validator.go
@@ -85,8 +85,8 @@ func (v *Validator) ValidateX509SVID(svid *x509.Certificate, id spiffeid.ID) err
 	}
 
 	if len(svid.ExtKeyUsage) > 0 {
-		hasServerAuth := hasExtKeyUsage(svid.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
-		hasClientAuth := hasExtKeyUsage(svid.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+		hasServerAuth := slices.Contains(svid.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+		hasClientAuth := slices.Contains(svid.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
 		switch {
 		case !hasServerAuth && hasClientAuth:
 			return errors.New("invalid X509-SVID: missing serverAuth extended key usage")
@@ -129,7 +129,7 @@ func (v *Validator) ValidateWorkloadJWTSVID(rawToken string, id spiffeid.ID) err
 		return fmt.Errorf(`invalid JWT-SVID "nbf" claim: not yet valid until %s`, claims.NotBefore.Time().Format(time.RFC3339))
 	case len(claims.Audience) == 0:
 		return errors.New(`invalid JWT-SVID "aud" claim: required but missing`)
-	case hasEmptyAudienceValue(claims.Audience):
+	case slices.Contains(claims.Audience, ""):
 		return errors.New(`invalid JWT-SVID "aud" claim: contains empty value`)
 	}
 	return nil
@@ -164,13 +164,4 @@ func checkX509CertificateExpiration(cert *x509.Certificate, now time.Time) error
 		return fmt.Errorf("already expired as of %s", cert.NotAfter.Format(time.RFC3339))
 	}
 	return nil
-}
-
-func hasExtKeyUsage(extKeyUsage []x509.ExtKeyUsage, want x509.ExtKeyUsage) bool {
-	return slices.Contains(extKeyUsage, want)
-}
-
-func hasEmptyAudienceValue(audience jwt.Audience) bool {
-	// shift audience
-	return slices.Contains(audience, "")
 }

--- a/pkg/server/credvalidator/validator.go
+++ b/pkg/server/credvalidator/validator.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/andres-erbsen/clock"
@@ -166,20 +167,10 @@ func checkX509CertificateExpiration(cert *x509.Certificate, now time.Time) error
 }
 
 func hasExtKeyUsage(extKeyUsage []x509.ExtKeyUsage, want x509.ExtKeyUsage) bool {
-	for _, candidate := range extKeyUsage {
-		if candidate == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(extKeyUsage, want)
 }
 
 func hasEmptyAudienceValue(audience jwt.Audience) bool {
 	// shift audience
-	for _, value := range audience {
-		if value == "" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(audience, "")
 }

--- a/pkg/server/endpoints/bundle/internal/autocert/autocert.go
+++ b/pkg/server/endpoints/bundle/internal/autocert/autocert.go
@@ -61,6 +61,7 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -376,13 +377,7 @@ func supportsECDSA(hello *tls.ClientHelloInfo) bool {
 		}
 	}
 	if hello.SupportedCurves != nil {
-		ecdsaOK := false
-		for _, curve := range hello.SupportedCurves {
-			if curve == tls.CurveP256 {
-				ecdsaOK = true
-				break
-			}
-		}
+		ecdsaOK := slices.Contains(hello.SupportedCurves, tls.CurveP256)
 		if !ecdsaOK {
 			return false
 		}

--- a/pkg/server/plugin/keymanager/gcpkms/client_fake.go
+++ b/pkg/server/plugin/keymanager/gcpkms/client_fake.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"maps"
 	"path"
 	"reflect"
 	"regexp"
@@ -102,9 +103,7 @@ func (fck *fakeCryptoKey) fetchFakeCryptoKeyVersions() map[string]*fakeCryptoKey
 	}
 
 	fakeCryptoKeyVersions := make(map[string]*fakeCryptoKeyVersion, len(fck.fakeCryptoKeyVersions))
-	for key, fakeCryptoKeyVersion := range fck.fakeCryptoKeyVersions {
-		fakeCryptoKeyVersions[key] = fakeCryptoKeyVersion
-	}
+	maps.Copy(fakeCryptoKeyVersions, fck.fakeCryptoKeyVersions)
 	return fakeCryptoKeyVersions
 }
 
@@ -160,9 +159,7 @@ func (fs *fakeStore) fetchFakeCryptoKeys() map[string]*fakeCryptoKey {
 	}
 
 	fakeCryptoKeys := make(map[string]*fakeCryptoKey, len(fs.fakeCryptoKeys))
-	for key, fakeCryptoKey := range fs.fakeCryptoKeys {
-		fakeCryptoKeys[key] = fakeCryptoKey
-	}
+	maps.Copy(fakeCryptoKeys, fs.fakeCryptoKeys)
 	return fakeCryptoKeys
 }
 

--- a/pkg/server/plugin/nodeattestor/awsiid/iid.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid.go
@@ -227,13 +227,7 @@ func (p *IIDAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 		}
 	}
 
-	inTrustAcctList := false
-	for _, id := range c.LocalValidAcctIDs {
-		if attestationData.AccountID == id {
-			inTrustAcctList = true
-			break
-		}
-	}
+	inTrustAcctList := slices.Contains(c.LocalValidAcctIDs, attestationData.AccountID)
 
 	ctx, cancel := context.WithTimeout(stream.Context(), awsTimeout)
 	defer cancel()
@@ -612,12 +606,7 @@ func instanceProfileNameFromArn(profileArn string) (string, error) {
 }
 
 func isValidAWSPartition(partition string) bool {
-	for _, p := range partitions {
-		if p == partition {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(partitions, partition)
 }
 
 func validateOrganizationConfig(config *IIDAttestorConfig) error {

--- a/pkg/server/plugin/nodeattestor/azuremsi/msi_test.go
+++ b/pkg/server/plugin/nodeattestor/azuremsi/msi_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -243,7 +244,7 @@ func (s *MSIAttestorSuite) TestAttestSuccessWithCustomSPIFFEIDTemplate() {
 
 	payload := s.signAttestPayload("KEYID", resourceID, "TENANTID", "PRINCIPALID")
 
-	selectorValues := append([]string{}, vmSelectors...)
+	selectorValues := slices.Clone(vmSelectors)
 	sort.Strings(selectorValues)
 
 	var expected []*common.Selector
@@ -778,7 +779,7 @@ func (f *fakeAzureCredential) GetToken(context.Context, policy.TokenRequestOptio
 }
 
 func makeAttestPayload(token string) []byte {
-	return []byte(fmt.Sprintf(`{"token": %q}`, token))
+	return fmt.Appendf(nil, `{"token": %q}`, token)
 }
 
 func expectNoChallenge(context.Context, []byte) ([]byte, error) {

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit.go
@@ -3,6 +3,7 @@ package gcpiit
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -159,14 +160,7 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 		return err
 	}
 
-	projectIDMatchesAllowList := false
-	for _, projectID := range c.ProjectIDAllowList {
-		if identityMetadata.ProjectID == projectID {
-			projectIDMatchesAllowList = true
-			break
-		}
-	}
-	if !projectIDMatchesAllowList {
+	if !slices.Contains(c.ProjectIDAllowList, identityMetadata.ProjectID) {
 		return status.Errorf(codes.PermissionDenied, "identity token project ID %q is not in the allow list", identityMetadata.ProjectID)
 	}
 

--- a/pkg/server/plugin/nodeattestor/k8spsat/psat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8spsat/psat_test.go
@@ -430,7 +430,7 @@ func (s *AttestorSuite) requireAttestError(payload []byte, expectCode codes.Code
 }
 
 func makePayload(cluster, token string) []byte {
-	return []byte(fmt.Sprintf(`{"cluster": %q, "token": %q}`, cluster, token))
+	return fmt.Appendf(nil, `{"cluster": %q, "token": %q}`, cluster, token)
 }
 
 func createAndWriteSelfSignedCert(cn string, signer crypto.Signer, path string) error {

--- a/pkg/server/plugin/nodeattestor/k8ssat/sat_test.go
+++ b/pkg/server/plugin/nodeattestor/k8ssat/sat_test.go
@@ -469,7 +469,7 @@ func (s *AttestorSuite) createBuilder(signer jose.Signer, namespace, serviceAcco
 }
 
 func makePayload(cluster, token string) []byte {
-	return []byte(fmt.Sprintf(`{"cluster": %q, "token": %q}`, cluster, token))
+	return fmt.Appendf(nil, `{"cluster": %q, "token": %q}`, cluster, token)
 }
 
 func createAndWriteSelfSignedCert(cn string, signer crypto.Signer, path string) error {

--- a/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
+++ b/pkg/server/plugin/notifier/gcsbundle/gcsbundle_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sync"
 	"testing"
 
@@ -292,7 +293,7 @@ func (c *fakeBucketClient) PutObject(_ context.Context, bucket, object string, d
 		return err
 	}
 
-	c.data = append([]byte(nil), data...)
+	c.data = slices.Clone(data)
 	return nil
 }
 
@@ -310,7 +311,7 @@ func (c *fakeBucketClient) AppendPutObjectError(err error) {
 
 func (c *fakeBucketClient) GetBundleData() []byte {
 	c.mu.Lock()
-	data := append([]byte(nil), c.data...)
+	data := slices.Clone(c.data)
 	c.mu.Unlock()
 	return data
 }

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
 	"runtime/debug"
@@ -789,9 +790,7 @@ func (c *fakeKubeClient) Patch(_ context.Context, namespace, configMap string, p
 	if entry.Data == nil {
 		entry.Data = map[string]string{}
 	}
-	for key, data := range patchedMap.Data {
-		entry.Data[key] = data
-	}
+	maps.Copy(entry.Data, patchedMap.Data)
 	return nil
 }
 

--- a/pkg/server/plugin/upstreamauthority/ejbca/ejbca_test.go
+++ b/pkg/server/plugin/upstreamauthority/ejbca/ejbca_test.go
@@ -737,9 +737,9 @@ func generateCSR(subject string, dnsNames []string, uris []string, ipAddresses [
 
 	if subject != "" {
 		// Split the subject into its individual parts
-		parts := strings.Split(subject, ",")
+		parts := strings.SplitSeq(subject, ",")
 
-		for _, part := range parts {
+		for part := range parts {
 			// Split the part into key and value
 			keyValue := strings.SplitN(part, "=", 2)
 


### PR DESCRIPTION
Recent [gopls](https://pkg.go.dev/golang.org/x/tools/gopls) [versions](https://github.com/golang/tools/releases/tag/gopls%2Fv0.18.0) contain a "[modernize](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize)" pass that can also be run standalone. Run this on the spire repo, with small manual fixups afterwards.

The command I ran was:

    go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...

If this finds favour, it may also make sense to add this as a linter to CI. It seems golangci-lint [won't](https://github.com/golangci/golangci-lint/discussions/5466) be adding support for it directly, so we'd have to do it ourselves.