### PR TITLE
Fix race condition in TestHostForwarding

### DIFF
--- a/pkg/server/plugin/nodeattestor/v1_test.go
+++ b/pkg/server/plugin/nodeattestor/v1_test.go
@@ -187,8 +187,8 @@ func TestHostForwarding(t *testing.T) {
 		return challenge, nil
 	})
 
+	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Nil(t, err)
 }
 
 func loadV1Plugin(t *testing.T, plugin *fakeV1Plugin) nodeattestor.NodeAttestor {


### PR DESCRIPTION
The TestHostForwarding test was failing intermittently when run with the race detector due to checking the result for nil before checking for errors.

Example of failure: https://github.com/spiffe/spire/actions/runs/21146254980/job/60812531067#step:5:208

When an error occurs, the result is nil, and the race detector's different timing could cause the nil check to fail before providing a clear error message.
This change reorders the assertions to check the error first with require.NoError(), then verify the result is not nil. This ensures the test fails with a clear error message if something goes wrong and eliminates the race condition.