### PR TITLE
Use UpstreamAuthority.SubscribeToLocalBundle RPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spiffe/go-spiffe/v2 v2.5.0
 	github.com/spiffe/spire-api-sdk v1.2.5-0.20250109200630-101d5e7de758
-	github.com/spiffe/spire-plugin-sdk v1.4.4-0.20240701180828-594312f4444d
+	github.com/spiffe/spire-plugin-sdk v1.4.4-0.20250606112051-68609d83ce7c
 	github.com/stretchr/testify v1.10.0
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/valyala/fastjson v1.6.4

--- a/go.sum
+++ b/go.sum
@@ -1662,8 +1662,8 @@ github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8W
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20250109200630-101d5e7de758 h1:7zZbXRN0z8IFjx8CQbkK25nypdaFq+ntCiRQGTNfdvY=
 github.com/spiffe/spire-api-sdk v1.2.5-0.20250109200630-101d5e7de758/go.mod h1:4uuhFlN6KBWjACRP3xXwrOTNnvaLp1zJs8Lribtr4fI=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20240701180828-594312f4444d h1:Upcyq8u1aWFHTQSEskwxBE2PehobpY+M21LXXDS/mPw=
-github.com/spiffe/spire-plugin-sdk v1.4.4-0.20240701180828-594312f4444d/go.mod h1:GA6o2PVLwyJdevT6KKt5ZXCY/ziAPna13y/seGk49Ik=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20250606112051-68609d83ce7c h1:Y2C0USw8YgFfzZpt/Tm+dYuf0swSbcDy5sOF7FHtCyE=
+github.com/spiffe/spire-plugin-sdk v1.4.4-0.20250606112051-68609d83ce7c/go.mod h1:GA6o2PVLwyJdevT6KKt5ZXCY/ziAPna13y/seGk49Ik=
 github.com/ssgreg/nlreturn/v2 v2.2.1 h1:X4XDI7jstt3ySqGU86YGAURbxw3oTDPK9sPEi6YEwQ0=
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/stbenjam/no-sprintf-host-port v0.2.0 h1:i8pxvGrt1+4G0czLr/WnmyH7zbZ8Bg8etvARQ1rpyl4=

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -453,14 +453,21 @@ func (m *Manager) SubscribeToLocalBundle(ctx context.Context) error {
 		return nil
 	}
 
