### PR TITLE
Fix for TestTLSConfig/update_key_file_with_an_invalid_key_start_error_log_loop test

### DIFF
--- a/pkg/common/diskcertmanager/cert_manager_test.go
+++ b/pkg/common/diskcertmanager/cert_manager_test.go
@@ -26,6 +26,9 @@ import (
 var (
 	oidcServerKey    = testkey.MustEC256()
 	oidcServerKeyNew = testkey.MustEC256()
+
+	// testModTimeCounter ensures strictly monotonic ModTimes across all writeFile calls
+	testModTimeCounter time.Time
 )
 
 const (
@@ -362,21 +365,16 @@ func TestTLSConfig(t *testing.T) {
 }
 
 func writeFile(t *testing.T, name string, data []byte) {
-	// Ensure ModTime will be different from previous write by setting it explicitly.
-	// This handles filesystems with coarse ModTime resolution (e.g., 1-second granularity).
-	newModTime := time.Now()
-	info, err := os.Stat(name)
-	switch {
-	case err == nil:
-		newModTime = info.ModTime().Add(time.Second)
-	case os.IsNotExist(err):
-		// File doesn't exist - use time.Now()
-	default:
-		require.NoError(t, err, "failed to stat file before writing")
+	// Ensure ModTime is strictly monotonic across all writes in the test.
+	// This handles filesystems with coarse ModTime resolution (e.g., 1-second granularity)
+	// and ensures the cert manager always detects changes.
+	if testModTimeCounter.IsZero() {
+		testModTimeCounter = time.Now()
 	}
+	testModTimeCounter = testModTimeCounter.Add(time.Second)
 
 	require.NoError(t, os.WriteFile(name, data, 0600))
-	require.NoError(t, os.Chtimes(name, newModTime, newModTime))
+	require.NoError(t, os.Chtimes(name, testModTimeCounter, testModTimeCounter))
 }
 
 func removeFile(t *testing.T, name string) {


### PR DESCRIPTION
This is one more commit to fix the TestTLSConfig/update_key_file_with_an_invalid_key_start_error_log_loop test.

We need to use a monotonic counter for file modification times. The test could still fail because the file watcher relies on ModTime comparison to detect changes, and rapid sequential file writes could receive duplicate or out-of-order ModTimes due to filesystem time resolution (e.g., 1-second granularity) and timing variations on CI machines.

Example of recent failure: https://github.com/spiffe/spire/actions/runs/21081414094/job/60635790891?pr=6564

With this PR, the test uses a global counter (testModTimeCounter) that ensures each writeFile call gets a strictly increasing ModTime, guaranteeing the cert manager detects every file change regardless of execution timing or test order.

This complements #6551, #6528, and #6533.