### PR TITLE
Use Rego v1 for all Rego evaluations

### DIFF
--- a/doc/authorization_policy_engine.md
+++ b/doc/authorization_policy_engine.md
@@ -18,7 +18,6 @@ server {
             local {
                 rego_path = "./conf/server/policy.rego"
                 policy_data_path = "./conf/server/policy_data.json"
-                use_rego_v1 = true
             }
         }
     }

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -115,7 +115,6 @@ This may be useful for templating configuration files, for example across differ
 |:------------------------------|-------------------------------------------------------------------------------------------|----------------|
 | `rego_path`                   | File to retrieve OPA rego policy for authorization.                                       |                |
 | `policy_data_path`            | File to retrieve databindings for policy evaluation.                                      |                |
-| `use_rego_v1`                 | Use rego V1 when evaluating the policy. This will become the default in a future release. | false          |
 
 ### Profiling Names
 

--- a/pkg/server/api/middleware/authorization_test.go
+++ b/pkg/server/api/middleware/authorization_test.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -324,7 +323,7 @@ func TestWithAuthorizationPreprocess(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			policyEngine, err := authpolicy.NewEngineFromRego(ctx, tt.rego, inmem.NewFromObject(map[string]any{}), ast.RegoV1)
+			policyEngine, err := authpolicy.NewEngineFromRego(ctx, tt.rego, inmem.NewFromObject(map[string]any{}))
 			require.NoError(t, err, "failed to initialize policy engine")
 
 			// Set up an authorization middleware with one method.

--- a/pkg/server/authpolicy/defaults.go
+++ b/pkg/server/authpolicy/defaults.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 
-	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/util"
 )
@@ -24,5 +23,5 @@ func DefaultAuthPolicy(ctx context.Context) (*Engine, error) {
 	}
 	store := inmem.NewFromObject(json)
 
-	return NewEngineFromRego(ctx, defaultPolicyRego, store, ast.RegoV1)
+	return NewEngineFromRego(ctx, defaultPolicyRego, store)
 }

--- a/pkg/server/authpolicy/policy_test.go
+++ b/pkg/server/authpolicy/policy_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/storage/inmem"
 	"github.com/open-policy-agent/opa/v1/util"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -221,7 +220,7 @@ func TestPolicy(t *testing.T) {
 			ctx := context.Background()
 
 			// Check with NewEngineFromRego
-			pe, err := authpolicy.NewEngineFromRego(ctx, tt.rego, store, ast.RegoV1)
+			pe, err := authpolicy.NewEngineFromRego(ctx, tt.rego, store)
 			require.Nil(t, err, "failed to create policy engine")
 
 			res, err := pe.Eval(ctxIn, tt.input)
@@ -242,7 +241,6 @@ func TestPolicy(t *testing.T) {
 				LocalOpaProvider: &authpolicy.LocalOpaProviderConfig{
 					RegoPath:       regoFile,
 					PolicyDataPath: permsFile,
-					UseRegoV1:      true,
 				},
 			}
 			log, _ := test.NewNullLogger()
@@ -434,7 +432,7 @@ func TestNewEngineFromRego(t *testing.T) {
 			// a bad store
 			store := inmem.New()
 
-			_, err := authpolicy.NewEngineFromRego(ctx, tt.rego, store, ast.RegoV1)
+			_, err := authpolicy.NewEngineFromRego(ctx, tt.rego, store)
 			require.Equal(t, err == nil, tt.success)
 		})
 	}


### PR DESCRIPTION
Remove `use_rego_v1` configuration field and make Rego v1 the new default version for SPIRE Server OPA authorization policies.

Fixes #5887.