### PR TITLE
Fix flaky envoy-sds-v3 integration test

### DIFF
--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -34,7 +34,7 @@ setup-tests() {
 test-envoy() {
     # Ensure connectivity for both TLS and mTLS
 
-    MAXCHECKSPERPORT=15
+    MAXCHECKSPERPORT=30
     CHECKINTERVAL=1
 
     TRY() { docker compose exec -T downstream-socat-mtls /bin/sh -c 'echo HELLO_MTLS | socat -u STDIN TCP:localhost:8001'; }


### PR DESCRIPTION
Fix flaky envoy-sds-v3 integration test by increasing the connectivity check timeout from 15 to 30 seconds.
The test may be failing intermittently in CI because 15 seconds is insufficient for containers to fully initialize, particularly for the SPIRE agents to complete attestation, fetch SVIDs, establish the SDS connection with Envoy, and for Envoy to retrieve certificates.
The increased timeout should provide adequate time for all initialization steps to complete.

Example of a failure: https://github.com/spiffe/spire/actions/runs/21052030692/job/60540834982?pr=6547