### PR TITLE
Update default integration test binary and image versions

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -232,7 +232,7 @@ download-bin() {
 }
 
 download-kind() {
-    KINDVERSION=${KINDVERSION:-v0.11.1}
+    KINDVERSION=${KINDVERSION:-v0.27.0}
     KINDPATH=$(command -v kind || echo)
     UNAME=$(uname | awk '{print tolower($0)}')
     ARCH=$(uname -m)
@@ -254,7 +254,7 @@ download-kind() {
 }
 
 download-helm() {
-    HELMVERSION=${HELMVERSION:-v3.11.1}
+    HELMVERSION=${HELMVERSION:-v3.17.1}
     HELMPATH=$(command -v helm || echo)
     UNAME=$(uname | awk '{print tolower($0)}')
     ARCH=$(uname -m)
@@ -281,7 +281,7 @@ download-helm() {
 }
 
 download-kubectl() {
-    WANTVERSION=${KUBECTLVERSION:-v1.21.1}
+    WANTVERSION=${KUBECTLVERSION:-v1.30.10}
     KUBECTLPATH=$(command -v kubectl || echo)
     UNAME=$(uname | awk '{print tolower($0)}')
     ARCH=$(uname -m)
@@ -311,7 +311,7 @@ download-kubectl() {
 }
 
 start-kind-cluster() {
-    K8SIMAGE=${K8SIMAGE:-kindest/node:v1.21.1}
+    K8SIMAGE=${K8SIMAGE:-kindest/node:v1.30.10}
 
     local kind_path=$1
     local kind_name=$2


### PR DESCRIPTION
**Affected functionality**
CI tools and images

**Description of change**
Update the default version of some of the binaries we use in the integration tests. The current ones are quite old and overdue for an update.

For the ones tied to a k8s release, kindes/node and kubectl, I chose 1.30.10 which is the oldest currently supported version. We still have the k8s integration test which checks against a range of versions of these, so it shouldn't change our test coverage there.

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

