### PR TITLE
Fix TestPruning panic in the node package

### DIFF
--- a/pkg/server/node/manager_test.go
+++ b/pkg/server/node/manager_test.go
@@ -98,7 +98,9 @@ func (s *ManagerSuite) TestPruning() {
 	s.clock.Add(defaultJobInterval)
 	s.Require().Eventuallyf(func() bool {
 		listResp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{})
-		s.NoError(err)
+		if err != nil {
+			return false
+		}
 		return reflect.DeepEqual([]*common.AttestedNode{
 			attestedNodeBanned,
 			attestedNodeNonReattestable,
@@ -111,7 +113,9 @@ func (s *ManagerSuite) TestPruning() {
 	s.clock.Add(defaultJobInterval)
 	s.Require().Eventuallyf(func() bool {
 		listResp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{})
-		s.NoError(err)
+		if err != nil {
+			return false
+		}
 		return reflect.DeepEqual([]*common.AttestedNode{
 			attestedNodeBanned,
 			attestedNodeNonReattestable,
@@ -123,7 +127,9 @@ func (s *ManagerSuite) TestPruning() {
 	s.clock.Add(defaultJobInterval)
 	s.Require().Eventuallyf(func() bool {
 		listResp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{})
-		s.NoError(err)
+		if err != nil {
+			return false
+		}
 		return reflect.DeepEqual([]*common.AttestedNode{
 			attestedNodeBanned,
 			attestedNodeNonReattestable,
@@ -135,7 +141,9 @@ func (s *ManagerSuite) TestPruning() {
 	s.Require().Eventuallyf(func() bool {
 		s.m.Prune(ctx, 2*expiredFor, true)
 		listResp, err := s.ds.ListAttestedNodes(ctx, &datastore.ListAttestedNodesRequest{})
-		s.Require().NoError(err)
+		if err != nil {
+			return false
+		}
 		return reflect.DeepEqual([]*common.AttestedNode{
 			attestedNodeBanned,
 		}, listResp.Nodes)


### PR DESCRIPTION
I've noticed a panic in the TestPruning function of the node package.
This is an example: https://github.com/spiffe/spire/actions/runs/21561802392/job/62126971111#step:6:211

The test was using `s.NoError(err)` and `s.Require().NoError(err)` inside `Eventually` callbacks, which run in goroutines. These assertion methods call `FailNow()`, which panics when invoked from a goroutine.

This PR replaces these assertions with error checking that returns `false` when an error occurs, allowing Eventually to retry the condition.