### PR TITLE
Docs/aws s3 bundlepublisher irsa

### DIFF
--- a/doc/plugin_server_bundlepublisher_aws_s3.md
+++ b/doc/plugin_server_bundlepublisher_aws_s3.md
@@ -45,6 +45,7 @@ When using IRSA, the `access_key_id` and `secret_access_key` configuration optio
 When running on EKS with an associated IAM role, the environment variables `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` are automatically set by EKS when IRSA is configured. The plugin uses these to obtain temporary credentials.
 
 To use IRSA:
+
 1. Configure your Service Account with the proper IAM role annotation.
 2. Omit `access_key_id` and `secret_access_key` from the `plugin_data` configuration.
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Documentation for `aws_s3` BundlePublisher plugin.

**Description of change**
Updated the `aws_s3` BundlePublisher documentation to explicitly explain how to use IAM Roles for Service Accounts (IRSA) on EKS.
- Added a new section "Using IRSA (IAM Roles for Service Accounts) with aws_s3 BundlePublisher".
- Clarified that the plugin uses the default AWS SDK credential chain.
- Provided a configuration example omitting static credentials.

**Which issue this PR fixes**
#6109
