### PR TITLE
Add diagnostic logging to Envoy SDS integration tests

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -351,3 +351,11 @@ set-kubectl-context() {
     log-info "setting kubectl cluster context..."
     "${kubectl_path}" cluster-info --context "${context}"
 }
+
+dump-multiple-container-logs() {
+    log-warn "Dumping container logs for diagnostics..."
+    for container in "$@"; do
+        log-warn "=== Logs for ${container} ==="
+        docker compose logs "${container}" || log-warn "Failed to get logs for ${container}"
+    done
+}

--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -66,10 +66,14 @@ test-envoy() {
     done
 
     if [ -z "${MTLS_OK}" ]; then
+        log-warn "MTLS proxy check failed after ${MAXCHECKSPERPORT} attempts"
+        dump-multiple-container-logs upstream-proxy downstream-proxy upstream-socat downstream-socat-mtls downstream-socat-tls
         fail-now "MTLS Proxying failed"
     fi
 
     if [ -z "${TLS_OK}" ]; then
+        log-warn "TLS proxy check failed after ${MAXCHECKSPERPORT} attempts"
+        dump-multiple-container-logs upstream-proxy downstream-proxy upstream-socat downstream-socat-mtls downstream-socat-tls
         fail-now "TLS Proxying failed"
     fi
 }


### PR DESCRIPTION
Improve debugging of Envoy SDS integration test failures by adding diagnostic logging that dumps container logs when connectivity checks fail.

This PR adds a new `dump-multiple-container-logs()` helper function to the common test utilities that takes container names as parameters and dumps all logs from each container. When a test times out, it now shows which specific check failed (MTLS or TLS), which container was being tested, and complete logs from all relevant containers (proxies and socat instances).