### PR TITLE
cgroups: correct wording of error message; add unified cgroups test

### DIFF
--- a/pkg/agent/common/cgroups/cgroups.go
+++ b/pkg/agent/common/cgroups/cgroups.go
@@ -43,7 +43,7 @@ func GetCgroups(pid int32, fs FileSystem) ([]Cgroup, error) {
 		token := scanner.Text()
 		substrings := strings.SplitN(token, ":", 3)
 		if len(substrings) < 3 {
-			return nil, fmt.Errorf("cgroup entry contains %v colons, but expected at least 2 colons: %q", len(substrings), token)
+			return nil, fmt.Errorf("invalid cgroup entry, contains %v colon separated fields but expected at least 3: %q", len(substrings), token)
 		}
 		cgroups = append(cgroups, Cgroup{
 			HierarchyID:    substrings[0],


### PR DESCRIPTION

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?

**Affected functionality**
cgroup error message language
cgroup unit tests


**Description of changes**
modifies language of error message to more accurately reflect the problem
increases cgroup unit tests to also include unified cgroups example

