### PR TITLE
[WIP] - x509 cache hint for registration entries

### DIFF
--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -345,7 +345,9 @@ func (m *manager) fetchEntries(ctx context.Context) (_ *cache.UpdateEntries, _ *
 		case entry.StoreSvid:
 			storeEntries[entryID] = entry
 		default:
-			cacheEntries[entryID] = entry
+			if !entry.X509SvidCacheHint.GetJwtOnly() {
+				cacheEntries[entryID] = entry
+			}
 		}
 	}
 

--- a/pkg/server/datastore/sqlstore/migration.go
+++ b/pkg/server/datastore/sqlstore/migration.go
@@ -267,12 +267,12 @@ import (
 
 const (
 	// the latest schema version of the database in the code
-	latestSchemaVersion = 23
+	latestSchemaVersion = 24
 
 	// lastMinorReleaseSchemaVersion is the schema version supported by the
 	// last minor release. When the migrations are opportunistically pruned
 	// from the code after a minor release, this number should be updated.
-	lastMinorReleaseSchemaVersion = 23
+	lastMinorReleaseSchemaVersion = 24
 )
 
 // the current code version
@@ -498,6 +498,8 @@ func migrateVersion(tx *gorm.DB, currVersion int, log logrus.FieldLogger) (versi
 	// }
 	//
 	switch currVersion { //nolint: gocritic,revive // No upgrade required yet, keeping switch for future additions
+	case 24:
+		err = migrateToV24(tx)
 	default:
 		err = newSQLError("no migration support for unknown schema version %d", currVersion)
 	}
@@ -506,6 +508,13 @@ func migrateVersion(tx *gorm.DB, currVersion int, log logrus.FieldLogger) (versi
 	}
 
 	return nextVersion, nil
+}
+
+func migrateToV24(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&RegisteredEntry{}).Error; err != nil {
+		return newWrappedSQLError(err)
+	}
+	return nil
 }
 
 func addFederatedRegistrationEntriesRegisteredEntryIDIndex(tx *gorm.DB) error {

--- a/pkg/server/datastore/sqlstore/models.go
+++ b/pkg/server/datastore/sqlstore/models.go
@@ -112,6 +112,10 @@ type RegisteredEntry struct {
 
 	// TTL of JWT identities derived from this entry
 	JWTSvidTTL int32 `gorm:"column:jwt_svid_ttl"`
+
+	// X509SvidCacheHint contains a set of options and flags that inform the
+	// agent behaviour with respect to pre-fetching and refreshing X509 SVIDs
+	X509SvidCacheHint []byte `gorm:"size:255,column:x509_svid_cache_hint"` // corresponds to TINYBLOB in MySQL
 }
 
 // RegisteredEntryEvent holds the entry id of a registered entry that had an event

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -2504,17 +2504,23 @@ func createRegistrationEntry(tx *gorm.DB, entry *common.RegistrationEntry) (*com
 		return nil, err
 	}
 
+	X509SvidCacheHint, err := proto.Marshal(entry.X509SvidCacheHint)
+	if err != nil {
+		return nil, err
+	}
+
 	newRegisteredEntry := RegisteredEntry{
-		EntryID:    entryID,
-		SpiffeID:   entry.SpiffeId,
-		ParentID:   entry.ParentId,
-		TTL:        entry.X509SvidTtl,
-		Admin:      entry.Admin,
-		Downstream: entry.Downstream,
-		Expiry:     entry.EntryExpiry,
-		StoreSvid:  entry.StoreSvid,
-		JWTSvidTTL: entry.JwtSvidTtl,
-		Hint:       entry.Hint,
+		EntryID:           entryID,
+		SpiffeID:          entry.SpiffeId,
+		ParentID:          entry.ParentId,
+		TTL:               entry.X509SvidTtl,
+		Admin:             entry.Admin,
+		Downstream:        entry.Downstream,
+		Expiry:            entry.EntryExpiry,
+		StoreSvid:         entry.StoreSvid,
+		JWTSvidTTL:        entry.JwtSvidTtl,
+		Hint:              entry.Hint,
+		X509SvidCacheHint: X509SvidCacheHint,
 	}
 
 	if err := tx.Create(&newRegisteredEntry).Error; err != nil {
@@ -2629,7 +2635,8 @@ SELECT
 	NULL AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 WHERE id IN (SELECT id FROM listing)
@@ -2637,7 +2644,7 @@ WHERE id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -2650,7 +2657,7 @@ WHERE
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -2658,7 +2665,7 @@ WHERE registered_entry_id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -2693,7 +2700,8 @@ SELECT
 	NULL ::integer AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 WHERE id IN (SELECT id FROM listing)
@@ -2701,7 +2709,7 @@ WHERE id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -2714,7 +2722,7 @@ WHERE
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -2722,7 +2730,7 @@ WHERE registered_entry_id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -2753,7 +2761,8 @@ SELECT
 	D.id AS dns_name_id,
 	D.value AS dns_name,
 	E.revision_number,
-	E.jwt_svid_ttl AS reg_jwt_svid_ttl
+	E.jwt_svid_ttl AS reg_jwt_svid_ttl,
+	E.x509_svid_cache_hint AS x509_svid_cache_hint
 FROM
 	registered_entries E
 LEFT JOIN
@@ -2795,7 +2804,8 @@ SELECT
 	NULL AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 WHERE id IN (SELECT id FROM listing)
@@ -2803,7 +2813,7 @@ WHERE id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -2816,7 +2826,7 @@ WHERE
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -2824,7 +2834,7 @@ WHERE registered_entry_id IN (SELECT id FROM listing)
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 WHERE registered_entry_id IN (SELECT id FROM listing)
@@ -3006,7 +3016,8 @@ SELECT
 	NULL AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 `)
@@ -3025,7 +3036,7 @@ FROM
 UNION
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -3040,7 +3051,7 @@ ON
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 `)
@@ -3051,7 +3062,7 @@ FROM
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 `)
@@ -3101,7 +3112,8 @@ SELECT
 	NULL ::integer AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 `)
