### PR TITLE
Add ratelimit check during PostStatus API

### DIFF
--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -480,6 +480,10 @@ func (s *Service) RenewAgent(ctx context.Context, req *agentv1.RenewAgentRequest
 func (s *Service) PostStatus(ctx context.Context, req *agentv1.PostStatusRequest) (*agentv1.PostStatusResponse, error) {
 	log := rpccontext.Logger(ctx)
 
+	if err := rpccontext.RateLimit(ctx, 1); err != nil {
+		return nil, api.MakeErr(log, status.Code(err), "rejecting request due to post status rate limiting", err)
+	}
+
 	callerID, ok := rpccontext.CallerID(ctx)
 	if !ok {
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)


### PR DESCRIPTION
Looks like I missed that this check is also needed when adding a new ratelimit to an API. This leads to the following error in the output:

```
ERRO[0004] Rate limiter went unused; this is a bug       authorized_as=agent authorized_via=datastore caller_addr="127.0.0.1:44074" caller_id="spiffe://example.org/spire/agent/join_token/924754e9-4046-4e36-90e7-af78515b8f9d" method=PostStatus request_id=db89715a-febb-434e-be69-e7868dc08e22 service=agent.v1.Agent subsystem_name=api
```