### PR TITLE
update urls in README.md to modified location of CNCF security assessments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The SPIFFE community maintains the SPIRE project. Information on the various SIG
 A third party security firm ([Cure53](https://cure53.de/)) completed a security audit of SPIFFE and SPIRE in February of 2021. Additionally, the [CNCF Technical Advisory Group for Security](https://github.com/cncf/tag-security) conducted two assessments on SPIFFE and SPIRE in 2018 and 2020. Please find the reports and supporting material, including the threat model exercise results, below.
 
 - [Cure53 Security Audit Report](doc/cure53-report.pdf)
-- [SIG-Security SPIFFE/SPIRE Security Assessment: summary](https://github.com/cncf/sig-security/tree/main/assessments/projects/spiffe-spire)
-- [SIG-Security SPIFFE/SPIRE Security Assessment: full assessment](https://github.com/cncf/sig-security/blob/main/assessments/projects/spiffe-spire/self-assessment.md)
+- [SIG-Security SPIFFE/SPIRE Security Assessment: summary](https://github.com/cncf/sig-security/tree/main/community/assessments/projects/spiffe-spire)
+- [SIG-Security SPIFFE/SPIRE Security Assessment: full assessment](https://github.com/cncf/sig-security/blob/main/community/assessments/projects/spiffe-spire/self-assessment.md)
 - [Scrutinizing SPIRE to Sensibly Strengthen SPIFFE Security](https://blog.spiffe.io/scrutinizing-spire-security-9c82ba542019)
 
 ### Reporting Security Vulnerabilities


### PR DESCRIPTION
**Pull Request check list**

- [ x] Commit conforms to CONTRIBUTING.md?
- [na ] Proper tests/regressions included?
- [na] Documentation updated?

**Description of change**
location of security assessments were moved by https://github.com/cncf/tag-security/commit/50d5f61d7f9dfb88dd3639a1579304f504eaedd3