-	err := m.upstreamClient.SubscribeToLocalBundle(ctx)
-	switch {
-	case status.Code(err) == codes.Unimplemented:
-		return nil
-	case err != nil:
-		return err
-	default:
-		return nil
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			err := m.upstreamClient.SubscribeToLocalBundle(ctx)
+			switch {
+			case status.Code(err) == codes.Unimplemented:
+				return nil
+			case err != nil:
+				return err
+			default:
+				return nil
+			}
+		}
 	}
 }
 

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -71,6 +71,7 @@ type AuthorityManager interface {
 	IsUpstreamAuthority() bool
 	PublishJWTKey(ctx context.Context, jwtKey *common.PublicKey) ([]*common.PublicKey, error)
 	NotifyTaintedX509Authority(ctx context.Context, authorityID string) error
+	SubscribeToLocalBundle(ctx context.Context) error
 }
 
 type Config struct {
@@ -445,6 +446,22 @@ func (m *Manager) PublishJWTKey(ctx context.Context, jwtKey *common.PublicKey) (
 	}
 
 	return bundle.JwtSigningKeys, nil
+}
+
+func (m *Manager) SubscribeToLocalBundle(ctx context.Context) error {
+	if m.upstreamClient == nil {
+		return nil
+	}
+
+	err := m.upstreamClient.SubscribeToLocalBundle(ctx)
+	switch {
+	case status.Code(err) == codes.Unimplemented:
+		return nil
+	case err != nil:
+		return err
+	default:
+		return nil
+	}
 }
 
 func (m *Manager) PruneBundle(ctx context.Context) (err error) {

--- a/pkg/server/ca/rotator/rotator.go
+++ b/pkg/server/ca/rotator/rotator.go
@@ -37,6 +37,8 @@ type CAManager interface {
 	ActivateJWTKey(ctx context.Context)
 	RotateJWTKey(ctx context.Context)
 
+	SubscribeToLocalBundle(ctx context.Context) error
+
 	PruneBundle(ctx context.Context) error
 	PruneCAJournals(ctx context.Context) error
 }
@@ -77,9 +79,24 @@ func (r *Rotator) Run(ctx context.Context) error {
 	if err := r.c.Manager.NotifyBundleLoaded(ctx); err != nil {
 		return err
 	}
+
 	err := util.RunTasks(ctx,
 		func(ctx context.Context) error {
 			return r.rotateEvery(ctx, rotateInterval)
+		},
+		func(ctx context.Context) error {
+			var lastError error
+			for {
+				select {
+				case <-ctx.Done():
+					return lastError
+				case <-time.After(5 * time.Second):
+					lastError = r.c.Manager.SubscribeToLocalBundle(ctx)
+					if lastError == nil {
+						return nil
+					}
+				}
+			}
 		},
 		func(ctx context.Context) error {
 			return r.pruneBundleEvery(ctx, pruneBundleInterval)

--- a/pkg/server/ca/rotator/rotator.go
+++ b/pkg/server/ca/rotator/rotator.go
@@ -85,18 +85,7 @@ func (r *Rotator) Run(ctx context.Context) error {
 			return r.rotateEvery(ctx, rotateInterval)
 		},
 		func(ctx context.Context) error {
-			var lastError error
-			for {
-				select {
-				case <-ctx.Done():
-					return lastError
-				case <-time.After(5 * time.Second):
-					lastError = r.c.Manager.SubscribeToLocalBundle(ctx)
-					if lastError == nil {
-						return nil
-					}
-				}
-			}
+			return r.c.Manager.SubscribeToLocalBundle(ctx)
 		},
 		func(ctx context.Context) error {
 			return r.pruneBundleEvery(ctx, pruneBundleInterval)

--- a/pkg/server/ca/rotator/rotator_test.go
+++ b/pkg/server/ca/rotator/rotator_test.go
@@ -506,6 +506,10 @@ func (f *fakeCAManager) RotateJWTKey(context.Context) {
 	f.jwtKeyCh <- struct{}{}
 }
 
+func (f *fakeCAManager) SubscribeToLocalBundle(ctx context.Context) error {
+	return nil
+}
+
 func (f *fakeCAManager) PruneBundle(context.Context) error {
 	defer func() {
 		f.pruneBundleCh <- struct{}{}

--- a/pkg/server/ca/upstream_client_test.go
+++ b/pkg/server/ca/upstream_client_test.go
@@ -151,6 +151,43 @@ func TestUpstreamClientPublishJWTKey_NotImplemented(t *testing.T) {
 	require.Nil(t, jwtKeys)
 }
 
+func TestUpstreamClientSubscribeToLocalBundle(t *testing.T) {
+	client, updater, ua := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+		TrustDomain:               trustDomain,
+		UseSubscribeToLocalBundle: true,
+	})
+
+	err := client.SubscribeToLocalBundle(t.Context())
+	require.NoError(t, err)
+
+	// We should get an update with the initial CA and a list of empty JWT keys since
+	// the fakeupstreamauthority does not create one by default.
+	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
+	spiretest.RequireProtoListEqual(t, []*common.PublicKey{}, updater.WaitForAppendedJWTKeys(t))
+
+	// Trigger an update to the upstream bundle by rotating the root
+	// certificate and wait for the bundle updater to receive the update.
+	ua.RotateX509CA()
+	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
+	spiretest.RequireProtoListEqual(t, []*common.PublicKey{}, updater.WaitForAppendedJWTKeys(t))
+
+	key1 := makePublicKey(t, "KEY1")
+	ua.AppendJWTKey(key1)
+	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
+	spiretest.RequireProtoListEqual(t, []*common.PublicKey{key1}, updater.WaitForAppendedJWTKeys(t))
+
+	// Trigger an update to the upstream bundle by rotating the root
+	// certificate and wait for the bundle updater to receive the update.
+	ua.RotateX509CA()
+	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
+	spiretest.RequireProtoListEqual(t, []*common.PublicKey{key1}, updater.WaitForAppendedJWTKeys(t))
+
+	key2 := makePublicKey(t, "KEY2")
+	ua.AppendJWTKey(key2)
+	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
+	spiretest.RequireProtoListEqual(t, []*common.PublicKey{key1, key2}, updater.WaitForAppendedJWTKeys(t))
+}
+
 func setUpUpstreamClientTest(t *testing.T, config fakeupstreamauthority.Config) (*ca.UpstreamClient, *fakeBundleUpdater, *fakeupstreamauthority.UpstreamAuthority) {
 	plugin, upstreamAuthority := fakeupstreamauthority.Load(t, config)
 	updater := newFakeBundleUpdater()

--- a/pkg/server/ca/upstream_client_test.go
+++ b/pkg/server/ca/upstream_client_test.go
@@ -31,7 +31,7 @@ var (
 )
 
 func TestUpstreamClientMintX509CA_HandlesBundleUpdates(t *testing.T) {
-	client, updater, ua := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+	client, updater, ua := setupUpstreamClientTest(t, fakeupstreamauthority.Config{
 		TrustDomain:     trustDomain,
 		UseIntermediate: true,
 	})
@@ -101,7 +101,7 @@ func TestUpstreamClientMintX509CA_FailsOnBadFirstResponse(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			client, _, _ := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+			client, _, _ := setupUpstreamClientTest(t, fakeupstreamauthority.Config{
 				TrustDomain:              trustDomain,
 				MutateMintX509CAResponse: tt.mutate,
 			})
@@ -120,7 +120,7 @@ func TestUpstreamClientMintX509CA_FailsOnBadFirstResponse(t *testing.T) {
 }
 
 func TestUpstreamClientPublishJWTKey_HandlesBundleUpdates(t *testing.T) {
-	client, updater, ua := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+	client, updater, ua := setupUpstreamClientTest(t, fakeupstreamauthority.Config{
 		TrustDomain: trustDomain,
 	})
 
@@ -141,7 +141,7 @@ func TestUpstreamClientPublishJWTKey_HandlesBundleUpdates(t *testing.T) {
 }
 
 func TestUpstreamClientPublishJWTKey_NotImplemented(t *testing.T) {
-	client, _, _ := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+	client, _, _ := setupUpstreamClientTest(t, fakeupstreamauthority.Config{
 		TrustDomain:           trustDomain,
 		DisallowPublishJWTKey: true,
 	})
@@ -152,7 +152,7 @@ func TestUpstreamClientPublishJWTKey_NotImplemented(t *testing.T) {
 }
 
 func TestUpstreamClientSubscribeToLocalBundle(t *testing.T) {
-	client, updater, ua := setUpUpstreamClientTest(t, fakeupstreamauthority.Config{
+	client, updater, ua := setupUpstreamClientTest(t, fakeupstreamauthority.Config{
 		TrustDomain:               trustDomain,
 		UseSubscribeToLocalBundle: true,
 	})
@@ -163,13 +163,13 @@ func TestUpstreamClientSubscribeToLocalBundle(t *testing.T) {
 	// We should get an update with the initial CA and a list of empty JWT keys since
 	// the fakeupstreamauthority does not create one by default.
 	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
-	spiretest.RequireProtoListEqual(t, []*common.PublicKey{}, updater.WaitForAppendedJWTKeys(t))
+	require.Empty(t, updater.WaitForAppendedJWTKeys(t))
 
 	// Trigger an update to the upstream bundle by rotating the root
 	// certificate and wait for the bundle updater to receive the update.
 	ua.RotateX509CA()
 	require.Equal(t, ua.X509Roots(), updater.WaitForAppendedX509Roots(t))
-	spiretest.RequireProtoListEqual(t, []*common.PublicKey{}, updater.WaitForAppendedJWTKeys(t))
+	require.Empty(t, updater.WaitForAppendedJWTKeys(t))
 
 	key1 := makePublicKey(t, "KEY1")
 	ua.AppendJWTKey(key1)
@@ -188,7 +188,7 @@ func TestUpstreamClientSubscribeToLocalBundle(t *testing.T) {
 	spiretest.RequireProtoListEqual(t, []*common.PublicKey{key1, key2}, updater.WaitForAppendedJWTKeys(t))
 }
 
-func setUpUpstreamClientTest(t *testing.T, config fakeupstreamauthority.Config) (*ca.UpstreamClient, *fakeBundleUpdater, *fakeupstreamauthority.UpstreamAuthority) {
+func setupUpstreamClientTest(t *testing.T, config fakeupstreamauthority.Config) (*ca.UpstreamClient, *fakeBundleUpdater, *fakeupstreamauthority.UpstreamAuthority) {
 	plugin, upstreamAuthority := fakeupstreamauthority.Load(t, config)
 	updater := newFakeBundleUpdater()
 

--- a/pkg/server/plugin/upstreamauthority/awspca/pca.go
+++ b/pkg/server/plugin/upstreamauthority/awspca/pca.go
@@ -311,6 +311,10 @@ func (*PCAPlugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyRe
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *PCAPlugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func (p *PCAPlugin) getConfig() (*configuration, error) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()

--- a/pkg/server/plugin/upstreamauthority/awssecret/awssecret.go
+++ b/pkg/server/plugin/upstreamauthority/awssecret/awssecret.go
@@ -196,6 +196,10 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyReq
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func (p *Plugin) loadUpstreamCAAndCerts(trustDomain spiffeid.TrustDomain, keyPEMstr, certsPEMstr, bundleCertsPEMstr string) (*x509svid.UpstreamCA, []*x509.Certificate, []*x509.Certificate, error) {
 	key, err := pemutil.ParsePrivateKey([]byte(keyPEMstr))
 	if err != nil {

--- a/pkg/server/plugin/upstreamauthority/certmanager/certmanager.go
+++ b/pkg/server/plugin/upstreamauthority/certmanager/certmanager.go
@@ -261,6 +261,10 @@ func (*Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyReque
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func newCertManagerClient(configPath string) (client.Client, error) {
 	config, err := getKubeConfig(configPath)
 	if err != nil {

--- a/pkg/server/plugin/upstreamauthority/disk/disk.go
+++ b/pkg/server/plugin/upstreamauthority/disk/disk.go
@@ -157,6 +157,10 @@ func (*Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyReque
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func (p *Plugin) reloadCA() (*x509svid.UpstreamCA, *caCerts, error) {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()

--- a/pkg/server/plugin/upstreamauthority/ejbca/ejbca.go
+++ b/pkg/server/plugin/upstreamauthority/ejbca/ejbca.go
@@ -319,8 +319,12 @@ func (p *Plugin) MintX509CAAndSubscribe(req *upstreamauthorityv1.MintX509CAReque
 }
 
 // The EJBCA UpstreamAuthority plugin does not support publishing JWT keys.
-func (p *Plugin) PublishJWTKeyAndSubscribe(_ *upstreamauthorityv1.PublishJWTKeyRequest, _ upstreamauthorityv1.UpstreamAuthority_PublishJWTKeyAndSubscribeServer) error {
+func (p *Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyRequest, upstreamauthorityv1.UpstreamAuthority_PublishJWTKeyAndSubscribeServer) error {
 	return status.Error(codes.Unimplemented, "publishing JWT keys is not supported by the EJBCA UpstreamAuthority plugin")
+}
+
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
 }
 
 // setConfig replaces the configuration atomically under a write lock.

--- a/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
+++ b/pkg/server/plugin/upstreamauthority/gcpcas/gcpcas.go
@@ -164,6 +164,10 @@ func (p *Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyReq
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func (p *Plugin) Configure(_ context.Context, req *configv1.ConfigureRequest) (*configv1.ConfigureResponse, error) {
 	// Parse HCL config payload into config struct
 	newConfig, _, err := pluginconf.Build(req, buildConfig)

--- a/pkg/server/plugin/upstreamauthority/upstreamauthority.go
+++ b/pkg/server/plugin/upstreamauthority/upstreamauthority.go
@@ -33,7 +33,7 @@ type UpstreamAuthority interface {
 	// will return io.EOF when called.
 	PublishJWTKey(ctx context.Context, jwtKey *common.PublicKey) (jwtAuthorities []*common.PublicKey, stream UpstreamJWTAuthorityStream, err error)
 
-	// GetUpstreamAuthorities can be used to sync the local trust bundle with
+	// SubscribeToLocalBundle can be used to sync the local trust bundle with
 	// the upstream trust bundle.
 	// Support for this method is optional but strongly recommended.
 	// The function returns the latest set of upstream authorities and a

--- a/pkg/server/plugin/upstreamauthority/upstreamauthority.go
+++ b/pkg/server/plugin/upstreamauthority/upstreamauthority.go
@@ -32,6 +32,16 @@ type UpstreamAuthority interface {
 	// the upstream authority does not support streaming updates, the stream
 	// will return io.EOF when called.
 	PublishJWTKey(ctx context.Context, jwtKey *common.PublicKey) (jwtAuthorities []*common.PublicKey, stream UpstreamJWTAuthorityStream, err error)
+
+	// GetUpstreamAuthorities can be used to sync the local trust bundle with
+	// the upstream trust bundle.
+	// Support for this method is optional but strongly recommended.
+	// The function returns the latest set of upstream authorities and a
+	// stream for streaming upstream authority updates. The returned stream
+	// MUST be closed when the caller is no longer interested in updates. If
+	// the upstream authority does not support streaming updates, the stream
+	// will return io.EOF when called.
+	SubscribeToLocalBundle(ctx context.Context) (x509CAs []*x509certificate.X509Authority, jwtAuthorities []*common.PublicKey, stream LocalBundleUpdateStream, err error)
 }
 
 type UpstreamX509AuthorityStream interface {
@@ -48,14 +58,27 @@ type UpstreamX509AuthorityStream interface {
 }
 
 type UpstreamJWTAuthorityStream interface {
-	// RecvUpstreamJWTAuthorities returns the latest set of upstream X.509
+	// RecvUpstreamJWTAuthorities returns the latest set of upstream JWT
 	// authorities. The call blocks until the update is received, the Close()
-	// method is called, or the context originally passed into MintX509CA is
+	// method is called, or the context originally passed into PublishJWTKey is
 	// canceled. If the function returns an error, no more updates will be
 	// available over the stream.
 	RecvUpstreamJWTAuthorities() ([]*common.PublicKey, error)
 
 	// Close() closes the stream. It MUST be called by callers of PublishJWTKey
+	// when they are done with the stream.
+	Close()
+}
+
+type LocalBundleUpdateStream interface {
+	// RecvLocalBundleUpdate returns the latest local trust domain bundle
+	// The call blocks until the update is received, the Close()
+	// method is called, or the context originally passed into GetTrustBundle is
+	// canceled. If the function returns an error, no more updates will be
+	// available over the stream.
+	RecvLocalBundleUpdate() ([]*x509certificate.X509Authority, []*common.PublicKey, error)
+
+	// Close() closes the stream. It MUST be called by callers of GetTrustBundle
 	// when they are done with the stream.
 	Close()
 }

--- a/pkg/server/plugin/upstreamauthority/v1.go
+++ b/pkg/server/plugin/upstreamauthority/v1.go
@@ -93,6 +93,39 @@ func (v1 *V1) PublishJWTKey(ctx context.Context, jwtKey *common.PublicKey) (_ []
 	return jwtKeys, &v1UpstreamJWTAuthorityStream{v1: v1, stream: stream, cancel: cancel}, nil
 }
 
+func (v1 *V1) SubscribeToLocalBundle(ctx context.Context) (_ []*x509certificate.X509Authority, _ []*common.PublicKey, _ LocalBundleUpdateStream, err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		// Only cancel the context if the function fails. Otherwise, the
+		// returned stream will be in charge of cancellation.
+		if err != nil {
+			defer cancel()
+		}
+	}()
+
+	stream, err := v1.UpstreamAuthorityPluginClient.SubscribeToLocalBundle(ctx, &upstreamauthorityv1.SubscribeToLocalBundleRequest{})
+	if err != nil {
+		return nil, nil, nil, v1.WrapErr(err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, nil, nil, v1.streamError(err)
+	}
+
+	jwtKeys, err := v1.toCommonProtos(resp.UpstreamJwtKeys)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	x509Authorities, err := v1.parseX509Authorities(resp.UpstreamX509Roots)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return x509Authorities, jwtKeys, &v1LocalBundleStream{v1: v1, stream: stream, cancel: cancel}, nil
+}
+
 func (v1 *V1) parseMintX509CAFirstResponse(resp *upstreamauthorityv1.MintX509CAResponse) ([]*x509.Certificate, []*x509certificate.X509Authority, error) {
 	x509CA, err := x509certificate.FromPluginProtos(resp.X509CaChain)
 	if err != nil {
@@ -206,5 +239,43 @@ func (s *v1UpstreamJWTAuthorityStream) RecvUpstreamJWTAuthorities() ([]*common.P
 }
 
 func (s *v1UpstreamJWTAuthorityStream) Close() {
+	s.cancel()
+}
+
+type v1LocalBundleStream struct {
+	v1     *V1
+	stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleClient
+	cancel context.CancelFunc
+}
+
+func (s *v1LocalBundleStream) RecvLocalBundleUpdate() ([]*x509certificate.X509Authority, []*common.PublicKey, error) {
+	for {
+		resp, err := s.stream.Recv()
+		switch {
+		case errors.Is(err, io.EOF):
+			// This is expected if the plugin does not support streaming
+			// authority updates.
+			return nil, nil, err
+		case err != nil:
+			return nil, nil, s.v1.WrapErr(err)
+		}
+
+		x509Authorities, err := s.v1.parseX509Authorities(resp.UpstreamX509Roots)
+		if len(resp.UpstreamX509Roots) != 0 && err != nil {
+			s.v1.Log.WithError(err).Warn("Failed to parse an X.509 root update from the upstream authority plugin. Please report this bug.")
+			continue
+		}
+
+		jwtKeys, err := s.v1.toCommonProtos(resp.UpstreamJwtKeys)
+		if len(resp.UpstreamJwtKeys) != 0 && err != nil {
+			s.v1.Log.WithError(err).Warn("Failed to parse an JWT key update from the upstream authority plugin. Please report this bug.")
+			continue
+		}
+
+		return x509Authorities, jwtKeys, nil
+	}
+}
+
+func (s *v1LocalBundleStream) Close() {
 	s.cancel()
 }

--- a/pkg/server/plugin/upstreamauthority/v1.go
+++ b/pkg/server/plugin/upstreamauthority/v1.go
@@ -261,13 +261,13 @@ func (s *v1LocalBundleStream) RecvLocalBundleUpdate() ([]*x509certificate.X509Au
 		}
 
 		x509Authorities, err := s.v1.parseX509Authorities(resp.UpstreamX509Roots)
-		if len(resp.UpstreamX509Roots) != 0 && err != nil {
+		if err != nil {
 			s.v1.Log.WithError(err).Warn("Failed to parse an X.509 root update from the upstream authority plugin. Please report this bug.")
 			continue
 		}
 
 		jwtKeys, err := s.v1.toCommonProtos(resp.UpstreamJwtKeys)
-		if len(resp.UpstreamJwtKeys) != 0 && err != nil {
+		if err != nil {
 			s.v1.Log.WithError(err).Warn("Failed to parse an JWT key update from the upstream authority plugin. Please report this bug.")
 			continue
 		}

--- a/pkg/server/plugin/upstreamauthority/vault/vault.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault.go
@@ -292,6 +292,10 @@ func (*Plugin) PublishJWTKeyAndSubscribe(*upstreamauthorityv1.PublishJWTKeyReque
 	return status.Error(codes.Unimplemented, "publishing upstream is unsupported")
 }
 
+func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLocalBundleRequest, stream upstreamauthorityv1.UpstreamAuthority_SubscribeToLocalBundleServer) error {
+	return status.Error(codes.Unimplemented, "fetching upstream trust bundle is unsupported")
+}
+
 func (p *Plugin) genClientParams(method AuthMethod, config *Configuration) (*ClientParams, error) {
 	cp := &ClientParams{
 		VaultAddr:     p.getEnvOrDefault(envVaultAddr, config.VaultAddr),

--- a/test/integration/suites/nested-rotation/00-setup
+++ b/test/integration/suites/nested-rotation/00-setup
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-pwd
-
 # create shared folder for root agent socket
 mkdir -p -m 777 shared/rootSocket
 

--- a/test/integration/suites/nested-rotation/00-setup
+++ b/test/integration/suites/nested-rotation/00-setup
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+pwd
+
 # create shared folder for root agent socket
 mkdir -p -m 777 shared/rootSocket
 
@@ -8,6 +10,12 @@ mkdir -p -m 777 shared/intermediateASocket
 
 # create shared folder for intermediateB agent socket
 mkdir -p -m 777 shared/intermediateBSocket
+
+# create shared folder for intermediateA server
+mkdir -p -m 777 shared/intermediateA/data
+
+# create shared folder for intermediateB server
+mkdir -p -m 777 shared/intermediateB/data
 
 # root certificates
 "${ROOTDIR}/setup/x509pop/setup.sh" root/server root/agent

--- a/test/integration/suites/nested-rotation/11-rotation-after-restart
+++ b/test/integration/suites/nested-rotation/11-rotation-after-restart
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+check-key-present() {
+  keyID=${2}
+  # Check at most 20 times (with one second in between) that the server has
+  # successfully started.
+  MAXCHECKS=20
+  CHECKINTERVAL=1
+  for ((i=1;i<=MAXCHECKS;i++)); do
+      log-info "checking for bundle to contain key id ${keyID} ($i of $MAXCHECKS max)..."
+      if docker compose exec -T $1 /opt/spire/bin/spire-server bundle show --format spiffe | grep -q ${keyID}; then
+        return 0
+      fi
+      sleep "${CHECKINTERVAL}"
+  done
+
+  fail-now "timed out waiting for key to be present in server bundle"
+}
+
+# Stop leaf servers and agents. This prevents them from publishing keys
+# and affecting the test. They rotate CAs/keys much more often so it's
+# possible for them to rotate during the test causing the intermediate server
+# to also start listening for updates from the upstream server.
+docker compose stop leafA-agent leafB-agent leafA-server leafB-server
+
+log-debug "restarting intermediateB server..."
+
+# Restart intermediateB server to make sure that it sees updates
+# even after restart. The intermediate servers have a longer CA TTL
+# so it should allow us to see if upstream authorities fail to propagate
+# after restart.
+docker compose restart intermediateB-server
+check-server-started intermediateB-server
+
+log-debug "rotating intermediateA JWT authority..."
+new_authority_id=$(docker compose exec -T intermediateA-server \
+  /opt/spire/bin/spire-server localauthority jwt prepare -output json | jq -r .prepared_authority.authority_id) || fail-now "could not prepare new JWT authority"
+
+log-debug "activating intermediateA JWT authority..."
+docker compose exec -T intermediateA-server \
+  /opt/spire/bin/spire-server localauthority jwt activate -authorityID ${new_authority_id} || fail-now "Could not activate new JWT authority"
+
+check-key-present intermediateB-server ${new_authority_id}

--- a/test/integration/suites/nested-rotation/docker-compose.yaml
+++ b/test/integration/suites/nested-rotation/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
     volumes:
       # Add root agent socket
       - ./shared/rootSocket:/opt/spire/sockets
+      - ./shared/intermediateA/data:/opt/spire/data/server
       - ./intermediateA/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   intermediateA-agent:
@@ -82,6 +83,7 @@ services:
     volumes:
       # Add root agent socket
       - ./shared/rootSocket:/opt/spire/sockets
+      - ./shared/intermediateB/data:/opt/spire/data/server
       - ./intermediateB/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   intermediateB-agent:

--- a/test/integration/suites/nested-rotation/intermediateA/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateA/server/server.conf
@@ -20,8 +20,10 @@ plugins {
 			ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
 		}
 	}
-	KeyManager "memory" {
-		plugin_data = {}
+	KeyManager "disk" {
+		plugin_data = {
+			keys_path = "/opt/spire/data/server/keys.json"
+		}
 	}
  	UpstreamAuthority "spire" {
  	    plugin_data = {

--- a/test/integration/suites/nested-rotation/intermediateB/server/server.conf
+++ b/test/integration/suites/nested-rotation/intermediateB/server/server.conf
@@ -20,8 +20,10 @@ plugins {
 			ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
 		}
 	}
-	KeyManager "memory" {
-		plugin_data = {}
+	KeyManager "disk" {
+		plugin_data = {
+			keys_path = "/opt/spire/data/server/keys.json"
+		}
 	}
  	UpstreamAuthority "spire" {
  	    plugin_data = {


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
UpstreamAuthority plugins.

**Description of change**
If the UpstreamAuthority plugin implements the GetTrustBundle RPC use it to keep the trust bundle of the trust domain in sync. This allows us to get bundle updates before we create a new CA or key.

**Which issue this PR fixes**
fixes #6083

