### PR TITLE
fix: subject_types_supported cannot be an empty list

### DIFF
--- a/support/oidc-discovery-provider/handler.go
+++ b/support/oidc-discovery-provider/handler.go
@@ -135,7 +135,7 @@ func (h *Handler) serveWellKnown(w http.ResponseWriter, r *http.Request) {
 
 		AuthorizationEndpoint:            "",
 		ResponseTypesSupported:           []string{"id_token"},
-		SubjectTypesSupported:            []string{},
+		SubjectTypesSupported:            []string{"public"},
 		IDTokenSigningAlgValuesSupported: []string{"RS256", "ES256", "ES384"},
 	}
 

--- a/support/oidc-discovery-provider/handler_test.go
+++ b/support/oidc-discovery-provider/handler_test.go
@@ -40,7 +40,9 @@ func TestHandlerHTTPS(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -208,7 +210,9 @@ func TestHandlerHTTPInsecure(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -321,7 +325,9 @@ func TestHandlerHTTP(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -342,7 +348,9 @@ func TestHandlerHTTP(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -363,7 +371,9 @@ func TestHandlerHTTP(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -489,7 +499,9 @@ func TestHandlerProxied(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -600,7 +612,9 @@ func TestHandlerJWTIssuer(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -621,7 +635,9 @@ func TestHandlerJWTIssuer(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -642,7 +658,9 @@ func TestHandlerJWTIssuer(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -663,7 +681,9 @@ func TestHandlerJWTIssuer(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -684,7 +704,9 @@ func TestHandlerJWTIssuer(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -743,7 +765,9 @@ func TestHandlerJWTIssuerAndJWKSURI(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -801,7 +825,9 @@ func TestHandlerAdvertisedURL(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -822,7 +848,9 @@ func TestHandlerAdvertisedURL(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -843,7 +871,9 @@ func TestHandlerAdvertisedURL(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -864,7 +894,9 @@ func TestHandlerAdvertisedURL(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -885,7 +917,9 @@ func TestHandlerAdvertisedURL(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -942,7 +976,9 @@ func TestHandlerPrefix(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -963,7 +999,9 @@ func TestHandlerPrefix(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -984,7 +1022,9 @@ func TestHandlerPrefix(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",
@@ -1005,7 +1045,9 @@ func TestHandlerPrefix(t *testing.T) {
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": [
+    "public"
+  ],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",

--- a/test/integration/suites/oidc-discovery-provider/expected-oidc-config.json
+++ b/test/integration/suites/oidc-discovery-provider/expected-oidc-config.json
@@ -5,7 +5,7 @@
   "response_types_supported": [
     "id_token"
   ],
-  "subject_types_supported": [],
+  "subject_types_supported": ["public"],
   "id_token_signing_alg_values_supported": [
     "RS256",
     "ES256",


### PR DESCRIPTION
Closes #6125

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
OIDC provider discovery document.

**Description of change**
Populates the `subject_types_supported` value in the OIDC provider discovery document.

**Which issue this PR fixes**
#6125

