### PR TITLE
Update to Ubuntu 24.04 base dev image image.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM ubuntu:24.04
 WORKDIR /spire
 RUN apt-get update && apt-get -y install \
     curl unzip git build-essential ca-certificates libssl-dev

--- a/doc/SPIRE101.md
+++ b/doc/SPIRE101.md
@@ -44,15 +44,16 @@ If you don't already have Docker installed, please follow these [installation in
    $ make dev-shell
    ```
 
-3. Create a user with uid 1000. The uid will be registered as a selector of the workload's SPIFFE ID. During kernel based attestation the workload process will be interrogated for the registered uid.
+3. Create a user with uid 1001. The uid will be registered as a selector of the workload's SPIFFE ID. During kernel based attestation the workload process will be interrogated for the registered uid.
 
    ```shell
-   (in dev shell) # useradd -u 1000 workload
+   (in dev shell) # useradd -u 1001 workload
    ```
 
-4. Build SPIRE by running the **build** target. The build target builds all the SPIRE binaries.
+4. Build SPIRE by running the **build** target. The build target builds all the SPIRE binaries. This requires configuring `git` to know that the temporary docker container is safe.
 
    ```shell
+   (in dev shell) # git config --global --add safe.directory /spire
    (in dev shell) # make build
    ```
 
@@ -169,12 +170,12 @@ If you don't already have Docker installed, please follow these [installation in
     (in dev shell) # ./bin/spire-server entry create \
         -parentID spiffe://example.org/host \
         -spiffeID spiffe://example.org/workload \
-        -selector unix:uid:1000
+        -selector unix:uid:1001
     ```
 
     At this point, the target workload has been registered with the SPIRE Server. We can now call the Workload API using a command line program to request the workload SVID from the SPIRE Agent.
 
-12. Simulate the Workload API interaction and retrieve the workload SVID bundle by running the `api` subcommand in the agent. Run the command as user **_workload_** created in step #3 with uid 1000
+12. Simulate the Workload API interaction and retrieve the workload SVID bundle by running the `api` subcommand in the agent. Run the command as user **_workload_** created in step #3 with uid 1001
 
     ```shell
     (in dev shell) # su -c "./bin/spire-agent api fetch x509 " workload
@@ -183,6 +184,6 @@ If you don't already have Docker installed, please follow these [installation in
 13. Examine the output. Optionally, you may write the SVID and key to disk with `-write` in order to examine them in detail.
 
     ```shell
-    (in dev shell) # su -c "./bin/spire-agent api fetch x509 -write ./" workload
-    (in dev shell) # openssl x509 -in ./svid.0.pem -text -noout
+    (in dev shell) # su -c "./bin/spire-agent api fetch x509 -write /tmp" workload
+    (in dev shell) # openssl x509 -in /tmp/svid.0.pem -text -noout
     ```


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [X] Proper tests/regressions included?
- [X] Documentation updated?

**Affected functionality**
No change.

**Description of change**
Updates Dockerfile.dev to use Ubuntu LTS 24.04 and other necessary workflow changes.

1. uid 1000 -> 1001 because the default `ubuntu` user is uid 1000.
2. git configuration of the /spire directory as safe is required.
3. Update example certificate write directory to `/tmp` as the current directory doesn't have permission for `workload` to write to it.

**Which issue this PR fixes**
fixes #5935

