### PR TITLE
Increase Dependabot open pull requests limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,9 @@ updates:
     update-types: ["version-update:semver-patch"]
   - dependency-name: "cloud.google.com/go/*"
     update-types: ["version-update:semver-patch"]
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 20
 - package-ecosystem: "github-actions"
   directory: "/"
-  schedule: 
+  schedule:
    interval: daily
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 20


### PR DESCRIPTION
Now that we have a merge queue, there is less reason to limit the maximum number of open pull requests for version updates.

Reviews of Dependabot PRs have historically been lightweight, and our unit tests, linting, and integration tests have proven effective at catching incompatibilities when bumping dependencies.

I'm proposing to increase the limit to 20. Having more PRs open concurrently will allow dependency updates to be processed faster without batching them, eliminating the need for context switching when reviewing updates.