@@ -3119,7 +3131,7 @@ FROM
 UNION ALL
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -3134,7 +3146,7 @@ ON
 UNION ALL
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 `)
@@ -3145,7 +3157,7 @@ FROM
 UNION ALL
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 `)
@@ -3194,7 +3206,8 @@ SELECT
 	D.id AS dns_name_id,
 	D.value AS dns_name,
 	E.revision_number,
-	E.jwt_svid_ttl AS reg_jwt_svid_ttl
+	E.jwt_svid_ttl AS reg_jwt_svid_ttl,
+	E.x509_svid_cache_hint AS x509_svid_cache_hint
 FROM
 	registered_entries E
 LEFT JOIN
@@ -3268,7 +3281,8 @@ SELECT
 	NULL AS dns_name_id,
 	NULL AS dns_name,
 	revision_number,
-	jwt_svid_ttl AS reg_jwt_svid_ttl
+	jwt_svid_ttl AS reg_jwt_svid_ttl,
+	x509_svid_cache_hint
 FROM
 	registered_entries
 `)
@@ -3286,7 +3300,7 @@ FROM
 UNION
 
 SELECT
-	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL
+	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
 FROM
 	bundles B
 INNER JOIN
@@ -3301,7 +3315,7 @@ ON
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
 FROM
 	dns_names
 `)
@@ -3312,7 +3326,7 @@ FROM
 UNION
 
 SELECT
