### PR TITLE
docs: update CONTRIBUTING.md and README.md for OIDC discovery provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ A Makefile is provided for common actions.
 * `make all` - builds all binaries, lints code, and runs all unit tests
 * `make bin/spire-server` - builds SPIRE server
 * `make bin/spire-agent` - builds SPIRE agent
+* `make bin/oidc-discovery-provider` - builds SPIRE oidc-discovery-provider
 * `make images` - builds SPIRE docker images
 * `make test` - runs unit tests
 

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -38,7 +38,7 @@ The configuration file is **required** by the provider. It contains
 |-------------------------|---------|--------------------|------------------------------------------------------------------------|----------|
 | `acme`                  | section | required[1]        | Provides the ACME configuration.                                       |          |
 | `serving_cert_file`     | section | required\[1\]\[4\] | Provides the serving certificate configuration.                        |          |
-| `allow_insecure_scheme` | string  | optional\[3\]      | Serves OIDC configuration response with HTTP url.                      | `false`  |
+| `allow_insecure_scheme` | bool    | optional\[3\]      | Serves OIDC configuration response with HTTP url.                      | `false`  |
 | `domains`               | strings | required           | One or more domains the provider is being served from.                 |          |
 | `experimental`          | section | optional           | The experimental options that are subject to change or removal.        |          |
 | `insecure_addr`         | string  | optional\[3\]      | Exposes the service on http.                                           |          |


### PR DESCRIPTION
- Added build command for OIDC discovery provider to CONTRIBUTING.md.
- Changed data type of `allow_insecure_scheme` from string to bool in OIDC discovery provider README.md.
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md
2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->
**Pull Request check list**
- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
OIDC discovery provider documentation and build instructions.

**Description of change**
This PR fixes two documentation issues for the OIDC discovery provider:

1. **CONTRIBUTING.md**: Added missing build command for the OIDC discovery provider to help contributors build and test this component.

2. **README.md**: Corrected the data type specification for `allow_insecure_scheme` configuration parameter from string to boolean, which matches the actual implementation and usage.

These changes improve the developer experience by providing accurate build instructions and configuration documentation.

**Which issue this PR fixes**
fixes #6287