### PR TITLE
doc: fix `x509pop` URI SAN selector documentation

### DIFF
--- a/doc/plugin_server_nodeattestor_x509pop.md
+++ b/doc/plugin_server_nodeattestor_x509pop.md
@@ -44,7 +44,7 @@ A sample configuration:
 | Common Name      | `x509pop:subject:cn:example.org`                                  | The Subject's Common Name (see X.500 Distinguished Names)                                                                                                                                                  |
 | SHA1 Fingerprint | `x509pop:ca:fingerprint:0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33` | The SHA1 fingerprint as a hex string for each cert in the PoP chain, excluding the leaf.                                                                                                                   |
 | SerialNumber     | `x509pop:serialnumber:0a1b2c3d4e5f`                               | The leaf certificate serial number as a lowercase hexadecimal string                                                                                                                                       |
-| San              | `x509pop:san:<key>:<value>`                                       | The san selectors on the leaf certificate. The expected format of the uri san is `x509pop://<trust_domain>/<key>:<value>`. One selector is exposed per uri san corresponding to x509pop uri scheme. string |
+| San              | `x509pop:san:<key>:<value>`                                       | The san selectors on the leaf certificate. The expected format of the uri san is `x509pop://<trust_domain>/<key>/<value>`. One selector is exposed per uri san corresponding to x509pop uri scheme. string |
 
 ## SVID Path Prefix
 


### PR DESCRIPTION
The san selector uri should be of the form

`x509pop://<trust-domain>/<key>/<value>`

as is implemented at [1].

[1] https://github.com/spiffe/spire/blob/c68c6a452d1fdb9e482eeaad56c1a61248609a3a/pkg/server/plugin/nodeattestor/x509pop/x509pop.go#L377
