### PR TITLE
docs: Fix markdown link syntax nits

### DIFF
--- a/doc/plugin_server_nodeattestor_x509pop.md
+++ b/doc/plugin_server_nodeattestor_x509pop.md
@@ -22,7 +22,7 @@ spiffe://<trust_domain>/spire/agent/x509pop/<fingerprint>
 | `svid_prefix`            | The prefix of the SVID to use for matching valid SVIDS and exchanging them for Node SVIDs                                                                                                                                                   | /spire-exchange                                                 |
 | `ca_bundle_path`      | The path to the trusted CA bundle on disk. The file must contain one or more PEM blocks forming the set of trusted root CA's for chain-of-trust verification. If the CA certificates are in more than one file, use `ca_bundle_paths` instead. |                                                                 |
 | `ca_bundle_paths`     | A list of paths to trusted CA bundles on disk. The files must contain one or more PEM blocks forming the set of trusted root CA's for chain-of-trust verification.                                                                             |                                                                 |
-| `agent_path_template` | A URL path portion format of Agent's SPIFFE ID. Describe in text/template format.                                                                                                                                                              | `See [Agent Path Template](#agent-path-template) for details`   |
+| `agent_path_template` | A URL path portion format of Agent's SPIFFE ID. Describe in text/template format.                                                                                                                                                              | See [Agent Path Template](#agent-path-template) for details   |
 
 A sample configuration:
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -261,7 +261,7 @@ When setting a `bundle_endpoint`, it is `required` to specify the bundle profile
 
 Allowed profiles:
 
-- `https_web` allow to configure either the [Automated Certificate Management Environment](#Configuration options for `federation.bundle_endpoint.profile "https_web".acme`) or the [serving cert file](#Configure options for 'federation.bundle_endpoint.porfile "https_web".serving_cert_file') section.
+- `https_web` allow to configure either the [Automated Certificate Management Environment](#configuration-options-for-federationbundle_endpointprofile-https_webacme) or the [serving cert file](#configuration-options-for-federationbundle_endpointprofile-https_webserving_cert_file) section.
 - `https_spiffe`
 
 ### Configuration options for `federation.bundle_endpoint.profile "https_web".acme`


### PR DESCRIPTION
Fix markdown link nits encountered when interfacing the docs site.

https://spiffe.io/docs/latest/deploying/spire_server/#configuration-options-for-federationbundle_endpointprofile

https://github.com/spiffe/spire/blob/v1.12.3/doc/plugin_server_nodeattestor_x509pop.md

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->


