### PR TITLE
Improve performance for fetching authorized entries

### DIFF
--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -21,6 +21,7 @@ import (
 	svidv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/svid/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/api/entry/v1"
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/spiretest"
@@ -1023,7 +1024,13 @@ func (c *fakeEntryServer) GetAuthorizedEntries(_ context.Context, in *entryv1.Ge
 
 func (c *fakeEntryServer) SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer) error {
 	const entryPageSize = 2
-	return entry.SyncAuthorizedEntries(stream, c.entries, entryPageSize)
+
+	entries := []api.ReadOnlyEntry{}
+	for _, entry := range c.entries {
+		entries = append(entries, api.NewReadOnlyEntry(entry))
+	}
+
+	return entry.SyncAuthorizedEntries(stream, entries, entryPageSize)
 }
 
 type fakeBundleServer struct {

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -15,7 +15,7 @@ import (
 type AuthorizedEntryFetcher interface {
 	// LookupAuthorizedEntries fetches the entries in entryIDs that the
 	// specified SPIFFE ID is authorized for
-	LookupAuthorizedEntries(ctx context.Context, id spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error)
+	LookupAuthorizedEntries(ctx context.Context, id spiffeid.ID, entryIDs map[string]struct{}) (map[string]ReadOnlyEntry, error)
 	// FetchAuthorizedEntries fetches the entries that the specified
 	// SPIFFE ID is authorized for
 	FetchAuthorizedEntries(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error)

--- a/pkg/server/api/api.go
+++ b/pkg/server/api/api.go
@@ -18,7 +18,7 @@ type AuthorizedEntryFetcher interface {
 	LookupAuthorizedEntries(ctx context.Context, id spiffeid.ID, entryIDs map[string]struct{}) (map[string]ReadOnlyEntry, error)
 	// FetchAuthorizedEntries fetches the entries that the specified
 	// SPIFFE ID is authorized for
-	FetchAuthorizedEntries(ctx context.Context, id spiffeid.ID) ([]*types.Entry, error)
+	FetchAuthorizedEntries(ctx context.Context, id spiffeid.ID) ([]ReadOnlyEntry, error)
 }
 
 // AttestedNodeToProto converts an agent from the given *common.AttestedNode with

--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -11,11 +11,121 @@ import (
 	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/common"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
 	hintMaximumLength = 1024
 )
+
+type ReadOnlyEntry struct {
+	entry *types.Entry
+}
+
+func NewReadOnlyEntry(entry *types.Entry) ReadOnlyEntry {
+	return ReadOnlyEntry{
+		entry: entry,
+	}
+}
+
+func (e *ReadOnlyEntry) GetSpiffeId() *types.SPIFFEID {
+	return &types.SPIFFEID{
+		TrustDomain: e.entry.SpiffeId.TrustDomain,
+		Path:        e.entry.SpiffeId.Path,
+	}
+}
+
+func (e *ReadOnlyEntry) GetX509SvidTtl() int32 {
+	return e.entry.X509SvidTtl
+}
+
+func (e *ReadOnlyEntry) GetJwtSvidTtl() int32 {
+	return e.entry.JwtSvidTtl
+}
+
+func (e *ReadOnlyEntry) GetDnsNames() []string {
+	return slices.Clone(e.entry.DnsNames)
+}
+
+func (e *ReadOnlyEntry) GetRevisionNumber() int64 {
+	return e.entry.RevisionNumber
+}
+
+// Manually clone the entry instead of using the protobuf helpers
+// since those are two times slower.
+func (e *ReadOnlyEntry) Clone(mask *types.EntryMask) *types.Entry {
+	if mask == nil {
+		return proto.Clone(e.entry).(*types.Entry)
+	}
+
+	clone := &types.Entry{}
+	clone.Id = e.entry.Id
+	if mask.SpiffeId {
+		clone.SpiffeId = e.GetSpiffeId()
+	}
+
+	if mask.ParentId {
+		clone.ParentId = &types.SPIFFEID{
+			TrustDomain: e.entry.ParentId.TrustDomain,
+			Path:        e.entry.ParentId.Path,
+		}
+	}
+
+	if mask.Selectors {
+		for _, selector := range e.entry.Selectors {
+			clone.Selectors = append(clone.Selectors, &types.Selector{
+				Type:  selector.Type,
+				Value: selector.Value,
+			})
+		}
+	}
+
+	if mask.FederatesWith {
+		clone.FederatesWith = slices.Clone(e.entry.FederatesWith)
+	}
+
+	if mask.Admin {
+		clone.Admin = e.entry.Admin
+	}
+
+	if mask.Downstream {
+		clone.Downstream = e.entry.Admin
+	}
+
+	if mask.ExpiresAt {
+		clone.ExpiresAt = e.entry.ExpiresAt
+	}
+
+	if mask.DnsNames {
+		clone.DnsNames = slices.Clone(e.entry.DnsNames)
+	}
+
+	if mask.RevisionNumber {
+		clone.RevisionNumber = e.entry.RevisionNumber
+	}
+
+	if mask.StoreSvid {
+		clone.StoreSvid = e.entry.StoreSvid
+	}
+
+	if mask.X509SvidTtl {
+		clone.X509SvidTtl = e.entry.X509SvidTtl
+	}
+
+	if mask.JwtSvidTtl {
+		clone.JwtSvidTtl = e.entry.JwtSvidTtl
+	}
+
+	if mask.Hint {
+		clone.Hint = e.entry.Hint
+	}
+
+	if mask.CreatedAt {
+		clone.CreatedAt = e.entry.CreatedAt
+	}
+
+	return clone
+}
 
 // RegistrationEntriesToProto converts RegistrationEntry's into Entry's
 func RegistrationEntriesToProto(es []*common.RegistrationEntry) ([]*types.Entry, error) {

--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -28,6 +28,10 @@ func NewReadOnlyEntry(entry *types.Entry) ReadOnlyEntry {
 	}
 }
 
+func (e ReadOnlyEntry) GetId() string {
+	return e.entry.Id
+}
+
 func (e *ReadOnlyEntry) GetSpiffeId() *types.SPIFFEID {
 	return &types.SPIFFEID{
 		TrustDomain: e.entry.SpiffeId.TrustDomain,
@@ -49,6 +53,10 @@ func (e *ReadOnlyEntry) GetDnsNames() []string {
 
 func (e *ReadOnlyEntry) GetRevisionNumber() int64 {
 	return e.entry.RevisionNumber
+}
+
+func (e *ReadOnlyEntry) GetCreatedAt() int64 {
+	return e.entry.CreatedAt
 }
 
 // Manually clone the entry instead of using the protobuf helpers

--- a/pkg/server/api/entry/v1/service.go
+++ b/pkg/server/api/entry/v1/service.go
@@ -390,6 +390,7 @@ func (s *Service) GetAuthorizedEntries(ctx context.Context, req *entryv1.GetAuth
 	if err != nil {
 		return nil, err
 	}
+
 	for i, entry := range entries {
 		applyMask(entry, req.OutputMask)
 		entries[i] = entry

--- a/pkg/server/api/entry/v1/service.go
+++ b/pkg/server/api/entry/v1/service.go
@@ -391,14 +391,12 @@ func (s *Service) GetAuthorizedEntries(ctx context.Context, req *entryv1.GetAuth
 		return nil, err
 	}
 
-	for i, entry := range entries {
-		applyMask(entry, req.OutputMask)
-		entries[i] = entry
+	resp := &entryv1.GetAuthorizedEntriesResponse{}
+
+	for _, entry := range entries {
+		resp.Entries = append(resp.Entries, entry.Clone(req.OutputMask))
 	}
 
-	resp := &entryv1.GetAuthorizedEntriesResponse{
-		Entries: entries,
-	}
 	rpccontext.AuditRPC(ctx)
 
 	return resp, nil
@@ -424,7 +422,7 @@ func (s *Service) SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntri
 	return SyncAuthorizedEntries(stream, entries, s.entryPageSize)
 }
 
-func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, entries []*types.Entry, entryPageSize int) (err error) {
+func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, entries []api.ReadOnlyEntry, entryPageSize int) (err error) {
 	// Receive the initial request with the output mask.
 	req, err := stream.Recv()
 	if err != nil {
@@ -447,18 +445,17 @@ func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, ent
 
 	// Apply output mask to entries. The output mask field will be
 	// intentionally ignored on subsequent requests.
-	for i, entry := range entries {
-		applyMask(entry, req.OutputMask)
-		entries[i] = entry
-	}
+	initialOutputMask := req.OutputMask
 
 	// If the number of entries is less than or equal to the entry page size,
 	// then just send the full list back. Otherwise, we'll send a sparse list
 	// and then stream back full entries as requested.
 	if len(entries) <= entryPageSize {
-		return stream.Send(&entryv1.SyncAuthorizedEntriesResponse{
-			Entries: entries,
-		})
+		resp := &entryv1.SyncAuthorizedEntriesResponse{}
+		for _, entry := range entries {
+			resp.Entries = append(resp.Entries, entry.Clone(initialOutputMask))
+		}
+		return stream.Send(resp)
 	}
 
 	// Prepopulate the entry page used in the response with empty entry structs.
@@ -475,9 +472,9 @@ func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, ent
 			more = true
 		}
 		for j, entry := range entries[i : i+n] {
-			entryRevisions[j].Id = entry.Id
-			entryRevisions[j].RevisionNumber = entry.RevisionNumber
-			entryRevisions[j].CreatedAt = entry.CreatedAt
+			entryRevisions[j].Id = entry.GetId()
+			entryRevisions[j].RevisionNumber = entry.GetRevisionNumber()
+			entryRevisions[j].CreatedAt = entry.GetCreatedAt()
 		}
 
 		if err := stream.Send(&entryv1.SyncAuthorizedEntriesResponse{
@@ -530,7 +527,7 @@ func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, ent
 		entriesToSearch := entries
 		for _, id := range req.Ids {
 			i, found := sort.Find(len(entriesToSearch), func(i int) int {
-				return strings.Compare(id, entriesToSearch[i].Id)
+				return strings.Compare(id, entriesToSearch[i].GetId())
 			})
 			if found {
 				if len(resp.Entries) == entryPageSize {
@@ -543,7 +540,7 @@ func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, ent
 					}
 					resp.Entries = resp.Entries[:0]
 				}
-				resp.Entries = append(resp.Entries, entriesToSearch[i])
+				resp.Entries = append(resp.Entries, entriesToSearch[i].Clone(initialOutputMask))
 			}
 			entriesToSearch = entriesToSearch[i:]
 			if len(entriesToSearch) == 0 {
@@ -560,7 +557,7 @@ func SyncAuthorizedEntries(stream entryv1.Entry_SyncAuthorizedEntriesServer, ent
 }
 
 // fetchEntries fetches authorized entries using caller ID from context
-func (s *Service) fetchEntries(ctx context.Context, log logrus.FieldLogger) ([]*types.Entry, error) {
+func (s *Service) fetchEntries(ctx context.Context, log logrus.FieldLogger) ([]api.ReadOnlyEntry, error) {
 	callerID, ok := rpccontext.CallerID(ctx)
 	if !ok {
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)
@@ -844,8 +841,8 @@ func fieldsFromCountEntryFilter(ctx context.Context, td spiffeid.TrustDomain, fi
 	return fields
 }
 
-func sortEntriesByID(entries []*types.Entry) {
+func sortEntriesByID(entries []api.ReadOnlyEntry) {
 	sort.Slice(entries, func(a, b int) bool {
-		return entries[a].Id < entries[b].Id
+		return entries[a].GetId() < entries[b].GetId()
 	})
 }

--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -4849,13 +4849,13 @@ func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spif
 
 	entriesMap := make(map[string]api.ReadOnlyEntry)
 	for _, entry := range entries {
-		entriesMap[entry.GetId()] = api.NewReadOnlyEntry(entry)
+		entriesMap[entry.GetId()] = entry
 	}
 
 	return entriesMap, nil
 }
 
-func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
+func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]api.ReadOnlyEntry, error) {
 	if f.err != "" {
 		return nil, status.Error(codes.Internal, f.err)
 	}
@@ -4869,7 +4869,12 @@ func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiff
 		return nil, fmt.Errorf("provided caller id is different to expected")
 	}
 
-	return f.entries, nil
+	entries := []api.ReadOnlyEntry{}
+	for _, entry := range f.entries {
+		entries = append(entries, api.NewReadOnlyEntry(entry))
+	}
+
+	return entries, nil
 }
 
 type HasID interface {

--- a/pkg/server/api/entry/v1/service_test.go
+++ b/pkg/server/api/entry/v1/service_test.go
@@ -4841,15 +4841,15 @@ type entryFetcher struct {
 	entries []*types.Entry
 }
 
-func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]*types.Entry, error) {
+func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]api.ReadOnlyEntry, error) {
 	entries, err := f.FetchAuthorizedEntries(ctx, agentID)
 	if err != nil {
 		return nil, err
 	}
 
-	entriesMap := make(map[string]*types.Entry)
+	entriesMap := make(map[string]api.ReadOnlyEntry)
 	for _, entry := range entries {
-		entriesMap[entry.GetId()] = entry
+		entriesMap[entry.GetId()] = api.NewReadOnlyEntry(entry)
 	}
 
 	return entriesMap, nil

--- a/pkg/server/api/entry_test.go
+++ b/pkg/server/api/entry_test.go
@@ -2,6 +2,8 @@ package api_test
 
 import (
 	"context"
+	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestRegistrationEntryToProto(t *testing.T) {
@@ -646,5 +649,156 @@ func TestProtoToRegistrationEntry(t *testing.T) {
 			require.NoError(t, err)
 			spiretest.AssertProtoEqual(t, tt.expectEntry, entry)
 		})
+	}
+}
+
+func TestReadOnlyEntryIsReadOnly(t *testing.T) {
+	expiresAt := time.Now().Unix()
+	entry := &types.Entry{
+		Id:          "entry1",
+		ParentId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+		SpiffeId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/bar"},
+		X509SvidTtl: 70,
+		JwtSvidTtl:  80,
+		Selectors: []*types.Selector{
+			{Type: "unix", Value: "uid:1000"},
+			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"domain1.com",
+			"domain2.com",
+		},
+		Admin:          true,
+		ExpiresAt:      expiresAt,
+		DnsNames:       []string{"dns1", "dns2"},
+		Downstream:     true,
+		RevisionNumber: 99,
+		Hint:           "external",
+		CreatedAt:      1678731397,
+		StoreSvid:      true,
+	}
+	readOnlyEntry := api.NewReadOnlyEntry(entry)
+
+	clonedEntry := readOnlyEntry.Clone(protoutil.AllTrueEntryMask)
+	clonedEntry.Admin = false
+	clonedEntry.DnsNames = nil
+
+	require.NotEqual(t, entry.DnsNames, clonedEntry.DnsNames)
+	require.NotEqual(t, entry.Admin, clonedEntry.Admin)
+}
+
+func TestReadOnlyEntryClone(t *testing.T) {
+	expiresAt := time.Now().Unix()
+	entry := &types.Entry{
+		Id:          "entry1",
+		ParentId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+		SpiffeId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/bar"},
+		X509SvidTtl: 70,
+		JwtSvidTtl:  80,
+		Selectors: []*types.Selector{
+			{Type: "unix", Value: "uid:1000"},
+			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"domain1.com",
+			"domain2.com",
+		},
+		Admin:          true,
+		ExpiresAt:      expiresAt,
+		DnsNames:       []string{"dns1", "dns2"},
+		Downstream:     true,
+		RevisionNumber: 99,
+		Hint:           "external",
+		CreatedAt:      1678731397,
+		StoreSvid:      true,
+	}
+
+	// Verify that we our test entry has all fields set to make sure
+	// the Clone method doesn't miss any new fields.
+	value := reflect.ValueOf(entry).Elem()
+	valueType := value.Type()
+	for i := range value.NumField() {
+		fieldType := valueType.Field(i)
+		fieldValue := value.Field(i)
+		// Skip the protobuf internal fields
+		if strings.HasPrefix(fieldType.Name, "XXX_") {
+			continue
+		}
+		if slices.Index([]string{"state", "sizeCache", "unknownFields"}, fieldType.Name) != -1 {
+			continue
+		}
+
+		require.False(t, fieldValue.IsZero(), "Field '%s' is not set", value.Type().Field(i).Name)
+	}
+
+	readOnlyEntry := api.NewReadOnlyEntry(entry)
+
+	protoClone := proto.Clone(entry).(*types.Entry)
+	readOnlyClone := readOnlyEntry.Clone(protoutil.AllTrueEntryMask)
+
+	spiretest.AssertProtoEqual(t, protoClone, readOnlyClone)
+}
+
+func BenchmarkEntryClone(b *testing.B) {
+	expiresAt := time.Now().Unix()
+	entry := &types.Entry{
+		Id:          "entry1",
+		ParentId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+		SpiffeId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/bar"},
+		X509SvidTtl: 70,
+		JwtSvidTtl:  80,
+		Selectors: []*types.Selector{
+			{Type: "unix", Value: "uid:1000"},
+			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"domain1.com",
+			"domain2.com",
+		},
+		Admin:          true,
+		ExpiresAt:      expiresAt,
+		DnsNames:       []string{"dns1", "dns2"},
+		Downstream:     true,
+		RevisionNumber: 99,
+		Hint:           "external",
+		CreatedAt:      1678731397,
+		StoreSvid:      true,
+	}
+
+	for b.Loop() {
+		_ = proto.Clone(entry).(*types.Entry)
+	}
+}
+
+func BenchmarkReadOnlyEntryClone(b *testing.B) {
+	expiresAt := time.Now().Unix()
+	entry := &types.Entry{
+		Id:          "entry1",
+		ParentId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+		SpiffeId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/bar"},
+		X509SvidTtl: 70,
+		JwtSvidTtl:  80,
+		Selectors: []*types.Selector{
+			{Type: "unix", Value: "uid:1000"},
+			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"domain1.com",
+			"domain2.com",
+		},
+		Admin:          true,
+		ExpiresAt:      expiresAt,
+		DnsNames:       []string{"dns1", "dns2"},
+		Downstream:     true,
+		RevisionNumber: 99,
+		Hint:           "external",
+		CreatedAt:      1678731397,
+		StoreSvid:      true,
+	}
+	readOnlyEntry := api.NewReadOnlyEntry(entry)
+	allTrueMask := protoutil.AllTrueEntryMask
+
+	for b.Loop() {
+		_ = readOnlyEntry.Clone(allTrueMask)
 	}
 }

--- a/pkg/server/api/entry_test.go
+++ b/pkg/server/api/entry_test.go
@@ -687,6 +687,43 @@ func TestReadOnlyEntryIsReadOnly(t *testing.T) {
 	require.NotEqual(t, entry.Admin, clonedEntry.Admin)
 }
 
+func TestReadOnlyEntry(t *testing.T) {
+	expiresAt := time.Now().Unix()
+	entry := &types.Entry{
+		Id:          "entry1",
+		ParentId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/foo"},
+		SpiffeId:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/bar"},
+		X509SvidTtl: 70,
+		JwtSvidTtl:  80,
+		Selectors: []*types.Selector{
+			{Type: "unix", Value: "uid:1000"},
+			{Type: "unix", Value: "gid:1000"},
+		},
+		FederatesWith: []string{
+			"domain1.com",
+			"domain2.com",
+		},
+		Admin:          true,
+		ExpiresAt:      expiresAt,
+		DnsNames:       []string{"dns1", "dns2"},
+		Downstream:     true,
+		RevisionNumber: 99,
+		Hint:           "external",
+		CreatedAt:      1678731397,
+		StoreSvid:      true,
+	}
+
+	// Verify that all getters return the expected value
+	readOnlyEntry := api.NewReadOnlyEntry(entry)
+	require.Equal(t, readOnlyEntry.GetId(), entry.Id)
+	require.Equal(t, readOnlyEntry.GetSpiffeId(), entry.SpiffeId)
+	require.Equal(t, readOnlyEntry.GetX509SvidTtl(), entry.X509SvidTtl)
+	require.Equal(t, readOnlyEntry.GetJwtSvidTtl(), entry.JwtSvidTtl)
+	require.Equal(t, readOnlyEntry.GetDnsNames(), entry.DnsNames)
+	require.Equal(t, readOnlyEntry.GetRevisionNumber(), entry.RevisionNumber)
+	require.Equal(t, readOnlyEntry.GetCreatedAt(), entry.CreatedAt)
+}
+
 func TestReadOnlyEntryClone(t *testing.T) {
 	expiresAt := time.Now().Unix()
 	entry := &types.Entry{

--- a/pkg/server/api/svid/v1/service.go
+++ b/pkg/server/api/svid/v1/service.go
@@ -210,7 +210,7 @@ func (s *Service) BatchNewX509SVID(ctx context.Context, req *svidv1.BatchNewX509
 	return &svidv1.BatchNewX509SVIDResponse{Results: results}, nil
 }
 
-func (s *Service) findEntries(ctx context.Context, log logrus.FieldLogger, entries map[string]struct{}) (map[string]*types.Entry, error) {
+func (s *Service) findEntries(ctx context.Context, log logrus.FieldLogger, entries map[string]struct{}) (map[string]api.ReadOnlyEntry, error) {
 	callerID, ok := rpccontext.CallerID(ctx)
 	if !ok {
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)
@@ -224,7 +224,7 @@ func (s *Service) findEntries(ctx context.Context, log logrus.FieldLogger, entri
 }
 
 // newX509SVID creates an X509-SVID using data from registration entry and key from CSR
-func (s *Service) newX509SVID(ctx context.Context, param *svidv1.NewX509SVIDParams, entries map[string]*types.Entry) *svidv1.BatchNewX509SVIDResponse_Result {
+func (s *Service) newX509SVID(ctx context.Context, param *svidv1.NewX509SVIDParams, entries map[string]api.ReadOnlyEntry) *svidv1.BatchNewX509SVIDResponse_Result {
 	log := rpccontext.Logger(ctx)
 
 	switch {

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -2178,15 +2178,15 @@ type entryFetcher struct {
 	entries []*types.Entry
 }
 
-func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]*types.Entry, error) {
+func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, _ map[string]struct{}) (map[string]api.ReadOnlyEntry, error) {
 	entries, err := f.FetchAuthorizedEntries(ctx, agentID)
 	if err != nil {
 		return nil, err
 	}
 
-	entriesMap := make(map[string]*types.Entry)
+	entriesMap := make(map[string]api.ReadOnlyEntry)
 	for _, entry := range entries {
-		entriesMap[entry.GetId()] = entry
+		entriesMap[entry.GetId()] = api.NewReadOnlyEntry(entry)
 	}
 
 	return entriesMap, nil

--- a/pkg/server/api/svid/v1/service_test.go
+++ b/pkg/server/api/svid/v1/service_test.go
@@ -1163,6 +1163,7 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 	}
 	invalidEntry := &types.Entry{
 		Id:       "invalid",
+		SpiffeId: &types.SPIFFEID{},
 		ParentId: api.ProtoFromID(agentID),
 	}
 	test.ef.entries = []*types.Entry{workloadEntry, dnsEntry, ttlEntry, x509TtlEntry, invalidEntry}
@@ -1329,7 +1330,7 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 						Message: "Entry has malformed SPIFFE ID",
 						Data: logrus.Fields{
 							telemetry.RegistrationID: "invalid",
-							logrus.ErrorKey:          "request must specify SPIFFE ID",
+							logrus.ErrorKey:          "trust domain is missing",
 						},
 					},
 					{
@@ -1341,7 +1342,7 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 							telemetry.RegistrationID: "invalid",
 							telemetry.Csr:            api.HashByte(m["invalid"]),
 							telemetry.StatusCode:     "Internal",
-							telemetry.StatusMessage:  "entry has malformed SPIFFE ID: request must specify SPIFFE ID",
+							telemetry.StatusMessage:  "entry has malformed SPIFFE ID: trust domain is missing",
 							telemetry.SPIFFEID:       "",
 						},
 					},
@@ -1661,7 +1662,7 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 						Message: "Entry has malformed SPIFFE ID",
 						Data: logrus.Fields{
 							telemetry.RegistrationID: "invalid",
-							logrus.ErrorKey:          "request must specify SPIFFE ID",
+							logrus.ErrorKey:          "trust domain is missing",
 						},
 					},
 					{
@@ -1673,7 +1674,7 @@ func TestServiceBatchNewX509SVID(t *testing.T) {
 							telemetry.RegistrationID: "invalid",
 							telemetry.Csr:            api.HashByte(m["invalid"]),
 							telemetry.StatusCode:     "Internal",
-							telemetry.StatusMessage:  "entry has malformed SPIFFE ID: request must specify SPIFFE ID",
+							telemetry.StatusMessage:  "entry has malformed SPIFFE ID: trust domain is missing",
 							telemetry.SPIFFEID:       "",
 						},
 					},
@@ -2186,27 +2187,32 @@ func (f *entryFetcher) LookupAuthorizedEntries(ctx context.Context, agentID spif
 
 	entriesMap := make(map[string]api.ReadOnlyEntry)
 	for _, entry := range entries {
-		entriesMap[entry.GetId()] = api.NewReadOnlyEntry(entry)
+		entriesMap[entry.GetId()] = entry
 	}
 
 	return entriesMap, nil
 }
 
-func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
+func (f *entryFetcher) FetchAuthorizedEntries(ctx context.Context, agentID spiffeid.ID) ([]api.ReadOnlyEntry, error) {
 	if f.err != "" {
 		return nil, status.Error(codes.Internal, f.err)
 	}
 
 	caller, ok := rpccontext.CallerID(ctx)
 	if !ok {
-		return nil, errors.New("no caller ID on context")
+		return nil, errors.New("missing caller ID")
 	}
 
 	if caller != agentID {
 		return nil, fmt.Errorf("provided caller id is different to expected")
 	}
 
-	return f.entries, nil
+	entries := []api.ReadOnlyEntry{}
+	for _, entry := range f.entries {
+		entries = append(entries, api.NewReadOnlyEntry(entry))
+	}
+
+	return entries, nil
 }
 
 type fakeRateLimiter struct {

--- a/pkg/server/authorizedentries/cache.go
+++ b/pkg/server/authorizedentries/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/server/api"
 )
 
 const (
@@ -59,7 +60,7 @@ func NewCache(clk clock.Clock) *Cache {
 	}
 }
 
-func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries map[string]struct{}) map[string]*types.Entry {
+func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries map[string]struct{}) map[string]api.ReadOnlyEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -72,7 +73,7 @@ func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries ma
 	// updated with the node selectors for the agent.
 	agent, _ := c.agentsByID.Get(agentRecord{ID: agentID.String()})
 
-	foundEntries := make(map[string]*types.Entry)
+	foundEntries := make(map[string]api.ReadOnlyEntry)
 
 	parentSeen := allocStringSet()
 	defer freeStringSet(parentSeen)
@@ -192,7 +193,7 @@ func (c *Cache) appendDescendents(records []entryRecord, parentID string, parent
 	return records
 }
 
-func (c *Cache) addDescendants(foundEntries map[string]*types.Entry, parentID string, requestedEntries map[string]struct{}, parentSeen stringSet) {
+func (c *Cache) addDescendants(foundEntries map[string]api.ReadOnlyEntry, parentID string, requestedEntries map[string]struct{}, parentSeen stringSet) {
 	if _, ok := parentSeen[parentID]; ok {
 		return
 	}
@@ -205,7 +206,7 @@ func (c *Cache) addDescendants(foundEntries map[string]*types.Entry, parentID st
 		}
 
 		if _, ok := requestedEntries[record.EntryID]; ok {
-			foundEntries[record.EntryID] = cloneEntry(record.EntryCloneOnly)
+			foundEntries[record.EntryID] = api.NewReadOnlyEntry(record.EntryCloneOnly)
 		}
 		c.addDescendants(foundEntries, record.SPIFFEID, requestedEntries, parentSeen)
 		return true

--- a/pkg/server/authorizedentries/cache.go
+++ b/pkg/server/authorizedentries/cache.go
@@ -88,7 +88,7 @@ func (c *Cache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedEntries ma
 	return foundEntries
 }
 
-func (c *Cache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
+func (c *Cache) GetAuthorizedEntries(agentID spiffeid.ID) []api.ReadOnlyEntry {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/pkg/server/authorizedentries/cache_test.go
+++ b/pkg/server/authorizedentries/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/idutil"
+	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/test/clock"
 	"github.com/spiffe/spire/test/spiretest"
@@ -432,8 +433,16 @@ func assertAuthorizedEntries(tb testing.TB, cache *Cache, agentID spiffeid.ID, a
 		return m
 	}
 
+	readOnlyEntriesMap := func(entries []api.ReadOnlyEntry) map[string]*types.Entry {
+		m := make(map[string]*types.Entry)
+		for _, entry := range entries {
+			m[entry.GetId()] = entry.Clone(protoutil.AllTrueEntryMask)
+		}
+		return m
+	}
+
 	wantMap := entriesMap(wantEntries)
-	gotMap := entriesMap(cache.GetAuthorizedEntries(agentID))
+	gotMap := readOnlyEntriesMap(cache.GetAuthorizedEntries(agentID))
 
 	for id, want := range wantMap {
 		got, ok := gotMap[id]

--- a/pkg/server/authorizedentries/entries.go
+++ b/pkg/server/authorizedentries/entries.go
@@ -2,7 +2,7 @@ package authorizedentries
 
 import (
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
-	"google.golang.org/protobuf/proto"
+	"github.com/spiffe/spire/pkg/server/api"
 )
 
 type entryRecord struct {
@@ -29,17 +29,13 @@ func entryRecordByParentID(a, b entryRecord) bool {
 	}
 }
 
-func cloneEntriesFromRecords(entryRecords []entryRecord) []*types.Entry {
+func cloneEntriesFromRecords(entryRecords []entryRecord) []api.ReadOnlyEntry {
 	if len(entryRecords) == 0 {
 		return nil
 	}
-	cloned := make([]*types.Entry, 0, len(entryRecords))
+	cloned := make([]api.ReadOnlyEntry, 0, len(entryRecords))
 	for _, entryRecord := range entryRecords {
-		cloned = append(cloned, cloneEntry(entryRecord.EntryCloneOnly))
+		cloned = append(cloned, api.NewReadOnlyEntry(entryRecord.EntryCloneOnly))
 	}
 	return cloned
-}
-
-func cloneEntry(entry *types.Entry) *types.Entry {
-	return proto.Clone(entry).(*types.Entry)
 }

--- a/pkg/server/cache/entrycache/fullcache.go
+++ b/pkg/server/cache/entrycache/fullcache.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/server/api"
-	"google.golang.org/protobuf/proto"
 )
 
 var (
@@ -30,7 +29,7 @@ var _ Cache = (*FullEntryCache)(nil)
 // at a particular moment in time.
 type Cache interface {
 	LookupAuthorizedEntries(agentID spiffeid.ID, entries map[string]struct{}) map[string]api.ReadOnlyEntry
-	GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry
+	GetAuthorizedEntries(agentID spiffeid.ID) []api.ReadOnlyEntry
 }
 
 // Selector is a key-value attribute of a node or workload.
@@ -190,13 +189,13 @@ func (c *FullEntryCache) LookupAuthorizedEntries(agentID spiffeid.ID, requestedE
 }
 
 // GetAuthorizedEntries gets all authorized registration entries for a given Agent SPIFFE ID.
-func (c *FullEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
+func (c *FullEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []api.ReadOnlyEntry {
 	seen := allocSeenSet()
 	defer freeSeenSet(seen)
 
-	foundEntries := []*types.Entry{}
+	foundEntries := []api.ReadOnlyEntry{}
 	c.crawl(spiffeIDFromID(agentID), seen, func(entry *types.Entry) {
-		foundEntries = append(foundEntries, proto.Clone(entry).(*types.Entry))
+		foundEntries = append(foundEntries, api.NewReadOnlyEntry(entry))
 	})
 
 	return foundEntries

--- a/pkg/server/cache/entrycache/fullcache_ds.go
+++ b/pkg/server/cache/entrycache/fullcache_ds.go
@@ -23,8 +23,8 @@ var (
 )
 
 // BuildFromDataStore builds a Cache using the provided datastore as the data source
-func BuildFromDataStore(ctx context.Context, ds datastore.DataStore) (*FullEntryCache, error) {
-	return Build(ctx, makeEntryIteratorDS(ds), makeAgentIteratorDS(ds))
+func BuildFromDataStore(ctx context.Context, trustDomain string, ds datastore.DataStore) (*FullEntryCache, error) {
+	return Build(ctx, trustDomain, makeEntryIteratorDS(ds), makeAgentIteratorDS(ds))
 }
 
 type entryIteratorDS struct {

--- a/pkg/server/endpoints/authorized_entryfetcher.go
+++ b/pkg/server/endpoints/authorized_entryfetcher.go
@@ -8,7 +8,6 @@ import (
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/authorizedentries"
@@ -60,7 +59,7 @@ func (a *AuthorizedEntryFetcherWithEventsBasedCache) LookupAuthorizedEntries(ctx
 	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil
 }
 
-func (a *AuthorizedEntryFetcherWithEventsBasedCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
+func (a *AuthorizedEntryFetcherWithEventsBasedCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]api.ReadOnlyEntry, error) {
 	return a.cache.GetAuthorizedEntries(agentID), nil
 }
 

--- a/pkg/server/endpoints/authorized_entryfetcher.go
+++ b/pkg/server/endpoints/authorized_entryfetcher.go
@@ -56,7 +56,7 @@ func NewAuthorizedEntryFetcherWithEventsBasedCache(ctx context.Context, log logr
 	}, nil
 }
 
-func (a *AuthorizedEntryFetcherWithEventsBasedCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error) {
+func (a *AuthorizedEntryFetcherWithEventsBasedCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]api.ReadOnlyEntry, error) {
 	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil
 }
 

--- a/pkg/server/endpoints/authorized_entryfetcher_test.go
+++ b/pkg/server/endpoints/authorized_entryfetcher_test.go
@@ -411,8 +411,8 @@ func TestUpdateRegistrationEntriesCacheSkippedStartupEvents(t *testing.T) {
 	entries, err := ef.FetchAuthorizedEntries(ctx, agentID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
-	require.Equal(t, entry2.EntryId, entries[0].Id)
-	require.Equal(t, entry2.SpiffeId, idutil.RequireIDProtoString(entries[0].SpiffeId))
+	require.Equal(t, entry2.EntryId, entries[0].GetId())
+	require.Equal(t, entry2.SpiffeId, idutil.RequireIDProtoString(entries[0].GetSpiffeId()))
 
 	// Recreate First Registration Entry and delete the event associated with this create
 	entry1, err = ds.CreateRegistrationEntry(ctx, &common.RegistrationEntry{
@@ -438,8 +438,8 @@ func TestUpdateRegistrationEntriesCacheSkippedStartupEvents(t *testing.T) {
 	entries, err = ef.FetchAuthorizedEntries(ctx, agentID)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
-	require.Equal(t, entry2.EntryId, entries[0].Id)
-	require.Equal(t, entry2.SpiffeId, idutil.RequireIDProtoString(entries[0].SpiffeId))
+	require.Equal(t, entry2.EntryId, entries[0].GetId())
+	require.Equal(t, entry2.SpiffeId, idutil.RequireIDProtoString(entries[0].GetSpiffeId()))
 
 	// Add back in first event
 	err = ds.CreateRegistrationEntryEventForTesting(ctx, &datastore.RegistrationEntryEvent{
@@ -460,8 +460,8 @@ func TestUpdateRegistrationEntriesCacheSkippedStartupEvents(t *testing.T) {
 	entryIDs := make([]string, 0, 2)
 	spiffeIDs := make([]string, 0, 2)
 	for _, entry := range entries {
-		entryIDs = append(entryIDs, entry.Id)
-		spiffeIDs = append(spiffeIDs, idutil.RequireIDProtoString(entry.SpiffeId))
+		entryIDs = append(entryIDs, entry.GetId())
+		spiffeIDs = append(spiffeIDs, idutil.RequireIDProtoString(entry.GetSpiffeId()))
 	}
 	require.Contains(t, entryIDs, entry1.EntryId)
 	require.Contains(t, entryIDs, entry2.EntryId)
@@ -582,8 +582,8 @@ func TestUpdateAttestedNodesCacheSkippedEvents(t *testing.T) {
 	entries, err = ef.FetchAuthorizedEntries(ctx, agent2)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
-	require.Equal(t, entry.EntryId, entries[0].Id)
-	require.Equal(t, entry.SpiffeId, idutil.RequireIDProtoString(entries[0].SpiffeId))
+	require.Equal(t, entry.EntryId, entries[0].GetId())
+	require.Equal(t, entry.SpiffeId, idutil.RequireIDProtoString(entries[0].GetSpiffeId()))
 }
 
 func TestUpdateAttestedNodesCacheSkippedStartupEvents(t *testing.T) {
@@ -713,8 +713,8 @@ func TestUpdateAttestedNodesCacheSkippedStartupEvents(t *testing.T) {
 	entries, err = ef.FetchAuthorizedEntries(ctx, agent1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(entries))
-	require.Equal(t, entry.EntryId, entries[0].Id)
-	require.Equal(t, entry.SpiffeId, idutil.RequireIDProtoString(entries[0].SpiffeId))
+	require.Equal(t, entry.EntryId, entries[0].GetId())
+	require.Equal(t, entry.SpiffeId, idutil.RequireIDProtoString(entries[0].GetSpiffeId()))
 }
 
 // AgentsByIDCacheCount

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -146,7 +146,7 @@ func New(ctx context.Context, c Config) (*Endpoints, error) {
 		buildCacheFn := func(ctx context.Context) (_ entrycache.Cache, err error) {
 			call := telemetry.StartCall(c.Metrics, telemetry.Entry, telemetry.Cache, telemetry.Reload)
 			defer call.Done(&err)
-			return entrycache.BuildFromDataStore(ctx, c.Catalog.GetDataStore())
+			return entrycache.BuildFromDataStore(ctx, c.TrustDomain.String(), c.Catalog.GetDataStore())
 		}
 
 		efFullCache, err := NewAuthorizedEntryFetcherWithFullCache(ctx, buildCacheFn, c.Log, c.Clock, ds, c.CacheReloadInterval, c.PruneEventsOlderThan)

--- a/pkg/server/endpoints/endpoints_test.go
+++ b/pkg/server/endpoints/endpoints_test.go
@@ -195,7 +195,7 @@ func TestListenAndServe(t *testing.T) {
 	clk := clock.NewMock(t)
 
 	buildCacheFn := func(ctx context.Context) (entrycache.Cache, error) {
-		return entrycache.BuildFromDataStore(ctx, ds)
+		return entrycache.BuildFromDataStore(ctx, testTD.String(), ds)
 	}
 
 	ef, err := NewAuthorizedEntryFetcherWithFullCache(context.Background(), buildCacheFn, log, clk, ds, defaultCacheReloadInterval, defaultPruneEventsOlderThan)

--- a/pkg/server/endpoints/entryfetcher.go
+++ b/pkg/server/endpoints/entryfetcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
-	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/cache/entrycache"
 	"github.com/spiffe/spire/pkg/server/datastore"
@@ -55,7 +54,7 @@ func (a *AuthorizedEntryFetcherWithFullCache) LookupAuthorizedEntries(ctx contex
 	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil
 }
 
-func (a *AuthorizedEntryFetcherWithFullCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]*types.Entry, error) {
+func (a *AuthorizedEntryFetcherWithFullCache) FetchAuthorizedEntries(_ context.Context, agentID spiffeid.ID) ([]api.ReadOnlyEntry, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.cache.GetAuthorizedEntries(agentID), nil

--- a/pkg/server/endpoints/entryfetcher.go
+++ b/pkg/server/endpoints/entryfetcher.go
@@ -49,7 +49,7 @@ func NewAuthorizedEntryFetcherWithFullCache(ctx context.Context, buildCache entr
 	}, nil
 }
 
-func (a *AuthorizedEntryFetcherWithFullCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]*types.Entry, error) {
+func (a *AuthorizedEntryFetcherWithFullCache) LookupAuthorizedEntries(ctx context.Context, agentID spiffeid.ID, entryIDs map[string]struct{}) (map[string]api.ReadOnlyEntry, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.cache.LookupAuthorizedEntries(agentID, entryIDs), nil

--- a/pkg/server/endpoints/entryfetcher_test.go
+++ b/pkg/server/endpoints/entryfetcher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/common/protoutil"
 	"github.com/spiffe/spire/pkg/server/api"
 	"github.com/spiffe/spire/pkg/server/cache/entrycache"
 	"github.com/spiffe/spire/proto/spire/common"
@@ -39,8 +40,12 @@ func (f *staticEntryCache) LookupAuthorizedEntries(agentID spiffeid.ID, _ map[st
 	return entriesMap
 }
 
-func (sef *staticEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []*types.Entry {
-	return sef.entries[agentID]
+func (sef *staticEntryCache) GetAuthorizedEntries(agentID spiffeid.ID) []api.ReadOnlyEntry {
+	entries := []api.ReadOnlyEntry{}
+	for _, entry := range sef.entries[agentID] {
+		entries = append(entries, api.NewReadOnlyEntry(entry))
+	}
+	return entries
 }
 
 func newStaticEntryCache(entries map[spiffeid.ID][]*types.Entry) *staticEntryCache {
@@ -80,6 +85,14 @@ func TestNewAuthorizedEntryFetcherWithFullCacheErrorBuildingCache(t *testing.T) 
 	assert.Nil(t, ef)
 }
 
+func entriesFromReadOnlyEntries(readOnlyEntries []api.ReadOnlyEntry) []*types.Entry {
+	entries := []*types.Entry{}
+	for _, readOnlyEntry := range readOnlyEntries {
+		entries = append(entries, readOnlyEntry.Clone(protoutil.AllTrueEntryMask))
+	}
+	return entries
+}
+
 func TestFetchRegistrationEntries(t *testing.T) {
 	ctx := context.Background()
 	log, _ := test.NewNullLogger()
@@ -102,7 +115,7 @@ func TestFetchRegistrationEntries(t *testing.T) {
 
 	entries, err := ef.FetchAuthorizedEntries(ctx, agentID)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, entries)
+	assert.Equal(t, expected, entriesFromReadOnlyEntries(entries))
 }
 
 func TestRunRebuildCacheTask(t *testing.T) {
@@ -228,7 +241,7 @@ func TestRunRebuildCacheTask(t *testing.T) {
 	req = waitForRequest()
 	entries, err = ef.FetchAuthorizedEntries(ctx, agentID)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEntries, entries)
+	assert.Equal(t, expectedEntries, entriesFromReadOnlyEntries(entries))
 	sendResult(req, entryMap, nil)
 }
 

--- a/pkg/server/endpoints/entryfetcher_test.go
+++ b/pkg/server/endpoints/entryfetcher_test.go
@@ -28,12 +28,12 @@ type staticEntryCache struct {
 	entries map[spiffeid.ID][]*types.Entry
 }
 
-func (f *staticEntryCache) LookupAuthorizedEntries(agentID spiffeid.ID, _ map[string]struct{}) map[string]*types.Entry {
+func (f *staticEntryCache) LookupAuthorizedEntries(agentID spiffeid.ID, _ map[string]struct{}) map[string]api.ReadOnlyEntry {
 	entries := f.entries[agentID]
 
-	entriesMap := make(map[string]*types.Entry)
+	entriesMap := make(map[string]api.ReadOnlyEntry)
 	for _, entry := range entries {
-		entriesMap[entry.GetId()] = entry
+		entriesMap[entry.GetId()] = api.NewReadOnlyEntry(entry)
 	}
 
 	return entriesMap

--- a/pkg/server/endpoints/middleware_test.go
+++ b/pkg/server/endpoints/middleware_test.go
@@ -59,7 +59,7 @@ func TestAuthorizedEntryFetcherWithFullCache(t *testing.T) {
 
 	entries, err := f.FetchAuthorizedEntries(context.Background(), agentID)
 	assert.NoError(t, err)
-	assert.ElementsMatch(t, expectedEntries, entries)
+	assert.ElementsMatch(t, expectedEntries, entriesFromReadOnlyEntries(entries))
 }
 
 func TestAgentAuthorizer(t *testing.T) {


### PR DESCRIPTION
This does a bunch of speedups to authorized entries lookup (used for syncing agent entries but also for signing SVIDs):
* Make the caches return a new type, ReadOnlyEntry. This delays the clone of the entry from the cache until we actually need to clone it. Useful for SyncAuthorizedEntries where we retrieve all entries that the agent is authorized for but would only need to clone a few of them that we actually send to the agent. Also useful for signing SVIDs which can clone just the fields of the entry that are used.
* Switch from proto.Clone to our own Clone method. This allows us to combine cloning with output mask application, which avoid cloning some fields. This is also 1.5-2x faster than proto.Clone
* The entry cache can use just the path component of the entry when storing entries in the cache. This avoid some unnecessary work, which was seen in spire-server cpu profile data.

Some of the benchmarks we have in the tests show good improvements. Seen improvements also while running this, although somewhat smaller than the benchmark since some of the work still needs to be done in other places. Before:
```
BenchmarkBuildInMemory-16                             55          21637647 ns/op        14817260 B/op     100311 allocs/op
BenchmarkGetAuthorizedEntriesInMemory-16            5833            205069 ns/op          291966 B/op       3005 allocs/op
BenchmarkEntryLookup-16                               46          25513459 ns/op         5123503 B/op     136200 allocs/op
```

and after:
```
BenchmarkBuildInMemory-16                             54          19256267 ns/op         9915763 B/op     100310 allocs/op
BenchmarkGetAuthorizedEntriesInMemory-16           64569             17356 ns/op            9338 B/op         10 allocs/op
BenchmarkEntryLookup-16                              100          11445476 ns/op          156498 B/op       1536 allocs/op
```

For the events based cache. Before:
```
BenchmarkGetAuthorizedEntriesInMemory-16            9115            131016 ns/op          205207 B/op       1513 allocs/op
BenchmarkEntryLookup-16                               57          18919070 ns/op          209983 B/op       2461 allocs/op
```

and after:
```
BenchmarkGetAuthorizedEntriesInMemory-16           23606             50479 ns/op           68260 B/op         13 allocs/op
BenchmarkEntryLookup-16                               62          17778846 ns/op           91850 B/op       1180 allocs/op
```