### PR TITLE
integration tests: wait for spire-server to come up

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -83,6 +83,14 @@ docker-cleanup() {
     docker compose down -v --remove-orphans
 }
 
+docker-spire-server-up() {
+    docker-up "$@"
+
+    for container in "$@"; do
+        check-server-started ${container}
+    done
+}
+
 fingerprint() {
 	# calculate the SHA1 digest of the DER bytes of the certificate using the
 	# "coreutils" output format (`-r`) to provide uniform output from

--- a/test/integration/suites-windows/windows-service/01-start-server-service
+++ b/test/integration/suites-windows/windows-service/01-start-server-service
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./common
 
-docker-spire-server-up spire-server
+docker-up spire-server
 
 create-service spire-server C:/spire/bin/spire-server.exe
 start-service spire-server run -config C:/spire/conf/server/server.conf

--- a/test/integration/suites-windows/windows-service/01-start-server-service
+++ b/test/integration/suites-windows/windows-service/01-start-server-service
@@ -1,7 +1,7 @@
 #!/bin/bash
 source ./common
 
-docker-up spire-server
+docker-spire-server-up spire-server
 
 create-service spire-server C:/spire/bin/spire-server.exe
 start-service spire-server run -config C:/spire/conf/server/server.conf

--- a/test/integration/suites-windows/windows-workload-attestor/01-start-server
+++ b/test/integration/suites-windows/windows-workload-attestor/01-start-server
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server
 

--- a/test/integration/suites/admin-endpoints/01-start-server
+++ b/test/integration/suites/admin-endpoints/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server-a spire-server-b
+docker-spire-server-up spire-server-a spire-server-b

--- a/test/integration/suites/agent-cli/01-start-server
+++ b/test/integration/suites/agent-cli/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/debug-endpoints/01-start-server
+++ b/test/integration/suites/debug-endpoints/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/delegatedidentity/01-start-server
+++ b/test/integration/suites/delegatedidentity/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/downstream-endpoints/01-start-server
+++ b/test/integration/suites/downstream-endpoints/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -2,7 +2,7 @@
 
 setup-tests() {
     # Bring up the server
-    docker-up spire-server
+    docker-spire-server-up spire-server
 
     # Bootstrap the agent
     log-debug "bootstrapping downstream agent..."

--- a/test/integration/suites/evict-agent/01-start-server
+++ b/test/integration/suites/evict-agent/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/fetch-x509-svids/01-start-server
+++ b/test/integration/suites/fetch-x509-svids/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/force-rotation-jwt-authority/01-start-server
+++ b/test/integration/suites/force-rotation-jwt-authority/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/force-rotation-upstream-authority/01-start-server
+++ b/test/integration/suites/force-rotation-upstream-authority/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/join-token/01-start-server
+++ b/test/integration/suites/join-token/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/node-attestation/01-start-server
+++ b/test/integration/suites/node-attestation/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/node-re-attestation/01-start-server
+++ b/test/integration/suites/node-re-attestation/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/oidc-discovery-provider/01-start-server
+++ b/test/integration/suites/oidc-discovery-provider/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/rotation/01-start-server
+++ b/test/integration/suites/rotation/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/spire-server-cli/01-start-server
+++ b/test/integration/suites/spire-server-cli/01-start-server
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 docker build --target spire-server-alpine -t spire-server-alpine .
-docker-up spire-server
+docker-spire-server-up spire-server
 

--- a/test/integration/suites/svidstore/01-start-server
+++ b/test/integration/suites/svidstore/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server

--- a/test/integration/suites/sync-authorized-entries/01-start-server
+++ b/test/integration/suites/sync-authorized-entries/01-start-server
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-up spire-server
+docker-spire-server-up spire-server


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Integration tests

**Description of change**
We don't wait for spire-server to be up before trying to make use of it. This sometimes leads to failures in integration tests, for example when trying to read the bundle because it might not be available yet.

