### PR TITLE
Fix nightly and release workflows by updating cosign to v2.6.2

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: v2.2.3
+          cosign-release: v2.6.2
       - name: Install regctl
         uses: regclient/actions/regctl-installer@148669fe4b19151fcab6e00c6df2db43b9e2b097 # main
       - name: Build images

--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -607,7 +607,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
-          cosign-release: v2.2.3
+          cosign-release: v2.6.2
       - name: Install regctl
         uses: regclient/actions/regctl-installer@148669fe4b19151fcab6e00c6df2db43b9e2b097 # main
       - name: Download archived images


### PR DESCRIPTION
The nightly build has been failing since cosign-installer was upgraded from v3.7.0 to v4.0.0.

The v4 installer requires cosign v2.6.0 or later, but the workflows are still using v2.2.3, causing the error "bundle does not contain cert for verification, please provide public key" that can be seen in the Nightly build since the upgrade to v4.0.0.

This PR updates both the nightly_build.yaml and release_build.yaml workflows to use cosign v2.6.2, which should resolve the compatibility issue, allowing image signing to work correctly with the new installer version.