### PR TITLE
Fix kubectl wait syntax in integration tests

### DIFF
--- a/test/integration/suites/upstream-authority-ejbca/02-deploy-spire
+++ b/test/integration/suites/upstream-authority-ejbca/02-deploy-spire
@@ -21,4 +21,4 @@ for secret in "${secrets[@]}"; do
 done
 
 ./bin/kubectl -n spire apply -k conf/server
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait pods -n spire -l app=spire-server --for=condition=Ready --timeout=60s

--- a/test/integration/suites/upstream-authority-vault/02-deploy-spire-and-verify-auth
+++ b/test/integration/suites/upstream-authority-vault/02-deploy-spire-and-verify-auth
@@ -14,7 +14,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
               --from-literal=approle_id=$APPROLE_ID \
               --from-literal=secret_id=$SECRET_ID 
 ./bin/kubectl apply -k ./conf/server/approle-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait pods -n spire -l app=spire-server --for=condition=Ready --timeout=60s
 ./bin/kubectl delete -k ./conf/server/approle-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -22,7 +22,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
 # Verify K8s Auth
 log-info "verifying k8s auth..."
 ./bin/kubectl apply -k ./conf/server/k8s-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait pods -n spire -l app=spire-server --for=condition=Ready --timeout=60s
 ./bin/kubectl delete -k ./conf/server/k8s-auth
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
 
@@ -32,7 +32,7 @@ log-info "verifying cert auth..."
               --from-file=client.pem=client.pem \
               --from-file=client_key.pem=client_key.pem
 ./bin/kubectl apply -k ./conf/server/cert-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait pods -n spire -l app=spire-server --for=condition=Ready --timeout=60s
 ./bin/kubectl delete -k ./conf/server/cert-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -43,4 +43,4 @@ TOKEN=$(./bin/kubectl exec -n vault vault-0 -- vault token create -policy=spire 
 ./bin/kubectl create secret -n spire generic vault-credential \
               --from-literal=token=$TOKEN
 ./bin/kubectl apply -k ./conf/server/token-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait pods -n spire -l app=spire-server --for=condition=Ready --timeout=60s


### PR DESCRIPTION
Fixed incorrect `kubectl wait` command syntax in the upstream-authority-vault and upstream-authority-ejbca integration test suites. The commands were using `--for condition=Ready` (with a space) instead of the correct `--for=condition=Ready` (with an equals sign), causing the wait commands to fail with "error: no matching resources found". 

Example of a failure: https://github.com/spiffe/spire/actions/runs/21143694183/job/60804882737?pr=6573#step:9:1531

The corrected syntax matches other SPIRE integration tests that already use the proper `--for=condition=Ready` format.