-	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL
+	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL
 FROM
 	selectors
 `)
@@ -3804,25 +3818,26 @@ func fillNodeSelectorFromRow(nodeSelector *common.Selector, r *nodeSelectorRow) 
 }
 
 type entryRow struct {
-	EId            uint64
-	EntryID        sql.NullString
-	SpiffeID       sql.NullString
-	ParentID       sql.NullString
-	RegTTL         sql.NullInt64
-	Admin          sql.NullBool
-	Downstream     sql.NullBool
-	Expiry         sql.NullInt64
-	SelectorID     sql.NullInt64
-	SelectorType   sql.NullString
-	SelectorValue  sql.NullString
-	StoreSvid      sql.NullBool
-	Hint           sql.NullString
-	CreatedAt      sql.NullTime
-	TrustDomain    sql.NullString
-	DNSNameID      sql.NullInt64
-	DNSName        sql.NullString
-	RevisionNumber sql.NullInt64
-	RegJwtSvidTTL  sql.NullInt64
+	EId               uint64
+	EntryID           sql.NullString
+	SpiffeID          sql.NullString
+	ParentID          sql.NullString
+	RegTTL            sql.NullInt64
+	Admin             sql.NullBool
+	Downstream        sql.NullBool
+	Expiry            sql.NullInt64
+	SelectorID        sql.NullInt64
+	SelectorType      sql.NullString
+	SelectorValue     sql.NullString
+	StoreSvid         sql.NullBool
+	Hint              sql.NullString
+	CreatedAt         sql.NullTime
+	TrustDomain       sql.NullString
+	DNSNameID         sql.NullInt64
+	DNSName           sql.NullString
+	RevisionNumber    sql.NullInt64
+	RegJwtSvidTTL     sql.NullInt64
+	X509SvidCacheHint sql.Null[[]byte]
 }
 
 func scanEntryRow(rs *sql.Rows, r *entryRow) error {
@@ -3846,6 +3861,7 @@ func scanEntryRow(rs *sql.Rows, r *entryRow) error {
 		&r.DNSName,
 		&r.RevisionNumber,
 		&r.RegJwtSvidTTL,
+		&r.X509SvidCacheHint,
 	))
 }
 
@@ -3906,6 +3922,11 @@ func fillEntryFromRow(entry *common.RegistrationEntry, r *entryRow) error {
 	}
 	if r.CreatedAt.Valid {
 		entry.CreatedAt = roundedInSecondsUnix(r.CreatedAt.Time)
+	}
+
+	entry.X509SvidCacheHint = &common.RegistrationEntry_X509SvidCacheHint{}
+	if err := proto.Unmarshal(r.X509SvidCacheHint.V, entry.X509SvidCacheHint); err != nil {
+		return newSQLError("invalid value for X.509 cache hint: %s", err)
 	}
 
 	return nil
@@ -4004,6 +4025,13 @@ func updateRegistrationEntry(tx *gorm.DB, e *common.RegistrationEntry, mask *com
 	}
 	if mask == nil || mask.Hint {
 		entry.Hint = e.Hint
+	}
+	if mask == nil || mask.X509SvidCacheHint {
+		X509SvidCacheHint, err := proto.Marshal(e.X509SvidCacheHint)
+		if err != nil {
+			return nil, err
+		}
+		entry.X509SvidCacheHint = X509SvidCacheHint
 	}
 
 	// Revision number is increased by 1 on every update call
@@ -4458,6 +4486,9 @@ func validateRegistrationEntry(entry *common.RegistrationEntry) error {
 	// it is done to avoid users to mix selectors from different platforms in
 	// entries with storable SVIDs
 	if entry.StoreSvid {
+		if entry.X509SvidCacheHint.GetJwtOnly() {
+			return newValidationError("specifying cache behaviour is incompatible with storable SVIDs")
+		}
 		// Selectors must never be empty
 		tpe := entry.Selectors[0].Type
 		for _, t := range entry.Selectors {
@@ -4587,22 +4618,28 @@ func modelToEntry(tx *gorm.DB, model RegisteredEntry) (*common.RegistrationEntry
 		federatesWith = append(federatesWith, bundle.TrustDomain)
 	}
 
+	X509SvidCacheHint := &common.RegistrationEntry_X509SvidCacheHint{}
+	if err := proto.Unmarshal(model.X509SvidCacheHint, X509SvidCacheHint); err != nil {
+		return nil, err
+	}
+
 	return &common.RegistrationEntry{
-		EntryId:        model.EntryID,
-		Selectors:      selectors,
-		SpiffeId:       model.SpiffeID,
-		ParentId:       model.ParentID,
-		X509SvidTtl:    model.TTL,
-		FederatesWith:  federatesWith,
-		Admin:          model.Admin,
-		Downstream:     model.Downstream,
-		EntryExpiry:    model.Expiry,
-		DnsNames:       dnsList,
-		RevisionNumber: model.RevisionNumber,
-		StoreSvid:      model.StoreSvid,
-		JwtSvidTtl:     model.JWTSvidTTL,
-		Hint:           model.Hint,
-		CreatedAt:      roundedInSecondsUnix(model.CreatedAt),
+		EntryId:           model.EntryID,
+		Selectors:         selectors,
+		SpiffeId:          model.SpiffeID,
+		ParentId:          model.ParentID,
+		X509SvidTtl:       model.TTL,
+		FederatesWith:     federatesWith,
+		Admin:             model.Admin,
+		Downstream:        model.Downstream,
+		EntryExpiry:       model.Expiry,
+		DnsNames:          dnsList,
+		RevisionNumber:    model.RevisionNumber,
+		StoreSvid:         model.StoreSvid,
+		JwtSvidTtl:        model.JWTSvidTTL,
+		Hint:              model.Hint,
+		X509SvidCacheHint: X509SvidCacheHint,
+		CreatedAt:         roundedInSecondsUnix(model.CreatedAt),
 	}, nil
 }
 

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -2119,6 +2119,9 @@ func (s *PluginSuite) TestCreateOrReturnRegistrationEntry() {
 					"abcd.efg",
 					"somehost",
 				},
+				X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+					JwtOnly: false,
+				},
 			}
 			entry = tt.modifyEntry(entry)
 
@@ -2175,6 +2178,9 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 					"abcd.efg",
 					"somehost",
 				},
+				X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+					JwtOnly: false,
+				},
 			},
 		},
 		{
@@ -2186,7 +2192,10 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 				SpiffeId:    "SpiffeId",
 				ParentId:    "ParentId",
 				X509SvidTtl: 1,
-				StoreSvid:   true,
+				X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+					JwtOnly: false,
+				},
+				StoreSvid: true,
 			},
 		},
 		{
@@ -2198,7 +2207,10 @@ func (s *PluginSuite) TestFetchRegistrationEntry() {
 				SpiffeId:    "SpiffeId",
 				ParentId:    "ParentId",
 				X509SvidTtl: 1,
-				Hint:        "external",
+				X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+					JwtOnly: false,
+				},
+				Hint: "external",
 			},
 		},
 	} {
@@ -2323,6 +2335,9 @@ func (s *PluginSuite) TestPruneRegistrationEntries() {
 		SpiffeId:    "SpiffeId",
 		ParentId:    "ParentId",
 		X509SvidTtl: 1,
+		X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+			JwtOnly: false,
+		},
 		EntryExpiry: now.Unix(),
 	}
 
@@ -3187,7 +3202,10 @@ func (s *PluginSuite) TestUpdateRegistrationEntry() {
 		SpiffeId:    "spiffe://example.org/foo",
 		ParentId:    "spiffe://example.org/bar",
 		X509SvidTtl: 1,
-		JwtSvidTtl:  20,
+		X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{
+			JwtOnly: false,
+		},
+		JwtSvidTtl: 20,
 	})
 
 	entry.X509SvidTtl = 11
@@ -3195,6 +3213,9 @@ func (s *PluginSuite) TestUpdateRegistrationEntry() {
 	entry.Admin = true
 	entry.Downstream = true
 	entry.Hint = "internal"
+	entry.X509SvidCacheHint = &common.RegistrationEntry_X509SvidCacheHint{
+		JwtOnly: false,
+	}
 
 	updatedRegistrationEntry, err := s.ds.UpdateRegistrationEntry(ctx, entry, nil)
 	s.Require().NoError(err)
@@ -3260,31 +3281,33 @@ func (s *PluginSuite) TestUpdateRegistrationEntryWithMask() {
 	// Note that most of the input validation is done in the API layer and has more extensive tests there.
 	now := time.Now().Unix()
 	oldEntry := &common.RegistrationEntry{
-		ParentId:      "spiffe://example.org/oldParentId",
-		SpiffeId:      "spiffe://example.org/oldSpiffeId",
-		X509SvidTtl:   1000,
-		JwtSvidTtl:    3000,
-		Selectors:     []*common.Selector{{Type: "Type1", Value: "Value1"}},
-		FederatesWith: []string{"spiffe://dom1.org"},
-		Admin:         false,
-		EntryExpiry:   1000,
-		DnsNames:      []string{"dns1"},
-		Downstream:    false,
-		StoreSvid:     false,
+		ParentId:          "spiffe://example.org/oldParentId",
+		SpiffeId:          "spiffe://example.org/oldSpiffeId",
+		X509SvidTtl:       1000,
+		JwtSvidTtl:        3000,
+		Selectors:         []*common.Selector{{Type: "Type1", Value: "Value1"}},
+		FederatesWith:     []string{"spiffe://dom1.org"},
+		Admin:             false,
+		EntryExpiry:       1000,
+		DnsNames:          []string{"dns1"},
+		Downstream:        false,
+		StoreSvid:         false,
+		X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{},
 	}
 	newEntry := &common.RegistrationEntry{
-		ParentId:      "spiffe://example.org/oldParentId",
-		SpiffeId:      "spiffe://example.org/newSpiffeId",
-		X509SvidTtl:   4000,
-		JwtSvidTtl:    6000,
-		Selectors:     []*common.Selector{{Type: "Type2", Value: "Value2"}},
-		FederatesWith: []string{"spiffe://dom2.org"},
-		Admin:         false,
-		EntryExpiry:   1000,
-		DnsNames:      []string{"dns2"},
-		Downstream:    false,
-		StoreSvid:     true,
-		Hint:          "internal",
+		ParentId:          "spiffe://example.org/oldParentId",
+		SpiffeId:          "spiffe://example.org/newSpiffeId",
+		X509SvidTtl:       4000,
+		JwtSvidTtl:        6000,
+		Selectors:         []*common.Selector{{Type: "Type2", Value: "Value2"}},
+		FederatesWith:     []string{"spiffe://dom2.org"},
+		Admin:             false,
+		EntryExpiry:       1000,
+		DnsNames:          []string{"dns2"},
+		Downstream:        false,
+		StoreSvid:         true,
+		Hint:              "internal",
+		X509SvidCacheHint: &common.RegistrationEntry_X509SvidCacheHint{},
 	}
 	badEntry := &common.RegistrationEntry{
 		ParentId:      "not a good parent id",

--- a/pkg/server/datastore/sqlstore/testdata/entries.json
+++ b/pkg/server/datastore/sqlstore/testdata/entries.json
@@ -17,7 +17,10 @@
         "spiffe_id": "spiffe://id1",
         "parent_id": "spiffe://parent",
         "ttl": 200,
-        "dns_names": ["a", "b"]
+        "dns_names": [
+            "a",
+            "b"
+        ]
     },
     {
         "selectors": [
@@ -89,6 +92,28 @@
         ],
         "spiffe_id": "spiffe://id5",
         "parent_id": "spiffe://parent2",
+        "ttl": 200
+    },
+    {
+        "selectors": [
+            {
+                "type": "b",
+                "value": "2"
+            },
+            {
+                "type": "c",
+                "value": "3"
+            },
+            {
+                "type": "d",
+                "value": "4"
+            }
+        ],
+        "spiffe_id": "spiffe://id6",
+        "parent_id": "spiffe://parent2",
+        "x509_svid_cache_hint": {
+            "jwt_only": true
+        },
         "ttl": 200
     }
 ]

--- a/proto/spire/common/common.pb.go
+++ b/proto/spire/common/common.pb.go
@@ -364,9 +364,10 @@ type RegistrationEntry struct {
 	// identity should be used by a workload when more than one SVID is returned.
 	Hint string `protobuf:"bytes,14,opt,name=hint,proto3" json:"hint,omitempty"`
 	// * Time of creation, in seconds from epoch
-	CreatedAt     int64 `protobuf:"varint,15,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	CreatedAt         int64                                `protobuf:"varint,15,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	X509SvidCacheHint *RegistrationEntry_X509SvidCacheHint `protobuf:"bytes,16,opt,name=x509_svid_cache_hint,json=x509SvidCacheHint,proto3" json:"x509_svid_cache_hint,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *RegistrationEntry) Reset() {
@@ -504,24 +505,32 @@ func (x *RegistrationEntry) GetCreatedAt() int64 {
 	return 0
 }
 
+func (x *RegistrationEntry) GetX509SvidCacheHint() *RegistrationEntry_X509SvidCacheHint {
+	if x != nil {
+		return x.X509SvidCacheHint
+	}
+	return nil
+}
+
 // * The RegistrationEntryMask is used to update only selected fields of the RegistrationEntry
 type RegistrationEntryMask struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Selectors     bool                   `protobuf:"varint,1,opt,name=selectors,proto3" json:"selectors,omitempty"`
-	ParentId      bool                   `protobuf:"varint,2,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
-	SpiffeId      bool                   `protobuf:"varint,3,opt,name=spiffe_id,json=spiffeId,proto3" json:"spiffe_id,omitempty"`
-	X509SvidTtl   bool                   `protobuf:"varint,4,opt,name=x509_svid_ttl,json=x509SvidTtl,proto3" json:"x509_svid_ttl,omitempty"`
-	FederatesWith bool                   `protobuf:"varint,5,opt,name=federates_with,json=federatesWith,proto3" json:"federates_with,omitempty"`
-	EntryId       bool                   `protobuf:"varint,6,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
-	Admin         bool                   `protobuf:"varint,7,opt,name=admin,proto3" json:"admin,omitempty"`
-	Downstream    bool                   `protobuf:"varint,8,opt,name=downstream,proto3" json:"downstream,omitempty"`
-	EntryExpiry   bool                   `protobuf:"varint,9,opt,name=entryExpiry,proto3" json:"entryExpiry,omitempty"`
-	DnsNames      bool                   `protobuf:"varint,10,opt,name=dns_names,json=dnsNames,proto3" json:"dns_names,omitempty"`
-	StoreSvid     bool                   `protobuf:"varint,11,opt,name=store_svid,json=storeSvid,proto3" json:"store_svid,omitempty"`
-	JwtSvidTtl    bool                   `protobuf:"varint,12,opt,name=jwt_svid_ttl,json=jwtSvidTtl,proto3" json:"jwt_svid_ttl,omitempty"`
-	Hint          bool                   `protobuf:"varint,13,opt,name=hint,proto3" json:"hint,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Selectors         bool                   `protobuf:"varint,1,opt,name=selectors,proto3" json:"selectors,omitempty"`
+	ParentId          bool                   `protobuf:"varint,2,opt,name=parent_id,json=parentId,proto3" json:"parent_id,omitempty"`
+	SpiffeId          bool                   `protobuf:"varint,3,opt,name=spiffe_id,json=spiffeId,proto3" json:"spiffe_id,omitempty"`
+	X509SvidTtl       bool                   `protobuf:"varint,4,opt,name=x509_svid_ttl,json=x509SvidTtl,proto3" json:"x509_svid_ttl,omitempty"`
+	FederatesWith     bool                   `protobuf:"varint,5,opt,name=federates_with,json=federatesWith,proto3" json:"federates_with,omitempty"`
+	EntryId           bool                   `protobuf:"varint,6,opt,name=entry_id,json=entryId,proto3" json:"entry_id,omitempty"`
+	Admin             bool                   `protobuf:"varint,7,opt,name=admin,proto3" json:"admin,omitempty"`
+	Downstream        bool                   `protobuf:"varint,8,opt,name=downstream,proto3" json:"downstream,omitempty"`
+	EntryExpiry       bool                   `protobuf:"varint,9,opt,name=entryExpiry,proto3" json:"entryExpiry,omitempty"`
+	DnsNames          bool                   `protobuf:"varint,10,opt,name=dns_names,json=dnsNames,proto3" json:"dns_names,omitempty"`
+	StoreSvid         bool                   `protobuf:"varint,11,opt,name=store_svid,json=storeSvid,proto3" json:"store_svid,omitempty"`
+	JwtSvidTtl        bool                   `protobuf:"varint,12,opt,name=jwt_svid_ttl,json=jwtSvidTtl,proto3" json:"jwt_svid_ttl,omitempty"`
+	Hint              bool                   `protobuf:"varint,13,opt,name=hint,proto3" json:"hint,omitempty"`
+	X509SvidCacheHint bool                   `protobuf:"varint,14,opt,name=x509_svid_cache_hint,json=x509SvidCacheHint,proto3" json:"x509_svid_cache_hint,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *RegistrationEntryMask) Reset() {
@@ -641,6 +650,13 @@ func (x *RegistrationEntryMask) GetJwtSvidTtl() bool {
 func (x *RegistrationEntryMask) GetHint() bool {
 	if x != nil {
 		return x.Hint
+	}
+	return false
+}
+
+func (x *RegistrationEntryMask) GetX509SvidCacheHint() bool {
+	if x != nil {
+		return x.X509SvidCacheHint
 	}
 	return false
 }
@@ -1060,6 +1076,54 @@ func (x *AttestedNodeMask) GetCanReattest() bool {
 	return false
 }
 
+// * Represents a set of options informing the agent behaviour with respect to
+// pre-fecthing and caching X509 SVIDs. This is meant to prevent unnecessary effort
+// spent on providing X509 SVIDs to workloads, which are likely to ask only for JWT SVID.
+type RegistrationEntry_X509SvidCacheHint struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// * Flag indicating whether the workload is likely to require only JWT SVID.
+	JwtOnly       bool `protobuf:"varint,1,opt,name=jwt_only,json=jwtOnly,proto3" json:"jwt_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RegistrationEntry_X509SvidCacheHint) Reset() {
+	*x = RegistrationEntry_X509SvidCacheHint{}
+	mi := &file_spire_common_common_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegistrationEntry_X509SvidCacheHint) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegistrationEntry_X509SvidCacheHint) ProtoMessage() {}
+
+func (x *RegistrationEntry_X509SvidCacheHint) ProtoReflect() protoreflect.Message {
+	mi := &file_spire_common_common_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RegistrationEntry_X509SvidCacheHint.ProtoReflect.Descriptor instead.
+func (*RegistrationEntry_X509SvidCacheHint) Descriptor() ([]byte, []int) {
+	return file_spire_common_common_proto_rawDescGZIP(), []int{5, 0}
+}
+
+func (x *RegistrationEntry_X509SvidCacheHint) GetJwtOnly() bool {
+	if x != nil {
+		return x.JwtOnly
+	}
+	return false
+}
+
 var File_spire_common_common_proto protoreflect.FileDescriptor
 
 const file_spire_common_common_proto_rawDesc = "" +
@@ -1082,7 +1146,7 @@ const file_spire_common_common_proto_rawDesc = "" +
 	"\x16new_cert_serial_number\x18\x05 \x01(\tR\x13newCertSerialNumber\x12+\n" +
 	"\x12new_cert_not_after\x18\x06 \x01(\x03R\x0fnewCertNotAfter\x124\n" +
 	"\tselectors\x18\a \x03(\v2\x16.spire.common.SelectorR\tselectors\x12!\n" +
-	"\fcan_reattest\x18\b \x01(\bR\vcanReattest\"\xfb\x03\n" +
+	"\fcan_reattest\x18\b \x01(\bR\vcanReattest\"\x8f\x05\n" +
 	"\x11RegistrationEntry\x124\n" +
 	"\tselectors\x18\x01 \x03(\v2\x16.spire.common.SelectorR\tselectors\x12\x1b\n" +
 	"\tparent_id\x18\x02 \x01(\tR\bparentId\x12\x1b\n" +
@@ -1104,7 +1168,10 @@ const file_spire_common_common_proto_rawDesc = "" +
 	"jwtSvidTtl\x12\x12\n" +
 	"\x04hint\x18\x0e \x01(\tR\x04hint\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x0f \x01(\x03R\tcreatedAt\"\x9f\x03\n" +
+	"created_at\x18\x0f \x01(\x03R\tcreatedAt\x12b\n" +
+	"\x14x509_svid_cache_hint\x18\x10 \x01(\v21.spire.common.RegistrationEntry.X509SvidCacheHintR\x11x509SvidCacheHint\x1a.\n" +
+	"\x11X509SvidCacheHint\x12\x19\n" +
+	"\bjwt_only\x18\x01 \x01(\bR\ajwtOnly\"\xd0\x03\n" +
 	"\x15RegistrationEntryMask\x12\x1c\n" +
 	"\tselectors\x18\x01 \x01(\bR\tselectors\x12\x1b\n" +
 	"\tparent_id\x18\x02 \x01(\bR\bparentId\x12\x1b\n" +
@@ -1123,7 +1190,8 @@ const file_spire_common_common_proto_rawDesc = "" +
 	"store_svid\x18\v \x01(\bR\tstoreSvid\x12 \n" +
 	"\fjwt_svid_ttl\x18\f \x01(\bR\n" +
 	"jwtSvidTtl\x12\x12\n" +
-	"\x04hint\x18\r \x01(\bR\x04hint\"P\n" +
+	"\x04hint\x18\r \x01(\bR\x04hint\x12/\n" +
+	"\x14x509_svid_cache_hint\x18\x0e \x01(\bR\x11x509SvidCacheHint\"P\n" +
 	"\x13RegistrationEntries\x129\n" +
 	"\aentries\x18\x01 \x03(\v2\x1f.spire.common.RegistrationEntryR\aentries\"K\n" +
 	"\vCertificate\x12\x1b\n" +
@@ -1170,34 +1238,36 @@ func file_spire_common_common_proto_rawDescGZIP() []byte {
 	return file_spire_common_common_proto_rawDescData
 }
 
-var file_spire_common_common_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_spire_common_common_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_spire_common_common_proto_goTypes = []any{
-	(*Empty)(nil),                 // 0: spire.common.Empty
-	(*AttestationData)(nil),       // 1: spire.common.AttestationData
-	(*Selector)(nil),              // 2: spire.common.Selector
-	(*Selectors)(nil),             // 3: spire.common.Selectors
-	(*AttestedNode)(nil),          // 4: spire.common.AttestedNode
-	(*RegistrationEntry)(nil),     // 5: spire.common.RegistrationEntry
-	(*RegistrationEntryMask)(nil), // 6: spire.common.RegistrationEntryMask
-	(*RegistrationEntries)(nil),   // 7: spire.common.RegistrationEntries
-	(*Certificate)(nil),           // 8: spire.common.Certificate
-	(*PublicKey)(nil),             // 9: spire.common.PublicKey
-	(*Bundle)(nil),                // 10: spire.common.Bundle
-	(*BundleMask)(nil),            // 11: spire.common.BundleMask
-	(*AttestedNodeMask)(nil),      // 12: spire.common.AttestedNodeMask
+	(*Empty)(nil),                               // 0: spire.common.Empty
+	(*AttestationData)(nil),                     // 1: spire.common.AttestationData
+	(*Selector)(nil),                            // 2: spire.common.Selector
+	(*Selectors)(nil),                           // 3: spire.common.Selectors
+	(*AttestedNode)(nil),                        // 4: spire.common.AttestedNode
+	(*RegistrationEntry)(nil),                   // 5: spire.common.RegistrationEntry
+	(*RegistrationEntryMask)(nil),               // 6: spire.common.RegistrationEntryMask
+	(*RegistrationEntries)(nil),                 // 7: spire.common.RegistrationEntries
+	(*Certificate)(nil),                         // 8: spire.common.Certificate
+	(*PublicKey)(nil),                           // 9: spire.common.PublicKey
+	(*Bundle)(nil),                              // 10: spire.common.Bundle
+	(*BundleMask)(nil),                          // 11: spire.common.BundleMask
+	(*AttestedNodeMask)(nil),                    // 12: spire.common.AttestedNodeMask
+	(*RegistrationEntry_X509SvidCacheHint)(nil), // 13: spire.common.RegistrationEntry.X509SvidCacheHint
 }
 var file_spire_common_common_proto_depIdxs = []int32{
-	2, // 0: spire.common.Selectors.entries:type_name -> spire.common.Selector
-	2, // 1: spire.common.AttestedNode.selectors:type_name -> spire.common.Selector
-	2, // 2: spire.common.RegistrationEntry.selectors:type_name -> spire.common.Selector
-	5, // 3: spire.common.RegistrationEntries.entries:type_name -> spire.common.RegistrationEntry
-	8, // 4: spire.common.Bundle.root_cas:type_name -> spire.common.Certificate
-	9, // 5: spire.common.Bundle.jwt_signing_keys:type_name -> spire.common.PublicKey
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	2,  // 0: spire.common.Selectors.entries:type_name -> spire.common.Selector
+	2,  // 1: spire.common.AttestedNode.selectors:type_name -> spire.common.Selector
+	2,  // 2: spire.common.RegistrationEntry.selectors:type_name -> spire.common.Selector
+	13, // 3: spire.common.RegistrationEntry.x509_svid_cache_hint:type_name -> spire.common.RegistrationEntry.X509SvidCacheHint
+	5,  // 4: spire.common.RegistrationEntries.entries:type_name -> spire.common.RegistrationEntry
+	8,  // 5: spire.common.Bundle.root_cas:type_name -> spire.common.Certificate
+	9,  // 6: spire.common.Bundle.jwt_signing_keys:type_name -> spire.common.PublicKey
+	7,  // [7:7] is the sub-list for method output_type
+	7,  // [7:7] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_spire_common_common_proto_init() }
@@ -1211,7 +1281,7 @@ func file_spire_common_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_spire_common_common_proto_rawDesc), len(file_spire_common_common_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/spire/common/common.proto
+++ b/proto/spire/common/common.proto
@@ -96,6 +96,14 @@ message RegistrationEntry {
     string hint = 14;
     /** Time of creation, in seconds from epoch */
     int64 created_at = 15;
+    /** Represents a set of options informing the agent behaviour with respect to
+    pre-fecthing and caching X509 SVIDs. This is meant to prevent unnecessary effort
+    spent on providing X509 SVIDs to workloads, which are likely to ask only for JWT SVID. */
+    message X509SvidCacheHint {
+        /** Flag indicating whether the workload is likely to require only JWT SVID. */
+        bool jwt_only = 1;
+    }
+    X509SvidCacheHint x509_svid_cache_hint = 16;
 }
 
 /** The RegistrationEntryMask is used to update only selected fields of the RegistrationEntry */
@@ -113,6 +121,7 @@ message RegistrationEntryMask {
     bool store_svid = 11;
     bool jwt_svid_ttl = 12;
     bool hint = 13;
+    bool x509_svid_cache_hint = 14;
 }
 
 


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->
This is a draft PR aiming to implement some of the suggestions discussed in https://github.com/spiffe/spire/issues/6129. It adds a new field to `RegisteredEntry` represented by an opaque protobuf-encoded message. The message is meant to contain flags and other fields guiding the agent's behavior with respect to pre-fetching and caching of X509 SVIDs. The intention is to reduce unnecessary work performed by the agent, in case the client is unlikely to ever ask for an X509 SVID and prefers JWT instead. For now only one boolean flag `JWTOnly` is introduced. Other fields may be added later to fine-tune the logic and cover various edge-cases. 
The bulk of this draft is to define the new field in the message definition, update the datastore and have the existing tests pass. The actual usage of the field in `fetchEntries` is purely indicative and requires further consideration.

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
* adds a new field to `RegisteredEntry` and the underlying datastore table
* allows flagging registration entries as preferring JWT SVID over X509
**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->
Fixes https://github.com/spiffe/spire/issues/6129
