### PR TITLE
Fix flaky envoy-sds-v3 integration test with increased timeout and enhanced failure diagnostics

### DIFF
--- a/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
+++ b/test/integration/suites/envoy-sds-v3/00-test-envoy-releases
@@ -32,21 +32,6 @@ setup-tests() {
 }
 
 test-envoy() {
-    # Log initial diagnostic information
-    log-info "=== Pre-check diagnostics ==="
-
-    log-info "Checking SPIRE agent sockets..."
-    docker compose exec -T upstream-proxy ls -la /opt/shared/agent.sock || log-warn "upstream agent socket not found"
-    docker compose exec -T downstream-proxy ls -la /opt/shared/agent.sock || log-warn "downstream agent socket not found"
-
-    log-info "Checking supervisor process status..."
-    docker compose exec -T upstream-proxy supervisorctl status
-    docker compose exec -T downstream-proxy supervisorctl status
-
-    log-info "Checking Envoy admin endpoints..."
-    docker compose exec -T upstream-proxy curl -sf http://localhost:9901/ready || log-warn "upstream Envoy not ready"
-    docker compose exec -T downstream-proxy curl -sf http://localhost:9901/ready || log-warn "downstream Envoy not ready"
-
     # Ensure connectivity for both TLS and mTLS
 
     MAXCHECKSPERPORT=30


### PR DESCRIPTION
The envoy-sds-v3 integration test has been intermittently failing in CI presumably due to insufficient time for containers to fully initialize. This is an example: https://github.com/spiffe/spire/actions/runs/21414423528/job/61660370257#step:9:546
The lack of detailed logging makes a little difficult to debug the proble,.

This PR increases the connectivity check timeout from 15 to 30 seconds, providing adequate time for the SPIRE agents to complete attestation, fetch SVIDs, establish the SDS connection with Envoy, and for Envoy to retrieve certificates.

Success logging also now reports the number of attempts required, that can help to identify performance degradation trends over time.