### PR TITLE
Use sha of branch for caching windows executables

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -207,7 +207,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./bin/
-          key: ${{ runner.os }}-executables-${{ hashFiles('**/*.exe') }}
+          key: ${{ runner.os }}-executables-${{ github.sha }}
       - name: Build images
         run: make images-windows
       - name: Export images
@@ -592,7 +592,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./bin/
-          key: ${{ runner.os }}-executables-${{ hashFiles('**/*.exe') }}
+          key: ${{ runner.os }}-executables-${{ github.sha }}
       - name: Build artifacts
         run: ./.github/workflows/scripts/build_artifacts.sh ${{ runner.os }}
       - name: Archive artifacts

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -192,7 +192,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./bin/
-          key: ${{ runner.os }}-executables-${{ hashFiles('**/*.exe') }}
+          key: ${{ runner.os }}-executables-${{ github.sha }}
       - name: Build images
         run: make images-windows
       - name: Export images
@@ -554,7 +554,7 @@ jobs:
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./bin/
-          key: ${{ runner.os }}-executables-${{ hashFiles('**/*.exe') }}
+          key: ${{ runner.os }}-executables-${{ github.sha }}
       - name: Archive artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Windows CI runs.

**Description of change**
Using the executables does not work because they do not exist when we try to fetch from the cache. This means we may end up fetching executables from previous runs of the workflows on the branch.

**Which issue this PR fixes**
fixes #6044

