### PR TITLE
Fix for TestEndpoints to be compatible with go-spiffe v2.6.0

### DIFF
--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -259,7 +259,7 @@ type FakeManager struct {
 
 type FakeWorkloadAPIServer struct {
 	Attestor PeerTrackerAttestor
-	*workload_pb.UnimplementedSpiffeWorkloadAPIServer
+	workload_pb.UnimplementedSpiffeWorkloadAPIServer
 }
 
 func (s FakeWorkloadAPIServer) FetchJWTSVID(ctx context.Context, _ *workload_pb.JWTSVIDRequest) (*workload_pb.JWTSVIDResponse, error) {


### PR DESCRIPTION
go-spiffe now uses protoc_version 30.2 which makes a change in protoc-gen-go-grpc generated files.

The UnimplementedSpiffeWorkloadAPIServer should now be embedded by value instead of pointer to avoid a nil pointer dereference when methods are called.
See [this](https://github.com/spiffe/go-spiffe/commit/9df97cf13cdd6164426e4e94d422a0465e7e75b9#diff-273f46c54f695d09b1cbb0b0ede1cd102fd323dbec813aeea72f170faccdbaa3R172) commit for reference (https://github.com/spiffe/go-spiffe/pull/335).