### PR TITLE
Fix for `TestTLSConfig/success_watching_cert_file_changes ` flaky test

### DIFF
--- a/pkg/common/diskcertmanager/cert_manager_test.go
+++ b/pkg/common/diskcertmanager/cert_manager_test.go
@@ -105,6 +105,9 @@ func TestTLSConfig(t *testing.T) {
 		certManager.WatchFileChanges(ctx)
 	}()
 
+	// Wait for the file watcher's ticker to be created before proceeding
+	clk.WaitForTicker(time.Second, "waiting for file watcher ticker to be created")
+
 	tlsConfig := certManager.GetTLSConfig()
 
 	t.Run("error when configuration does not contain serving cert file settings", func(t *testing.T) {


### PR DESCRIPTION
Fix for `TestTLSConfig/success_watching_cert_file_changes ` flaky test where the test would occasionally fail with "Condition never satisfied" errors when checking for certificate updates.

The test had a race condition where it would advance the mock clock and immediately check for certificate updates, but the watcher goroutine's ticker might not have been fully initialized yet. This caused intermittent failures when the test ran before the ticker was ready.

Added `clk.WaitForTicker()` synchronization after starting the file watcher goroutine. This ensures the ticker is fully initialized before any test cases execute, eliminating the race condition.

- Failure example: https://github.com/spiffe/spire/actions/runs/20438610644/job/58726076282#step:5:105
- Fixes https://github.com/spiffe/spire/issues/4324
