### PR TITLE
Fix unmatched braces in server_full config file

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -855,6 +855,7 @@ plugins {
     #              # workload_api_named_pipe_name: Pipe name of the SPIRE Agent API named pipe (Windows only).
     #              # workload_api_named_pipe_name = ""
     #         # }
+    #     }
     # }
 
     # UpstreamAuthority "cert-manager": Uses cert-manager in a target


### PR DESCRIPTION
**Affected functionality**  
None. This change affects only the example configuration file formatting.

**Description of change**  
Added a missing closing brace in `server_full.conf` around line 841 to restore
brace balance. 

**Which issue this PR fixes**  
Fixes #6364