### PR TITLE
Revert "Fix metrics/health checks when retry_bootstrap=true (#6063)"

### DIFF
--- a/pkg/common/health/cache.go
+++ b/pkg/common/health/cache.go
@@ -110,7 +110,6 @@ func (c *cache) start(ctx context.Context) error {
 
 func (c *cache) startRunner(ctx context.Context) {
 	c.log.Debug("Initializing health checkers")
-	seenStartupError := make(map[string]string)
 	checkFunc := func() {
 		for name, checker := range c.getCheckerSubsystems() {
 			state, err := verifyStatus(checker.checkable)
@@ -120,19 +119,9 @@ func (c *cache) startRunner(ctx context.Context) {
 				checkTime: c.clk.Now(),
 			}
 			if err != nil {
-				if state.Started == nil || *state.Started {
-					c.log.WithField("check", name).
-						WithError(err).
-						Error("Health check has failed")
-				} else {
-					strErr := err.Error()
-					if val, ok := seenStartupError[name]; !ok || val != strErr {
-						c.log.WithField("check", name).
-							WithError(err).
-							Warn("Health check has failed. Starting up still.")
-						seenStartupError[name] = strErr
-					}
-				}
+				c.log.WithField("check", name).
+					WithError(err).
+					Error("Health check has failed")
 				checkState.err = err
 			}
 

--- a/pkg/common/health/cache_test.go
+++ b/pkg/common/health/cache_test.go
@@ -106,7 +106,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check failed",
 				Data: logrus.Fields{
 					telemetry.Check:   "bar",
-					telemetry.Details: "{<nil> false false {} {}}",
+					telemetry.Details: "{false false {} {}}",
 					telemetry.Error:   "subsystem is not live or ready",
 				},
 			},
@@ -163,7 +163,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check recovered",
 				Data: logrus.Fields{
 					telemetry.Check:    "bar",
-					telemetry.Details:  "{<nil> true true {} {}}",
+					telemetry.Details:  "{true true {} {}}",
 					telemetry.Duration: "1",
 					telemetry.Error:    "subsystem is not live or ready",
 					telemetry.Failures: "1",
@@ -251,7 +251,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check failed",
 				Data: logrus.Fields{
 					telemetry.Check:   "foo",
-					telemetry.Details: "{<nil> false false {live is failing} {ready is failing}}",
+					telemetry.Details: "{false false {live is failing} {ready is failing}}",
 					telemetry.Error:   "subsystem is not live or ready",
 				},
 			},
@@ -354,7 +354,7 @@ func TestHealthFailsAndRecover(t *testing.T) {
 				Message: "Health check recovered",
 				Data: logrus.Fields{
 					telemetry.Check:    "foo",
-					telemetry.Details:  "{<nil> true true {} {}}",
+					telemetry.Details:  "{true true {} {}}",
 					telemetry.Duration: "120",
 					telemetry.Error:    "subsystem is not live or ready",
 					telemetry.Failures: "2",

--- a/pkg/common/health/health.go
+++ b/pkg/common/health/health.go
@@ -20,10 +20,6 @@ const (
 
 // State is the health state of a subsystem.
 type State struct {
-	// Started is whether the subsystem is finished starting.
-	// if undefined, it is treated as started=true.
-	Started *bool
-
 	// Live is whether the subsystem is live (i.e. in a good state
 	// or in a state it can recover from while remaining alive). Global
 	// liveness is only reported true if all subsystems report live.
@@ -138,37 +134,27 @@ func (c *checker) ListenAndServe(ctx context.Context) error {
 	return nil
 }
 
-// StartedState returns the global startup state.
-func (c *checker) StartedState() bool {
-	startup, _, _, _, _ := c.checkStates()
-
-	return startup
-}
-
 // LiveState returns the global live state and details.
 func (c *checker) LiveState() (bool, any) {
-	_, live, _, details, _ := c.checkStates()
+	live, _, details, _ := c.checkStates()
 
 	return live, details
 }
 
 // ReadyState returns the global ready state and details.
 func (c *checker) ReadyState() (bool, any) {
-	_, _, ready, _, details := c.checkStates()
+	_, ready, _, details := c.checkStates()
 
 	return ready, details
 }
 
-func (c *checker) checkStates() (bool, bool, bool, any, any) {
-	isStarted, isLive, isReady := true, true, true
+func (c *checker) checkStates() (bool, bool, any, any) {
+	isLive, isReady := true, true
 
 	liveDetails := make(map[string]any)
 	readyDetails := make(map[string]any)
 	for subsystemName, subsystemState := range c.cache.getStatuses() {
 		state := subsystemState.details
-		if state.Started == nil || !*state.Started {
-			isStarted = false
-		}
 		if !state.Live {
 			isLive = false
 		}
@@ -181,7 +167,7 @@ func (c *checker) checkStates() (bool, bool, bool, any, any) {
 		readyDetails[subsystemName] = state.ReadyDetails
 	}
 
-	return isStarted, isLive, isReady, liveDetails, readyDetails
+	return isLive, isReady, liveDetails, readyDetails
 }
 
 func (c *checker) liveHandler(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/common/util/task.go
+++ b/pkg/common/util/task.go
@@ -7,46 +7,6 @@ import (
 	"sync"
 )
 
-type TaskRunner struct {
-	wg     sync.WaitGroup
-	ctx    context.Context
-	cancel context.CancelCauseFunc
-}
-
-func NewTaskRunner(ctx context.Context, cancel context.CancelCauseFunc) *TaskRunner {
-	return &TaskRunner{
-		ctx:    ctx,
-		cancel: cancel,
-	}
-}
-
-func (t *TaskRunner) StartTasks(tasks ...func(context.Context) error) {
-	runTask := func(task func(context.Context) error) (err error) {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack()))
-			}
-			t.wg.Done()
-		}()
-		return task(t.ctx)
-	}
-
-	t.wg.Add(len(tasks))
-	for _, task := range tasks {
-		go func() {
-			err := runTask(task)
-			if err != nil {
-				t.cancel(err)
-			}
-		}()
-	}
-}
-
-func (t *TaskRunner) Wait() error {
-	t.wg.Wait()
-	return context.Cause(t.ctx)
-}
-
 // RunTasks executes all the provided functions concurrently and waits for
 // them all to complete. If a function returns an error, all other functions
 // are canceled (i.e. the context they are passed is canceled) and the error is
@@ -56,8 +16,43 @@ func (t *TaskRunner) Wait() error {
 // RunTasks MUST support cancellation via the provided context for RunTasks to
 // work properly.
 func RunTasks(ctx context.Context, tasks ...func(context.Context) error) error {
-	nctx, cancel := context.WithCancelCause(ctx)
-	t := NewTaskRunner(nctx, cancel)
-	t.StartTasks(tasks...)
-	return t.Wait()
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(ctx)
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	errch := make(chan error, len(tasks))
+
+	runTask := func(task func(context.Context) error) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic: %v\n%s\n", r, string(debug.Stack()))
+			}
+			wg.Done()
+		}()
+		return task(ctx)
+	}
+
+	wg.Add(len(tasks))
+	for _, task := range tasks {
+		go func() {
+			errch <- runTask(task)
+		}()
+	}
+
+	for complete := 0; complete < len(tasks); {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-errch:
+			if err != nil {
+				return err
+			}
+			complete++
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This reverts commit 41aedaea5a8011de0235f0b92b3e6b6a3ac4275f.
We found that this is a change in the behavior (#6150) and a change like this is more suitable to have in a minor release rather than in a patch release.