### PR TITLE
Only update stored keys after successfully publishing update

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/spire.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire.go
@@ -243,14 +243,14 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(req *upstreamauthorityv1.PublishJWTKe
 		newKeys := p.getBundle().JwtAuthorities
 		// Send response when new JWT authority
 		if !arePublicKeysEqual(keys, newKeys) {
-			keys = newKeys
 			err := stream.Send(&upstreamauthorityv1.PublishJWTKeyResponse{
-				UpstreamJwtKeys: keys,
+				UpstreamJwtKeys: newKeys,
 			})
 			if err != nil {
 				p.log.Error("Cannot send upstream JWT keys", "error", err)
 				return err
 			}
+			keys = newKeys
 		}
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
Noticed this while looking over https://github.com/spiffe/spire/issues/6083. I don't know if that's the issue there, but it does seem like an issue.