### PR TITLE
Increase aws_iid attestor AWS timeout to 20s

### DIFF
--- a/pkg/server/plugin/nodeattestor/awsiid/iid.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	awsTimeout      = 5 * time.Second
+	awsTimeout      = 20 * time.Second
 	instanceFilters = []ec2types.Filter{
 		{
 			Name: aws.String("instance-state-name"),


### PR DESCRIPTION
This change addresses timeouts in the aws_iid server node attestor when using the verify_organization feature against large AWS Organizations. In our environment (~800 accounts), fetching the account list takes ~10 seconds on average, with per-call round‑trip times around 120 ms and occasional spikes above 2 seconds. The current hardcoded 5‑second timeout is too aggressive for this scenario and causes intermittent attestation failures.

To improve reliability, the AWS request timeout used by the aws_iid attestor is increased from 5 seconds to 20 seconds. This aligns with observed latency and provides enough headroom for slower ListAccounts pagination without changing the overall behavior of the attestor or its caching logic.
