### PR TITLE
Wait for server to come up before using it

### DIFF
--- a/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
+++ b/test/integration/suites/envoy-sds-v3-spiffe-auth/00-test-envoy-releases.sh
@@ -2,8 +2,7 @@
 
 setup-tests() {
     # Bring up servers
-    docker-up upstream-spire-server
-    docker-up downstream-federated-spire-server
+    docker-spire-server-up upstream-spire-server downstream-federated-spire-server
 
     # Bootstrap agents
     log-debug "bootstrapping downstream federated agent..."


### PR DESCRIPTION
This test fails from time to time in CI. It seems like we should be waiting for the server to come up before trying to use it to get its bundle.