### PR TITLE
Fix flaky TestManagerConfigPeriodicRefresh unit test

### DIFF
--- a/pkg/server/bundle/client/manager_test.go
+++ b/pkg/server/bundle/client/manager_test.go
@@ -180,8 +180,14 @@ func TestManagerConfigPeriodicRefresh(t *testing.T) {
 	})
 
 	// Wait until the config is refreshed and a bundle refresh happens
-	test.AdvanceTime(bundleutil.MinimumRefreshHint + time.Millisecond)
+	test.AdvanceTime(configRefreshInterval + time.Millisecond)
 	test.WaitForConfigRefresh()
+	test.WaitForBundleRefresh(bundleutil.MinimumRefreshHint) // td3
+	assert.Equal(t, 1, test.UpdateCount(td1))
+	assert.Equal(t, 1, test.UpdateCount(td2))
+	assert.Equal(t, 1, test.UpdateCount(td3))
+
+	test.AdvanceTime(bundleutil.MinimumRefreshHint + time.Millisecond)
 	test.WaitForBundleRefresh(bundleutil.MinimumRefreshHint) // td2
 	test.WaitForBundleRefresh(bundleutil.MinimumRefreshHint) // td3
 
@@ -192,7 +198,7 @@ func TestManagerConfigPeriodicRefresh(t *testing.T) {
 	}, test.GetTrustDomainConfigs())
 	assert.Equal(t, 1, test.UpdateCount(td1))
 	assert.Equal(t, 2, test.UpdateCount(td2))
-	assert.Equal(t, 1, test.UpdateCount(td3))
+	assert.Equal(t, 2, test.UpdateCount(td3))
 }
 
 func TestManagerConfigManualRefresh(t *testing.T) {


### PR DESCRIPTION
This test sometimes flakes in the following way:

```
--- FAIL: TestManagerConfigPeriodicRefresh (0.02s)
    manager_test.go:199:
                Error Trace:    /home/sorin/github/spiffe/spire/pkg/server/bundle/client/manager_test.go:199
                Error:          Not equal:
                                expected: 2
                                actual  : 1
                Test:           TestManagerConfigPeriodicRefresh
FAIL
FAIL    github.com/spiffe/spire/pkg/server/bundle/client        0.073s
FAIL
```

The problem is that the configRefresh also does one refresh of the bundle so we have to do the refresh, wait for td3 to finish refreshing and only then advance time to test the periodic refresh.

fixes #5707