### PR TITLE
Lower log level of cotainer not found retry

### DIFF
--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -390,7 +390,7 @@ func (p *Plugin) Attest(ctx context.Context, req *workloadattestorv1.AttestReque
 		}
 
 		// wait a bit for containers to initialize before trying again.
-		log.Warn("Container id not found", telemetry.RetryInterval, config.PollRetryInterval)
+		log.Debug("Container id not found", telemetry.RetryInterval, config.PollRetryInterval)
 
 		select {
 		case <-p.clock.After(config.PollRetryInterval):


### PR DESCRIPTION
This can appear somewhat frequently, more so now that the pod list is cached. We already have a warning for when the container it is not found at all, no point warning about retrying.