### PR TITLE
Restore merge_group trigger in DCO workflow to fix merge queue timeouts

### DIFF
--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -2,6 +2,9 @@ name: DCO
 on:
   pull_request: {}
   workflow_dispatch: {}
+  merge_group:
+    types:
+      - checks_requested
 jobs:
   check-dco:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This restores the `merge_group` trigger in the DCO workflow that was removed in #6564.

The trigger is required because `check-dco` is configured as a required status check in branch protection. Without it, the workflow never runs in merge queue and the check never reports, causing PRs to be automatically removed due to timeout. 

The conditional logic added in #6566 ensures DCO validation is skipped in merge queue (avoiding email mismatch errors) while still reporting the required status check.