### PR TITLE
feat: Allow JWT signing keys to be shared (closes #4699)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+SPIRE is the SPIFFE Runtime Environment: a server + agent toolchain that attests workloads and issues SPIFFE IDs / SVIDs (X.509 and JWT). It is a CNCF graduated project. This is `github.com/spiffe/spire` (here, an Indeed fork; default branch `main-indeed`).
+
+## Build / test / lint
+
+Everything goes through the `Makefile`, which pins and auto-installs its own toolchain (protoc, golangci-lint, Go) under `.build/`. Use the make targets rather than raw tools — notably, `make lint-code` runs golangci-lint via `go run .../golangci-lint@<pinned-version>`, so a system-installed `golangci-lint` of a different version (which fails against this repo's Go target) is irrelevant.
+
+- `make build` — build all binaries (`bin/spire-server`, `bin/spire-agent`, `bin/oidc-discovery-provider`); `make bin/spire-server` for one.
+- `make test` — full unit suite (`go test ./...`). `make race-test` for the `-race` variant. `COVERPROFILE=out.cov make test` for coverage.
+- `make lint` — `lint-code` (golangci-lint, config in `.golangci.yml`) + `lint-md`.
+- `make all` — build + lint + test.
+- `make generate` — regenerate protobuf / plugin / service `.pb.go` from `.proto`; `make generate-check` verifies generated code is current (must run on a clean tree). Run after editing any `.proto`.
+- `make govulncheck`, `make tidy` / `tidy-check`.
+
+Running focused tests directly with `go test` is fine and faster than `make test`:
+- Single package: `go test ./pkg/server/ca/manager/`
+- Single test: `go test ./pkg/common/bundleutil/ -run TestDedupSigningKeysByKid`
+- Datastore and several plugins use **testify suites**, so the top-level `Test*` is the suite entry and methods are addressed with `/`: e.g. `go test ./pkg/server/datastore/sqlstore/ -run 'TestPlugin/TestAppendBundle'`.
+
+Datastore unit tests run against **sqlite3** by default. MySQL/Postgres dialects are exercised via the integration harness (`test/integration/`, `make integration`), not plain `go test`.
+
+## Architecture
+
+Two processes, mirrored layouts: `pkg/server/` (the trust-domain authority) and `pkg/agent/` (runs on each node, attests workloads, exposes the SPIFFE Workload API). CLI entrypoints are in `cmd/spire-server` and `cmd/spire-agent`; `support/oidc-discovery-provider` serves a JWKS/OIDC endpoint from the trust bundle.
+
+**Plugin framework (central).** Almost all pluggable behavior is a gRPC plugin built on `github.com/spiffe/spire-plugin-sdk`. Plugin categories live under `pkg/{server,agent}/plugin/<category>/<impl>/` — server: `keymanager`, `nodeattestor`, `upstreamauthority`, `notifier`, `bundlepublisher`, `credentialcomposer`; agent: `keymanager`, `nodeattestor`, `workloadattestor`, `svidstore`. Each impl exposes a `BuiltIn()` (`catalog.MakeBuiltIn(...)`); built-ins are wired into the process by being listed in `pkg/{server,agent}/catalog/<category>.go`. Plugins can also run as external binaries over the same gRPC contract, so an implementation must never assume in-process calls. The category interface package (e.g. `pkg/server/plugin/keymanager`) is the neutral contract shared by the host (CA manager, etc.) and the impls — put cross-cutting constants there, not in an impl or in `pkg/server/ca`.
+
+**Server CA + HA rotation.** `pkg/server/ca/manager` prepares/activates/rotates the X509 CA, JWT, and WIT signing keys; `journal.go` persists rotation state to the datastore's `CAJournal` record. Multiple servers in one trust domain share the datastore (HA): each server finds *its* journal by matching a KeyManager key's X.509 SubjectKeyID against `active_x509_authority_id`. Key material is obtained from the configured `keymanager` plugin by a deterministic logical key ID (`x509-CA-*`, `JWT-Signer-*`, `WIT-Signer-*`, built in `slot.go`); the bundle (`common.Bundle`) is keyed by the JWT `kid`.
+
+**Datastore.** The `datastore` plugin interface (`pkg/server/datastore`) is implemented by `sqlstore` (GORM over sqlite/MySQL/Postgres). Schema lives in `models.go`; migrations are versioned. Per repo convention, **a datastore/schema change must ship a full minor release before any code depends on it** — add the column/migration first, wire up the dependent logic in a later release.
+
+**Protobuf.** `.proto` under `proto/spire/` (public API/common types) and `proto/private/` (internal, e.g. the CA journal). Generated `*.pb.go` is checked in and produced by `make generate`; never hand-edit generated files.
+
+## Conventions
+
+- This is a Go module (`go 1.26.3`); run `make tidy` after dependency changes.
+- `make generate` after any `.proto` edit, and keep the generated output committed.
+- Follow the existing testify-suite style when extending datastore/plugin tests; plugins use in-package fakes (`client_fake.go`) rather than network calls.
+- `pkg/common/` is the only place shared by server, agent, and plugins — keep agent/server-specific code out of it.
+
+## The task: shared JWT signing keys (fix "too many JWKS keys", #4699 / PR #6537)
+
+This branch (`too_many_jwks_keys`) lets multiple SPIRE servers in one trust domain **share JWT signing key material** so the JWKS endpoint stops accumulating one key per server. The feature is configured per KeyManager plugin via a `shared_keys { ... }` block. Read this whole section before touching the CA manager or any keymanager plugin.
+
+### The core problem and goal
+
+In HA, every server independently prepares/activates/rotates its own JWT signing key, so the trust bundle's `JwtSigningKeys` (served as JWKS) grows with the server count and rotation history. Goal: when servers share the same JWT key *material*, that key should appear **once** in the JWKS, and the feature must not break X509 CA issuance or HA journal rotation. Only **JWT** keys are shared; X509 CA and WIT keys stay per-server.
+
+### Challenges and how they were solved
+
+1. **Random `kid` → no dedup.** The JWT/WIT `kid` was random (old `newKeyID()` via `crypto/rand`), independent of the key. Two servers sharing one key emitted different `kid`s, so the same public key landed in the JWKS under N `kid`s. **Solution:** derive the `kid` deterministically from the public key — `deterministicKeyID(signer)` in `pkg/server/ca/manager/manager.go` calls `x509util.GetSubjectKeyID` + `SubjectKeyIDToString` (the same SKI derivation X509 authority IDs use). Now all servers compute the same `kid` for the same key. (`newJWTKey`/`newWITKey` use it; the old `newKeyID`/`keyIDFromBytes` were removed.)
+
+2. **`NotAfter` divergence → deterministic `kid` alone still doesn't dedup.** The bundle is merged in `appendBundle` (`pkg/server/datastore/sqlstore/sqlstore.go`) via `bundleutil.MergeBundles`, which dedups by the *entire* `PublicKey.String()` — including `NotAfter`. Each server computes `NotAfter = now + caTTL` independently, so the same shared key still produced two entries with the *same* `kid` (which also tripped the "another key with the same KeyID" guards in `taintJWTKey`/`revokeJWTKey`). **Solution:** `bundleutil.DedupSigningKeysByKid(bundle)` collapses JWT/WIT entries sharing a `kid` to one, keeping the **max `NotAfter`** and OR-ing `TaintedKey`; called right after `MergeBundles` in `appendBundle`. It is a no-op when `kid`s are distinct, so non-shared deployments are unaffected. **Do not** change `MergeBundles` itself (it has other callers and intentionally compares full content).
+
+3. **Restart key-ownership / journal collision.** A server finds *its* CA journal in `findCAJournal` (`pkg/server/ca/manager/journal.go`) by computing the X509 SubjectKeyID of each key `km.GetKeys()` returns and matching `active_x509_authority_id`. This assumes the key store is private to the server. Naively sharing *all* key types means `km.GetKeys()` returns other servers' X509 keys, so a restarting server can adopt a **foreign journal**. **Solution:** scope sharing to **JWT keys only**. X509 CA and WIT keys remain per-server (namespaced by a server identifier), so `km.GetKeys()` returns this server's unique X509 key + the shared JWT keys, the X509 match stays unique, and **`findCAJournal` needed no change**. A server identifier is therefore **required even when `shared_keys` is enabled**. The JWT-vs-other distinction is made by key-ID prefix via `keymanager.IsSharedKeyID(id)` (true iff prefix `JWT-Signer-`); the prefixes `X509CAKeyIDPrefix`/`JWTSignerKeyIDPrefix`/`WITSignerKeyIDPrefix` are exported from `pkg/server/plugin/keymanager/constant.go` and used by both `slot.go` and every plugin.
+
+4. **Cross-server race when creating/rotating the shared key.** Two servers preparing the same shared JWT key at once must not both mint new material. **Solution (already present in the plugins, kept JWT-only):** a distributed lock plus an optimistic freshness check. On `GenerateKey` for a JWT key, the plugin (a) optimistically reuses an existing key if it was created within a **15-minute freshness window** (`sharedKeyFreshnessThreshold`) and the key type matches; otherwise (b) acquires a lock (a lock alias/label/tag whose value is a timestamp), re-checks freshness, creates the key, then releases the lock. Stale locks older than **`lockTTL` (10 min)** are broken. Per-server in-process races are separately serialized (e.g. disk takes a file lock; awskms holds `p.mu`). These lock/freshness paths are now gated on `IsSharedKeyID` so X509/WIT never take the shared path.
+
+5. **Discovery on restart (which keys are mine).** With a shared store, a server must rediscover the shared JWT keys **and** its own per-server X509/WIT keys, without picking up other servers' per-server keys. **Solution:** each plugin's key discovery became composite — match shared JWT keys by the configured template/regex, and match per-server keys only when they carry this server's identity (server-id alias prefix / label / tag). See per-plugin notes.
+
+### Per-plugin mechanics (`pkg/server/plugin/keymanager/<impl>/`)
+
+All four share the policy "JWT shared, X509/WIT per-server, server identifier required when shared," but each KeyManager identifies and stores keys differently:
+
+- **disk** (`disk/disk.go`) — single shared keys file on a shared volume. Trickiest. Added a per-server id (`key_identifier_file`/`key_identifier_value` → `getOrCreateServerID`) and a `server_id` field on each on-disk `keyEntryRecord`. JWT keys are stored under the `crypto_key_template`-derived slot (shared across servers); X509/WIT under a `<serverID>/<keyID>` slot. Load **filters** to this server's records + shared JWT records; writes use **raw read-modify-write** (`persistKey`/`loadKeyData`/`writeKeyData`) so a server never clobbers another server's records in the shared file. Reuse (`checkReuse`) applies the 15-min window only to JWT keys.
+- **awskms** (`awskms/awskms.go`, `fetcher.go`) — KMS aliases. `generateAliasName` branches: JWT → `jwt_key_alias_template`; else → the per-server alias `alias/SPIRE_SERVER/<td>/<serverID>/<keyID>` (`aliasFromSpireKeyID`). `GenerateKey` routes non-JWT keys through the simple create-and-alias path; only JWT keys use the lock/freshness path. The fetcher's `keyIDExtractor` is composite: try the shared `key_id_extraction_regex`, else the per-server alias prefix.
+- **gcpkms** (`gcpkms/gcpkms.go`, `fetcher.go`) — Cloud KMS, **label-filter** discovery. `generateCryptoKeyID` branches (JWT → `crypto_key_template`; else `spire-key-<serverID>-<keyID>`). A `useSharedKey := sharedKeysEnabled && IsSharedKeyID(id)` local gates every shared block in `createKey` (optimistic reuse, KID label, lock-label acquisition/release, freshness re-check). In shared mode the fetcher lists *all* active keys in the trust domain (broad label filter) and the composite extractor narrows per-server keys via the `spire-server-id` label.
+- **azurekeyvault** (`azure_key_vault.go`, `fetcher.go`) — Key Vault, **tag** based. Same `useSharedKey` gating in `createKey` (incl. the rotation-deletion branch). `generateKeyName` branches (JWT → `jwt_key_template`; else `spire-key-<uuid>-<keyID>` — per-server names use a random UUID, and server identity lives in the `spire-server-id` tag, so the name parser is serverID-agnostic). Composite extractor: regex for JWT, else `spire-server-id` tag == this server.
+
+### Key files / symbols
+
+- `pkg/server/ca/manager/manager.go` — `deterministicKeyID`, `newJWTKey`/`newWITKey`.
+- `pkg/server/ca/manager/slot.go` — `x509CAKmKeyID`/`jwtKeyKmKeyID`/`witKeyKmKeyID` (use the exported prefix constants).
+- `pkg/server/ca/manager/journal.go` — `findCAJournal` (the per-server binding that JWT-only scoping protects).
+- `pkg/common/bundleutil/bundle.go` — `DedupSigningKeysByKid` / `dedupPublicKeysByKid`; wired in `pkg/server/datastore/sqlstore/sqlstore.go` `appendBundle`.
+- `pkg/server/plugin/keymanager/constant.go` — `IsSharedKeyID` and the key-ID prefix constants.
+- Plugin docs: `doc/plugin_server_keymanager_{disk,aws_kms,gcp_kms,azure_key_vault}.md`.
+
+### Status and what's left
+
+Done and committed (4 commits, newest last: `c46739c9` core kid+dedup, then `awskms`, `gcpkms`, `azurekeyvault`). Each component has unit tests; per plugin see `Test...SharedKeys...` and the `*_OnlyJWTKeysAreShared` tests; disk also has a restart/dual-discovery test (`TestSharedKeyOnlyJWTKeysAreShared`).
+
+**Out of scope (intended follow-ups, not yet done):**
+- Populating/querying `active_jwt_authority_id` — the `CAJournal` model column exists (added upstream in #4465) but is **never written or read** by application code. Wiring it would give JWT keys first-class journal identity for cross-server coordination. Remember the datastore minor-release rule before depending on it.
+- Cross-server **tainting / bundle-removal** coordination: a deterministic `kid` removes duplicate entries but does not decide *which* server may rotate/taint/remove a shared key. Reviewers (sorindumitru on PR #6537) flagged this as the remaining hard problem; it likely needs server-to-server signaling.
+
+### Gotchas for the next agent
+
+- **Deterministic-`kid` convergence is gradual.** On upgrade, `kid`s are loaded from the journal (`slot.go` `loadJWTKeySlotFromEntry`), so existing keys keep their old random `kid`; only newly-prepared keys get deterministic ones. The plugin docs already state existing keys can't be used after enabling shared mode (start fresh).
+- **gcp/azure per-server name parsers assume a UUID-shaped server id** (`getSPIREKeyIDFromCryptoKeyName`, `spireKeyIDFromKeyName` use a fixed UUID-length offset). This is pre-existing; a generated `key_identifier_file` (UUID) is safe, a short custom `key_identifier_value` can mis-parse per-server names on rediscovery.
+- **FIPS** mode changes the SKI hash (`pkg/common/x509util/keyid.go`: SHA-256-first-20 vs SHA-1), so the `kid` value differs by mode — servers sharing a key must run the same FIPS mode.
+- **Test fakes** return *deterministic* key material (`test/testkey`), and azure's fake `CreateKey` stamps its own `serverID` ignoring passed tags — so the JWT-only tests assert on **storage layout / names / tags**, not key bytes.
+- When adding a new exported symbol, no doc comment is required (`.golangci.yml` does not enable revive's `exported` rule), but match the surrounding style. Run `make lint-code` (not a system `golangci-lint`).

--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -2,6 +2,11 @@
 
 The `aws_kms` key manager plugin leverages the AWS Key Management Service (KMS) to create, maintain and rotate key pairs (as [Customer Master Keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#master_keys), or CMKs), and sign SVIDs as needed, with the private key never leaving KMS.
 
+The plugin supports two modes of operation:
+
+- **Standard Mode**: Each SPIRE server manages its own set of keys identified by a unique server ID
+- **Shared Keys Mode**: Multiple SPIRE servers (including multi-region deployments) can discover and use the same signing keys based on configurable templates and regular expressions
+
 ## Configuration
 
 The plugin accepts the following configuration options:
@@ -11,9 +16,15 @@ The plugin accepts the following configuration options:
 | access_key_id        | string | see [AWS KMS Access](#aws-kms-access)       | The Access Key Id used to authenticate to KMS                                                                               | Value of the AWS_ACCESS_KEY_ID environment variable     |
 | secret_access_key    | string | see [AWS KMS Access](#aws-kms-access)       | The Secret Access Key used to authenticate to KMS                                                                           | Value of the AWS_SECRET_ACCESS_KEY environment variable |
 | region               | string | yes                                         | The region where the keys will be stored                                                                                    |                                                         |
-| key_identifier_file  | string | Required if key_identifier_value is not set | A file path location where information about generated keys will be persisted                                               |                                                         |
-| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                   |                                                         |
+| key_identifier_file  | string | See [Key Identifier](#key-identifier)       | A file path location where information about generated keys will be persisted                                               |                                                         |
+| key_identifier_value | string | See [Key Identifier](#key-identifier)       | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                   |                                                         |
 | key_policy_file      | string | no                                          | A file path location to a custom key policy in JSON format                                                                  | ""                                                      |
+| key_tags             | map    | no                                          | A map of tags to apply to created keys                                                                                      |                                                         |
+| shared_keys          | object | no                                          | Configuration for shared keys mode (see [Shared Keys Configuration](#shared-keys-configuration))                            |                                                         |
+
+### Key Identifier
+
+Either `key_identifier_file` or `key_identifier_value` is required, including in shared keys mode. Only JWT signing keys are shared between servers (via the templates and regex); X509 CA and WIT keys remain per-server and are namespaced by the server identifier.
 
 ### Alias and Key Management
 
@@ -40,7 +51,46 @@ The plugin attempts to detect and prune stale aliases. To facilitate stale alias
 
 The plugin also attempts to detect and prune stale keys. All keys managed by the plugin are assigned a `Description` of the form `SPIRE_SERVER/{TRUST_DOMAIN}`. The plugin periodically scans the keys. Any key with a `Description` matching the proper form, that is both unassociated with any alias and has a `CreationDate` older than 48 hours, is removed.
 
-### Key tagging
+### Shared Keys Configuration
+
+The plugin supports a shared keys mode that allows multiple SPIRE servers to discover and use the same JWT signing keys. This is useful for multi-server and multi-region deployments where servers need to coordinate key usage. Only JWT signing keys are shared; X509 CA and WIT keys remain per-server (identified by the `key_identifier_file`/`key_identifier_value` server identifier).
+
+When the `shared_keys` configuration block is present, the plugin operates in shared keys mode. This block accepts the following options:
+
+| Key                       | Type   | Required | Description                                                                                                                  |
+|---------------------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| jwt_key_alias_template    | string | yes      | A Go template to generate the KMS alias for JWT keys                                                                         |
+| lock_alias_template       | string | yes      | A Go template to generate the KMS alias used for distributed locking during rotation                                         |
+| key_id_extraction_regex   | string | yes      | A regex with one capturing group to extract the SPIRE Key ID from KMS alias names                                            |
+
+> **Note**: Any existing keys cannot be used after turning on the shared keys feature.
+
+> **Note**: Shared keys mode increases API call volume. Each `GenerateKey` call issues additional `ListAliases`, `DescribeKey`, and `CreateAlias` requests for lock acquisition and key discovery. Ensure your AWS account's KMS management-API request quota (separate from the cryptographic-operation quota) is sufficient for your server count and rotation cadence.
+
+#### Template Context
+
+The alias templates support [Sprig v3](http://masterminds.github.io/sprig/) functions and have access to the following variables:
+
+- `.Region`: The configured AWS region
+- `.TrustDomain`: The configured trust domain
+- `.ServerID`: The server ID (if configured)
+- `.Env`: The value of the `SPIRE_ENV` environment variable
+- `.KeyID`: The SPIRE Key ID being requested (e.g., `jwt-signer`, `x509-CA-A`)
+
+#### Regex-based Discovery
+
+The `key_id_extraction_regex` must include **one capturing group** that extracts the SPIRE Key ID from the KMS alias name.
+
+Example: `^alias/spire/[^/]+/([^/]+)$` matches `alias/spire/us-east-1/jwt-signer` and extracts `jwt-signer`.
+
+#### Distributed Locking and Coordination
+
+When multiple servers share keys, they must coordinate to prevent race conditions during key rotation:
+
+1. **Distributed Locking**: Before creating or rotating a key, the plugin acquires a distributed lock by creating a KMS alias determined by `lock_alias_template`
+2. **Freshness Check**: If the lock is acquired, the plugin checks if the key was recently rotated (within the last 15 minutes) by another server. If so, it reuses the existing fresh key instead of generating a duplicate
+
+### Key Tagging
 
 The plugin supports tagging of KMS keys with user-defined tags using the `key_tags` configuration option. These tags are specified as key-value pairs and are applied to all KMS keys created by the plugin.
 
@@ -128,28 +178,75 @@ is set, the plugin uses the policy defined in the file instead of the default po
 
 ## Sample Plugin Configuration
 
-### Basic configuration
+### Standard Mode (Single Server)
+
+Basic configuration for a single SPIRE server:
 
 ```hcl
 KeyManager "aws_kms" {
     plugin_data {
         region = "us-east-2"
-        key_metadata_file = "./key_metadata"
+        key_identifier_file = "./server_id"
     }
 }
 ```
 
-### Configuration with tags
+### Standard Mode with Tags
 
 ```hcl
 KeyManager "aws_kms" {
     plugin_data {
         region = "us-east-2"
-        key_metadata_file = "./key_metadata"
+        key_identifier_file = "./server_id"
         key_tags = {
             Environment = "production"
             Team        = "security"
             Component   = "spire"
+        }
+    }
+}
+```
+
+### Shared Keys Mode (Multi-Server)
+
+Configuration for multiple SPIRE servers sharing keys:
+
+```hcl
+KeyManager "aws_kms" {
+    plugin_data {
+        region = "us-east-1"
+        
+        shared_keys {
+            # Template matches alias/spire/us-east-1/jwt-signer
+            jwt_key_alias_template = "alias/spire/{{ .Region }}/{{ .KeyID }}"
+            
+            # Regex extracts 'jwt-signer' from the alias
+            key_id_extraction_regex = "^alias/spire/[^/]+/([^/]+)$"
+            
+            # Lock alias for safe rotation coordination
+            lock_alias_template = "alias/spire/lock/{{ .Region }}/{{ .KeyID }}"
+        }
+    }
+}
+```
+
+### Shared Keys Mode with Environment-based Keys
+
+```hcl
+KeyManager "aws_kms" {
+    plugin_data {
+        region = "us-west-2"
+        
+        shared_keys {
+            # Use environment variable for multi-environment deployments
+            jwt_key_alias_template = "alias/spire/{{ .Env }}/{{ .Region }}/{{ .KeyID }}"
+            key_id_extraction_regex = "^alias/spire/[^/]+/[^/]+/([^/]+)$"
+            lock_alias_template = "alias/spire/lock/{{ .Env }}/{{ .Region }}/{{ .KeyID }}"
+        }
+        
+        key_tags = {
+            Environment = "production"
+            Region      = "us-west-2"
         }
     }
 }

--- a/doc/plugin_server_keymanager_azure_key_vault.md
+++ b/doc/plugin_server_keymanager_azure_key_vault.md
@@ -6,19 +6,29 @@ Microsoft Azure principal can view or export the raw cryptographic key material
 represented by a key. Instead, Key Vault accesses the key material on behalf of
 SPIRE.
 
+The plugin supports two modes of operation:
+
+- **Standard Mode**: Each SPIRE server manages its own set of keys identified by a unique server ID
+- **Shared Keys Mode**: Multiple SPIRE servers (including multi-region deployments) can discover and use the same signing keys based on configurable templates and regular expressions
+
 ## Configuration
 
 The plugin accepts the following configuration options:
 
 | Key                  | Type    | Required                                    | Description                                                                                                                                                      | Default |
 |----------------------|---------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| key_identifier_file  | string  | Required if key_identifier_value is not set | A file path location where information about generated keys will be persisted. See "[Management of keys](#management-of-keys)" for more information.             | ""      |
-| key_identifier_value | string  | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`).                                                                       | ""      |
+| key_identifier_file  | string  | See [Key Identifier](#key-identifier)       | A file path location where information about generated keys will be persisted. See "[Management of keys](#management-of-keys)" for more information.             | ""      |
+| key_identifier_value | string  | See [Key Identifier](#key-identifier)       | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`).                                                                       | ""      |
 | key_vault_uri        | string  | Yes                                         | The Key Vault URI where the keys managed by this plugin reside.                                                                                                  | ""      |
 | subscription_id      | string  | [Optional](#authenticating-to-azure)        | The subscription id.                                                                                                                                             | ""      |
 | app_id               | string  | [Optional](#authenticating-to-azure)        | The application id.                                                                                                                                              | ""      |
 | app_secret           | string  | [Optional](#authenticating-to-azure)        | The application secret.                                                                                                                                          | ""      |
 | tenant_id            | string  | [Optional](#authenticating-to-azure)        | The tenant id.                                                                                                                                                   | ""      |
+| shared_keys          | object  | no                                          | Configuration for shared keys mode (see [Shared Keys Configuration](#shared-keys-configuration))                                                                 | ""      |
+
+### Key Identifier
+
+Either `key_identifier_file` or `key_identifier_value` is required, including in shared keys mode. Only JWT signing keys are shared between servers (identified via the templates and regex); X509 CA and WIT keys remain per-server and are tagged with the server identifier.
 
 ### Authenticating to Azure
 
@@ -42,6 +52,41 @@ When a key is rotated, a new version is added to the Key.
 
 Note that Azure does not support deleting individual key versions, instead, the key itself is deleted by the plugin
 when it's no longer being used by a server in the trust domain the server belongs to.
+
+### Shared Keys Configuration
+
+The plugin supports a shared keys mode that allows multiple SPIRE servers to discover and use the same JWT signing keys. This is useful for multi-server and multi-region deployments where servers need to coordinate key usage. Only JWT signing keys are shared; X509 CA and WIT keys remain per-server (identified by the `key_identifier_file`/`key_identifier_value` server identifier).
+
+When the `shared_keys` configuration block is present, the plugin operates in shared keys mode. This block accepts the following options:
+
+| Key                      | Type   | Required | Description                                                                                                                  |
+|--------------------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| jwt_key_template         | string | yes      | A Go template to generate the Key Vault key name for JWT keys                                                                |
+| key_id_extraction_regex  | string | yes      | A regex with one capturing group to extract the SPIRE Key ID from Key Vault key names                                        |
+
+> **Note**: Any existing keys cannot be used after turning on the shared keys feature.
+
+> **Note**: Shared keys mode increases Key Vault data-plane API call volume. Each `GenerateKey` call issues additional `ListKeys`, `GetKey`, and `UpdateKey` requests for lock acquisition and key discovery. Azure Key Vault's default management-operation throughput limit (2000 requests per 10 seconds) may need to be increased for large deployments or frequent rotations.
+
+#### Template Context
+
+The key name template supports [Sprig v3](http://masterminds.github.io/sprig/) functions and has access to the following variables:
+
+- `.TrustDomain`: The configured trust domain
+- `.ServerID`: The server ID (if configured)
+- `.KeyID`: The SPIRE Key ID being requested (e.g., `jwt-signer`, `x509-CA-A`)
+
+#### Regex-based Discovery
+
+The `key_id_extraction_regex` must include **one capturing group** that extracts the SPIRE Key ID from the Key Vault key name.
+
+Example: `^spire-[^-]+-(.+)$` matches `spire-example-com-jwt-signer` and extracts `jwt-signer`.
+
+#### Freshness Check and Coordination
+
+When multiple servers share keys, they coordinate to prevent unnecessary key creation:
+
+1. **Freshness Check**: Before creating a new key version, the plugin checks if the key was recently created (within the last 15 minutes) by another server. If so, it reuses the existing fresh key instead of generating a duplicate
 
 ### Management of keys
 
@@ -72,7 +117,7 @@ where a key identifier file can't be persisted.
 
 The plugin attempts to detect and delete stale keys. To facilitate stale
 keys detection, the plugin actively updates the `Updated` field of all keys managed by the server every 6 hours.
-Within the Key Vault the plugin is configured to use (`key_vaut_uri`), the plugin periodically scans the keys looking
+Within the Key Vault the plugin is configured to use (`key_vault_uri`), the plugin periodically scans the keys looking
 for active keys within the trust domain that have their `Updated` field value older than two weeks and deletes them.
 
 ### Required permissions
@@ -94,6 +139,60 @@ Cryptographic Operations
 ```text
 Sign
 Verify
+```
+
+## Sample Plugin Configuration
+
+### Standard Mode (Single Server)
+
+Basic configuration for a single SPIRE server:
+
+```hcl
+KeyManager "azure_key_vault" {
+    plugin_data {
+        key_vault_uri = "https://example-vault.vault.azure.net/"
+        key_identifier_file = "./server_id"
+    }
+}
+```
+
+### Shared Keys Mode (Multi-Server)
+
+Configuration for multiple SPIRE servers sharing keys:
+
+```hcl
+KeyManager "azure_key_vault" {
+    plugin_data {
+        key_vault_uri = "https://example-vault.vault.azure.net/"
+        
+        shared_keys {
+            # Template matches spire-example-com-jwt-signer
+            jwt_key_template = "spire-{{ .TrustDomain | replace \".\" \"-\" }}-{{ .KeyID }}"
+            
+            # Regex extracts 'jwt-signer' from the key name
+            key_id_extraction_regex = "^spire-[^-]+-(.+)$"
+        }
+    }
+}
+```
+
+### Shared Keys Mode with Static Credentials
+
+```hcl
+KeyManager "azure_key_vault" {
+    plugin_data {
+        key_vault_uri = "https://example-vault.vault.azure.net/"
+        subscription_id = "subscription-id"
+        app_id = "app-id"
+        app_secret = "app-secret"
+        tenant_id = "tenant-id"
+        
+        shared_keys {
+            jwt_key_template = "spire-{{ .TrustDomain | replace \".\" \"-\" }}-{{ .KeyID }}"
+            key_id_extraction_regex = "^spire-[^-]+-(.+)$"
+        }
+    }
+}
 ```
 
 ## Supported Key Types

--- a/doc/plugin_server_keymanager_disk.md
+++ b/doc/plugin_server_keymanager_disk.md
@@ -5,9 +5,22 @@ disk.
 
 The plugin accepts the following configuration options:
 
-| Configuration | Description                   |
-|---------------|-------------------------------|
-| keys_path     | Path to the keys file on disk |
+| Configuration        | Description                                                                                                                                  |
+|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| keys_path            | Path to the keys file on disk                                                                                                                 |
+| key_identifier_file  | A path (local to this server) used to persist an auto-generated, per-server identifier. Required with `shared_keys` unless `key_identifier_value` is set. |
+| key_identifier_value | An explicit, stable per-server identifier. Required with `shared_keys` unless `key_identifier_file` is set.                                   |
+| shared_keys          | Configuration for shared keys                                                                                                                 |
+
+ The `shared_keys` configuration block has the following members:
+
+| Configuration       | Description                                                                                                                           |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| crypto_key_template | A golang text/template (with [Sprig v3](http://masterminds.github.io/sprig/) functions available) used to derive the ID JWT keys are stored under in the file. `{{ .TrustDomain }}` and `{{ .KeyID }}` are available. The template must vary with `{{ .KeyID }}`. |
+
+> **Note**: Only JWT signing keys are shared between servers. X509 CA and WIT keys remain per-server, namespaced by the server identifier, so each server keeps its own. This is why a `key_identifier_file` or `key_identifier_value` is required when `shared_keys` is enabled.
+
+> **Note**: Any existing keys cannot be used after turning on the shared keys feature. Additionally, using the `disk` key manager with the `shared_keys` feature requires a network-accessible shared volume (e.g., NFS v4, or a cloud-managed network filesystem) mounted on every SPIRE server instance that participates in key sharing. File-lock contention on the shared volume scales with server count and rotation cadence; prefer a low-latency mount.
 
 A sample configuration:
 
@@ -15,6 +28,10 @@ A sample configuration:
     KeyManager "disk" {
         plugin_data = {
             keys_path = "/opt/spire/data/server/keys.json"
+            key_identifier_file = "/opt/spire/data/server/server-id"
+            shared_keys = {
+                crypto_key_template = "{{ .TrustDomain }}-{{ .KeyID }}"
+            }
         }
     }
 ```

--- a/doc/plugin_server_keymanager_gcp_kms.md
+++ b/doc/plugin_server_keymanager_gcp_kms.md
@@ -6,6 +6,11 @@ Google Cloud principal can view or export the raw cryptographic key material
 represented by a key. Instead, Cloud KMS accesses the key material on behalf of
 SPIRE.
 
+The plugin supports two modes of operation:
+
+- **Standard Mode**: Each SPIRE server manages its own set of keys identified by a unique server ID
+- **Shared Keys Mode**: Multiple SPIRE servers (including multi-region deployments) can discover and use the same signing keys based on configurable templates and regular expressions
+
 ## Configuration
 
 The plugin accepts the following configuration options:
@@ -13,10 +18,15 @@ The plugin accepts the following configuration options:
 | Key                  | Type   | Required                                    | Description                                                                                                                                                                                    | Default                                                         |
 |----------------------|--------|---------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
 | key_policy_file      | string | no                                          | A file path location to a custom [IAM Policy (v3)](https://cloud.google.com/pubsub/docs/reference/rpc/google.iam.v1#google.iam.v1.Policy) in JSON format to be attached to created CryptoKeys. | ""                                                              |
-| key_identifier_file  | string | Required if key_identifier_value is not set | A file path location where key metadata used by the plugin will be persisted. See "[Management of keys](#management-of-keys)" for more information.                                            | ""                                                              |
-| key_identifier_value | string | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                                                                                      | ""                                                              |
+| key_identifier_file  | string | See [Key Identifier](#key-identifier)       | A file path location where key metadata used by the plugin will be persisted. See "[Management of keys](#management-of-keys)" for more information.                                            | ""                                                              |
+| key_identifier_value | string | See [Key Identifier](#key-identifier)       | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                                                                                      | ""                                                              |
 | key_ring             | string | yes                                         | Resource ID of the key ring where the keys managed by this plugin reside, in the format projects/\*/locations/\*/keyRings/\*                                                                   | ""                                                              |
 | service_account_file | string | no                                          | Path to the service account file used to authenticate with the Cloud KMS API.                                                                                                                  | Value of `GOOGLE_APPLICATION_CREDENTIALS` environment variable. |
+| shared_keys          | object | no                                          | Configuration for shared keys mode (see [Shared Keys Configuration](#shared-keys-configuration))                                                                                               | ""                                                              |
+
+### Key Identifier
+
+Either `key_identifier_file` or `key_identifier_value` is required, including in shared keys mode. Only JWT signing keys are shared between servers (identified via the templates and regex); X509 CA and WIT keys remain per-server and are namespaced by the server identifier.
 
 ### Authenticating with the Cloud KMS API
 
@@ -39,6 +49,41 @@ versions.
 For each SPIRE Key ID that the server manages, this plugin maintains a
 CryptoKey. When a key is rotated, a new CryptoKeyVersion is added to the
 CryptoKey and the rotated CryptoKeyVersion is scheduled for destruction.
+
+### Shared Keys Configuration
+
+The plugin supports a shared keys mode that allows multiple SPIRE servers to discover and use the same JWT signing keys. This is useful for multi-server and multi-region deployments where servers need to coordinate key usage. Only JWT signing keys are shared; X509 CA and WIT keys remain per-server (identified by the `key_identifier_file`/`key_identifier_value` server identifier).
+
+When the `shared_keys` configuration block is present, the plugin operates in shared keys mode. This block accepts the following options:
+
+| Key                      | Type   | Required | Description                                                                                                                  |
+
+| crypto_key_template      | string | yes      | A Go template to generate the CryptoKey name                                                                                 |
+|--------------------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------|
+| key_id_extraction_regex  | string | yes      | A regex with one capturing group to extract the SPIRE Key ID from CryptoKey names                                            |
+
+> **Note**: Any existing keys cannot be used after turning on the shared keys feature.
+
+> **Note**: Shared keys mode increases Cloud KMS read API usage. Each `GenerateKey` call issues additional `ListCryptoKeys`, `GetCryptoKey`, and `UpdateCryptoKey` (for lock labels) requests. Cloud KMS has a default read quota of 1500 requests per minute per project; monitor this metric when running multiple SPIRE servers with frequent key rotations.
+
+#### Template Context
+
+The CryptoKey name template supports standard Go template functions and has access to the following variables:
+
+- `.TrustDomain`: The configured trust domain, sanitized for GCP label use (`.` replaced with `-`)
+- `.KeyID`: The SPIRE Key ID being requested (e.g., `jwt-signer`, `x509-CA-A`)
+
+#### Regex-based Discovery
+
+The `key_id_extraction_regex` must include **one capturing group** that extracts the SPIRE Key ID from the CryptoKey name.
+
+Example: `^spire-key-[^-]+-(.+)$` matches `spire-key-abc123-jwt-signer` and extracts `jwt-signer`.
+
+#### Freshness Check and Coordination
+
+When multiple servers share keys, they coordinate to prevent unnecessary key creation:
+
+1. **Freshness Check**: Before creating a new CryptoKeyVersion, the plugin checks if the CryptoKey was recently created (within the last 15 minutes) by another server. If so, it reuses the existing fresh key instead of generating a duplicate
 
 ### Management of keys
 
@@ -154,11 +199,51 @@ Custom IAM policies must be defined using
 
 ## Sample Plugin Configuration
 
+### Standard Mode (Single Server)
+
+Basic configuration for a single SPIRE server:
+
 ```hcl
 KeyManager "gcp_kms" {
-    plugin_data {        
-        key_ring = "projects/project-id/locations/location/keyRings/keyring"
-        key_metadata_file = "./gcpkms-key-metadata"
+    plugin_data {
+        key_ring = "projects/project-id/locations/us-east1/keyRings/spire"
+        key_identifier_file = "./server_id"
+    }
+}
+```
+
+### Shared Keys Mode (Multi-Server)
+
+Configuration for multiple SPIRE servers sharing keys:
+
+```hcl
+KeyManager "gcp_kms" {
+    plugin_data {
+        key_ring = "projects/project-id/locations/us-east1/keyRings/spire"
+        
+        shared_keys {
+            # Template matches spire-key-abc123-jwt-signer
+            crypto_key_template = "spire-key-{{ .TrustDomain }}-{{ .KeyID }}"
+            
+            # Regex extracts 'jwt-signer' from the CryptoKey name
+            key_id_extraction_regex = "^spire-key-[^-]+-(.+)$"
+        }
+    }
+}
+```
+
+### Shared Keys Mode with Custom Service Account
+
+```hcl
+KeyManager "gcp_kms" {
+    plugin_data {
+        key_ring = "projects/project-id/locations/us-west2/keyRings/spire"
+        service_account_file = "/path/to/service-account.json"
+        
+        shared_keys {
+            crypto_key_template = "spire-key-{{ .TrustDomain }}-{{ .KeyID }}"
+            key_id_extraction_regex = "^spire-key-[^-]+-(.+)$"
+        }
     }
 }
 ```

--- a/pkg/common/bundleutil/bundle.go
+++ b/pkg/common/bundleutil/bundle.go
@@ -222,6 +222,52 @@ func MergeBundles(a, b *common.Bundle) (*common.Bundle, bool) {
 	return c, changed
 }
 
+func DedupSigningKeysByKid(bundle *common.Bundle) bool {
+	jwtKeys, jwtChanged := dedupPublicKeysByKid(bundle.JwtSigningKeys)
+	witKeys, witChanged := dedupPublicKeysByKid(bundle.WitSigningKeys)
+	if jwtChanged {
+		bundle.JwtSigningKeys = jwtKeys
+	}
+	if witChanged {
+		bundle.WitSigningKeys = witKeys
+	}
+	return jwtChanged || witChanged
+}
+
+func dedupPublicKeysByKid(keys []*common.PublicKey) ([]*common.PublicKey, bool) {
+	order := make([]string, 0, len(keys))
+	chosen := make(map[string]*common.PublicKey, len(keys))
+	tainted := make(map[string]bool, len(keys))
+	duplicates := false
+	for _, key := range keys {
+		if existing, ok := chosen[key.Kid]; ok {
+			duplicates = true
+			tainted[key.Kid] = tainted[key.Kid] || key.TaintedKey
+			if key.NotAfter > existing.NotAfter {
+				chosen[key.Kid] = key
+			}
+			continue
+		}
+		order = append(order, key.Kid)
+		chosen[key.Kid] = key
+		tainted[key.Kid] = key.TaintedKey
+	}
+	if !duplicates {
+		return keys, false
+	}
+
+	deduped := make([]*common.PublicKey, 0, len(order))
+	for _, kid := range order {
+		key := chosen[kid]
+		if key.TaintedKey != tainted[kid] {
+			key = proto.Clone(key).(*common.PublicKey)
+			key.TaintedKey = tainted[kid]
+		}
+		deduped = append(deduped, key)
+	}
+	return deduped, true
+}
+
 // PruneBundle removes the bundle RootCAs and JWT keys that expired before a given time
 // It returns an error if pruning results in a bundle with no CAs or keys
 func PruneBundle(bundle *common.Bundle, expiration time.Time, log logrus.FieldLogger) (*common.Bundle, bool, error) {

--- a/pkg/common/bundleutil/dedup_test.go
+++ b/pkg/common/bundleutil/dedup_test.go
@@ -1,0 +1,73 @@
+package bundleutil
+
+import (
+	"testing"
+
+	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedupSigningKeysByKid(t *testing.T) {
+	t.Run("collapses duplicate kid keeping max NotAfter", func(t *testing.T) {
+		bundle := &common.Bundle{
+			JwtSigningKeys: []*common.PublicKey{
+				{Kid: "A", PkixBytes: []byte("a"), NotAfter: 100},
+				{Kid: "A", PkixBytes: []byte("a"), NotAfter: 200},
+				{Kid: "B", PkixBytes: []byte("b"), NotAfter: 150},
+			},
+		}
+
+		changed := DedupSigningKeysByKid(bundle)
+
+		assert.True(t, changed)
+		require.Len(t, bundle.JwtSigningKeys, 2)
+		assert.Equal(t, "A", bundle.JwtSigningKeys[0].Kid)
+		assert.EqualValues(t, 200, bundle.JwtSigningKeys[0].NotAfter)
+		assert.Equal(t, "B", bundle.JwtSigningKeys[1].Kid)
+	})
+
+	t.Run("no-op when all kids distinct", func(t *testing.T) {
+		keys := []*common.PublicKey{
+			{Kid: "A", NotAfter: 100},
+			{Kid: "B", NotAfter: 200},
+		}
+		bundle := &common.Bundle{JwtSigningKeys: keys}
+
+		changed := DedupSigningKeysByKid(bundle)
+
+		assert.False(t, changed)
+		require.Len(t, bundle.JwtSigningKeys, 2)
+	})
+
+	t.Run("merged entry is tainted if any duplicate is tainted", func(t *testing.T) {
+		bundle := &common.Bundle{
+			JwtSigningKeys: []*common.PublicKey{
+				{Kid: "A", NotAfter: 200, TaintedKey: false},
+				{Kid: "A", NotAfter: 100, TaintedKey: true},
+			},
+		}
+
+		changed := DedupSigningKeysByKid(bundle)
+
+		assert.True(t, changed)
+		require.Len(t, bundle.JwtSigningKeys, 1)
+		assert.EqualValues(t, 200, bundle.JwtSigningKeys[0].NotAfter)
+		assert.True(t, bundle.JwtSigningKeys[0].TaintedKey)
+	})
+
+	t.Run("dedups WIT signing keys too", func(t *testing.T) {
+		bundle := &common.Bundle{
+			WitSigningKeys: []*common.PublicKey{
+				{Kid: "W", NotAfter: 100},
+				{Kid: "W", NotAfter: 300},
+			},
+		}
+
+		changed := DedupSigningKeysByKid(bundle)
+
+		assert.True(t, changed)
+		require.Len(t, bundle.WitSigningKeys, 1)
+		assert.EqualValues(t, 300, bundle.WitSigningKeys[0].NotAfter)
+	})
+}

--- a/pkg/server/ca/manager/kid_test.go
+++ b/pkg/server/ca/manager/kid_test.go
@@ -1,0 +1,31 @@
+package manager
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeterministicKeyID(t *testing.T) {
+	key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	key2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	kid1a, err := deterministicKeyID(key1)
+	require.NoError(t, err)
+	require.NotEmpty(t, kid1a)
+
+	kid1b, err := deterministicKeyID(key1)
+	require.NoError(t, err)
+
+	kid2, err := deterministicKeyID(key2)
+	require.NoError(t, err)
+
+	assert.Equal(t, kid1a, kid1b, "the same key must yield the same kid")
+	assert.NotEqual(t, kid1a, kid2, "different keys must yield different kids")
+}

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -1,7 +1,6 @@
 package manager
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/rand"
@@ -1208,7 +1207,7 @@ func (u *bundleUpdater) appendBundle(ctx context.Context, bundle *common.Bundle)
 }
 
 func newJWTKey(signer crypto.Signer, expiresAt time.Time) (*ca.JWTKey, error) {
-	kid, err := newKeyID()
+	kid, err := deterministicKeyID(signer)
 	if err != nil {
 		return nil, err
 	}
@@ -1221,7 +1220,7 @@ func newJWTKey(signer crypto.Signer, expiresAt time.Time) (*ca.JWTKey, error) {
 }
 
 func newWITKey(signer crypto.Signer, expiresAt time.Time) (*ca.WITKey, error) {
-	kid, err := newKeyID()
+	kid, err := deterministicKeyID(signer)
 	if err != nil {
 		return nil, err
 	}
@@ -1233,22 +1232,12 @@ func newWITKey(signer crypto.Signer, expiresAt time.Time) (*ca.WITKey, error) {
 	}, nil
 }
 
-func newKeyID() (string, error) {
-	choices := make([]byte, 32)
-	_, err := rand.Read(choices)
+func deterministicKeyID(signer crypto.Signer) (string, error) {
+	subjectKeyID, err := x509util.GetSubjectKeyID(signer.Public())
 	if err != nil {
 		return "", err
 	}
-	return keyIDFromBytes(choices), nil
-}
-
-func keyIDFromBytes(choices []byte) string {
-	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	buf := new(bytes.Buffer)
-	for _, choice := range choices {
-		buf.WriteByte(alphabet[int(choice)%len(alphabet)])
-	}
-	return buf.String()
+	return x509util.SubjectKeyIDToString(subjectKeyID), nil
 }
 
 func publicKeyFromJWTKey(jwtKey *ca.JWTKey) (*common.PublicKey, error) {

--- a/pkg/server/ca/manager/slot.go
+++ b/pkg/server/ca/manager/slot.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server/ca"
 	"github.com/spiffe/spire/pkg/server/catalog"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"github.com/spiffe/spire/proto/private/server/journal"
 	"github.com/spiffe/spire/proto/spire/common"
 	"google.golang.org/grpc/codes"
@@ -592,15 +593,15 @@ func (s *SlotLoader) makeSigner(ctx context.Context, keyID string) (crypto.Signe
 }
 
 func x509CAKmKeyID(id string) string {
-	return fmt.Sprintf("x509-CA-%s", id)
+	return keymanager.X509CAKeyIDPrefix + id
 }
 
 func jwtKeyKmKeyID(id string) string {
-	return fmt.Sprintf("JWT-Signer-%s", id)
+	return keymanager.JWTSignerKeyIDPrefix + id
 }
 
 func witKeyKmKeyID(id string) string {
-	return fmt.Sprintf("WIT-Signer-%s", id)
+	return keymanager.WITSignerKeyIDPrefix + id
 }
 
 func containsJwkSigningKeyID(keys []*common.PublicKey, kid string) bool {

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -1284,6 +1284,9 @@ func appendBundle(tx *gorm.DB, b *common.Bundle) (*common.Bundle, error) {
 	}
 
 	bundle, changed := bundleutil.MergeBundles(bundle, b)
+	if bundleutil.DedupSigningKeysByKid(bundle) {
+		changed = true
+	}
 	if changed {
 		bundle.SequenceNumber++
 		newModel, err := bundleToModel(bundle)

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -837,6 +837,36 @@ func (s *PluginSuite) TestTaintJWTKey() {
 	validateBundle(taintedKey, 1)
 }
 
+func (s *PluginSuite) TestAppendBundleDedupsSigningKeysByKid() {
+	t := s.T()
+
+	bundle := bundleutil.BundleProtoFromRootCAs("spiffe://foo", nil)
+	bundle.JwtSigningKeys = []*common.PublicKey{
+		{Kid: "shared", PkixBytes: []byte("pkix"), NotAfter: 100},
+	}
+	_, err := s.ds.CreateBundle(ctx, bundle)
+	require.NoError(t, err)
+
+	// A second server publishes the same shared key with a later NotAfter.
+	appended := bundleutil.BundleProtoFromRootCAs("spiffe://foo", nil)
+	appended.JwtSigningKeys = []*common.PublicKey{
+		{Kid: "shared", PkixBytes: []byte("pkix"), NotAfter: 200},
+	}
+	_, err = s.ds.AppendBundle(ctx, appended)
+	require.NoError(t, err)
+
+	fetched, err := s.ds.FetchBundle(ctx, "spiffe://foo")
+	require.NoError(t, err)
+	require.Len(t, fetched.JwtSigningKeys, 1)
+	require.Equal(t, "shared", fetched.JwtSigningKeys[0].Kid)
+	require.EqualValues(t, 200, fetched.JwtSigningKeys[0].NotAfter)
+
+	// With a single entry per kid, tainting the shared key succeeds.
+	publicKey, err := s.ds.TaintJWTKey(ctx, "spiffe://foo", "shared")
+	require.NoError(t, err)
+	require.NotNil(t, publicKey)
+}
+
 func (s *PluginSuite) TestRevokeJWTKey() {
 	t := s.T()
 	// Setup

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -1,6 +1,7 @@
 package awskms
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -11,8 +12,10 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
+	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/andres-erbsen/clock"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
@@ -26,6 +29,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -44,6 +48,9 @@ const (
 
 	disposeKeysFrequency = time.Hour * 48
 	keyThreshold         = time.Hour * 48
+
+	sharedKeyFreshnessThreshold = 15 * time.Minute
+	lockTTL                     = 10 * time.Minute
 )
 
 var (
@@ -91,11 +98,18 @@ type Plugin struct {
 	stsClient      stsClient
 	trustDomain    string
 	serverID       string
+	region         string
 	scheduleDelete chan string
 	cancelTasks    context.CancelFunc
 	hooks          pluginHooks
 	keyPolicy      *string
 	keyTags        []types.Tag
+
+	// Shared keys configuration
+	sharedKeysEnabled   bool
+	jwtKeyAliasTemplate *template.Template
+	lockAliasTemplate   *template.Template
+	keyIDRegex          *regexp.Regexp
 }
 
 // Config provides configuration context for the plugin
@@ -107,6 +121,13 @@ type Config struct {
 	KeyIdentifierValue string            `hcl:"key_identifier_value" json:"key_identifier_value"`
 	KeyPolicyFile      string            `hcl:"key_policy_file" json:"key_policy_file"`
 	KeyTags            map[string]string `hcl:"key_tags" json:"key_tags"`
+	SharedKeys         *SharedKeysConfig `hcl:"shared_keys" json:"shared_keys"`
+}
+
+type SharedKeysConfig struct {
+	JWTKeyAliasTemplate  string `hcl:"jwt_key_alias_template" json:"jwt_key_alias_template"`
+	LockAliasTemplate    string `hcl:"lock_alias_template" json:"lock_alias_template"`
+	KeyIDExtractionRegex string `hcl:"key_id_extraction_regex" json:"key_id_extraction_regex"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
@@ -136,7 +157,6 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 	if newConfig.KeyIdentifierFile == "" && newConfig.KeyIdentifierValue == "" {
 		status.ReportError("configuration requires a key identifier file or a key identifier value")
 	}
-
 	if newConfig.KeyIdentifierFile != "" && newConfig.KeyIdentifierValue != "" {
 		status.ReportError("configuration can't have a key identifier file and a key identifier value at the same time")
 	}
@@ -147,6 +167,34 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		}
 	}
 
+	if newConfig.SharedKeys != nil {
+		if newConfig.SharedKeys.JWTKeyAliasTemplate == "" {
+			status.ReportError("configuration missing jwt_key_alias_template in shared_keys")
+		} else {
+			if _, err := template.New("jwt_key_alias_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.JWTKeyAliasTemplate); err != nil {
+				status.ReportErrorf("failed to parse jwt_key_alias_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.LockAliasTemplate == "" {
+			status.ReportError("configuration missing lock_alias_template in shared_keys")
+		} else {
+			if _, err := template.New("lock_alias_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockAliasTemplate); err != nil {
+				status.ReportErrorf("failed to parse lock_alias_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.KeyIDExtractionRegex == "" {
+			status.ReportError("configuration missing key_id_extraction_regex in shared_keys")
+		} else {
+			re, err := regexp.Compile(newConfig.SharedKeys.KeyIDExtractionRegex)
+			if err != nil {
+				status.ReportErrorf("failed to compile key_id_extraction_regex: %v", err)
+			} else if re.NumSubexp() != 1 {
+				status.ReportError("key_id_extraction_regex must have exactly one capturing group")
+			}
+		}
+	}
 	return newConfig
 }
 
@@ -198,7 +246,9 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 			return nil, err
 		}
 	}
-	p.log.Debug("Loaded server id", "server_id", serverID)
+	if serverID != "" {
+		p.log.Debug("Loaded server id", "server_id", serverID)
+	}
 
 	awsCfg, err := newAWSConfig(ctx, newConfig)
 	if err != nil {
@@ -215,11 +265,46 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		return nil, status.Errorf(codes.Internal, "failed to create KMS client: %v", err)
 	}
 
+	trustDomain := sanitizeTrustDomain(req.CoreConfiguration.TrustDomain)
+	perServerExtractor := func(aliasName string) (string, bool) {
+		prefix := path.Join(aliasPrefix, trustDomain, serverID) + "/"
+		trimmed := strings.TrimPrefix(aliasName, prefix)
+		if trimmed == aliasName {
+			return "", false
+		}
+		return decodeKeyID(trimmed), true
+	}
+
+	var keyIDExtractor func(string) (string, bool)
+	if newConfig.SharedKeys != nil {
+		p.sharedKeysEnabled = true
+		p.jwtKeyAliasTemplate = template.Must(template.New("jwt_key_alias_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.JWTKeyAliasTemplate))
+		p.lockAliasTemplate = template.Must(template.New("lock_alias_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockAliasTemplate))
+		p.keyIDRegex = regexp.MustCompile(newConfig.SharedKeys.KeyIDExtractionRegex)
+
+		re := p.keyIDRegex
+		// In shared keys mode only JWT keys are shared (discovered via the
+		// configured regex). X509 CA and WIT keys remain per-server, so they are
+		// discovered via this server's own alias prefix.
+		keyIDExtractor = func(aliasName string) (string, bool) {
+			if m := re.FindStringSubmatch(aliasName); len(m) >= 2 {
+				return m[1], true
+			}
+			return perServerExtractor(aliasName)
+		}
+	} else {
+		p.sharedKeysEnabled = false
+		p.jwtKeyAliasTemplate = nil
+		p.lockAliasTemplate = nil
+		p.keyIDRegex = nil
+
+		keyIDExtractor = perServerExtractor
+	}
+
 	fetcher := &keyFetcher{
-		log:         p.log,
-		kmsClient:   kc,
-		serverID:    serverID,
-		trustDomain: req.CoreConfiguration.TrustDomain,
+		log:            p.log,
+		kmsClient:      kc,
+		keyIDExtractor: keyIDExtractor,
 	}
 	p.log.Debug("Fetching key aliases from KMS")
 	keyEntries, err := fetcher.fetchKeyEntries(ctx)
@@ -235,6 +320,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	p.stsClient = sc
 	p.trustDomain = req.CoreConfiguration.TrustDomain
 	p.serverID = serverID
+	p.region = newConfig.Region
 
 	if len(newConfig.KeyTags) > 0 {
 		p.keyTags = buildKeyTags(newConfig.KeyTags)
@@ -267,6 +353,7 @@ func (p *Plugin) Validate(ctx context.Context, req *configv1.ValidateRequest) (*
 }
 
 // GenerateKey creates a key in KMS. If a key already exists in the local storage, it is updated.
+// In shared keys mode, implements optimistic coordination with lock acquisition to prevent race conditions.
 func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyRequest) (*keymanagerv1.GenerateKeyResponse, error) {
 	if req.KeyId == "" {
 		return nil, status.Error(codes.InvalidArgument, "key id is required")
@@ -275,15 +362,212 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 		return nil, status.Error(codes.InvalidArgument, "key type is required")
 	}
 
+	// Serialize all generations per server instance: prevents intra-server races on
+	// pluginData swap and ensures only one outstanding CreateKey per server.
+	// Cross-server contention is handled by the distributed lock alias inside the shared-keys path.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	spireKeyID := req.KeyId
+
+	// Only JWT signing keys are shared between servers. When shared keys mode is
+	// disabled, or for non-JWT keys (X509 CA, WIT) which always remain per-server,
+	// use simple key generation with this server's own alias.
+	if !p.sharedKeysEnabled || !keymanager.IsSharedKeyID(spireKeyID) {
+		newKeyEntry, err := p.createKey(ctx, spireKeyID, req.KeyType)
+		if err != nil {
+			return nil, err
+		}
+
+		err = p.assignAlias(ctx, newKeyEntry)
+		if err != nil {
+			return nil, err
+		}
+
+		p.entries[spireKeyID] = *newKeyEntry
+
+		return &keymanagerv1.GenerateKeyResponse{
+			PublicKey: newKeyEntry.PublicKey,
+		}, nil
+	}
+
+	// Shared keys mode: Implement optimistic coordination with lock acquisition
+	aliasName, err := p.generateAliasName(spireKeyID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate lock alias name if lock template is configured
+	var lockAlias string
+	if p.lockAliasTemplate != nil {
+		data := sharedKeysTemplateData(sanitizeTrustDomain(p.trustDomain), spireKeyID, p.serverID, p.region)
+
+		var buf bytes.Buffer
+		if err := p.lockAliasTemplate.Execute(&buf, data); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to execute lock_alias_template: %v", err)
+		}
+		lockAlias = buf.String()
+	}
+
+	// 1. Optimistic check: See if a fresh key already exists
+	aliasDesc, err := p.kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(aliasName),
+	})
+	if err == nil && aliasDesc.KeyMetadata != nil && aliasDesc.KeyMetadata.Enabled && aliasDesc.KeyMetadata.CreationDate != nil {
+		// Check freshness (15 minute threshold)
+		if p.hooks.clk.Now().Sub(*aliasDesc.KeyMetadata.CreationDate) < sharedKeyFreshnessThreshold {
+			// Check KeySpec matches
+			ks, ok := keySpecFromKeyType(req.KeyType)
+			if ok && aliasDesc.KeyMetadata.KeySpec == ks {
+				p.log.Info("Shared key was recently created. Reusing existing key.", "alias", aliasName, "key_id", *aliasDesc.KeyMetadata.KeyId)
+
+				// Fetch existing public key directly from KMS to return it
+				kmsPubKey, err := p.kmsClient.GetPublicKey(ctx, &kms.GetPublicKeyInput{KeyId: aliasDesc.KeyMetadata.KeyId})
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "failed to fetch existing public key: %v", err)
+				}
+
+				// Update local cache with existing key details
+				reusedEntry := &keyEntry{
+					Arn:       *aliasDesc.KeyMetadata.Arn,
+					AliasName: aliasName,
+					PublicKey: &keymanagerv1.PublicKey{
+						Id:          req.KeyId,
+						Type:        req.KeyType,
+						PkixData:    kmsPubKey.PublicKey,
+						Fingerprint: makeFingerprint(kmsPubKey.PublicKey),
+					},
+				}
+				p.entries[req.KeyId] = *reusedEntry
+
+				return &keymanagerv1.GenerateKeyResponse{
+					PublicKey: reusedEntry.PublicKey,
+				}, nil
+			}
+		}
+	} else if err != nil {
+		// Log but ignore error (maybe alias doesn't exist yet), proceed to generation
+		var notFound *types.NotFoundException
+		if !errors.As(err, &notFound) {
+			p.log.Debug("Failed to check existing key freshness (optimistic)", "alias", aliasName, "error", err)
+		}
+	}
+
+	// 2. Create the new key (CMK)
 	newKeyEntry, err := p.createKey(ctx, spireKeyID, req.KeyType)
 	if err != nil {
 		return nil, err
 	}
 
+	// 3. Acquire Lock (if configured)
+	if lockAlias != "" {
+		// Try to create the lock alias pointing to the new key
+		_, err := p.kmsClient.CreateAlias(ctx, &kms.CreateAliasInput{
+			AliasName:   aws.String(lockAlias),
+			TargetKeyId: &newKeyEntry.Arn,
+		})
+
+		if err != nil {
+			var alreadyExists *types.AlreadyExistsException
+			if errors.As(err, &alreadyExists) {
+				// Check if the existing lock is stale (> lockTTL) by inspecting the target
+				// key's creation date. If stale, force-break the lock and retry.
+				if lockDesc, descErr := p.kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(lockAlias)}); descErr == nil &&
+					lockDesc.KeyMetadata != nil && lockDesc.KeyMetadata.CreationDate != nil &&
+					p.hooks.clk.Now().Sub(*lockDesc.KeyMetadata.CreationDate) > lockTTL {
+					p.log.Warn("Stale rotation lock detected; force-breaking it.", "lock_alias", lockAlias,
+						"lock_age", p.hooks.clk.Now().Sub(*lockDesc.KeyMetadata.CreationDate))
+					if _, delErr := p.kmsClient.DeleteAlias(ctx, &kms.DeleteAliasInput{AliasName: aws.String(lockAlias)}); delErr != nil {
+						p.log.Error("Failed to delete stale lock alias", "lock_alias", lockAlias, "error", delErr)
+					} else if _, retryErr := p.kmsClient.CreateAlias(ctx, &kms.CreateAliasInput{
+						AliasName:   aws.String(lockAlias),
+						TargetKeyId: &newKeyEntry.Arn,
+					}); retryErr == nil {
+						p.log.Debug("Acquired rotation lock after breaking stale lock", "lock_alias", lockAlias)
+						goto lockAcquired
+					}
+				}
+
+				p.log.Warn("Rotation lock held by another instance. Aborting rotation.", "lock_alias", lockAlias)
+
+				// Clean up the unused key we just created
+				select {
+				case p.scheduleDelete <- newKeyEntry.Arn:
+					p.log.Debug("Unused key enqueued for deletion", keyArnTag, newKeyEntry.Arn)
+				default:
+					p.log.Error("Failed to enqueue unused key for deletion", keyArnTag, newKeyEntry.Arn)
+				}
+
+				return nil, status.Errorf(codes.Aborted, "rotation lock held: %v", err)
+			}
+			// Other error
+			return nil, status.Errorf(codes.Internal, "failed to acquire lock: %v", err)
+		}
+	lockAcquired:
+
+		p.log.Debug("Acquired rotation lock", "lock_alias", lockAlias)
+
+		// Defer Release Lock
+		defer func() {
+			_, err := p.kmsClient.DeleteAlias(ctx, &kms.DeleteAliasInput{
+				AliasName: aws.String(lockAlias),
+			})
+			if err != nil {
+				p.log.Error("Failed to release rotation lock", "lock_alias", lockAlias, "error", err)
+			} else {
+				p.log.Debug("Released rotation lock", "lock_alias", lockAlias)
+			}
+		}()
+	}
+
+	// 4. Check if the alias already points to a fresh key (concurrency check)
+	// We do this after acquiring the lock (if applicable) to ensure we are seeing the latest state.
+	aliasDesc, err = p.kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(newKeyEntry.AliasName),
+	})
+	if err == nil && aliasDesc.KeyMetadata != nil && aliasDesc.KeyMetadata.Enabled && aliasDesc.KeyMetadata.CreationDate != nil {
+		// Check freshness (15 minute threshold)
+		if p.hooks.clk.Now().Sub(*aliasDesc.KeyMetadata.CreationDate) < sharedKeyFreshnessThreshold {
+			// Check KeySpec matches
+			ks, ok := keySpecFromKeyType(req.KeyType)
+			if ok && aliasDesc.KeyMetadata.KeySpec == ks {
+				p.log.Info("Shared key was recently rotated by another instance. Reusing existing key.", "alias", newKeyEntry.AliasName, "key_id", *aliasDesc.KeyMetadata.KeyId)
+
+				// Cleanup the unused candidate key since we are reusing the existing one
+				select {
+				case p.scheduleDelete <- newKeyEntry.Arn:
+					p.log.Debug("Unused candidate key enqueued for deletion", keyArnTag, newKeyEntry.Arn)
+				default:
+					p.log.Error("Failed to enqueue unused candidate key for deletion", keyArnTag, newKeyEntry.Arn)
+				}
+
+				// Fetch existing public key directly from KMS to return it
+				kmsPubKey, err := p.kmsClient.GetPublicKey(ctx, &kms.GetPublicKeyInput{KeyId: aliasDesc.KeyMetadata.KeyId})
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "failed to fetch existing public key: %v", err)
+				}
+
+				// Update local cache with existing key details
+				reusedEntry := &keyEntry{
+					Arn:       *aliasDesc.KeyMetadata.Arn,
+					AliasName: newKeyEntry.AliasName,
+					PublicKey: &keymanagerv1.PublicKey{
+						Id:          req.KeyId,
+						Type:        req.KeyType,
+						PkixData:    kmsPubKey.PublicKey,
+						Fingerprint: makeFingerprint(kmsPubKey.PublicKey),
+					},
+				}
+				p.entries[req.KeyId] = *reusedEntry
+
+				return &keymanagerv1.GenerateKeyResponse{
+					PublicKey: reusedEntry.PublicKey,
+				}, nil
+			}
+		}
+	}
+
+	// 5. Assign the real alias (Rotation point)
 	err = p.assignAlias(ctx, newKeyEntry)
 	if err != nil {
 		return nil, err
@@ -408,9 +692,14 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		return nil, status.Error(codes.Internal, "malformed get public key response")
 	}
 
+	aliasName, err := p.generateAliasName(spireKeyID)
+	if err != nil {
+		return nil, err
+	}
+
 	return &keyEntry{
 		Arn:       *key.KeyMetadata.Arn,
-		AliasName: p.aliasFromSpireKeyID(spireKeyID),
+		AliasName: aliasName,
 		PublicKey: &keymanagerv1.PublicKey{
 			Id:          spireKeyID,
 			Type:        keyType,
@@ -633,7 +922,7 @@ func (p *Plugin) disposeAliases(ctx context.Context) error {
 			switch {
 			case alias.AliasName == nil || alias.LastUpdatedDate == nil || alias.AliasArn == nil:
 				continue
-				// if alias does not belong to trust domain skip
+			// if alias does not belong to trust domain skip
 			case !strings.HasPrefix(*alias.AliasName, p.aliasPrefixForTrustDomain()):
 				continue
 			// if alias belongs to current server skip
@@ -821,6 +1110,36 @@ func (p *Plugin) aliasPrefixForTrustDomain() string {
 func (p *Plugin) notifyDelete(err error) {
 	if p.hooks.scheduleDeleteSignal != nil {
 		p.hooks.scheduleDeleteSignal <- err
+	}
+}
+
+func (p *Plugin) generateAliasName(id string) (string, error) {
+	if p.sharedKeysEnabled && keymanager.IsSharedKeyID(id) {
+		data := sharedKeysTemplateData(sanitizeTrustDomain(p.trustDomain), id, p.serverID, p.region)
+
+		var buf bytes.Buffer
+		if err := p.jwtKeyAliasTemplate.Execute(&buf, data); err != nil {
+			return "", status.Errorf(codes.Internal, "failed to execute jwt_key_alias_template: %v", err)
+		}
+		return buf.String(), nil
+	}
+	return p.aliasFromSpireKeyID(id), nil
+}
+
+// sharedKeysTemplateData builds the template data struct for shared-keys templates.
+func sharedKeysTemplateData(trustDomain, keyID, serverID, region string) any {
+	return struct {
+		TrustDomain string
+		KeyID       string
+		ServerID    string
+		Region      string
+		Env         string
+	}{
+		TrustDomain: trustDomain,
+		KeyID:       keyID,
+		ServerID:    serverID,
+		Region:      region,
+		Env:         os.Getenv("SPIRE_ENV"),
 	}
 }
 

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ const (
 	KeyArn               = "arn:aws:kms:region:1234:key/abcd-fghi"
 	aliasName            = "alias/SPIRE_SERVER/test_example_org/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/spireKeyID"
 	spireKeyID           = "spireKeyID"
+	sharedJWTKeyID       = keymanager.JWTSignerKeyIDPrefix + spireKeyID
 	testTimeout          = 60 * time.Second
 )
 
@@ -2562,4 +2564,428 @@ func waitForSignal(t *testing.T, ch chan error) error {
 		t.Fail()
 	}
 	return nil
+}
+
+func TestConfigure_SharedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		err              string
+		code             codes.Code
+		configureRequest *configv1.ConfigureRequest
+	}{
+		{
+			name: "success: shared keys enabled",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+				}
+			}`),
+		},
+		{
+			name: "missing jwt_key_alias_template",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+				}
+			}`),
+			err:  "configuration missing jwt_key_alias_template in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing lock_alias_template",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+				}
+			}`),
+			err:  "configuration missing lock_alias_template in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing key_id_extraction_regex",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}"
+				}
+			}`),
+			err:  "configuration missing key_id_extraction_regex in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "invalid jwt_key_alias_template",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID ",
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+				}
+			}`),
+			err:  "failed to parse jwt_key_alias_template",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "invalid key_id_extraction_regex",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "[invalid"
+				}
+			}`),
+			err:  "failed to compile key_id_extraction_regex",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "key_id_extraction_regex without capture group",
+			configureRequest: configureRequestWithString(`{
+				"access_key_id":"access_key_id",
+				"secret_access_key":"secret_access_key",
+				"region":"us-west-2",
+				"key_identifier_value":"test-server",
+				"shared_keys": {
+					"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^alias/spire-jwt-.*$"
+				}
+			}`),
+			err:  "key_id_extraction_regex must have exactly one capturing group",
+			code: codes.InvalidArgument,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+			_, err := ts.plugin.Configure(ctx, tt.configureRequest)
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys(t *testing.T) {
+	sharedKeysConfig := `{
+		"access_key_id":"access_key_id",
+		"secret_access_key":"secret_access_key",
+		"region":"us-west-2",
+		"key_identifier_value":"test-server",
+		"shared_keys": {
+			"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+		}
+	}`
+
+	expectedAlias := "alias/spire-jwt-test_example_org-" + sharedJWTKeyID
+	expectedLockAlias := "alias/spire-lock-test_example_org-" + sharedJWTKeyID
+
+	for _, tt := range []struct {
+		name              string
+		err               string
+		code              codes.Code
+		fakeEntries       []fakeKeyEntry
+		request           *keymanagerv1.GenerateKeyRequest
+		createKeyErr      string
+		createAliasErr    string
+		deleteAliasErr    string // For lock release
+		describeKeyErr    string
+		getPublicKeyErr   string
+		instanceAccountID string
+		instanceRoleARN   string
+	}{
+		{
+			name: "success: new key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+		},
+		{
+			name: "success: reuse existing fresh key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeEntries: []fakeKeyEntry{
+				{
+					AliasName:    aws.String(expectedAlias),
+					KeyID:        aws.String(keyID),
+					KeySpec:      types.KeySpecEccNistP256,
+					Enabled:      true,
+					CreationDate: &unixEpoch, // Will be updated in test setup to be fresh
+					PublicKey:    []byte("foo"),
+				},
+			},
+		},
+		{
+			name: "success: rotate key (existing key stale)",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeEntries: []fakeKeyEntry{
+				{
+					AliasName:    aws.String(expectedAlias),
+					KeyID:        aws.String(keyID),
+					KeySpec:      types.KeySpecEccNistP256,
+					Enabled:      true,
+					CreationDate: &unixEpoch, // Stale
+					PublicKey:    []byte("foo"),
+				},
+			},
+		},
+		{
+			name: "fail: lock held",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			err:  "rotation lock held",
+			code: codes.Aborted,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+
+			// Adjust creation date for freshness test
+			if tt.name == "success: reuse existing fresh key" {
+				now := ts.clockHook.Now()
+				tt.fakeEntries[0].CreationDate = &now
+			}
+
+			ts.fakeKMSClient.setEntries(tt.fakeEntries)
+			ts.fakeKMSClient.setCreateKeyErr(tt.createKeyErr)
+
+			if tt.name == "fail: lock held" {
+				ts.fakeKMSClient.setCreateAliasesTypedErr(&types.AlreadyExistsException{Message: aws.String("already exists")})
+			} else if tt.createAliasErr != "" {
+				ts.fakeKMSClient.setCreateAliasesErr(tt.createAliasErr)
+			}
+
+			ts.fakeKMSClient.setDeleteAliasErr(tt.deleteAliasErr)
+			ts.fakeKMSClient.setDescribeKeyErr(tt.describeKeyErr)
+			ts.fakeKMSClient.setgetPublicKeyErr(tt.getPublicKeyErr)
+
+			configureReq := configureRequestWithString(sharedKeysConfig)
+			_, err := ts.plugin.Configure(ctx, configureReq)
+			require.NoError(t, err)
+
+			resp, err := ts.plugin.GenerateKey(ctx, tt.request)
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Verify lock was released if it was acquired (implied by success in rotation cases)
+			if tt.name == "success: new key" || tt.name == "success: rotate key (existing key stale)" {
+				// In the fake client, we can check if DeleteAlias was called for the lock alias?
+				// The fake client doesn't track calls easily, but we can check if the lock alias exists.
+				// It shouldn't exist.
+				_, ok := ts.fakeKMSClient.store.aliases[expectedLockAlias]
+				require.False(t, ok, "lock alias should be released")
+
+				// Verify the key alias exists
+				_, ok = ts.fakeKMSClient.store.aliases[expectedAlias]
+				require.True(t, ok, "key alias should exist")
+			}
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys_OnlyJWTKeysAreShared(t *testing.T) {
+	sharedKeysConfig := `{
+		"access_key_id":"access_key_id",
+		"secret_access_key":"secret_access_key",
+		"region":"us-west-2",
+		"key_identifier_value":"test-server",
+		"shared_keys": {
+			"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+		}
+	}`
+
+	x509KeyID := keymanager.X509CAKeyIDPrefix + "A"
+	jwtAlias := "alias/spire-jwt-test_example_org-" + sharedJWTKeyID
+	x509PerServerAlias := "alias/SPIRE_SERVER/test_example_org/test-server/" + x509KeyID
+
+	ts := setupTest(t)
+	_, err := ts.plugin.Configure(ctx, configureRequestWithString(sharedKeysConfig))
+	require.NoError(t, err)
+
+	// X509 CA keys are not shared: they use this server's per-server alias.
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   x509KeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	// JWT signing keys are shared: they use the shared template alias.
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	_, ok := ts.fakeKMSClient.store.aliases[x509PerServerAlias]
+	require.True(t, ok, "X509 CA key should use the per-server alias")
+	_, ok = ts.fakeKMSClient.store.aliases[jwtAlias]
+	require.True(t, ok, "JWT signing key should use the shared template alias")
+
+	_, ok = ts.fakeKMSClient.store.aliases["alias/spire-jwt-test_example_org-"+x509KeyID]
+	require.False(t, ok, "X509 CA key must not use the shared template alias")
+}
+
+func TestGenerateKey_SharedKeys_StaleLockBroken(t *testing.T) {
+	sharedKeysConfig := `{
+		"access_key_id":"access_key_id",
+		"secret_access_key":"secret_access_key",
+		"region":"us-west-2",
+		"key_identifier_value":"test-server",
+		"shared_keys": {
+			"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+		}
+	}`
+	expectedAlias := "alias/spire-jwt-test_example_org-" + sharedJWTKeyID
+	expectedLockAlias := "alias/spire-lock-test_example_org-" + sharedJWTKeyID
+
+	ts := setupTest(t)
+
+	// Advance clock by 15 minutes (beyond lockTTL=10m) so the stale key
+	// pre-created for the lock appears old.
+	ts.clockHook.Add(15 * time.Minute)
+
+	// Pre-seed a stale lock: create a key whose CreationDate is now in the past
+	// (before clock advance), then create the lock alias pointing to it.
+	staleKey := fakeKeyEntry{
+		AliasName:    aws.String(expectedLockAlias),
+		KeyID:        aws.String("stale-lock-key-id"),
+		KeySpec:      types.KeySpecEccNistP256,
+		Enabled:      true,
+		CreationDate: aws.Time(ts.clockHook.Now().Add(-15 * time.Minute)), // 15 min old
+		PublicKey:    []byte("stale"),
+	}
+	ts.fakeKMSClient.setEntries([]fakeKeyEntry{staleKey})
+
+	configureReq := configureRequestWithString(sharedKeysConfig)
+	_, err := ts.plugin.Configure(ctx, configureReq)
+	require.NoError(t, err)
+
+	resp, err := ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// The new key alias must exist and the lock must be released.
+	_, lockExists := ts.fakeKMSClient.store.aliases[expectedLockAlias]
+	require.False(t, lockExists, "stale lock should have been broken and released")
+	_, keyExists := ts.fakeKMSClient.store.aliases[expectedAlias]
+	require.True(t, keyExists, "key alias should exist after stale lock was broken")
+}
+
+func TestGenerateKey_SharedKeys_ConcurrentContention(t *testing.T) {
+	sharedKeysConfigFmt := `{
+		"access_key_id":"access_key_id",
+		"secret_access_key":"secret_access_key",
+		"region":"us-west-2",
+		"key_identifier_value":"%s",
+		"shared_keys": {
+			"jwt_key_alias_template": "alias/spire-jwt-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_alias_template": "alias/spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^alias/spire-jwt-[^-]+-(.+)$"
+		}
+	}`
+	expectedAlias := "alias/spire-jwt-test_example_org-" + sharedJWTKeyID
+
+	c := clock.NewMock()
+	fakeKMSClient := newKMSClientFake(t, c)
+	fakeSTSClient := newSTSClientFake()
+
+	makePlugin := func(serverID string) *Plugin {
+		p := newPlugin(
+			func(aws.Config) (kmsClient, error) { return fakeKMSClient, nil },
+			func(aws.Config) (stsClient, error) { return fakeSTSClient, nil },
+		)
+		km := new(keymanager.V1)
+		plugintest.Load(t, builtin(p), km)
+		p.hooks.clk = c
+		_, err := p.Configure(ctx, configureRequestWithString(fmt.Sprintf(sharedKeysConfigFmt, serverID)))
+		require.NoError(t, err)
+		return p
+	}
+
+	p1 := makePlugin("server-1")
+	p2 := makePlugin("server-2")
+
+	req := &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	}
+
+	type result struct {
+		resp *keymanagerv1.GenerateKeyResponse
+		err  error
+	}
+	results := make(chan result, 2)
+
+	var wg sync.WaitGroup
+	for _, p := range []*Plugin{p1, p2} {
+		wg.Add(1)
+		go func(p *Plugin) {
+			defer wg.Done()
+			resp, err := p.GenerateKey(ctx, req)
+			results <- result{resp, err}
+		}(p)
+	}
+	wg.Wait()
+	close(results)
+
+	_, aliasExists := fakeKMSClient.store.aliases[expectedAlias]
+	require.True(t, aliasExists, "JWT key alias should exist after concurrent generation")
+
+	var successes int
+	for r := range results {
+		if r.err == nil {
+			require.NotNil(t, r.resp)
+			successes++
+		}
+	}
+	require.Greater(t, successes, 0, "at least one GenerateKey call should succeed")
 }

--- a/pkg/server/plugin/keymanager/awskms/client_fake.go
+++ b/pkg/server/plugin/keymanager/awskms/client_fake.go
@@ -433,6 +433,12 @@ func (k *kmsClientFake) setCreateAliasesErr(fakeError string) {
 	}
 }
 
+func (k *kmsClientFake) setCreateAliasesTypedErr(err error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.createAliasErr = err
+}
+
 func (k *kmsClientFake) setUpdateAliasErr(fakeError string) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -514,15 +520,14 @@ type fakeAlias struct {
 }
 
 func (fs *fakeStore) SaveKeyEntry(input *fakeKeyEntry) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
 	if input.KeyID == nil {
 		input.KeyID = aws.String(strconv.Itoa(fs.nextID))
 		fs.nextID++
 	}
 	input.Arn = aws.String(arnFromKeyID(*input.KeyID))
-
-	fs.mu.Lock()
-	defer fs.mu.Unlock()
-
 	fs.keyEntries[*input.KeyID] = input
 }
 

--- a/pkg/server/plugin/keymanager/awskms/fetcher.go
+++ b/pkg/server/plugin/keymanager/awskms/fetcher.go
@@ -2,8 +2,6 @@ package awskms
 
 import (
 	"context"
-	"path"
-	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,10 +15,9 @@ import (
 )
 
 type keyFetcher struct {
-	log         hclog.Logger
-	kmsClient   kmsClient
-	serverID    string
-	trustDomain string
+	log            hclog.Logger
+	kmsClient      kmsClient
+	keyIDExtractor func(string) (string, bool)
 }
 
 func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) {
@@ -47,7 +44,7 @@ func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) 
 				continue
 			}
 
-			spireKeyID, ok := kf.spireKeyIDFromAlias(*alias.AliasName)
+			spireKeyID, ok := kf.keyIDExtractor(*alias.AliasName)
 			// ignore aliases/keys not belonging to this server
 			if !ok {
 				continue
@@ -131,14 +128,4 @@ func (kf *keyFetcher) fetchKeyEntryDetails(ctx context.Context, alias types.Alia
 			Fingerprint: makeFingerprint(publicKeyResp.PublicKey),
 		},
 	}, nil
-}
-
-func (kf *keyFetcher) spireKeyIDFromAlias(aliasName string) (string, bool) {
-	trustDomain := sanitizeTrustDomain(kf.trustDomain)
-	prefix := path.Join(aliasPrefix, trustDomain, kf.serverID) + "/"
-	trimmed := strings.TrimPrefix(aliasName, prefix)
-	if trimmed == aliasName {
-		return "", false
-	}
-	return decodeKeyID(trimmed), true
 }

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault.go
@@ -8,16 +8,20 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"math/big"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
+	sprig "github.com/Masterminds/sprig/v3"
 	"github.com/andres-erbsen/clock"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/gofrs/uuid/v5"
@@ -28,6 +32,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 	"google.golang.org/grpc/codes"
@@ -35,7 +40,9 @@ import (
 )
 
 const (
-	pluginName               = "azure_key_vault"
+	pluginName = "azure_key_vault"
+	lockTTL    = 10 * time.Minute
+
 	refreshKeysFrequency     = time.Hour * 6
 	algorithmTag             = "algorithm"
 	keyIDTag                 = "key_id"
@@ -46,6 +53,7 @@ const (
 	keyNamePrefix            = "spire-key"
 	tagNameServerID          = "spire-server-id"
 	tagNameServerTrustDomain = "spire-server-td"
+	tagNameKeyID             = "spire-key-id"
 )
 
 func BuiltIn() catalog.BuiltIn {
@@ -85,6 +93,15 @@ type Config struct {
 	SubscriptionID     string `hcl:"subscription_id" json:"subscription_id"`
 	AppID              string `hcl:"app_id" json:"app_id"`
 	AppSecret          string `hcl:"app_secret" json:"app_secret"`
+
+	// Shared keys configuration for multi-server deployments
+	SharedKeys *SharedKeysConfig `hcl:"shared_keys" json:"shared_keys"`
+}
+
+type SharedKeysConfig struct {
+	JWTKeyTemplate       string `hcl:"jwt_key_template" json:"jwt_key_template"`
+	LockTagTemplate      string `hcl:"lock_tag_template" json:"lock_tag_template"`
+	KeyIDExtractionRegex string `hcl:"key_id_extraction_regex" json:"key_id_extraction_regex"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
@@ -99,9 +116,30 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		status.ReportError("configuration is missing the Key Vault URI")
 	}
 
-	if newConfig.KeyIdentifierValue != "" {
-		if len(newConfig.KeyIdentifierValue) > 256 {
-			status.ReportError("Key identifier must not be longer than 256 characters")
+	if newConfig.SharedKeys != nil {
+		if newConfig.SharedKeys.JWTKeyTemplate == "" {
+			status.ReportError("configuration missing jwt_key_template in shared_keys")
+		} else {
+			if _, err := template.New("jwt_key_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.JWTKeyTemplate); err != nil {
+				status.ReportErrorf("failed to parse jwt_key_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.LockTagTemplate != "" {
+			if _, err := template.New("lock_tag_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockTagTemplate); err != nil {
+				status.ReportErrorf("failed to parse lock_tag_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.KeyIDExtractionRegex == "" {
+			status.ReportError("configuration missing key_id_extraction_regex in shared_keys")
+		} else {
+			re, err := regexp.Compile(newConfig.SharedKeys.KeyIDExtractionRegex)
+			if err != nil {
+				status.ReportErrorf("failed to compile key_id_extraction_regex: %v", err)
+			} else if re.NumSubexp() != 1 {
+				status.ReportError("key_id_extraction_regex must have exactly one capturing group")
+			}
 		}
 	}
 
@@ -113,7 +151,22 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		status.ReportError("configuration can't have a key identifier file and a key identifier value at the same time")
 	}
 
+	if newConfig.KeyIdentifierValue != "" {
+		if len(newConfig.KeyIdentifierValue) > 256 {
+			status.ReportError("Key identifier must not be longer than 256 characters")
+		}
+	}
+
 	return newConfig
+}
+
+type pluginData struct {
+	serverID          string
+	trustDomain       string
+	sharedKeysEnabled bool
+	keyNameTemplate   *template.Template
+	lockTagTemplate   *template.Template
+	keyIDRegex        *regexp.Regexp
 }
 
 // Plugin is the main representation of this keymanager plugin
@@ -125,12 +178,13 @@ type Plugin struct {
 	entries        map[string]keyEntry
 	entriesMtx     sync.RWMutex
 	keyVaultClient cloudKeyManagementService
-	trustDomain    string
-	serverID       string
 	scheduleDelete chan string
 	cancelTasks    context.CancelFunc
 	hooks          pluginHooks
 	keyTags        map[string]*string
+
+	pd    *pluginData
+	pdMtx sync.RWMutex
 }
 
 // New returns an instantiated plugin.
@@ -173,7 +227,45 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 			return nil, err
 		}
 	}
-	p.log.Debug("Loaded server id", "server_id", serverID)
+	if serverID != "" {
+		p.log.Debug("Loaded server id", "server_id", serverID)
+	}
+
+	pd := &pluginData{
+		serverID:    serverID,
+		trustDomain: strings.ReplaceAll(req.CoreConfiguration.TrustDomain, ".", "-"),
+	}
+
+	var keyIDExtractor func(*azkeys.KeyProperties) (string, bool)
+	if newConfig.SharedKeys != nil {
+		pd.sharedKeysEnabled = true
+		pd.keyNameTemplate = template.Must(template.New("jwt_key_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.JWTKeyTemplate))
+		if newConfig.SharedKeys.LockTagTemplate != "" {
+			pd.lockTagTemplate = template.Must(template.New("lock_tag_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockTagTemplate))
+		}
+		pd.keyIDRegex = regexp.MustCompile(newConfig.SharedKeys.KeyIDExtractionRegex)
+
+		re := pd.keyIDRegex
+		// In shared keys mode only JWT keys are shared (matched by the configured
+		// regex). X509 CA and WIT keys remain per-server: they are discovered only
+		// when their server-id tag matches this server.
+		keyIDExtractor = func(key *azkeys.KeyProperties) (string, bool) {
+			if m := re.FindStringSubmatch(key.KID.Name()); len(m) >= 2 {
+				return m[1], true
+			}
+			if sid, ok := key.Tags[tagNameServerID]; !ok || sid == nil || *sid != serverID {
+				return "", false
+			}
+			return spireKeyIDFromKeyName(key.KID.Name())
+		}
+	} else {
+		pd.sharedKeysEnabled = false
+		keyIDExtractor = func(key *azkeys.KeyProperties) (string, bool) {
+			return spireKeyIDFromKeyName(key.KID.Name())
+		}
+	}
+
+	p.setPluginData(pd)
 
 	var client cloudKeyManagementService
 
@@ -213,10 +305,12 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	}
 
 	fetcher := &keyFetcher{
-		keyVaultClient: client,
-		log:            p.log,
-		serverID:       serverID,
-		trustDomain:    req.CoreConfiguration.TrustDomain,
+		keyVaultClient:    client,
+		log:               p.log,
+		serverID:          serverID,
+		trustDomain:       req.CoreConfiguration.TrustDomain,
+		sharedKeysEnabled: newConfig.SharedKeys != nil,
+		keyIDExtractor:    keyIDExtractor,
 	}
 
 	p.log.Debug("Fetching keys from Azure Key Vault", "key_vault_uri", newConfig.KeyVaultURI)
@@ -230,8 +324,6 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 
 	p.setCache(keyEntries)
 	p.keyVaultClient = client
-	p.trustDomain = req.CoreConfiguration.TrustDomain
-	p.serverID = serverID
 	p.keyTags = make(map[string]*string)
 	p.keyTags[tagNameServerTrustDomain] = new(req.CoreConfiguration.TrustDomain)
 	p.keyTags[tagNameServerID] = new(serverID)
@@ -350,6 +442,12 @@ func (p *Plugin) disposeKeys(ctx context.Context) error {
 	pager := p.keyVaultClient.NewListKeyPropertiesPager(nil)
 	now := p.hooks.clk.Now()
 	maxStaleTime := now.Add(-maxStaleDuration)
+
+	pd, err := p.getPluginData()
+	if err != nil {
+		return err
+	}
+
 	for pager.More() {
 		resp, err := pager.NextPage(ctx)
 		if err != nil {
@@ -360,14 +458,14 @@ func (p *Plugin) disposeKeys(ctx context.Context) error {
 		for _, key := range resp.Value {
 			// Skip keys that do not belong to this trust domain
 			trustDomain, hasTD := key.Tags[tagNameServerTrustDomain]
-			if !hasTD || *trustDomain != p.trustDomain {
+			if !hasTD || *trustDomain != pd.trustDomain {
 				continue
 			}
 
 			// Keys are enqueued for deletion when they are rotated, so we skip
 			// here the keys that belong to this server. Stale keys from other
 			// servers in the trust domain are enqueued for deletion.
-			if p.serverID == *key.Tags[tagNameServerID] {
+			if pd.serverID == *key.Tags[tagNameServerID] {
 				continue
 			}
 
@@ -397,6 +495,9 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 		return nil, status.Error(codes.InvalidArgument, "key type is required")
 	}
 
+	// Serialize all generations per server instance: prevents intra-server races on
+	// pluginData swap and ensures only one outstanding CreateKey per server.
+	// Cross-server contention is handled by the distributed lock tag inside createKey.
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -414,7 +515,22 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 }
 
 func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keymanagerv1.KeyType) (*keyEntry, error) {
-	createKeyParameters, err := getCreateKeyParameters(keyType, p.keyTags)
+	pd, err := p.getPluginData()
+	if err != nil {
+		return nil, err
+	}
+
+	// Only JWT signing keys are shared between servers; X509 CA and WIT keys are
+	// always per-server, even in shared keys mode.
+	useSharedKey := pd.sharedKeysEnabled && keymanager.IsSharedKeyID(spireKeyID)
+
+	// Build tags including the KID tag for shared keys mode
+	tags := maps.Clone(p.keyTags)
+	if useSharedKey {
+		tags[tagNameKeyID] = new(spireKeyID)
+	}
+
+	createKeyParameters, err := getCreateKeyParameters(keyType, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -422,6 +538,147 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 	keyName, err := p.generateKeyName(spireKeyID)
 	if err != nil {
 		return nil, fmt.Errorf("could not generate key name: %w", err)
+	}
+
+	// OPTIMIZATION: Check for the existing fresh key (Optimistic coordination) for Shared Keys
+	if useSharedKey {
+		existingKey, err := p.keyVaultClient.GetKey(ctx, keyName, "", nil)
+		if err == nil && existingKey.Key != nil {
+			sharedKeyFreshnessThreshold := 15 * time.Minute
+			if existingKey.KeyBundle.Attributes != nil && existingKey.KeyBundle.Attributes.Created != nil {
+				if p.hooks.clk.Now().Sub(*existingKey.KeyBundle.Attributes.Created) < sharedKeyFreshnessThreshold {
+					// Check if algorithm matches
+					if keyTypeMatch(existingKey.KeyBundle, keyType) {
+						p.log.Info("Shared key is already fresh. Reusing existing key (optimistic).", "key_name", keyName)
+
+						rawKey, err := keyVaultKeyToRawKey(existingKey.Key)
+						if err != nil {
+							return nil, err
+						}
+						publicKey, err := x509.MarshalPKIXPublicKey(rawKey)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "failed to marshal public key: %v", err)
+						}
+
+						return &keyEntry{
+							KeyID:      string(*existingKey.Key.KID),
+							KeyName:    existingKey.Key.KID.Name(),
+							keyVersion: existingKey.Key.KID.Version(),
+							PublicKey: &keymanagerv1.PublicKey{
+								Id:          spireKeyID,
+								Type:        keyType,
+								PkixData:    publicKey,
+								Fingerprint: makeFingerprint(publicKey),
+							},
+						}, nil
+					}
+				}
+			}
+		}
+	}
+
+	// Acquire Lock (if configured) for shared keys mode
+	var lockTag string
+	if useSharedKey && pd.lockTagTemplate != nil {
+		data := sharedKeysTemplateData(pd.trustDomain, spireKeyID, pd.serverID)
+
+		var buf strings.Builder
+		if err := pd.lockTagTemplate.Execute(&buf, data); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to execute lock_tag_template: %v", err)
+		}
+		lockTag = buf.String()
+
+		// Lock tag value is RFC3339; stale tags older than lockTTL are overwritten.
+		latestKey, err := p.keyVaultClient.GetKey(ctx, keyName, "", nil)
+		if err == nil {
+			// Key exists, try to acquire lock
+			if latestKey.Tags == nil {
+				latestKey.Tags = make(map[string]*string)
+			}
+
+			if existingVal, ok := latestKey.Tags[lockTag]; ok && existingVal != nil {
+				// Determine if the lock is stale.
+				acquiredAt, parseErr := time.Parse(time.RFC3339, *existingVal)
+				isStale := parseErr != nil || p.hooks.clk.Now().Sub(acquiredAt) > lockTTL
+				if !isStale {
+					p.log.Warn("Rotation lock held by another instance. Aborting rotation.", "lock_tag", lockTag)
+					return nil, status.Errorf(codes.Aborted, "rotation lock held")
+				}
+				p.log.Warn("Stale rotation lock detected; overwriting it.", "lock_tag", lockTag,
+					"lock_age", p.hooks.clk.Now().Sub(acquiredAt))
+			}
+
+			lockAcquiredAt := p.hooks.clk.Now().UTC().Format(time.RFC3339)
+			latestKey.Tags[lockTag] = new(lockAcquiredAt)
+			// UpdateKeyParameters has no IfMatch field; this is a best-effort write.
+			// The lockTTL (10 min) bounds the worst-case race window.
+			_, err = p.keyVaultClient.UpdateKey(ctx, keyName, latestKey.Key.KID.Version(), azkeys.UpdateKeyParameters{
+				Tags: latestKey.Tags,
+			}, nil)
+
+			if err != nil {
+				p.log.Warn("Failed to acquire rotation lock (concurrent update). Aborting.", "error", err)
+				return nil, status.Errorf(codes.Aborted, "failed to acquire lock: %v", err)
+			}
+
+			p.log.Debug("Acquired rotation lock", "lock_tag", lockTag)
+
+			defer func() {
+				// Release lock
+				k, err := p.keyVaultClient.GetKey(ctx, keyName, "", nil)
+				if err != nil {
+					p.log.Error("Failed to get key to release lock", "error", err)
+					return
+				}
+				if k.Tags != nil {
+					delete(k.Tags, lockTag)
+				}
+				_, err = p.keyVaultClient.UpdateKey(ctx, keyName, k.Key.KID.Version(), azkeys.UpdateKeyParameters{
+					Tags: k.Tags,
+				}, nil)
+				if err != nil {
+					p.log.Error("Failed to release rotation lock", "lock_tag", lockTag, "error", err)
+				} else {
+					p.log.Debug("Released rotation lock", "lock_tag", lockTag)
+				}
+			}()
+		}
+	}
+
+	// Check if the Key already has a fresh version (concurrency check)
+	if useSharedKey {
+		existingKey, err := p.keyVaultClient.GetKey(ctx, keyName, "", nil)
+		if err == nil && existingKey.Key != nil {
+			sharedKeyFreshnessThreshold := 15 * time.Minute
+			if existingKey.KeyBundle.Attributes != nil && existingKey.KeyBundle.Attributes.Created != nil {
+				if p.hooks.clk.Now().Sub(*existingKey.KeyBundle.Attributes.Created) < sharedKeyFreshnessThreshold {
+					if keyTypeMatch(existingKey.KeyBundle, keyType) {
+						p.log.Info("Shared key was recently rotated by another instance. Reusing existing key.", "key_name", keyName)
+
+						rawKey, err := keyVaultKeyToRawKey(existingKey.Key)
+						if err != nil {
+							return nil, err
+						}
+						publicKey, err := x509.MarshalPKIXPublicKey(rawKey)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "failed to marshal public key: %v", err)
+						}
+
+						return &keyEntry{
+							KeyID:      string(*existingKey.Key.KID),
+							KeyName:    existingKey.Key.KID.Name(),
+							keyVersion: existingKey.Key.KID.Version(),
+							PublicKey: &keymanagerv1.PublicKey{
+								Id:          spireKeyID,
+								Type:        keyType,
+								PkixData:    publicKey,
+								Fingerprint: makeFingerprint(publicKey),
+							},
+						}, nil
+					}
+				}
+			}
+		}
 	}
 
 	createResp, err := p.keyVaultClient.CreateKey(ctx, keyName, *createKeyParameters, nil)
@@ -441,11 +698,13 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 	}
 
 	if keyEntry, ok := p.getKeyEntry(spireKeyID); ok {
-		select {
-		case p.scheduleDelete <- keyEntry.KeyName:
-			p.log.Debug("Key enqueued for deletion", keyNameTag, keyEntry.KeyName)
-		default:
-			p.log.Error("Failed to enqueue key for deletion", keyNameTag, keyEntry.KeyName)
+		if !useSharedKey {
+			select {
+			case p.scheduleDelete <- keyEntry.KeyName:
+				p.log.Debug("Key enqueued for deletion", keyNameTag, keyEntry.KeyName)
+			default:
+				p.log.Error("Failed to enqueue key for deletion", keyNameTag, keyEntry.KeyName)
+			}
 		}
 	}
 
@@ -460,6 +719,11 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 			Fingerprint: makeFingerprint(publicKey),
 		},
 	}, nil
+}
+
+func keyTypeMatch(keyBundle azkeys.KeyBundle, keyType keymanagerv1.KeyType) bool {
+	kt, ok := keyTypeFromKeySpec(keyBundle)
+	return ok && kt == keyType
 }
 
 // SignData creates a digital signature for the data to be signed
@@ -625,6 +889,25 @@ func (p *Plugin) setKeyEntry(keyID string, ke keyEntry) {
 	p.entries[keyID] = ke
 }
 
+// getPluginData gets the pluginData structure maintained by the plugin.
+func (p *Plugin) getPluginData() (*pluginData, error) {
+	p.pdMtx.RLock()
+	defer p.pdMtx.RUnlock()
+
+	if p.pd == nil {
+		return nil, status.Error(codes.FailedPrecondition, "plugin data not yet initialized")
+	}
+	return p.pd, nil
+}
+
+// setPluginData sets the pluginData structure maintained by the plugin.
+func (p *Plugin) setPluginData(pd *pluginData) {
+	p.pdMtx.Lock()
+	defer p.pdMtx.Unlock()
+
+	p.pd = pd
+}
+
 // scheduleDeleteTask is a long-running task that deletes keys that are stale
 func (p *Plugin) scheduleDeleteTask(ctx context.Context) {
 	backoffMin := 1 * time.Second
@@ -705,7 +988,23 @@ func getCreateKeyParameters(keyType keymanagerv1.KeyType, keyTags map[string]*st
 // The returned name has the form: spire-key-<UUID>-<SPIRE-KEY-ID>,
 // where UUID is a new randomly generated UUID and SPIRE-KEY-ID is provided
 // through the spireKeyID parameter.
+// If shared keys are enabled, it uses the jwt_key_template instead.
 func (p *Plugin) generateKeyName(spireKeyID string) (keyName string, err error) {
+	pd, err := p.getPluginData()
+	if err != nil {
+		return "", err
+	}
+
+	if pd.sharedKeysEnabled && keymanager.IsSharedKeyID(spireKeyID) {
+		data := sharedKeysTemplateData(pd.trustDomain, spireKeyID, pd.serverID)
+
+		var buf strings.Builder
+		if err := pd.keyNameTemplate.Execute(&buf, data); err != nil {
+			return "", status.Errorf(codes.Internal, "failed to execute jwt_key_template: %v", err)
+		}
+		return buf.String(), nil
+	}
+
 	uniqueID, err := generateUniqueID()
 	if err != nil {
 		return "", err
@@ -771,6 +1070,18 @@ func generateUniqueID() (id string, err error) {
 func makeFingerprint(pkixData []byte) string {
 	s := sha256.Sum256(pkixData)
 	return hex.EncodeToString(s[:])
+}
+
+func sharedKeysTemplateData(trustDomain, keyID, serverID string) any {
+	return struct {
+		TrustDomain string
+		KeyID       string
+		ServerID    string
+	}{
+		TrustDomain: trustDomain,
+		KeyID:       keyID,
+		ServerID:    serverID,
+	}
 }
 
 func signingAlgorithmForKeyVault(keyType keymanagerv1.KeyType, signerOpts any) (azkeys.SignatureAlgorithm, error) {

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -45,6 +47,7 @@ const (
 	trustDomain         = "test.example.org"
 	keyName             = "fake-key-name"
 	spireKeyID          = "spireKeyID"
+	sharedJWTKeyID      = keymanager.JWTSignerKeyIDPrefix + spireKeyID
 	testTimeout         = 60 * time.Second
 )
 
@@ -684,6 +687,7 @@ func TestGetPublicKey(t *testing.T) {
 			err:            "key id is required",
 			code:           codes.InvalidArgument,
 			generatedKeyID: "some-id",
+			queriedKeyID:   "",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -838,14 +842,15 @@ func TestRefreshKeys(t *testing.T) {
 }
 
 func TestDisposeKeys(t *testing.T) {
-	entry1 := makeFakeKeyEntry(t, keyName+"-1", trustDomain, "", azkeys.KeyTypeRSA, nil, new(4096))
-	entry2 := makeFakeKeyEntry(t, keyName+"-2", trustDomain, validServerID, azkeys.KeyTypeRSA, nil, new(2048))
-	entry3 := makeFakeKeyEntry(t, keyName+"-3", trustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
+	sanitizedTrustDomain := strings.ReplaceAll(trustDomain, ".", "-")
+	entry1 := makeFakeKeyEntry(t, keyName+"-1", sanitizedTrustDomain, "", azkeys.KeyTypeRSA, nil, new(4096))
+	entry2 := makeFakeKeyEntry(t, keyName+"-2", sanitizedTrustDomain, validServerID, azkeys.KeyTypeRSA, nil, new(2048))
+	entry3 := makeFakeKeyEntry(t, keyName+"-3", sanitizedTrustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
 	entry4 := makeFakeKeyEntry(t, keyName+"-4", "another-trust-domain", validServerID, azkeys.KeyTypeRSA, nil, new(4096))
 	entry5 := makeFakeKeyEntry(t, keyName+"-5", "another-trust-domain", "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil)
-	entry6 := makeFakeKeyEntry(t, keyName+"-6", trustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
-	entry7 := makeFakeKeyEntry(t, keyName+"-7", trustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil)
-	entry8 := makeFakeKeyEntry(t, keyName+"-8", trustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
+	entry6 := makeFakeKeyEntry(t, keyName+"-6", sanitizedTrustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
+	entry7 := makeFakeKeyEntry(t, keyName+"-7", sanitizedTrustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil)
+	entry8 := makeFakeKeyEntry(t, keyName+"-8", sanitizedTrustDomain, "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
 	entry9 := makeFakeKeyEntry(t, keyName+"-9", "some-other-trust-domain", "another_server_id", azkeys.KeyTypeEC, new(azkeys.CurveNameP384), nil)
 	for _, tt := range []struct {
 		name             string
@@ -893,7 +898,7 @@ func TestDisposeKeys(t *testing.T) {
 			ts.kmsClient.setListKeysErr(tt.listKeysErr)
 			ts.kmsClient.setGetKeyErr(tt.describeKeyErr)
 			ts.kmsClient.setListKeysErr(tt.listKeysErr)
-			scheduleDeleteSignal := make(chan error)
+			scheduleDeleteSignal := make(chan error, 100)
 			disposeKeysSignal := make(chan error)
 
 			ts.plugin.hooks.disposeKeysSignal = disposeKeysSignal
@@ -913,21 +918,11 @@ func TestDisposeKeys(t *testing.T) {
 			err = waitForSignal(t, disposeKeysSignal)
 			require.NoError(t, err)
 			// Wait till all the keys we expect to be deleted are deleted
-			// Wait for the 1st key to be deleted
-			err = waitForSignal(t, scheduleDeleteSignal)
-			require.NoError(t, err)
-			// Wait for the 2nd key to be deleted
-			err = waitForSignal(t, scheduleDeleteSignal)
-			require.NoError(t, err)
-			// Wait for the 3rd key to be deleted
-			err = waitForSignal(t, scheduleDeleteSignal)
-			require.NoError(t, err)
-			// Wait for the 4th key to be deleted
-			err = waitForSignal(t, scheduleDeleteSignal)
-			require.NoError(t, err)
-			// Wait for the 5th key to be deleted
-			err = waitForSignal(t, scheduleDeleteSignal)
-			require.NoError(t, err)
+			require.Eventually(t, func() bool {
+				ts.kmsClient.store.mu.RLock()
+				defer ts.kmsClient.store.mu.RUnlock()
+				return len(ts.kmsClient.store.fakeKeys) == len(tt.expectedEntries)
+			}, testTimeout, 100*time.Millisecond, "Timed out waiting for keys to be deleted")
 
 			// assert
 			storedKeys := ts.kmsClient.store.fakeKeys
@@ -1229,6 +1224,7 @@ func makeFakeKeyEntry(t *testing.T, keyName, trustDomain, serverID string, keyTy
 	var privateKey crypto.Signer
 	keyOperations := getKeyOperations()
 	kmsKeyID := validKeyVaultURI + path.Join("keys", fmt.Sprintf("%s-%s-%s", keyNamePrefix, fmt.Sprintf("%s-%s", getUUID(t), keyName), spireKeyID))
+	kmsKeyID = strings.ReplaceAll(kmsKeyID, "//keys", "/keys") // Fix double slash if present
 	switch {
 	case keyType == azkeys.KeyTypeEC && *curveName == azkeys.CurveNameP256:
 		privateKey = testkey.NewEC256(t)
@@ -1277,4 +1273,352 @@ func waitForSignal(t *testing.T, ch chan error) error {
 		t.Fail()
 	}
 	return nil
+}
+
+func TestConfigure_SharedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		err              string
+		code             codes.Code
+		configureRequest *configv1.ConfigureRequest
+	}{
+		{
+			name: "valid shared keys config",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_vault_uri": "%s",
+				"tenant_id": "%s",
+				"subscription_id": "%s",
+				"app_id": "%s",
+				"app_secret": "%s",
+				"key_identifier_value": "test-server",
+				"shared_keys": {
+					"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)),
+		},
+		{
+			name: "missing jwt_key_template",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_vault_uri": "%s",
+				"tenant_id": "%s",
+				"subscription_id": "%s",
+				"app_id": "%s",
+				"app_secret": "%s",
+				"shared_keys": {
+					"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)),
+			err:  "configuration missing jwt_key_template in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing key_id_extraction_regex",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_vault_uri": "%s",
+				"tenant_id": "%s",
+				"subscription_id": "%s",
+				"app_id": "%s",
+				"app_secret": "%s",
+				"shared_keys": {
+					"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}"
+				}
+			}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)),
+			err:  "configuration missing key_id_extraction_regex in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "invalid jwt_key_template",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_vault_uri": "%s",
+				"tenant_id": "%s",
+				"subscription_id": "%s",
+				"app_id": "%s",
+				"app_secret": "%s",
+				"shared_keys": {
+					"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID ",
+					"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)),
+			err:  "failed to parse jwt_key_template",
+			code: codes.InvalidArgument,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+			_, err := ts.plugin.Configure(ctx, tt.configureRequest)
+
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys(t *testing.T) {
+	sharedKeysConfig := fmt.Sprintf(`{
+		"key_vault_uri": "%s",
+		"tenant_id": "%s",
+		"subscription_id": "%s",
+		"app_id": "%s",
+		"app_secret": "%s",
+		"key_identifier_value": "test-server",
+		"shared_keys": {
+			"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)
+
+	expectedKeyName := "spire-key-test-example-org-" + sharedJWTKeyID
+	expectedLockTag := "spire-lock-test-example-org-" + sharedJWTKeyID
+
+	for _, tt := range []struct {
+		name            string
+		err             string
+		code            codes.Code
+		fakeEntries     []fakeKeyEntry
+		request         *keymanagerv1.GenerateKeyRequest
+		createKeyErr    string
+		getKeyErr       string
+		updateKeyErr    string // For lock acquisition/release
+		getPublicKeyErr string
+	}{
+		{
+			name: "success: new key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+		},
+		{
+			name: "success: reuse existing fresh key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeEntries: []fakeKeyEntry{
+				makeFakeKeyEntry(t, expectedKeyName, trustDomain, validServerID, azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil),
+			},
+		},
+		{
+			name: "success: rotate key (existing key stale)",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeEntries: []fakeKeyEntry{
+				func() fakeKeyEntry {
+					e := makeFakeKeyEntry(t, expectedKeyName, trustDomain, validServerID, azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil)
+					e.KeyBundle.Attributes.Created = &unixEpoch // Stale
+					// Fix name to match expectedKeyName (remove random UUID added by makeFakeKeyEntry)
+					e.KeyBundle.Key.KID = new(azkeys.ID(validKeyVaultURI + "keys/" + expectedKeyName))
+					return e
+				}(),
+			},
+		},
+		{
+			name: "fail: lock held",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeEntries: []fakeKeyEntry{
+				func() fakeKeyEntry {
+					e := makeFakeKeyEntry(t, expectedKeyName, trustDomain, validServerID, azkeys.KeyTypeEC, new(azkeys.CurveNameP256), nil)
+					e.KeyBundle.Attributes.Created = &unixEpoch // Stale
+					e.KeyBundle.Tags[expectedLockTag] = new("true")
+					// Fix name to match expectedKeyName (remove random UUID added by makeFakeKeyEntry)
+					e.KeyBundle.Key.KID = new(azkeys.ID(validKeyVaultURI + "keys/" + expectedKeyName))
+					return e
+				}(),
+			},
+			err:  "rotation lock held",
+			code: codes.Aborted,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+
+			// Adjust creation date for freshness test
+			if tt.name == "success: reuse existing fresh key" {
+				now := ts.clockHook.Now()
+				tt.fakeEntries[0].KeyBundle.Attributes.Created = &now
+			}
+
+			// For lock_held test, advance clock past freshness threshold so key appears stale,
+			// and stamp the lock tag with a recent (non-stale) RFC3339 timestamp so the TTL
+			// check does not prematurely break the lock.
+			if tt.name == "fail: lock held" {
+				ts.clockHook.Add(1 * time.Hour)
+				if len(tt.fakeEntries) > 0 {
+					now := ts.clockHook.Now()
+					tt.fakeEntries[0].KeyBundle.Tags[expectedLockTag] = new(now.UTC().Format(time.RFC3339))
+				}
+			}
+
+			ts.kmsClient.setEntries(tt.fakeEntries)
+			ts.kmsClient.setCreateKeyErr(tt.createKeyErr)
+			ts.kmsClient.setGetKeyErr(tt.getKeyErr)
+			ts.kmsClient.setUpdateKeyErr(tt.updateKeyErr)
+			ts.kmsClient.setGetPublicKeyErr(tt.getPublicKeyErr)
+
+			configureReq := configureRequestWithString(sharedKeysConfig)
+			_, err := ts.plugin.Configure(ctx, configureReq)
+			require.NoError(t, err)
+
+			resp, err := ts.plugin.GenerateKey(ctx, tt.request)
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Verify lock was released if it was acquired (implied by success in rotation cases)
+			if tt.name == "success: new key" || tt.name == "success: rotate key (existing key stale)" {
+				found := false
+				for _, key := range ts.kmsClient.store.fakeKeys {
+					if key.KeyBundle.Key.KID.Name() == expectedKeyName {
+						found = true
+						_, locked := key.KeyBundle.Tags[expectedLockTag]
+						require.False(t, locked, "lock tag should be released")
+						break
+					}
+				}
+				require.True(t, found, "key %q should exist", expectedKeyName)
+			}
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys_OnlyJWTKeysAreShared(t *testing.T) {
+	sharedKeysConfig := fmt.Sprintf(`{
+		"key_vault_uri": "%s",
+		"tenant_id": "%s",
+		"subscription_id": "%s",
+		"app_id": "%s",
+		"app_secret": "%s",
+		"key_identifier_value": "test-server",
+		"shared_keys": {
+			"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)
+
+	x509KeyID := keymanager.X509CAKeyIDPrefix + "A"
+	jwtKeyName := "spire-key-test-example-org-" + sharedJWTKeyID
+	x509SharedName := "spire-key-test-example-org-" + x509KeyID
+
+	ts := setupTest(t)
+	_, err := ts.plugin.Configure(ctx, configureRequestWithString(sharedKeysConfig))
+	require.NoError(t, err)
+
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{KeyId: x509KeyID, KeyType: keymanagerv1.KeyType_EC_P256})
+	require.NoError(t, err)
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{KeyId: sharedJWTKeyID, KeyType: keymanagerv1.KeyType_EC_P256})
+	require.NoError(t, err)
+
+	// JWT signing key uses the shared template key name.
+	_, ok := ts.kmsClient.store.fakeKeys[jwtKeyName]
+	require.True(t, ok, "JWT signing key should use the shared template key name")
+	// X509 CA key must not use the shared template key name.
+	_, ok = ts.kmsClient.store.fakeKeys[x509SharedName]
+	require.False(t, ok, "X509 CA key must not use the shared template key name")
+
+	// The X509 CA key exists under a per-server (UUID-based) name carrying this server's id tag.
+	var foundX509 bool
+	for name, key := range ts.kmsClient.store.fakeKeys {
+		if name != jwtKeyName && strings.HasSuffix(name, "-"+x509KeyID) {
+			foundX509 = true
+			sid, hasSID := key.KeyBundle.Tags[tagNameServerID]
+			require.True(t, hasSID && sid != nil, "X509 CA key must carry a server-id tag (per-server)")
+		}
+	}
+	require.True(t, foundX509, "X509 CA key should exist under a per-server name")
+}
+
+func TestGenerateKey_SharedKeys_ConcurrentContention(t *testing.T) {
+	sharedKeysConfigFmt := fmt.Sprintf(`{
+		"key_vault_uri": "%s",
+		"tenant_id": "%s",
+		"subscription_id": "%s",
+		"app_id": "%s",
+		"app_secret": "%s",
+		"key_identifier_value": "%%s",
+		"shared_keys": {
+			"jwt_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_tag_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyVaultURI, validTenantID, validSubscriptionID, validAppID, validAppSecret)
+	expectedKeyName := "spire-key-test-example-org-" + sharedJWTKeyID
+
+	c := clock.NewMock()
+	kmsClient := newKMSClientFake(t, validKeyVaultURI, trustDomain, validServerID, c)
+
+	makePlugin := func(serverID string) *Plugin {
+		p := newPlugin(
+			func(azcore.TokenCredential, string) (cloudKeyManagementService, error) { return kmsClient, nil },
+		)
+		km := new(keymanager.V1)
+		plugintest.Load(t, builtin(p), km)
+		p.hooks.clk = c
+		_, err := p.Configure(ctx, configureRequestWithString(fmt.Sprintf(sharedKeysConfigFmt, serverID)))
+		require.NoError(t, err)
+		return p
+	}
+
+	p1 := makePlugin("server-1")
+	p2 := makePlugin("server-2")
+
+	req := &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	}
+
+	type result struct {
+		resp *keymanagerv1.GenerateKeyResponse
+		err  error
+	}
+	results := make(chan result, 2)
+
+	var wg sync.WaitGroup
+	for _, p := range []*Plugin{p1, p2} {
+		wg.Add(1)
+		go func(p *Plugin) {
+			defer wg.Done()
+			resp, err := p.GenerateKey(ctx, req)
+			results <- result{resp, err}
+		}(p)
+	}
+	wg.Wait()
+	close(results)
+
+	found := false
+	for _, key := range kmsClient.store.fakeKeys {
+		if key.KeyBundle.Key.KID.Name() == expectedKeyName {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "key %q should exist after concurrent generation", expectedKeyName)
+
+	var successes int
+	for r := range results {
+		if r.err == nil {
+			require.NotNil(t, r.resp)
+			successes++
+		}
+	}
+	require.Greater(t, successes, 0, "at least one GenerateKey call should succeed")
 }

--- a/pkg/server/plugin/keymanager/azurekeyvault/client_fake.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/client_fake.go
@@ -218,7 +218,7 @@ func (k *kmsClientFake) DeleteKey(_ context.Context, name string, _ *azkeys.Dele
 	if k.deleteKeyErr != nil {
 		return azkeys.DeleteKeyResponse{}, k.deleteKeyErr
 	}
-	keyEntry, err := k.store.fetchKeyEntry(name)
+	keyEntry, err := k.store.FetchKeyEntry(name)
 	if err != nil {
 		return azkeys.DeleteKeyResponse{}, err
 	}
@@ -233,19 +233,27 @@ func (k *kmsClientFake) DeleteKey(_ context.Context, name string, _ *azkeys.Dele
 	return azkeys.DeleteKeyResponse{DeletedKey: deletedKey}, nil
 }
 
-func (k *kmsClientFake) UpdateKey(_ context.Context, name, _ string, _ azkeys.UpdateKeyParameters, _ *azkeys.UpdateKeyOptions) (azkeys.UpdateKeyResponse, error) {
+func (k *kmsClientFake) UpdateKey(_ context.Context, name, _ string, params azkeys.UpdateKeyParameters, _ *azkeys.UpdateKeyOptions) (azkeys.UpdateKeyResponse, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 	if k.updateKeyErr != nil {
 		return azkeys.UpdateKeyResponse{}, k.updateKeyErr
 	}
+
+	k.store.mu.Lock()
+	defer k.store.mu.Unlock()
+
 	keyEntry, err := k.store.fetchKeyEntry(name)
 	if err != nil {
 		return azkeys.UpdateKeyResponse{}, err
 	}
 
+	if params.Tags != nil {
+		keyEntry.KeyBundle.Tags = params.Tags
+	}
+
 	keyEntry.KeyBundle.Attributes.Updated = new(k.store.clk.Now())
-	k.store.SaveKeyEntry(keyEntry)
+	k.store.fakeKeys[keyEntry.KeyBundle.Key.KID.Name()] = keyEntry
 
 	keyBundle := &azkeys.KeyBundle{
 		Attributes: keyEntry.KeyBundle.Attributes,
@@ -262,7 +270,7 @@ func (k *kmsClientFake) GetKey(_ context.Context, keyName, _ string, _ *azkeys.G
 	if k.getKeyErr != nil {
 		return azkeys.GetKeyResponse{}, k.getKeyErr
 	}
-	keyEntry, err := k.store.fetchKeyEntry(keyName)
+	keyEntry, err := k.store.FetchKeyEntry(keyName)
 	if err != nil {
 		return azkeys.GetKeyResponse{}, err
 	}

--- a/pkg/server/plugin/keymanager/azurekeyvault/fetcher.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/fetcher.go
@@ -15,10 +15,12 @@ import (
 )
 
 type keyFetcher struct {
-	keyVaultClient cloudKeyManagementService
-	log            hclog.Logger
-	serverID       string
-	trustDomain    string
+	keyVaultClient    cloudKeyManagementService
+	log               hclog.Logger
+	serverID          string
+	trustDomain       string
+	sharedKeysEnabled bool
+	keyIDExtractor    func(*azkeys.KeyProperties) (string, bool)
 }
 
 // fetchKeyEntries requests Key Vault to get the list of keys that are
@@ -43,7 +45,7 @@ func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) 
 				continue
 			}
 
-			spireKeyID, ok := spireKeyIDFromKeyName(key.KID.Name())
+			spireKeyID, ok := kf.keyIDExtractor(key)
 			if !ok {
 				kf.log.Warn("Could not get SPIRE Key ID from key", keyNameTag, key.KID.Name())
 				continue
@@ -76,8 +78,19 @@ func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) 
 
 func (kf *keyFetcher) keyBelongsToServer(key *azkeys.KeyProperties) bool {
 	trustDomain, hasTD := key.Tags[tagNameServerTrustDomain]
+	if !hasTD {
+		return false
+	}
+	if *trustDomain != kf.trustDomain {
+		return false
+	}
+	// In shared keys mode any key in the trust domain may be a shared key;
+	// the keyIDExtractor (regex) will filter to the relevant ones.
+	if kf.sharedKeysEnabled {
+		return true
+	}
 	serverID, hasServerID := key.Tags[tagNameServerID]
-	return hasTD && hasServerID && *trustDomain == kf.trustDomain && *serverID == kf.serverID
+	return hasServerID && *serverID == kf.serverID
 }
 
 func (kf *keyFetcher) fetchKeyEntryDetails(ctx context.Context, keyProperties *azkeys.KeyProperties, spireKeyID string) (*keyEntry, error) {

--- a/pkg/server/plugin/keymanager/base/keymanagerbase.go
+++ b/pkg/server/plugin/keymanager/base/keymanagerbase.go
@@ -54,6 +54,11 @@ type Base struct {
 	entries map[string]*KeyEntry
 }
 
+// DefaultGenerator returns the standard crypto-based key generator used when no custom generator is provided.
+func DefaultGenerator() Generator {
+	return defaultGenerator{}
+}
+
 // New creates a new base key manager using the provided config.
 func New(config Config) *Base {
 	if config.Generator == nil {

--- a/pkg/server/plugin/keymanager/constant.go
+++ b/pkg/server/plugin/keymanager/constant.go
@@ -1,9 +1,22 @@
 package keymanager
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // rpcTimeout is used to provide a consistent timeout for all key manager
 // operations. It is not unusual to have a key manager implemented by a
 // remote API. The timeout prevents network failures or other similar failure
 // conditions from stalling critical SPIRE operations.
 const rpcTimeout = 30 * time.Second
+
+const (
+	X509CAKeyIDPrefix    = "x509-CA-"
+	JWTSignerKeyIDPrefix = "JWT-Signer-"
+	WITSignerKeyIDPrefix = "WIT-Signer-"
+)
+
+func IsSharedKeyID(keyID string) bool {
+	return strings.HasPrefix(keyID, JWTSignerKeyIDPrefix)
+}

--- a/pkg/server/plugin/keymanager/disk/disk.go
+++ b/pkg/server/plugin/keymanager/disk/disk.go
@@ -1,18 +1,30 @@
 package disk
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"sync"
+	"text/template"
+	"time"
 
+	sprig "github.com/Masterminds/sprig/v3"
+	"github.com/gofrs/uuid/v5"
 	"github.com/hashicorp/hcl"
 	keymanagerv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/server/keymanager/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	keymanagerbase "github.com/spiffe/spire/pkg/server/plugin/keymanager/base"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -35,7 +47,14 @@ func asBuiltIn(p *KeyManager) catalog.BuiltIn {
 }
 
 type configuration struct {
-	KeysPath string `hcl:"keys_path"`
+	KeysPath           string            `hcl:"keys_path"`
+	KeyIdentifierFile  string            `hcl:"key_identifier_file"`
+	KeyIdentifierValue string            `hcl:"key_identifier_value"`
+	SharedKeys         *SharedKeysConfig `hcl:"shared_keys"`
+}
+
+type SharedKeysConfig struct {
+	CryptoKeyTemplate string `hcl:"crypto_key_template"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
@@ -49,6 +68,15 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		status.ReportError("keys_path is required")
 	}
 
+	if newConfig.SharedKeys != nil {
+		if newConfig.SharedKeys.CryptoKeyTemplate == "" {
+			status.ReportError("crypto_key_template is required when shared_keys is enabled")
+		}
+		if newConfig.KeyIdentifierFile == "" && newConfig.KeyIdentifierValue == "" {
+			status.ReportError("key_identifier_file or key_identifier_value is required when shared_keys is enabled")
+		}
+	}
+
 	return newConfig
 }
 
@@ -56,15 +84,25 @@ type KeyManager struct {
 	*keymanagerbase.Base
 	configv1.UnimplementedConfigServer
 
-	mu     sync.Mutex
-	config *configuration
+	mu       sync.Mutex
+	config   *configuration
+	metadata map[string]time.Time
+
+	generator   Generator
+	tpl         *template.Template
+	trustDomain string
+	serverID    string
 }
 
 func newKeyManager(generator Generator) *KeyManager {
-	m := &KeyManager{}
+	if generator == nil {
+		generator = keymanagerbase.DefaultGenerator()
+	}
+	m := &KeyManager{
+		generator: generator,
+	}
 	m.Base = keymanagerbase.New(keymanagerbase.Config{
-		WriteEntries: m.writeEntries,
-		Generator:    generator,
+		Generator: generator,
 	})
 	return m
 }
@@ -78,7 +116,7 @@ func (m *KeyManager) Configure(_ context.Context, req *configv1.ConfigureRequest
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if err := m.configure(newConfig); err != nil {
+	if err := m.configure(newConfig, req.CoreConfiguration.TrustDomain); err != nil {
 		return nil, err
 	}
 
@@ -94,85 +132,430 @@ func (m *KeyManager) Validate(_ context.Context, req *configv1.ValidateRequest) 
 	}, nil
 }
 
-func (m *KeyManager) configure(config *configuration) error {
+func (m *KeyManager) configure(config *configuration, trustDomain string) error {
+	serverID := config.KeyIdentifierValue
+	if serverID == "" && config.KeyIdentifierFile != "" {
+		var err error
+		serverID, err = getOrCreateServerID(config.KeyIdentifierFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	var tpl *template.Template
+	if config.SharedKeys != nil {
+		var err error
+		tpl, err = template.New("crypto_key_template").Funcs(sprig.TxtFuncMap()).Parse(config.SharedKeys.CryptoKeyTemplate)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "failed to parse crypto_key_template: %v", err)
+		}
+		if err := validateTemplateVariesWithKeyID(tpl); err != nil {
+			return status.Errorf(codes.InvalidArgument, "crypto_key_template: %v", err)
+		}
+	}
+
 	// only load entry information on first configure
 	if m.config == nil {
-		entries, err := loadEntries(config.KeysPath)
+		entries, metadata, err := loadEntries(config.KeysPath, serverID, config.SharedKeys != nil)
 		if err != nil {
 			return err
 		}
 		m.Base.SetEntries(entries)
+		m.metadata = metadata
+		m.trustDomain = trustDomain
 	}
 
+	m.tpl = tpl
+	m.serverID = serverID
 	m.config = config
 	return nil
 }
 
-func (m *KeyManager) writeEntries(_ context.Context, entries []*keymanagerbase.KeyEntry) error {
+func (m *KeyManager) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyRequest) (*keymanagerv1.GenerateKeyResponse, error) {
+	if req.KeyId == "" {
+		return nil, status.Error(codes.InvalidArgument, "key id is required")
+	}
+	if req.KeyType == keymanagerv1.KeyType_UNSPECIFIED_KEY_TYPE {
+		return nil, status.Error(codes.InvalidArgument, "key type is required")
+	}
+
 	m.mu.Lock()
 	config := m.config
 	m.mu.Unlock()
 
 	if config == nil {
-		return status.Error(codes.FailedPrecondition, "not configured")
+		return nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
 
-	return writeEntries(config.KeysPath, entries)
-}
-
-type entriesData struct {
-	Keys map[string][]byte `json:"keys"`
-}
-
-func loadEntries(path string) ([]*keymanagerbase.KeyEntry, error) {
-	jsonBytes, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
+	// checkReuse returns the existing key entry if it can be reused: same logical ID,
+	// matching key type, and (in shared-keys mode) created within the freshness window.
+	checkReuse := func(entries []*keymanagerbase.KeyEntry, metadata map[string]time.Time) *keymanagerbase.KeyEntry {
+		var candidate *keymanagerbase.KeyEntry
+		for _, e := range entries {
+			if e.Id == req.KeyId {
+				candidate = e
+				break
+			}
 		}
+		if candidate == nil {
+			return nil
+		}
+
+		// Reject type-mismatched entries to avoid returning, e.g., an RSA key when EC is requested.
+		if storedType, ok := keyTypeFromSigner(candidate.PrivateKey); !ok || storedType != req.KeyType {
+			return nil
+		}
+
+		// Only JWT signing keys are shared across servers. X509 CA and WIT keys
+		// remain per-server, so they are never reused from the shared store.
+		if config.SharedKeys != nil && keymanager.IsSharedKeyID(req.KeyId) {
+			createdAt, ok := metadata[req.KeyId]
+			if ok && time.Since(createdAt) < 15*time.Minute {
+				return candidate
+			}
+			return nil
+		}
+
+		return nil
+	}
+
+	lock := newFileLock(config.KeysPath + ".lock")
+
+	// Phase 1: Optimistic Check
+	candidate, err := func() (*keymanagerbase.KeyEntry, error) {
+		if err := lock.Lock(); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to acquire lock: %v", err)
+		}
+		defer func() { _ = lock.Unlock() }()
+
+		entries, metadata, err := loadEntries(config.KeysPath, m.serverID, config.SharedKeys != nil)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update memory
+		m.Base.SetEntries(entries)
+		m.mu.Lock()
+		m.metadata = metadata
+
+		m.mu.Unlock()
+
+		return checkReuse(entries, metadata), nil
+	}()
+
+	if err != nil {
+		return nil, err
+	}
+	if candidate != nil {
+		return &keymanagerv1.GenerateKeyResponse{
+			PublicKey: candidate.PublicKey,
+		}, nil
+	}
+
+	// Phase 2: Generate
+	var newKey crypto.Signer
+	switch req.KeyType {
+	case keymanagerv1.KeyType_EC_P256:
+		newKey, err = m.generator.GenerateEC256Key()
+	case keymanagerv1.KeyType_EC_P384:
+		newKey, err = m.generator.GenerateEC384Key()
+	case keymanagerv1.KeyType_RSA_2048:
+		newKey, err = m.generator.GenerateRSA2048Key()
+	case keymanagerv1.KeyType_RSA_4096:
+		newKey, err = m.generator.GenerateRSA4096Key()
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unable to generate key %q for unknown key type %q", req.KeyId, req.KeyType)
+	}
+	if err != nil {
 		return nil, err
 	}
 
-	data := new(entriesData)
+	newEntry, err := keymanagerbase.MakeKeyEntryFromKey(req.KeyId, newKey)
+	if err != nil {
+		return nil, err
+	}
+
+	// Phase 3: Persist
+	if err := lock.Lock(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to acquire lock: %v", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	// Reload again
+	entries, metadata, err := loadEntries(config.KeysPath, m.serverID, config.SharedKeys != nil)
+	if err != nil {
+		return nil, err
+	}
+	m.Base.SetEntries(entries)
+	m.mu.Lock()
+	m.metadata = metadata
+	m.mu.Unlock()
+
+	// Double check reuse
+	if candidate := checkReuse(entries, metadata); candidate != nil {
+		return &keymanagerv1.GenerateKeyResponse{
+			PublicKey: candidate.PublicKey,
+		}, nil
+	}
+
+	// Persist the new key, preserving keys owned by other servers that share
+	// the same file.
+	if err := m.persistKey(config, req.KeyId, newKey, time.Now()); err != nil {
+		return nil, err
+	}
+
+	// Update memory with this server's view of the file.
+	entries, metadata, err = loadEntries(config.KeysPath, m.serverID, config.SharedKeys != nil)
+	if err != nil {
+		return nil, err
+	}
+	m.Base.SetEntries(entries)
+	m.mu.Lock()
+	m.metadata = metadata
+	m.mu.Unlock()
+
+	return &keymanagerv1.GenerateKeyResponse{
+		PublicKey: newEntry.PublicKey,
+	}, nil
+}
+
+type entriesData struct {
+	// Keys is a map of key ID to the key entry.
+	// The value can be either base64 encoded PKCS8 bytes (legacy) or a keyEntryRecord.
+	Keys map[string]json.RawMessage `json:"keys"`
+}
+
+type keyEntryRecord struct {
+	Id         string    `json:"id"`
+	PrivateKey []byte    `json:"private_key"` // #nosec G101
+	CreatedAt  time.Time `json:"created_at"`
+	ServerID   string    `json:"server_id,omitempty"`
+}
+
+func loadKeyData(path string) (*entriesData, error) {
+	data := &entriesData{Keys: make(map[string]json.RawMessage)}
+	jsonBytes, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return data, nil
+		}
+		return nil, err
+	}
 	if err := json.Unmarshal(jsonBytes, data); err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to decode keys JSON: %v", err)
 	}
-
-	var entries []*keymanagerbase.KeyEntry
-	for id, keyBytes := range data.Keys {
-		key, err := x509.ParsePKCS8PrivateKey(keyBytes)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to parse key %q: %v", id, err)
-		}
-		entry, err := keymanagerbase.MakeKeyEntryFromKey(id, key)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to make entry %q: %v", id, err)
-		}
-		entries = append(entries, entry)
+	if data.Keys == nil {
+		data.Keys = make(map[string]json.RawMessage)
 	}
-	return entries, nil
+	return data, nil
 }
 
-func writeEntries(path string, entries []*keymanagerbase.KeyEntry) error {
-	data := &entriesData{
-		Keys: make(map[string][]byte),
-	}
-	for _, entry := range entries {
-		keyBytes, err := x509.MarshalPKCS8PrivateKey(entry.PrivateKey)
-		if err != nil {
-			return err
-		}
-		data.Keys[entry.Id] = keyBytes
-	}
-
+func writeKeyData(path string, data *entriesData) error {
 	jsonBytes, err := json.MarshalIndent(data, "", "\t")
 	if err != nil {
 		return status.Errorf(codes.Internal, "unable to marshal entries: %v", err)
 	}
-
 	if err := diskutil.AtomicWritePrivateFile(path, jsonBytes); err != nil {
 		return status.Errorf(codes.Internal, "unable to write entries: %v", err)
 	}
-
 	return nil
+}
+
+// decodeRecord parses a stored key, supporting both the keyEntryRecord JSON format
+// and the legacy base64-encoded PKCS8 string format.
+func decodeRecord(storageID string, raw json.RawMessage) (logicalID string, keyBytes []byte, serverID string, createdAt time.Time, err error) {
+	// Detect format: JSON objects start with '{', legacy base64-encoded PKCS8 starts with '"'.
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var record keyEntryRecord
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return "", nil, "", time.Time{}, status.Errorf(codes.Internal, "unable to decode key %q: %v", storageID, err)
+		}
+		if record.PrivateKey == nil {
+			return "", nil, "", time.Time{}, status.Errorf(codes.Internal, "missing private key for key %q", storageID)
+		}
+		if record.Id == "" {
+			return "", nil, "", time.Time{}, status.Errorf(codes.Internal, "missing key id for key %q", storageID)
+		}
+		return record.Id, record.PrivateKey, record.ServerID, record.CreatedAt, nil
+	}
+
+	// Legacy format: the map value is a JSON string containing base64-encoded PKCS8 bytes.
+	if err := json.Unmarshal(raw, &keyBytes); err != nil {
+		return "", nil, "", time.Time{}, status.Errorf(codes.Internal, "unable to decode legacy key %q: %v", storageID, err)
+	}
+	return storageID, keyBytes, "", time.Time{}, nil
+}
+
+// loadEntries loads the key entries managed by this server. In shared mode the
+// keys file may contain keys owned by other servers; only the shared (JWT)
+// signing keys and this server's own keys are surfaced, so that GetKeys and the
+// CA journal lookup do not see another server's X509 CA or WIT keys.
+func loadEntries(path, serverID string, shared bool) ([]*keymanagerbase.KeyEntry, map[string]time.Time, error) {
+	data, err := loadKeyData(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var entries []*keymanagerbase.KeyEntry
+	metadata := make(map[string]time.Time)
+
+	for storageID, raw := range data.Keys {
+		logicalID, keyBytes, ownerServerID, createdAt, err := decodeRecord(storageID, raw)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if shared && !keymanager.IsSharedKeyID(logicalID) && ownerServerID != serverID {
+			continue
+		}
+
+		key, err := x509.ParsePKCS8PrivateKey(keyBytes)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "unable to parse key %q: %v", storageID, err)
+		}
+		entry, err := keymanagerbase.MakeKeyEntryFromKey(logicalID, key)
+		if err != nil {
+			return nil, nil, status.Errorf(codes.Internal, "unable to make entry %q: %v", storageID, err)
+		}
+		entries = append(entries, entry)
+		if !createdAt.IsZero() {
+			metadata[logicalID] = createdAt
+		}
+	}
+	return entries, metadata, nil
+}
+
+// storageIDFor computes the map key under which a key is stored in the keys file.
+// Shared (JWT) keys use the configured template so that all servers agree on the
+// same slot; other key types are namespaced per server so they remain isolated.
+func (m *KeyManager) storageIDFor(keyID string) (string, error) {
+	if m.tpl == nil {
+		return keyID, nil
+	}
+	if keymanager.IsSharedKeyID(keyID) {
+		var buf bytes.Buffer
+		if err := m.tpl.Execute(&buf, struct {
+			TrustDomain string
+			KeyID       string
+		}{TrustDomain: m.trustDomain, KeyID: keyID}); err != nil {
+			return "", status.Errorf(codes.Internal, "unable to calculate storage ID: %v", err)
+		}
+		return buf.String(), nil
+	}
+	return m.serverID + "/" + keyID, nil
+}
+
+// persistKey stores a single key in the keys file, preserving any keys owned by
+// other servers that share the same file.
+func (m *KeyManager) persistKey(config *configuration, keyID string, key crypto.Signer, createdAt time.Time) error {
+	data, err := loadKeyData(config.KeysPath)
+	if err != nil {
+		return err
+	}
+
+	storageID, err := m.storageIDFor(keyID)
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return err
+	}
+
+	record := keyEntryRecord{
+		Id:         keyID,
+		PrivateKey: keyBytes,
+		CreatedAt:  createdAt,
+	}
+	if config.SharedKeys != nil && !keymanager.IsSharedKeyID(keyID) {
+		record.ServerID = m.serverID
+	}
+
+	recordBytes, err := json.Marshal(record)
+	if err != nil {
+		return status.Errorf(codes.Internal, "unable to marshal key entry %q: %v", keyID, err)
+	}
+	data.Keys[storageID] = recordBytes
+
+	return writeKeyData(config.KeysPath, data)
+}
+
+func getOrCreateServerID(idPath string) (string, error) {
+	data, err := os.ReadFile(idPath)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return createServerID(idPath)
+	case err != nil:
+		return "", status.Errorf(codes.Internal, "failed to read server id from path: %v", err)
+	}
+
+	serverID, err := uuid.FromString(string(data))
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to parse server id from path: %v", err)
+	}
+	return serverID.String(), nil
+}
+
+func createServerID(idPath string) (string, error) {
+	u, err := uuid.NewV4()
+	if err != nil {
+		return "", status.Errorf(codes.Internal, "failed to generate id for server: %v", err)
+	}
+	id := u.String()
+	if err := diskutil.AtomicWritePrivateFile(idPath, []byte(id)); err != nil {
+		return "", status.Errorf(codes.Internal, "failed to persist server id on path: %v", err)
+	}
+	return id, nil
+}
+
+// validateTemplateVariesWithKeyID renders the template with two distinct key IDs and
+// returns an error if the outputs are identical (meaning the template ignores .KeyID,
+// which would cause all keys to collide on the same storage slot).
+func validateTemplateVariesWithKeyID(tpl *template.Template) error {
+	render := func(keyID string) (string, error) {
+		var buf bytes.Buffer
+		if err := tpl.Execute(&buf, struct {
+			TrustDomain string
+			KeyID       string
+		}{TrustDomain: "example-org", KeyID: keyID}); err != nil {
+			return "", err
+		}
+		return buf.String(), nil
+	}
+	a, err := render("__probe_a__")
+	if err != nil {
+		return err
+	}
+	b, err := render("__probe_b__")
+	if err != nil {
+		return err
+	}
+	if a == b {
+		return fmt.Errorf("must vary with .KeyID to avoid storage collisions (got %q for both probe values)", a)
+	}
+	return nil
+}
+
+// keyTypeFromSigner returns the SPIRE key type corresponding to a crypto.Signer's
+// underlying key material. Returns false if the type is unrecognised.
+func keyTypeFromSigner(signer crypto.Signer) (keymanagerv1.KeyType, bool) {
+	switch k := signer.Public().(type) {
+	case *ecdsa.PublicKey:
+		switch k.Curve {
+		case elliptic.P256():
+			return keymanagerv1.KeyType_EC_P256, true
+		case elliptic.P384():
+			return keymanagerv1.KeyType_EC_P384, true
+		}
+	case *rsa.PublicKey:
+		switch k.N.BitLen() {
+		case 2048:
+			return keymanagerv1.KeyType_RSA_2048, true
+		case 4096:
+			return keymanagerv1.KeyType_RSA_4096, true
+		}
+	}
+	return keymanagerv1.KeyType_UNSPECIFIED_KEY_TYPE, false
 }

--- a/pkg/server/plugin/keymanager/disk/disk_test.go
+++ b/pkg/server/plugin/keymanager/disk/disk_test.go
@@ -2,10 +2,13 @@ package disk_test
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/x509"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
@@ -41,7 +44,7 @@ func TestGenerateKeyBeforeConfigure(t *testing.T) {
 	plugintest.Load(t, disk.BuiltIn(), km)
 
 	_, err := km.GenerateKey(context.Background(), "id", keymanager.ECP256)
-	spiretest.RequireGRPCStatus(t, err, codes.FailedPrecondition, "keymanager(disk): failed to generate key: not configured")
+	spiretest.RequireGRPCStatus(t, err, codes.FailedPrecondition, "keymanager(disk): not configured")
 }
 
 func TestGenerateKeyPersistence(t *testing.T) {
@@ -52,7 +55,7 @@ func TestGenerateKeyPersistence(t *testing.T) {
 
 	// assert failure to generate key when directory is gone
 	_, err = km.GenerateKey(context.Background(), "id", keymanager.ECP256)
-	spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "unable to write entries")
+	spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "failed to acquire lock")
 
 	// create the directory and generate the key
 	mkdir(t, dir)
@@ -72,7 +75,7 @@ func TestGenerateKeyPersistence(t *testing.T) {
 	// remove the directory and try to overwrite. original key should remain.
 	rmdir(t, dir)
 	_, err = km.GenerateKey(context.Background(), "id", keymanager.ECP256)
-	spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "unable to write entries")
+	spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "failed to acquire lock")
 
 	keyOut, err = km.GetKey(context.Background(), "id")
 	require.NoError(t, err)
@@ -80,6 +83,214 @@ func TestGenerateKeyPersistence(t *testing.T) {
 		publicKeyBytes(t, keyIn),
 		publicKeyBytes(t, keyOut),
 	)
+}
+
+func TestSharedKeyReuse(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+	jwtKeyID := keymanager.JWTSignerKeyIDPrefix + "A"
+
+	configFmt := `
+		keys_path = %q
+		key_identifier_value = %q
+		shared_keys {
+			crypto_key_template = "{{ .TrustDomain }}-{{ .KeyID }}"
+		}
+	`
+
+	km1, err := loadPlugin(t, configFmt, keysPath, "server-a")
+	require.NoError(t, err)
+
+	k1, err := km1.GenerateKey(context.Background(), jwtKeyID, keymanager.RSA2048)
+	require.NoError(t, err)
+
+	// A second instance sharing the same file should load the JWT key.
+	km2, err := loadPlugin(t, configFmt, keysPath, "server-b")
+	require.NoError(t, err)
+
+	k2d, err := km2.GetKey(context.Background(), jwtKeyID)
+	require.NoError(t, err)
+	require.Equal(t, publicKeyBytes(t, k1), publicKeyBytes(t, k2d))
+
+	// Calling GenerateKey again on the second instance should reuse the fresh key.
+	k2, err := km2.GenerateKey(context.Background(), jwtKeyID, keymanager.RSA2048)
+	require.NoError(t, err)
+	require.Equal(t, publicKeyBytes(t, k1), publicKeyBytes(t, k2))
+
+	// Verify the key is stored under the template-derived storage ID.
+	fileBytes, err := os.ReadFile(keysPath)
+	require.NoError(t, err)
+	var fileData struct {
+		Keys map[string]struct {
+			Id        string    `json:"id"`
+			CreatedAt time.Time `json:"created_at"`
+		} `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(fileBytes, &fileData))
+
+	entry, ok := fileData.Keys["example.org-"+jwtKeyID]
+	require.True(t, ok, "key should be stored under template-derived ID")
+	require.Equal(t, jwtKeyID, entry.Id)
+	require.False(t, entry.CreatedAt.IsZero())
+}
+
+func TestSharedKeyOnlyJWTKeysAreShared(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+	jwtKeyID := keymanager.JWTSignerKeyIDPrefix + "A"
+	x509KeyID := keymanager.X509CAKeyIDPrefix + "A"
+
+	configFmt := `
+		keys_path = %q
+		key_identifier_value = %q
+		shared_keys {
+			crypto_key_template = "{{ .TrustDomain }}-{{ .KeyID }}"
+		}
+	`
+
+	kmA, err := loadPlugin(t, configFmt, keysPath, "server-a")
+	require.NoError(t, err)
+	kmB, err := loadPlugin(t, configFmt, keysPath, "server-b")
+	require.NoError(t, err)
+
+	// Both servers generate an X509 CA key and a JWT signing key under the same
+	// logical IDs.
+	for _, km := range []keymanager.KeyManager{kmA, kmB} {
+		_, err := km.GenerateKey(context.Background(), x509KeyID, keymanager.ECP256)
+		require.NoError(t, err)
+		_, err = km.GenerateKey(context.Background(), jwtKeyID, keymanager.ECP256)
+		require.NoError(t, err)
+	}
+
+	// The on-disk layout proves the scoping: each server's X509 CA key is stored
+	// under a per-server storage slot, while the JWT signing key is stored once
+	// under the shared, template-derived slot. (The fake key generator returns
+	// deterministic key material, so storage layout — not key bytes — is the
+	// reliable signal.)
+	storageIDs := readStorageIDs(t, keysPath)
+	require.Contains(t, storageIDs, "server-a/"+x509KeyID)
+	require.Contains(t, storageIDs, "server-b/"+x509KeyID)
+	require.Contains(t, storageIDs, "example.org-"+jwtKeyID)
+	require.NotContains(t, storageIDs, "example.org-"+x509KeyID,
+		"X509 CA key must not be stored under the shared template slot")
+
+	// Each server only sees its own X509 CA key plus the shared JWT key — never
+	// the other server's X509 CA key. This is what keeps the CA journal lookup
+	// unambiguous on restart. Simulate a restart of server A with a fresh instance.
+	kmARestart, err := loadPlugin(t, configFmt, keysPath, "server-a")
+	require.NoError(t, err)
+
+	_, err = kmARestart.GetKey(context.Background(), x509KeyID)
+	require.NoError(t, err)
+	_, err = kmARestart.GetKey(context.Background(), jwtKeyID)
+	require.NoError(t, err)
+
+	keys, err := kmARestart.GetKeys(context.Background())
+	require.NoError(t, err)
+	require.Len(t, keys, 2, "server A should see only its own X509 CA key and the shared JWT key")
+}
+
+func readStorageIDs(t *testing.T, keysPath string) map[string]struct{} {
+	fileBytes, err := os.ReadFile(keysPath)
+	require.NoError(t, err)
+	var fileData struct {
+		Keys map[string]json.RawMessage `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(fileBytes, &fileData))
+	ids := make(map[string]struct{}, len(fileData.Keys))
+	for id := range fileData.Keys {
+		ids[id] = struct{}{}
+	}
+	return ids
+}
+
+func TestSharedKeyRequiresServerIdentifier(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+
+	_, err := loadPlugin(t, `
+		keys_path = %q
+		shared_keys {
+			crypto_key_template = "{{ .TrustDomain }}-{{ .KeyID }}"
+		}
+	`, keysPath)
+	spiretest.RequireGRPCStatusContains(t, err, codes.InvalidArgument,
+		"key_identifier_file or key_identifier_value is required when shared_keys is enabled")
+}
+
+func TestSharedKeyLegacyLoad(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+
+	// Write a standard-mode plugin to create a legacy-format keys.json.
+	standardFmt := `keys_path = %q`
+	kmStd, err := loadPlugin(t, standardFmt, keysPath)
+	require.NoError(t, err)
+
+	keyIn, err := kmStd.GenerateKey(context.Background(), "my-key", keymanager.ECP256)
+	require.NoError(t, err)
+
+	// Reload in standard mode — should load the legacy file without error.
+	kmStd2, err := loadPlugin(t, standardFmt, keysPath)
+	require.NoError(t, err)
+	keyOut, err := kmStd2.GetKey(context.Background(), "my-key")
+	require.NoError(t, err)
+	require.Equal(t, publicKeyBytes(t, keyIn), publicKeyBytes(t, keyOut))
+}
+
+func TestSharedKeyTemplateCollisionGuard(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+
+	_, err := loadPlugin(t, `
+		keys_path = %q
+		key_identifier_value = "server-a"
+		shared_keys {
+			crypto_key_template = "fixed-name"
+		}
+	`, keysPath)
+	spiretest.RequireGRPCStatusContains(t, err, codes.InvalidArgument, "must vary with .KeyID")
+}
+
+func TestSharedKeyTypeReuseRejected(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	keysPath := filepath.Join(dir, "keys.json")
+
+	configFmt := `
+		keys_path = %q
+		key_identifier_value = "server-a"
+		shared_keys {
+			crypto_key_template = "{{ .TrustDomain }}-{{ .KeyID }}"
+		}
+	`
+	jwtKeyID := keymanager.JWTSignerKeyIDPrefix + "A"
+
+	km, err := loadPlugin(t, configFmt, keysPath)
+	require.NoError(t, err)
+
+	// Generate an RSA-2048 key.
+	rsaKey, err := km.GenerateKey(context.Background(), jwtKeyID, keymanager.RSA2048)
+	require.NoError(t, err)
+
+	// Reload to pick up the persisted key, then request EC_P256 for the same ID.
+	// The fresh RSA key must NOT be reused; a new EC key must be generated.
+	km2, err := loadPlugin(t, configFmt, keysPath)
+	require.NoError(t, err)
+
+	ecKey, err := km2.GenerateKey(context.Background(), jwtKeyID, keymanager.ECP256)
+	require.NoError(t, err)
+
+	// The returned EC public key must differ from the RSA public key.
+	require.NotEqual(t, publicKeyBytes(t, rsaKey), publicKeyBytes(t, ecKey),
+		"type-mismatched fresh key must not be reused")
+
+	// It must be an EC key, not RSA.
+	pkixBytes, err := x509.MarshalPKIXPublicKey(ecKey.Public())
+	require.NoError(t, err)
+	pub, err := x509.ParsePKIXPublicKey(pkixBytes)
+	require.NoError(t, err)
+	require.IsType(t, (*ecdsa.PublicKey)(nil), pub,
+		"expected ECDSA public key, got %T", pub)
 }
 
 func loadPlugin(t *testing.T, configFmt string, configArgs ...any) (keymanager.KeyManager, error) {

--- a/pkg/server/plugin/keymanager/disk/lock.go
+++ b/pkg/server/plugin/keymanager/disk/lock.go
@@ -1,0 +1,14 @@
+package disk
+
+import "os"
+
+// fileLock guards access to the keys file.
+// It uses a separate lock file to coordinate access.
+type fileLock struct {
+	path string
+	file *os.File
+}
+
+func newFileLock(path string) *fileLock {
+	return &fileLock{path: path}
+}

--- a/pkg/server/plugin/keymanager/disk/lock_posix.go
+++ b/pkg/server/plugin/keymanager/disk/lock_posix.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package disk
+
+import (
+	"os"
+	"syscall"
+)
+
+// Lock acquires an exclusive lock on the file.
+// It blocks until the lock is acquired.
+func (l *fileLock) Lock() error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	l.file = f
+
+	// LOCK_EX = Exclusive lock
+	// This blocks until the lock is available.
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		l.file.Close()
+		l.file = nil
+		return err
+	}
+	return nil
+}
+
+// Unlock releases the lock and closes the file.
+func (l *fileLock) Unlock() error {
+	if l.file == nil {
+		return nil
+	}
+	defer func() {
+		l.file.Close()
+		l.file = nil
+	}()
+
+	// LOCK_UN = Unlock
+	return syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+}

--- a/pkg/server/plugin/keymanager/disk/lock_windows.go
+++ b/pkg/server/plugin/keymanager/disk/lock_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package disk
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// Lock acquires an exclusive lock on the file.
+// It blocks until the lock is acquired.
+func (l *fileLock) Lock() error {
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return err
+	}
+	l.file = f
+
+	h := windows.Handle(f.Fd())
+	var overlapped windows.Overlapped
+
+	// Lock the entire file (max uint32 for low and high).
+	// LOCKFILE_EXCLUSIVE_LOCK ensures exclusive access.
+	// No LOCKFILE_FAIL_IMMEDIATELY means it blocks.
+	const reserved = 0
+	if err := windows.LockFileEx(h, windows.LOCKFILE_EXCLUSIVE_LOCK, reserved, 0xFFFFFFFF, 0xFFFFFFFF, &overlapped); err != nil {
+		l.file.Close()
+		l.file = nil
+		return err
+	}
+
+	return nil
+}
+
+// Unlock releases the lock and closes the file.
+func (l *fileLock) Unlock() error {
+	if l.file == nil {
+		return nil
+	}
+	defer func() {
+		l.file.Close()
+		l.file = nil
+	}()
+
+	h := windows.Handle(l.file.Fd())
+	var overlapped windows.Overlapped
+	const reserved = 0
+	return windows.UnlockFileEx(h, reserved, 0xFFFFFFFF, 0xFFFFFFFF, &overlapped)
+}

--- a/pkg/server/plugin/keymanager/gcpkms/client.go
+++ b/pkg/server/plugin/keymanager/gcpkms/client.go
@@ -18,6 +18,7 @@ type cloudKeyManagementService interface {
 	CreateCryptoKey(context.Context, *kmspb.CreateCryptoKeyRequest, ...gax.CallOption) (*kmspb.CryptoKey, error)
 	CreateCryptoKeyVersion(context.Context, *kmspb.CreateCryptoKeyVersionRequest, ...gax.CallOption) (*kmspb.CryptoKeyVersion, error)
 	DestroyCryptoKeyVersion(context.Context, *kmspb.DestroyCryptoKeyVersionRequest, ...gax.CallOption) (*kmspb.CryptoKeyVersion, error)
+	GetCryptoKey(context.Context, *kmspb.GetCryptoKeyRequest, ...gax.CallOption) (*kmspb.CryptoKey, error)
 	GetCryptoKeyVersion(context.Context, *kmspb.GetCryptoKeyVersionRequest, ...gax.CallOption) (*kmspb.CryptoKeyVersion, error)
 	GetPublicKey(context.Context, *kmspb.GetPublicKeyRequest, ...gax.CallOption) (*kmspb.PublicKey, error)
 	GetTokeninfo() (*oauth2.Tokeninfo, error)
@@ -50,6 +51,10 @@ func (c *kmsClient) CreateCryptoKeyVersion(ctx context.Context, req *kmspb.Creat
 
 func (c *kmsClient) DestroyCryptoKeyVersion(ctx context.Context, req *kmspb.DestroyCryptoKeyVersionRequest, opts ...gax.CallOption) (*kmspb.CryptoKeyVersion, error) {
 	return c.client.DestroyCryptoKeyVersion(ctx, req, opts...)
+}
+
+func (c *kmsClient) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest, opts ...gax.CallOption) (*kmspb.CryptoKey, error) {
+	return c.client.GetCryptoKey(ctx, req, opts...)
 }
 
 func (c *kmsClient) GetCryptoKeyVersion(ctx context.Context, req *kmspb.GetCryptoKeyVersionRequest, opts ...gax.CallOption) (*kmspb.CryptoKeyVersion, error) {

--- a/pkg/server/plugin/keymanager/gcpkms/client_fake.go
+++ b/pkg/server/plugin/keymanager/gcpkms/client_fake.go
@@ -468,8 +468,13 @@ func (k *fakeKMSClient) CreateCryptoKey(_ context.Context, req *kmspb.CreateCryp
 		return nil, k.createCryptoKeyErr
 	}
 
+	name := path.Join(req.Parent, "cryptoKeys", req.CryptoKeyId)
+	if _, ok := k.store.fetchFakeCryptoKey(name); ok {
+		return nil, status.Error(codes.AlreadyExists, fmt.Sprintf("CryptoKey %s already exists", name))
+	}
+
 	cryptoKey := &kmspb.CryptoKey{
-		Name:            path.Join(req.Parent, req.CryptoKeyId),
+		Name:            name,
 		Labels:          req.CryptoKey.Labels,
 		VersionTemplate: req.CryptoKey.VersionTemplate,
 	}
@@ -554,6 +559,18 @@ func (k *fakeKMSClient) DestroyCryptoKeyVersion(_ context.Context, req *kmspb.De
 	return cryptoKeyVersion, nil
 }
 
+func (k *fakeKMSClient) GetCryptoKey(_ context.Context, req *kmspb.GetCryptoKeyRequest, _ ...gax.CallOption) (*kmspb.CryptoKey, error) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	fck, ok := k.store.fetchFakeCryptoKey(req.Name)
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "CryptoKey %q not found", req.Name)
+	}
+
+	return fck.CryptoKey, nil
+}
+
 func (k *fakeKMSClient) GetCryptoKeyVersion(_ context.Context, req *kmspb.GetCryptoKeyVersionRequest, _ ...gax.CallOption) (*kmspb.CryptoKeyVersion, error) {
 	k.mu.RLock()
 	defer k.mu.RUnlock()
@@ -587,7 +604,10 @@ func (k *fakeKMSClient) GetPublicKey(_ context.Context, req *kmspb.GetPublicKeyR
 
 	if k.pemCrc32C != nil {
 		// Override pemCrc32C
-		fakeCryptoKeyVersion.publicKey.PemCrc32C = k.pemCrc32C
+		// Return a copy to avoid modifying the original stored key which might be shared
+		pkCopy := proto.Clone(fakeCryptoKeyVersion.publicKey).(*kmspb.PublicKey)
+		pkCopy.PemCrc32C = k.pemCrc32C
+		return pkCopy, nil
 	}
 
 	return fakeCryptoKeyVersion.publicKey, nil
@@ -752,8 +772,8 @@ func (k *fakeKMSClient) createFakeCryptoKeyVersion(cryptoKey *kmspb.CryptoKey, v
 	return &fakeCryptoKeyVersion{
 		privateKey: privateKey,
 		publicKey: &kmspb.PublicKey{
-			Pem:       pemCert.String(),
-			PemCrc32C: &wrapperspb.Int64Value{Value: int64(crc32Checksum(pemCert.Bytes()))},
+			Pem:       strings.ReplaceAll(pemCert.String(), "\r\n", "\n"),
+			PemCrc32C: &wrapperspb.Int64Value{Value: int64(crc32Checksum([]byte(strings.ReplaceAll(pemCert.String(), "\r\n", "\n"))))},
 		},
 		CryptoKeyVersion: &kmspb.CryptoKeyVersion{
 			Name:      path.Join(cryptoKey.Name, "cryptoKeyVersions", version),

--- a/pkg/server/plugin/keymanager/gcpkms/fetcher.go
+++ b/pkg/server/plugin/keymanager/gcpkms/fetcher.go
@@ -17,11 +17,13 @@ import (
 )
 
 type keyFetcher struct {
-	keyRing   string
-	kmsClient cloudKeyManagementService
-	log       hclog.Logger
-	serverID  string
-	tdHash    string
+	keyRing           string
+	kmsClient         cloudKeyManagementService
+	log               hclog.Logger
+	serverID          string
+	tdHash            string
+	keyIDExtractor    func(*kmspb.CryptoKey) (string, bool)
+	sharedKeysEnabled bool
 }
 
 // fetchKeyEntries requests Cloud KMS to get the list of CryptoKeys that are
@@ -31,10 +33,22 @@ func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) 
 	var keyEntriesMutex sync.Mutex
 	g, ctx := errgroup.WithContext(ctx)
 
+	// Build filter based on whether we're using shared keys or not
+	var filter string
+	if kf.sharedKeysEnabled {
+		// Shared keys mode: list all active keys in the trust domain. The key ID
+		// extractor narrows per-server (X509 CA/WIT) keys to this server, while
+		// shared JWT keys (created by any server) are matched by the configured regex.
+		filter = fmt.Sprintf("labels.%s = %s AND labels.%s = true",
+			labelNameServerTD, kf.tdHash, labelNameActive)
+	} else {
+		filter = fmt.Sprintf("labels.%s = %s AND labels.%s = %s AND labels.%s = true",
+			labelNameServerTD, kf.tdHash, labelNameServerID, kf.serverID, labelNameActive)
+	}
+
 	it := kf.kmsClient.ListCryptoKeys(ctx, &kmspb.ListCryptoKeysRequest{
 		Parent: kf.keyRing,
-		Filter: fmt.Sprintf("labels.%s = %s AND labels.%s = %s AND labels.%s = true",
-			labelNameServerTD, kf.tdHash, labelNameServerID, kf.serverID, labelNameActive),
+		Filter: filter,
 	})
 	for {
 		cryptoKey, err := it.Next()
@@ -44,9 +58,8 @@ func (kf *keyFetcher) fetchKeyEntries(ctx context.Context) ([]*keyEntry, error) 
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to list SPIRE Server keys in Cloud KMS: %v", err)
 		}
-		spireKeyID, ok := getSPIREKeyIDFromCryptoKeyName(cryptoKey.Name)
+		spireKeyID, ok := kf.keyIDExtractor(cryptoKey)
 		if !ok {
-			kf.log.Warn("Could not get SPIRE Key ID from CryptoKey", cryptoKeyNameTag, cryptoKey.Name)
 			continue
 		}
 

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms.go
@@ -11,10 +11,16 @@ import (
 	"fmt"
 	"hash/crc32"
 	"os"
+	"path"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 	"unicode"
+
+	sprig "github.com/Masterminds/sprig/v3"
 
 	"cloud.google.com/go/iam"
 	"cloud.google.com/go/iam/apiv1/iampb"
@@ -28,6 +34,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/diskutil"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/server/plugin/keymanager"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
@@ -54,8 +61,10 @@ const (
 	labelNameLastUpdate = "spire-last-update"
 	labelNameServerTD   = "spire-server-td"
 	labelNameActive     = "spire-active"
+	labelNameKeyID      = "spire-key-id"
 
 	getPublicKeyMaxAttempts = 10
+	lockTTL                 = 10 * time.Minute
 )
 
 func BuiltIn() catalog.BuiltIn {
@@ -89,9 +98,14 @@ type pluginHooks struct {
 }
 
 type pluginData struct {
-	customPolicy *iam.Policy3
-	serverID     string
-	tdHash       string
+	customPolicy      *iam.Policy3
+	serverID          string
+	tdHash            string
+	trustDomain       string
+	sharedKeysEnabled bool
+	cryptoKeyTemplate *template.Template
+	lockLabelTemplate *template.Template
+	keyIDRegex        *regexp.Regexp
 }
 
 // Plugin is the main representation of this keymanager plugin.
@@ -136,6 +150,15 @@ type Config struct {
 	// API. If not specified, the value of the GOOGLE_APPLICATION_CREDENTIALS
 	// environment variable is used.
 	ServiceAccountFile string `hcl:"service_account_file" json:"service_account_file"`
+
+	// Shared keys configuration for multi-server deployments
+	SharedKeys *SharedKeysConfig `hcl:"shared_keys" json:"shared_keys"`
+}
+
+type SharedKeysConfig struct {
+	CryptoKeyTemplate    string `hcl:"crypto_key_template" json:"crypto_key_template"`
+	LockLabelTemplate    string `hcl:"lock_label_template" json:"lock_label_template"`
+	KeyIDExtractionRegex string `hcl:"key_id_extraction_regex" json:"key_id_extraction_regex"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
@@ -146,6 +169,33 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 
 	if newConfig.KeyRing == "" {
 		status.ReportError("configuration is missing the key ring")
+	}
+
+	if newConfig.SharedKeys != nil {
+		if newConfig.SharedKeys.CryptoKeyTemplate == "" {
+			status.ReportError("configuration missing crypto_key_template in shared_keys")
+		} else {
+			if _, err := template.New("crypto_key_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.CryptoKeyTemplate); err != nil {
+				status.ReportErrorf("failed to parse crypto_key_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.LockLabelTemplate != "" {
+			if _, err := template.New("lock_label_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockLabelTemplate); err != nil {
+				status.ReportErrorf("failed to parse lock_label_template: %v", err)
+			}
+		}
+
+		if newConfig.SharedKeys.KeyIDExtractionRegex == "" {
+			status.ReportError("configuration missing key_id_extraction_regex in shared_keys")
+		} else {
+			re, err := regexp.Compile(newConfig.SharedKeys.KeyIDExtractionRegex)
+			if err != nil {
+				status.ReportErrorf("failed to compile key_id_extraction_regex: %v", err)
+			} else if re.NumSubexp() != 1 {
+				status.ReportError("key_id_extraction_regex must have exactly one capturing group")
+			}
+		}
 	}
 
 	if newConfig.KeyIdentifierFile == "" && newConfig.KeyIdentifierValue == "" {
@@ -209,7 +259,9 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 			return nil, err
 		}
 	}
-	p.log.Debug("Loaded server id", "server_id", serverID)
+	if serverID != "" {
+		p.log.Debug("Loaded server id", "server_id", serverID)
+	}
 
 	var customPolicy *iam.Policy3
 	if newConfig.KeyPolicyFile != "" {
@@ -224,11 +276,45 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	tdHashBytes := sha1.Sum([]byte(req.CoreConfiguration.TrustDomain)) //nolint: gosec // We use sha1 to hash trust domain names in 128 bytes to avoid label restrictions
 	tdHashString := hex.EncodeToString(tdHashBytes[:])
 
-	p.setPluginData(&pluginData{
+	pd := &pluginData{
 		customPolicy: customPolicy,
 		serverID:     serverID,
 		tdHash:       tdHashString,
-	})
+		trustDomain:  sanitizeTrustDomainForGCP(req.CoreConfiguration.TrustDomain),
+	}
+
+	var keyIDExtractor func(*kmspb.CryptoKey) (string, bool)
+	if newConfig.SharedKeys != nil {
+		pd.sharedKeysEnabled = true
+		pd.cryptoKeyTemplate = template.Must(template.New("crypto_key_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.CryptoKeyTemplate))
+		if newConfig.SharedKeys.LockLabelTemplate != "" {
+			pd.lockLabelTemplate = template.Must(template.New("lock_label_template").Funcs(sprig.TxtFuncMap()).Parse(newConfig.SharedKeys.LockLabelTemplate))
+		}
+		pd.keyIDRegex = regexp.MustCompile(newConfig.SharedKeys.KeyIDExtractionRegex)
+
+		re := pd.keyIDRegex
+		// In shared keys mode only JWT keys are shared (matched by the configured
+		// regex). X509 CA and WIT keys remain per-server: they are discovered only
+		// when their server-id label matches this server, so one server never
+		// adopts another server's keys.
+		keyIDExtractor = func(cryptoKey *kmspb.CryptoKey) (string, bool) {
+			name := path.Base(cryptoKey.Name)
+			if m := re.FindStringSubmatch(name); len(m) >= 2 {
+				return m[1], true
+			}
+			if cryptoKey.Labels[labelNameServerID] != serverID {
+				return "", false
+			}
+			return getSPIREKeyIDFromCryptoKeyName(cryptoKey.Name)
+		}
+	} else {
+		pd.sharedKeysEnabled = false
+		keyIDExtractor = func(cryptoKey *kmspb.CryptoKey) (string, bool) {
+			return getSPIREKeyIDFromCryptoKeyName(cryptoKey.Name)
+		}
+	}
+
+	p.setPluginData(pd)
 
 	var opts []option.ClientOption
 	if newConfig.ServiceAccountFile != "" {
@@ -241,11 +327,13 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	}
 
 	fetcher := &keyFetcher{
-		keyRing:   newConfig.KeyRing,
-		kmsClient: kc,
-		log:       p.log,
-		serverID:  serverID,
-		tdHash:    tdHashString,
+		keyRing:           newConfig.KeyRing,
+		kmsClient:         kc,
+		log:               p.log,
+		serverID:          serverID,
+		tdHash:            tdHashString,
+		keyIDExtractor:    keyIDExtractor,
+		sharedKeysEnabled: newConfig.SharedKeys != nil,
 	}
 	p.log.Debug("Fetching keys from Cloud KMS", "key_ring", newConfig.KeyRing)
 	keyEntries, err := fetcher.fetchKeyEntries(ctx)
@@ -295,6 +383,9 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 
 	pubKey, err := p.createKey(ctx, req.KeyId, req.KeyType)
 	if err != nil {
+		if status.Code(err) == codes.Aborted {
+			return nil, err
+		}
 		return nil, status.Errorf(codes.Internal, "failed to generate key: %v", err)
 	}
 
@@ -409,6 +500,7 @@ func (p *Plugin) SignData(ctx context.Context, req *keymanagerv1.SignDataRequest
 // a default policy is constructed and attached. This function requests Cloud KMS
 // to get the public key of the created CryptoKeyVersion. A keyEntry is returned
 // with the CryptoKey, CryptoKeyVersion and public key.
+// In shared keys mode, implements optimistic coordination with lock acquisition to prevent race conditions.
 func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keymanagerv1.KeyType) (*keymanagerv1.PublicKey, error) {
 	// If we already have this SPIRE Key ID cached, a new CryptoKeyVersion is
 	// added to the existing CryptoKey and the cache is updated. The old
@@ -427,16 +519,78 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		return nil, fmt.Errorf("could not generate CryptoKeyID: %w", err)
 	}
 
-	cryptoKeyLabels, err := p.getCryptoKeyLabels()
+	pd, err := p.getPluginData()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "could not get CryptoKey labels: %v", err)
+		return nil, err
 	}
+
+	// Only JWT signing keys are shared between servers; X509 CA and WIT keys are
+	// always per-server, even in shared keys mode.
+	useSharedKey := pd.sharedKeysEnabled && keymanager.IsSharedKeyID(spireKeyID)
 
 	config, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
 
+	// Use path.Join to ensure correct path construction regardless of trailing slashes in KeyRing
+	cryptoKeyName := path.Join(config.KeyRing, "cryptoKeys", cryptoKeyID)
+
+	// OPTIMIZATION: Check for the existing fresh key (Optimistic coordination) for Shared Keys
+	if useSharedKey {
+		existingCryptoKey, err := p.kmsClient.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+			Name: cryptoKeyName,
+		})
+
+		if err == nil && existingCryptoKey != nil {
+			itVersions := p.kmsClient.ListCryptoKeyVersions(ctx, &kmspb.ListCryptoKeyVersionsRequest{
+				Parent: cryptoKeyName,
+				Filter: "state = " + kmspb.CryptoKeyVersion_ENABLED.String(),
+			})
+
+			cryptoKeyVersion, err := itVersions.Next()
+			if err == nil && cryptoKeyVersion != nil && cryptoKeyVersion.CreateTime != nil {
+				sharedKeyFreshnessThreshold := 15 * time.Minute
+
+				if p.hooks.clk.Now().Sub(cryptoKeyVersion.CreateTime.AsTime()) < sharedKeyFreshnessThreshold {
+					if cryptoKeyVersion.Algorithm == algorithm {
+						p.log.Info("Shared key is already fresh. Reusing existing key (optimistic).", "crypto_key_name", cryptoKeyName, "crypto_key_version", cryptoKeyVersion.Name)
+
+						pubKey, err := getPublicKeyFromCryptoKeyVersion(ctx, p.log, p.kmsClient, cryptoKeyVersion.Name)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "failed to get public key: %v", err)
+						}
+
+						newKeyEntry := keyEntry{
+							cryptoKey:            existingCryptoKey,
+							cryptoKeyVersionName: cryptoKeyVersion.Name,
+							publicKey: &keymanagerv1.PublicKey{
+								Id:          spireKeyID,
+								Type:        keyType,
+								PkixData:    pubKey,
+								Fingerprint: makeFingerprint(pubKey),
+							},
+						}
+
+						p.setKeyEntry(spireKeyID, newKeyEntry)
+						return newKeyEntry.publicKey, nil
+					}
+				}
+			}
+		}
+	}
+
+	cryptoKeyLabels, err := p.getCryptoKeyLabels()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get CryptoKey labels: %v", err)
+	}
+
+	// In shared keys mode, add the KID label
+	if useSharedKey {
+		cryptoKeyLabels[labelNameKeyID] = sanitizeLabelValue(spireKeyID)
+	}
+
+	// Create the new CryptoKey
 	cryptoKey, err := p.kmsClient.CreateCryptoKey(ctx, &kmspb.CreateCryptoKeyRequest{
 		CryptoKey: &kmspb.CryptoKey{
 			Labels:  cryptoKeyLabels,
@@ -449,12 +603,148 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		Parent:      config.KeyRing,
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create CryptoKey: %v", err)
+		if status.Code(err) == codes.AlreadyExists {
+			p.log.Debug("CryptoKey already exists, using existing key", cryptoKeyNameTag, cryptoKeyName)
+			cryptoKey, err = p.kmsClient.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+				Name: cryptoKeyName,
+			})
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "failed to get existing CryptoKey after creation collision: %v", err)
+			}
+		} else {
+			return nil, status.Errorf(codes.Internal, "failed to create CryptoKey: %v", err)
+		}
 	}
 
 	log := p.log.With(cryptoKeyNameTag, cryptoKey.Name)
 	log.Debug("CryptoKey created", algorithmTag, algorithm)
 
+	// 3. Acquire Lock (if configured) for shared keys mode
+	var lockLabel string
+	if useSharedKey && pd.lockLabelTemplate != nil {
+		data := sharedKeysTemplateData(pd.trustDomain, spireKeyID, pd.serverID)
+
+		var buf strings.Builder
+		if err := pd.lockLabelTemplate.Execute(&buf, data); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to execute lock_label_template: %v", err)
+		}
+		lockLabel = buf.String()
+
+		// Fetch the latest state of the CryptoKey to read the current labels before modifying them.
+		// GCP UpdateCryptoKey does not enforce CAS on label updates; the lockTTL (10 min) is the
+		// safety net for concurrent writes — a small race window is possible but bounded.
+		latestCryptoKey, err := p.kmsClient.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+			Name: cryptoKey.Name,
+		})
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to get crypto key for locking: %v", err)
+		}
+		if latestCryptoKey.Labels == nil {
+			latestCryptoKey.Labels = make(map[string]string)
+		}
+
+		if existingVal, ok := latestCryptoKey.Labels[lockLabel]; ok {
+			// Determine if the lock is stale (unix-seconds stored as the label value).
+			acquiredAtSec, parseErr := strconv.ParseInt(existingVal, 10, 64)
+			acquiredAt := time.Unix(acquiredAtSec, 0)
+			isStale := parseErr != nil || p.hooks.clk.Now().Sub(acquiredAt) > lockTTL
+			if !isStale {
+				p.log.Warn("Rotation lock held by another instance. Aborting rotation.", "lock_label", lockLabel)
+				return nil, status.Errorf(codes.Aborted, "rotation lock held")
+			}
+			p.log.Warn("Stale rotation lock detected; overwriting it.", "lock_label", lockLabel,
+				"lock_age", p.hooks.clk.Now().Sub(acquiredAt))
+		}
+
+		latestCryptoKey.Labels[lockLabel] = strconv.FormatInt(p.hooks.clk.Now().Unix(), 10)
+		_, err = p.kmsClient.UpdateCryptoKey(ctx, &kmspb.UpdateCryptoKeyRequest{
+			CryptoKey: latestCryptoKey,
+			UpdateMask: &fieldmaskpb.FieldMask{
+				Paths: []string{"labels"},
+			},
+		})
+		if err != nil {
+			p.log.Warn("Failed to acquire rotation lock (concurrent update). Aborting.", "error", err)
+			return nil, status.Errorf(codes.Aborted, "failed to acquire lock: %v", err)
+		}
+
+		p.log.Debug("Acquired rotation lock", "lock_label", lockLabel)
+
+		defer func() {
+			// Re-fetch to get the latest labels state before releasing the lock.
+			k, err := p.kmsClient.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+				Name: cryptoKey.Name,
+			})
+			if err != nil {
+				p.log.Error("Failed to get crypto key to release lock", "error", err)
+				return
+			}
+			if k.Labels != nil {
+				delete(k.Labels, lockLabel)
+			}
+			_, err = p.kmsClient.UpdateCryptoKey(ctx, &kmspb.UpdateCryptoKeyRequest{
+				CryptoKey: k,
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"labels"},
+				},
+			})
+			if err != nil {
+				p.log.Error("Failed to release rotation lock", "lock_label", lockLabel, "error", err)
+			} else {
+				p.log.Debug("Released rotation lock", "lock_label", lockLabel)
+			}
+		}()
+	}
+
+	// 4. Check if the CryptoKey already has a fresh version (concurrency check)
+	if useSharedKey {
+		existingCryptoKey, err := p.kmsClient.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+			Name: cryptoKeyName,
+		})
+
+		if err == nil && existingCryptoKey != nil {
+			itVersions := p.kmsClient.ListCryptoKeyVersions(ctx, &kmspb.ListCryptoKeyVersionsRequest{
+				Parent: cryptoKeyName,
+				Filter: "state = " + kmspb.CryptoKeyVersion_ENABLED.String(),
+			})
+
+			cryptoKeyVersion, err := itVersions.Next()
+			if err == nil && cryptoKeyVersion != nil && cryptoKeyVersion.CreateTime != nil {
+				sharedKeyFreshnessThreshold := 15 * time.Minute
+
+				if p.hooks.clk.Now().Sub(cryptoKeyVersion.CreateTime.AsTime()) < sharedKeyFreshnessThreshold {
+					if cryptoKeyVersion.Algorithm == algorithm {
+						p.log.Info("Shared key was recently rotated by another instance. Reusing existing key.", "crypto_key_name", cryptoKeyName, "crypto_key_version", cryptoKeyVersion.Name)
+
+						if err := p.enqueueDestruction(cryptoKey.Name + "/cryptoKeyVersions/1"); err != nil {
+							p.log.Error("Failed to enqueue unused candidate CryptoKeyVersion for destruction", reasonTag, err)
+						}
+
+						pubKey, err := getPublicKeyFromCryptoKeyVersion(ctx, p.log, p.kmsClient, cryptoKeyVersion.Name)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "failed to get public key: %v", err)
+						}
+
+						reusedEntry := keyEntry{
+							cryptoKey:            existingCryptoKey,
+							cryptoKeyVersionName: cryptoKeyVersion.Name,
+							publicKey: &keymanagerv1.PublicKey{
+								Id:          spireKeyID,
+								Type:        keyType,
+								PkixData:    pubKey,
+								Fingerprint: makeFingerprint(pubKey),
+							},
+						}
+
+						p.setKeyEntry(spireKeyID, reusedEntry)
+						return reusedEntry.publicKey, nil
+					}
+				}
+			}
+		}
+	}
+
+	// 5. Set IAM policy and use the new CryptoKey
 	if err := p.setIamPolicy(ctx, cryptoKey.Name); err != nil {
 		log.Debug("Failed to set IAM policy")
 		return nil, status.Errorf(codes.Internal, "failed to set IAM policy: %v", err)
@@ -1030,12 +1320,53 @@ func cryptoKeyVersionAlgorithmFromKeyType(keyType keymanagerv1.KeyType) (kmspb.C
 // The returned identifier has the form: spire-key-<UUID>-<SPIRE-KEY-ID>,
 // where UUID is a new randomly generated UUID and SPIRE-KEY-ID is provided
 // through the spireKeyID parameter.
+// If shared keys are enabled, it uses the crypto_key_template instead.
 func (p *Plugin) generateCryptoKeyID(spireKeyID string) (cryptoKeyID string, err error) {
 	pd, err := p.getPluginData()
 	if err != nil {
 		return "", err
 	}
+
+	if pd.sharedKeysEnabled && keymanager.IsSharedKeyID(spireKeyID) {
+		data := sharedKeysTemplateData(pd.trustDomain, spireKeyID, pd.serverID)
+
+		var buf strings.Builder
+		if err := pd.cryptoKeyTemplate.Execute(&buf, data); err != nil {
+			return "", status.Errorf(codes.Internal, "failed to execute crypto_key_template: %v", err)
+		}
+
+		return buf.String(), nil
+	}
+
 	return fmt.Sprintf("%s-%s-%s", cryptoKeyNamePrefix, pd.serverID, spireKeyID), nil
+}
+
+// sharedKeysTemplateData builds the template data struct for shared-keys templates.
+func sharedKeysTemplateData(trustDomain, keyID, serverID string) any {
+	return struct {
+		TrustDomain string
+		KeyID       string
+		ServerID    string
+	}{
+		TrustDomain: trustDomain,
+		KeyID:       keyID,
+		ServerID:    serverID,
+	}
+}
+
+func sanitizeTrustDomainForGCP(trustDomain string) string {
+	// GCP CryptoKey names have restrictions, sanitize the trust domain
+	return strings.ReplaceAll(trustDomain, ".", "-")
+}
+
+// sanitizeLabelValue sanitizes a string to be used as a GCP label value
+// Label values must be lowercase, contain only letters, numbers, hyphens, and underscores
+func sanitizeLabelValue(value string) string {
+	// Convert to lowercase and replace dots and plus signs
+	value = strings.ToLower(value)
+	value = strings.ReplaceAll(value, ".", "-")
+	value = strings.ReplaceAll(value, "+", "_")
+	return value
 }
 
 // crc32Checksum returns the CRC-32 checksum of data using the polynomial
@@ -1116,8 +1447,8 @@ func getPublicKeyFromCryptoKeyVersion(ctx context.Context, log hclog.Logger, kms
 		kmsPublicKey, errGetPublicKey = kmsClient.GetPublicKey(ctx, &kmspb.GetPublicKeyRequest{Name: cryptoKeyVersionName})
 	}
 
-	// Perform integrity verification.
-	if int64(crc32Checksum([]byte(kmsPublicKey.Pem))) != kmsPublicKey.PemCrc32C.Value {
+	normalizedPem := strings.ReplaceAll(kmsPublicKey.Pem, "\r\n", "\n")
+	if int64(crc32Checksum([]byte(normalizedPem))) != kmsPublicKey.PemCrc32C.Value {
 		return nil, errors.New("response corrupted in-transit")
 	}
 

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -10,6 +10,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,6 +62,7 @@ dZglS5kKnYigmwDh+/U=
 `
 	spireKeyID1       = "spireKeyID-1"
 	spireKeyID2       = "spireKeyID-2"
+	sharedJWTKeyID1   = keymanager.JWTSignerKeyIDPrefix + spireKeyID1
 	testTimeout       = 60 * time.Second
 	validPolicyFile   = "custom_policy_file.json"
 	validServerID     = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -71,10 +75,11 @@ var (
 	cryptoKeyName1 = path.Join(validKeyRing, "cryptoKeys", fmt.Sprintf("test-crypto-key/spire-key-%s-spireKeyID-1", validServerID))
 	cryptoKeyName2 = path.Join(validKeyRing, "cryptoKeys", fmt.Sprintf("test-crypto-key/spire-key-%s-spireKeyID-2", validServerID))
 	fakeTime       = timestamppb.Now()
+	unixEpoch      = time.Unix(0, 0)
 
 	pubKey = &kmspb.PublicKey{
-		Pem:       pemCert,
-		PemCrc32C: &wrapperspb.Int64Value{Value: int64(crc32Checksum([]byte(pemCert)))},
+		Pem:       strings.ReplaceAll(pemCert, "\r\n", "\n"),
+		PemCrc32C: &wrapperspb.Int64Value{Value: int64(crc32Checksum([]byte(strings.ReplaceAll(pemCert, "\r\n", "\n"))))},
 	}
 )
 
@@ -1778,4 +1783,424 @@ func maxDuration(d1, d2 time.Duration) time.Duration {
 	}
 
 	return d2
+}
+
+func TestConfigure_SharedKeys(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		err              string
+		code             codes.Code
+		configureRequest *configv1.ConfigureRequest
+	}{
+		{
+			name: "valid shared keys config",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_identifier_value": "test-server",
+				"key_ring": "%s",
+				"shared_keys": {
+					"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyRing)),
+		},
+		{
+			name: "missing crypto_key_template",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_identifier_value": "test-server",
+				"key_ring": "%s",
+				"shared_keys": {
+					"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyRing)),
+			err:  "configuration missing crypto_key_template in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "missing key_id_extraction_regex",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_identifier_value": "test-server",
+				"key_ring": "%s",
+				"shared_keys": {
+					"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+					"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}"
+				}
+			}`, validKeyRing)),
+			err:  "configuration missing key_id_extraction_regex in shared_keys",
+			code: codes.InvalidArgument,
+		},
+		{
+			name: "invalid crypto_key_template",
+			configureRequest: configureRequestWithString(fmt.Sprintf(`{
+				"key_identifier_value": "test-server",
+				"key_ring": "%s",
+				"shared_keys": {
+					"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID ",
+					"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+					"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+				}
+			}`, validKeyRing)),
+			err:  "failed to parse crypto_key_template",
+			code: codes.InvalidArgument,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+			_, err := ts.plugin.Configure(ctx, tt.configureRequest)
+
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys(t *testing.T) {
+	sharedKeysConfig := fmt.Sprintf(`{
+		"key_identifier_value": "test-server",
+		"key_ring": "%s",
+		"shared_keys": {
+			"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyRing)
+
+	// Trust domain "test.example.org" is sanitized to "test-example-org" for both the
+	// crypto key name template and the lock label template (both use .TrustDomain = sanitized TD).
+	expectedCryptoKeyName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-example-org-"+sharedJWTKeyID1)
+	expectedLockLabel := "spire-lock-test-example-org-" + sharedJWTKeyID1
+
+	for _, tt := range []struct {
+		name                       string
+		err                        string
+		code                       codes.Code
+		fakeCryptoKeys             []*fakeCryptoKey
+		request                    *keymanagerv1.GenerateKeyRequest
+		createKeyErr               error
+		getCryptoKeyErr            error
+		updateCryptoKeyErr         error // For lock acquisition/release
+		getPublicKeyErr            error
+		destroyCryptoKeyVersionErr error
+	}{
+		{
+			name: "success: new key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID1,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+		},
+		{
+			name: "success: reuse existing fresh key",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID1,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeCryptoKeys: []*fakeCryptoKey{
+				{
+					CryptoKey: &kmspb.CryptoKey{
+						Name:            expectedCryptoKeyName,
+						Labels:          map[string]string{labelNameActive: "true"},
+						VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
+					},
+					fakeCryptoKeyVersions: map[string]*fakeCryptoKeyVersion{
+						"1": {
+							publicKey: pubKey,
+							CryptoKeyVersion: &kmspb.CryptoKeyVersion{
+								Algorithm:  kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+								Name:       fmt.Sprintf("%s/cryptoKeyVersions/1", expectedCryptoKeyName),
+								State:      kmspb.CryptoKeyVersion_ENABLED,
+								CreateTime: timestamppb.New(time.Now()), // Fresh
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "success: rotate key (existing key stale)",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID1,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeCryptoKeys: []*fakeCryptoKey{
+				{
+					CryptoKey: &kmspb.CryptoKey{
+						Name:            expectedCryptoKeyName,
+						Labels:          map[string]string{labelNameActive: "true"},
+						VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
+					},
+					fakeCryptoKeyVersions: map[string]*fakeCryptoKeyVersion{
+						"1": {
+							publicKey: pubKey,
+							CryptoKeyVersion: &kmspb.CryptoKeyVersion{
+								Algorithm:  kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+								Name:       fmt.Sprintf("%s/cryptoKeyVersions/1", expectedCryptoKeyName),
+								State:      kmspb.CryptoKeyVersion_ENABLED,
+								CreateTime: timestamppb.New(unixEpoch), // Stale
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "fail: lock held",
+			request: &keymanagerv1.GenerateKeyRequest{
+				KeyId:   sharedJWTKeyID1,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			},
+			fakeCryptoKeys: []*fakeCryptoKey{
+				{
+					CryptoKey: &kmspb.CryptoKey{
+						Name:            expectedCryptoKeyName,
+						Labels:          map[string]string{labelNameActive: "true", expectedLockLabel: "true"}, // Lock held
+						VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
+					},
+					fakeCryptoKeyVersions: map[string]*fakeCryptoKeyVersion{
+						"1": {
+							publicKey: pubKey,
+							CryptoKeyVersion: &kmspb.CryptoKeyVersion{
+								Algorithm:  kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+								Name:       fmt.Sprintf("%s/cryptoKeyVersions/1", expectedCryptoKeyName),
+								State:      kmspb.CryptoKeyVersion_ENABLED,
+								CreateTime: timestamppb.New(unixEpoch), // Stale
+							},
+						},
+					},
+				},
+			},
+			err:  "rotation lock held",
+			code: codes.Aborted,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+
+			// Adjust creation date for freshness test
+			if tt.name == "success: reuse existing fresh key" {
+				tt.fakeCryptoKeys[0].fakeCryptoKeyVersions["1"].CryptoKeyVersion.CreateTime = timestamppb.New(ts.clockHook.Now())
+			}
+
+			// For the lock-held test, stamp the lock label with a fresh (non-stale) unix timestamp.
+			if tt.name == "fail: lock held" && len(tt.fakeCryptoKeys) > 0 {
+				now := ts.clockHook.Now()
+				tt.fakeCryptoKeys[0].Labels[expectedLockLabel] = strconv.FormatInt(now.Unix(), 10)
+			}
+
+			ts.fakeKMSClient.putFakeCryptoKeys(tt.fakeCryptoKeys)
+			ts.fakeKMSClient.setCreateCryptoKeyErr(tt.createKeyErr)
+			ts.fakeKMSClient.setUpdateCryptoKeyErr(tt.updateCryptoKeyErr)
+			ts.fakeKMSClient.setDestroyCryptoKeyVersionErr(tt.destroyCryptoKeyVersionErr)
+
+			// We need to set getPublicKeyErr if needed, but for success cases it should be nil (default)
+			if tt.getPublicKeyErr != nil {
+				ts.fakeKMSClient.setGetPublicKeySequentialErrs(tt.getPublicKeyErr, 1)
+			}
+
+			ts.plugin.hooks.scheduleDestroySignal = make(chan error)
+
+			configureReq := configureRequestWithString(sharedKeysConfig)
+			_, err := ts.plugin.Configure(ctx, configureReq)
+			require.NoError(t, err)
+
+			resp, err := ts.plugin.GenerateKey(ctx, tt.request)
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			// Verify lock was released if it was acquired (implied by success in rotation cases)
+			if tt.name == "success: new key" || tt.name == "success: rotate key (existing key stale)" {
+				// Check if the crypto key exists
+				fakeKey, ok := ts.fakeKMSClient.store.fetchFakeCryptoKey(expectedCryptoKeyName)
+				require.True(t, ok, "crypto key should exist")
+
+				// Check lock label
+				_, locked := fakeKey.Labels[expectedLockLabel]
+				require.False(t, locked, "lock label should be released")
+			}
+		})
+	}
+}
+
+func TestGenerateKey_SharedKeys_OnlyJWTKeysAreShared(t *testing.T) {
+	sharedKeysConfig := fmt.Sprintf(`{
+		"key_identifier_value": "test-server",
+		"key_ring": "%s",
+		"shared_keys": {
+			"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyRing)
+
+	x509KeyID := keymanager.X509CAKeyIDPrefix + "A"
+	jwtCryptoKeyName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-example-org-"+sharedJWTKeyID1)
+	x509PerServerName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-server-"+x509KeyID)
+	x509SharedName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-example-org-"+x509KeyID)
+
+	ts := setupTest(t)
+	ts.plugin.hooks.scheduleDestroySignal = make(chan error)
+	_, err := ts.plugin.Configure(ctx, configureRequestWithString(sharedKeysConfig))
+	require.NoError(t, err)
+
+	// X509 CA keys are not shared: they use this server's per-server crypto key name.
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   x509KeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	// JWT signing keys are shared: they use the shared template crypto key name.
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID1,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	_, ok := ts.fakeKMSClient.store.fetchFakeCryptoKey(x509PerServerName)
+	require.True(t, ok, "X509 CA key should use the per-server crypto key name")
+	_, ok = ts.fakeKMSClient.store.fetchFakeCryptoKey(jwtCryptoKeyName)
+	require.True(t, ok, "JWT signing key should use the shared template crypto key name")
+	_, ok = ts.fakeKMSClient.store.fetchFakeCryptoKey(x509SharedName)
+	require.False(t, ok, "X509 CA key must not use the shared template crypto key name")
+}
+
+func TestGenerateKey_SharedKeys_StaleLockBroken(t *testing.T) {
+	sharedKeysConfig := fmt.Sprintf(`{
+		"key_identifier_value": "test-server",
+		"key_ring": "%s",
+		"shared_keys": {
+			"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyRing)
+
+	expectedCryptoKeyName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-example-org-"+sharedJWTKeyID1)
+	expectedLockLabel := "spire-lock-test-example-org-" + sharedJWTKeyID1
+
+	ts := setupTest(t)
+
+	// Advance clock by 15 minutes so the stale lock timestamp appears old.
+	ts.clockHook.Add(15 * time.Minute)
+	staleLockTime := ts.clockHook.Now().Add(-15 * time.Minute)
+
+	staleKeyWithLock := &fakeCryptoKey{
+		CryptoKey: &kmspb.CryptoKey{
+			Name: expectedCryptoKeyName,
+			Labels: map[string]string{
+				labelNameActive:   "true",
+				expectedLockLabel: strconv.FormatInt(staleLockTime.Unix(), 10),
+			},
+			VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
+		},
+		fakeCryptoKeyVersions: map[string]*fakeCryptoKeyVersion{
+			"1": {
+				publicKey: pubKey,
+				CryptoKeyVersion: &kmspb.CryptoKeyVersion{
+					Algorithm:  kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+					Name:       fmt.Sprintf("%s/cryptoKeyVersions/1", expectedCryptoKeyName),
+					State:      kmspb.CryptoKeyVersion_ENABLED,
+					CreateTime: timestamppb.New(unixEpoch), // Stale key version
+				},
+			},
+		},
+	}
+	ts.fakeKMSClient.putFakeCryptoKeys([]*fakeCryptoKey{staleKeyWithLock})
+	ts.plugin.hooks.scheduleDestroySignal = make(chan error)
+
+	configureReq := configureRequestWithString(sharedKeysConfig)
+	_, err := ts.plugin.Configure(ctx, configureReq)
+	require.NoError(t, err)
+
+	resp, err := ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID1,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err, "stale lock should be broken and rotation should succeed")
+	require.NotNil(t, resp)
+
+	// Lock label should be gone from the key after successful rotation.
+	fakeKey, ok := ts.fakeKMSClient.store.fetchFakeCryptoKey(expectedCryptoKeyName)
+	require.True(t, ok, "crypto key should exist")
+	_, locked := fakeKey.Labels[expectedLockLabel]
+	require.False(t, locked, "stale lock label should have been removed")
+}
+
+func TestGenerateKey_SharedKeys_ConcurrentContention(t *testing.T) {
+	sharedKeysConfigFmt := fmt.Sprintf(`{
+		"key_identifier_value": "%%s",
+		"key_ring": "%s",
+		"shared_keys": {
+			"crypto_key_template": "spire-key-{{ .TrustDomain }}-{{ .KeyID }}",
+			"lock_label_template": "spire-lock-{{ .TrustDomain }}-{{ .KeyID }}",
+			"key_id_extraction_regex": "^spire-key-test-example-org-(.+)$"
+		}
+	}`, validKeyRing)
+	expectedCryptoKeyName := path.Join(validKeyRing, "cryptoKeys", "spire-key-test-example-org-"+sharedJWTKeyID1)
+
+	c := clock.NewMock(t)
+	fakeCli := newKMSClientFake(t, c)
+
+	makePlugin := func(serverID string) *Plugin {
+		p := newPlugin(
+			func(ctx context.Context, opts ...option.ClientOption) (cloudKeyManagementService, error) {
+				fakeCli.opts = opts
+				return fakeCli, nil
+			},
+		)
+		km := new(keymanager.V1)
+		plugintest.Load(t, builtin(p), km)
+		p.hooks.clk = c
+		_, err := p.Configure(ctx, configureRequestWithString(fmt.Sprintf(sharedKeysConfigFmt, serverID)))
+		require.NoError(t, err)
+		return p
+	}
+
+	p1 := makePlugin("server-1")
+	p2 := makePlugin("server-2")
+
+	req := &keymanagerv1.GenerateKeyRequest{
+		KeyId:   sharedJWTKeyID1,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	}
+
+	type result struct {
+		resp *keymanagerv1.GenerateKeyResponse
+		err  error
+	}
+	results := make(chan result, 2)
+
+	var wg sync.WaitGroup
+	for _, p := range []*Plugin{p1, p2} {
+		wg.Add(1)
+		go func(p *Plugin) {
+			defer wg.Done()
+			resp, err := p.GenerateKey(ctx, req)
+			results <- result{resp, err}
+		}(p)
+	}
+	wg.Wait()
+	close(results)
+
+	_, cryptoKeyExists := fakeCli.store.fetchFakeCryptoKey(expectedCryptoKeyName)
+	require.True(t, cryptoKeyExists, "CryptoKey should exist after concurrent generation")
+
+	var successes int
+	for r := range results {
+		if r.err == nil {
+			require.NotNil(t, r.resp)
+			successes++
+		}
+	}
+	require.Greater(t, successes, 0, "at least one GenerateKey call should succeed")
 }


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
* AWS KMS KeyManager server plugin
* Azure Key Vault KeyManager server plugin
* GCP KMS KeyManager server plugin
* Disk KeyManager server plugin

**Description of change**
Adds the ability to share signing keys between server instances rather than each instance managing its own key pairs, so that the number of keys that will be exposed in the JWKS endpoint is reduced.

**Which issue this PR fixes**
#4699

