### PR TITLE
Fix metrics/health checks when retry_bootstrap=true

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -45,7 +45,8 @@ const (
 )
 
 type Agent struct {
-	c *Config
+	c       *Config
+	started bool
 }
 
 // Run the agent
@@ -97,6 +98,15 @@ func (a *Agent) Run(ctx context.Context) error {
 	defer cat.Close()
 
 	healthChecker := health.NewChecker(a.c.HealthChecks, a.c.Log)
+	if err := healthChecker.AddCheck("agent", a); err != nil {
+		return fmt.Errorf("failed adding healthcheck: %w", err)
+	}
+	tasks := []func(context.Context) error{
+		healthChecker.ListenAndServe,
+		metrics.ListenAndServe,
+	}
+	taskRunner := util.NewTaskRunner(ctx)
+	taskRunner.StartTasks(tasks...)
 
 	nodeAttestor := nodeattestor.JoinToken(a.c.Log, a.c.JoinToken)
 	if a.c.JoinToken == "" {
@@ -163,17 +173,12 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	endpoints := a.newEndpoints(metrics, manager, workloadAttestor)
 
-	if err := healthChecker.AddCheck("agent", a); err != nil {
-		return fmt.Errorf("failed adding healthcheck: %w", err)
-	}
-
-	tasks := []func(context.Context) error{
+	a.started = true
+	tasks = []func(context.Context) error{
 		manager.Run,
 		storeService.Run,
 		endpoints.ListenAndServe,
-		metrics.ListenAndServe,
 		catalog.ReconfigureTask(a.c.Log.WithField(telemetry.SubsystemName, "reconfigurer"), cat),
-		healthChecker.ListenAndServe,
 	}
 
 	if a.c.AdminBindAddress != nil {
@@ -185,7 +190,8 @@ func (a *Agent) Run(ctx context.Context) error {
 		tasks = append(tasks, a.c.LogReopener)
 	}
 
-	err = util.RunTasks(ctx, tasks...)
+	taskRunner.StartTasks(tasks...)
+	err = taskRunner.Wait()
 	if errors.Is(err, context.Canceled) {
 		err = nil
 	}
@@ -396,13 +402,14 @@ func (a *Agent) CheckHealth() health.State {
 	// for the X509SVID service.
 	// TODO: Better live check for agent.
 	return health.State{
-		Ready: err == nil,
-		Live:  err == nil,
+		Started: &a.started,
+		Ready:   err == nil,
+		Live:    (a.started || err == nil),
 		ReadyDetails: agentHealthDetails{
-			WorkloadAPIErr: errString(err),
+			WorkloadAPIErr: errString(false, err),
 		},
 		LiveDetails: agentHealthDetails{
-			WorkloadAPIErr: errString(err),
+			WorkloadAPIErr: errString(!a.started, err),
 		},
 	}
 }
@@ -426,7 +433,10 @@ type agentHealthDetails struct {
 	WorkloadAPIErr string `json:"make_new_x509_err,omitempty"`
 }
 
-func errString(err error) string {
+func errString(suppress bool, err error) string {
+	if suppress {
+		return ""
+	}
 	if err != nil {
 		return err.Error()
 	}

--- a/pkg/common/health/cache.go
+++ b/pkg/common/health/cache.go
@@ -110,6 +110,7 @@ func (c *cache) start(ctx context.Context) error {
 
 func (c *cache) startRunner(ctx context.Context) {
 	c.log.Debug("Initializing health checkers")
+	seenStartupError := make(map[string]string)
 	checkFunc := func() {
 		for name, checker := range c.getCheckerSubsystems() {
 			state, err := verifyStatus(checker.checkable)
@@ -119,9 +120,19 @@ func (c *cache) startRunner(ctx context.Context) {
 				checkTime: c.clk.Now(),
 			}
 			if err != nil {
-				c.log.WithField("check", name).
-					WithError(err).
-					Error("Health check has failed")
+				if state.Started == nil || *state.Started {
+					c.log.WithField("check", name).
+						WithError(err).
+						Error("Health check has failed")
+				} else {
+					strErr := err.Error()
+					if val, ok := seenStartupError[name]; !ok || val != strErr {
+						c.log.WithField("check", name).
+							WithError(err).
+							Warn("Health check has failed. Starting up still.")
+						seenStartupError[name] = strErr
+					}
+				}
 				checkState.err = err
 			}
 

--- a/pkg/common/health/cache_test.go
+++ b/pkg/common/health/cache_test.go
@@ -106,7 +106,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check failed",
 				Data: logrus.Fields{
 					telemetry.Check:   "bar",
-					telemetry.Details: "{false false {} {}}",
+					telemetry.Details: "{<nil> false false {} {}}",
 					telemetry.Error:   "subsystem is not live or ready",
 				},
 			},
@@ -163,7 +163,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check recovered",
 				Data: logrus.Fields{
 					telemetry.Check:    "bar",
-					telemetry.Details:  "{true true {} {}}",
+					telemetry.Details:  "{<nil> true true {} {}}",
 					telemetry.Duration: "1",
 					telemetry.Error:    "subsystem is not live or ready",
 					telemetry.Failures: "1",
@@ -251,7 +251,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check failed",
 				Data: logrus.Fields{
 					telemetry.Check:   "foo",
-					telemetry.Details: "{false false {live is failing} {ready is failing}}",
+					telemetry.Details: "{<nil> false false {live is failing} {ready is failing}}",
 					telemetry.Error:   "subsystem is not live or ready",
 				},
 			},
@@ -354,7 +354,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check recovered",
 				Data: logrus.Fields{
 					telemetry.Check:    "foo",
-					telemetry.Details:  "{true true {} {}}",
+					telemetry.Details:  "{<nil> true true {} {}}",
 					telemetry.Duration: "120",
 					telemetry.Error:    "subsystem is not live or ready",
 					telemetry.Failures: "2",

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -20,6 +20,10 @@ const (
 
 // State is the health state of a subsystem.
 type State struct {
+	// Started is whether the subsystem is finished starting.
+	// if undefined, it is treated as started=true.
+	Started *bool
+
 	// Live is whether the subsystem is live (i.e. in a good state
 	// or in a state it can recover from while remaining alive). Global
 	// liveness is only reported true if all subsystems report live.
@@ -134,27 +138,37 @@ func (c *checker) ListenAndServe(ctx context.Context) error {
 	return nil
 }
 
+// StartedState returns the global startup state.
+func (c *checker) StartedState() bool {
+	startup, _, _, _, _ := c.checkStates()
+
+	return startup
+}
+
 // LiveState returns the global live state and details.
 func (c *checker) LiveState() (bool, any) {
-	live, _, details, _ := c.checkStates()
+	_, live, _, details, _ := c.checkStates()
 
 	return live, details
 }
 
 // ReadyState returns the global ready state and details.
 func (c *checker) ReadyState() (bool, any) {
-	_, ready, _, details := c.checkStates()
+	_, _, ready, _, details := c.checkStates()
 
 	return ready, details
 }
 
-func (c *checker) checkStates() (bool, bool, any, any) {
-	isLive, isReady := true, true
+func (c *checker) checkStates() (bool, bool, bool, any, any) {
+	isStarted, isLive, isReady := true, true, true
 
 	liveDetails := make(map[string]any)
 	readyDetails := make(map[string]any)
 	for subsystemName, subsystemState := range c.cache.getStatuses() {
 		state := subsystemState.details
+		if state.Started == nil || !*state.Started {
+			isStarted = false
+		}
 		if !state.Live {
 			isLive = false
 		}
@@ -167,7 +181,7 @@ func (c *checker) checkStates() (bool, bool, any, any) {
 		readyDetails[subsystemName] = state.ReadyDetails
 	}
 
-	return isLive, isReady, liveDetails, readyDetails
+	return isStarted, isLive, isReady, liveDetails, readyDetails
 }
 
 func (c *checker) liveHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/common/util/task.go
+++ b/pkg/common/util/task.go
@@ -7,6 +7,68 @@ import (
 	"sync"
 )
 
+type TaskRunner struct {
+	wg        sync.WaitGroup
+	ctx       context.Context
+	cancels   []context.CancelFunc
+	errch     chan error
+	taskCount int
+}
+
+func NewTaskRunner(ctx context.Context) *TaskRunner {
+	return &TaskRunner{
+		ctx:   ctx,
+		errch: make(chan error, 1),
+	}
+}
+
+func (t *TaskRunner) StartTasks(tasks ...func(context.Context) error) {
+	ctx, cancel := context.WithCancel(t.ctx)
+	t.cancels = append(t.cancels, cancel)
+
+	runTask := func(task func(context.Context) error) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack()))
+			}
+			t.wg.Done()
+		}()
+		return task(ctx)
+	}
+
+	lenTasks := len(tasks)
+	t.taskCount += lenTasks
+	t.wg.Add(lenTasks)
+	for _, task := range tasks {
+		go func() {
+			t.errch <- runTask(task)
+		}()
+	}
+}
+
+func (t *TaskRunner) Wait() error {
+	defer func() {
+		for _, cancel := range t.cancels {
+			cancel()
+		}
+		t.wg.Wait()
+	}()
+
+	for complete := 0; complete < t.taskCount; {
+		select {
+		case <-t.ctx.Done():
+			return t.ctx.Err()
+		case err := <-t.errch:
+			if err != nil {
+				return err
+			}
+			complete++
+		}
+	}
+
+	return nil
+}
+
 // RunTasks executes all the provided functions concurrently and waits for
 // them all to complete. If a function returns an error, all other functions
 // are canceled (i.e. the context they are passed is canceled) and the error is
@@ -16,45 +78,9 @@ import (
 // RunTasks MUST support cancellation via the provided context for RunTasks to
 // work properly.
 func RunTasks(ctx context.Context, tasks ...func(context.Context) error) error {
-	var wg sync.WaitGroup
-	ctx, cancel := context.WithCancel(ctx)
-	defer func() {
-		cancel()
-		wg.Wait()
-	}()
-
-	errch := make(chan error, len(tasks))
-
-	runTask := func(task func(context.Context) error) (err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack()))
-			}
-			wg.Done()
-		}()
-		return task(ctx)
-	}
-
-	wg.Add(len(tasks))
-	for _, task := range tasks {
-		go func() {
-			errch <- runTask(task)
-		}()
-	}
-
-	for complete := 0; complete < len(tasks); {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case err := <-errch:
-			if err != nil {
-				return err
-			}
-			complete++
-		}
-	}
-
-	return nil
+	t := NewTaskRunner(ctx)
+	t.StartTasks(tasks...)
+	return t.Wait()
 }
 
 // SerialRun executes all the provided functions serially.


### PR DESCRIPTION

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] ~~Documentation updated?~~

**Affected functionality**
When retry_bootstrap is true, during the startup/retrying, health checks / metrics are not started. This time is currently is capped at 5 minutes, requiring fairly long health check delays on Kubernetes, and no ability to collect metrics on what its doing.

**Which issue this PR fixes**
fixes: https://github.com/spiffe/spire/issues/6051
