### PR TITLE
Fix success job to prevent merging PRs with failed tests

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -604,9 +604,15 @@ jobs:
   success:
     runs-on: ubuntu-22.04
     needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, integration-k8s, lint-windows, unit-test-windows, artifacts-windows, integration-windows]
+    if: always()
     timeout-minutes: 30
     permissions:
       contents: read
     steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: |
+          echo "One or more required jobs failed, were cancelled, or were skipped"
+          exit 1
       - name: Declare victory!
-        run: echo "# Successful" >> $GITHUB_STEP_SUMMARY
+        run: echo "# Successful - all required jobs passed" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The `success` job was being skipped when dependent jobs failed, causing GitHub to treat the required status check as passing. This allowed PRs with failing tests to be merged via the merge queue (I noticed this in commit 647413c, which had failed unit tests but was still merged).

This fix adds `if: always()` to ensure the success job runs even when dependencies fail, and explicitly checks that all required jobs succeeded. The job now fails if any dependency has a result of `failure`, `cancelled`, or `skipped`, rather than being skipped itself.

This is a documented pattern for GitHub Actions required status checks (see https://github.com/actions/runner/issues/2566).