### PR TITLE
Use a float64 to set the uptime_in_ms gauge metric.

### DIFF
--- a/pkg/common/telemetry/uptime.go
+++ b/pkg/common/telemetry/uptime.go
@@ -1,5 +1,5 @@
 package telemetry
 
-func EmitUptime(m Metrics, v float32) {
-	m.SetGauge([]string{"uptime_in_ms"}, v)
+func EmitUptime(m Metrics, v float64) {
+	m.SetPrecisionGauge([]string{"uptime_in_ms"}, v)
 }

--- a/pkg/common/uptime/uptime.go
+++ b/pkg/common/uptime/uptime.go
@@ -24,7 +24,7 @@ func reportMetrics(ctx context.Context, interval time.Duration, m telemetry.Metr
 	t := clk.Ticker(interval)
 	defer t.Stop()
 	for {
-		telemetry.EmitUptime(m, float32(Uptime()/time.Millisecond))
+		telemetry.EmitUptime(m, float64(Uptime()/time.Millisecond))
 		select {
 		case <-t.C:
 		case <-ctx.Done():

--- a/pkg/common/uptime/uptime_test.go
+++ b/pkg/common/uptime/uptime_test.go
@@ -35,7 +35,7 @@ type testMetrics struct {
 	setGaugeCallback func()
 }
 
-func (f *testMetrics) SetGauge(key []string, val float32) {
-	f.FakeMetrics.SetGauge(key, val)
+func (f *testMetrics) SetPrecisionGauge(key []string, val float64) {
+	f.FakeMetrics.SetPrecisionGauge(key, val)
 	f.setGaugeCallback()
 }


### PR DESCRIPTION
A float32 starts to lose precision at 16777216ms which is just under 5 hours.

Fixes https://github.com/spiffe/spire/issues/6048