### PR TITLE
Fix flaky TestTLSConfig/delete_cert_files_start_error_log_loop test

### DIFF
--- a/pkg/common/diskcertmanager/cert_manager_test.go
+++ b/pkg/common/diskcertmanager/cert_manager_test.go
@@ -231,13 +231,14 @@ func TestTLSConfig(t *testing.T) {
 		// Assert error logs were triggered (at least 1, at most testTickerIterations)
 		// Use Eventually to give the goroutine time to process the clock ticks
 		require.Eventually(t, func() bool {
-			errLogs := map[time.Time]struct{}{}
-			for _, entry := range logHook.AllEntries() {
+			entries := logHook.AllEntries()
+			errLogCount := 0
+			for _, entry := range entries {
 				if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, "Failed to load certificate: tls: failed to find any PEM data in certificate input") {
-					errLogs[entry.Time] = struct{}{}
+					errLogCount++
 				}
 			}
-			return len(errLogs) >= 1 && len(errLogs) <= testTickerIterations
+			return errLogCount >= 1 && errLogCount <= testTickerIterations
 		}, time.Second, 10*time.Millisecond, "expected 1-%d error logs", testTickerIterations)
 
 		// New cert is not loaded because it is invalid.
@@ -263,13 +264,14 @@ func TestTLSConfig(t *testing.T) {
 		// Assert error logs were triggered (at least 1, at most testTickerIterations)
 		// Use Eventually to give the goroutine time to process the clock ticks
 		require.Eventually(t, func() bool {
-			errLogs := map[time.Time]struct{}{}
-			for _, entry := range logHook.AllEntries() {
+			entries := logHook.AllEntries()
+			errLogCount := 0
+			for _, entry := range entries {
 				if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, "Failed to load certificate: tls: failed to find any PEM data in key input") {
-					errLogs[entry.Time] = struct{}{}
+					errLogCount++
 				}
 			}
-			return len(errLogs) >= 1 && len(errLogs) <= testTickerIterations
+			return errLogCount >= 1 && errLogCount <= testTickerIterations
 		}, time.Second, 10*time.Millisecond, "expected 1-%d error logs", testTickerIterations)
 
 		// New cert is not loaded because it is invalid.
@@ -310,13 +312,14 @@ func TestTLSConfig(t *testing.T) {
 		// Assert error logs were triggered (at least 1, at most testTickerIterations)
 		// Use Eventually to give the goroutine time to process the clock ticks
 		require.Eventually(t, func() bool {
-			errLogs := map[time.Time]struct{}{}
-			for _, entry := range logHook.AllEntries() {
+			entries := logHook.AllEntries()
+			errLogCount := 0
+			for _, entry := range entries {
 				if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, fmt.Sprintf("Failed to get file info, file path %q does not exist anymore; please check if the path is correct", keyFilePath)) {
-					errLogs[entry.Time] = struct{}{}
+					errLogCount++
 				}
 			}
-			return len(errLogs) >= 1 && len(errLogs) <= testTickerIterations
+			return errLogCount >= 1 && errLogCount <= testTickerIterations
 		}, time.Second, 10*time.Millisecond, "expected 1-%d error logs", testTickerIterations)
 
 		removeFile(t, certFilePath)
@@ -327,13 +330,14 @@ func TestTLSConfig(t *testing.T) {
 		// Assert error logs were triggered (at least 1, at most testTickerIterations)
 		// Use Eventually to give the goroutine time to process the clock ticks
 		require.Eventually(t, func() bool {
-			errLogs := map[time.Time]struct{}{}
-			for _, entry := range logHook.AllEntries() {
+			entries := logHook.AllEntries()
+			errLogCount := 0
+			for _, entry := range entries {
 				if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, fmt.Sprintf("Failed to get file info, file path %q does not exist anymore; please check if the path is correct", certFilePath)) {
-					errLogs[entry.Time] = struct{}{}
+					errLogCount++
 				}
 			}
-			return len(errLogs) >= 1 && len(errLogs) <= testTickerIterations
+			return errLogCount >= 1 && errLogCount <= testTickerIterations
 		}, time.Second, 10*time.Millisecond, "expected 1-%d error logs", testTickerIterations)
 
 		writeFile(t, keyFilePath, oidcServerKeyPem)


### PR DESCRIPTION
The test `TestTLSConfig/delete_cert_files_start_error_log_loop` could fail because it used `map[time.Time]struct{}` to deduplicate error log entries by timestamp when counting them. In rapid test execution with mock clocks, multiple log entries can share identical timestamps, causing the test to count fewer unique timestamps than actual log entries.

Example of failure: https://github.com/spiffe/spire/actions/runs/21139262035/job/60788895971#step:5:413

This led to intermittent failures when the assertion `len(errLogs) >= 1 && len(errLogs) <= testTickerIterations` failed.

The fix changes the log counting logic in all three affected test cases ("update cert file with an invalid cert start error log loop", "update key file with an invalid key start error log loop", and "delete cert files start error log loop") to directly count all matching log entries instead of deduplicating by timestamp.

This fix should address the root cause related with previous fixes in this test suite (#6565, #6551, #6533, #6528, #6513).