### PR TITLE
Flaky integration tests: Increase MAXCHECKS in check-server-started

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -99,9 +99,9 @@ fingerprint() {
 }
 
 check-server-started() {
-  # Check at most 20 times (with one second in between) that the server has
+  # Check at most 30 times (with one second in between) that the server has
   # successfully started.
-  MAXCHECKS=20
+  MAXCHECKS=30
   CHECKINTERVAL=1
   for ((i=1;i<=MAXCHECKS;i++)); do
       log-info "checking for starting server APIs ($i of $MAXCHECKS max)..."


### PR DESCRIPTION
We use `MAXCHECKS=30` in several check functions, but we have `MAXCHECKS=20` in the `check-server-started()` function.
Increase it to be 30 so we reduce the chances of flakiness in the CI.
Example of a failed run due to "timed out waiting for server to start" error: https://github.com/spiffe/spire/actions/runs/20574017119/job/59087459365