### PR TITLE
Update entry.go

### DIFF
--- a/pkg/server/api/entry.go
+++ b/pkg/server/api/entry.go
@@ -97,7 +97,7 @@ func (e *ReadOnlyEntry) Clone(mask *types.EntryMask) *types.Entry {
 	}
 
 	if mask.Downstream {
-		clone.Downstream = e.entry.Admin
+		clone.Downstream = e.entry.Downstream
 	}
 
 	if mask.ExpiresAt {


### PR DESCRIPTION
`ReadOnlyEntry.Clone()` incorrectly copies the `Admin` boolean into the `Downstream` field when applying an output mask. This causes SPIRE Server to return corrupted authorization metadata (`Downstream == Admin`) to clients of `GetAuthorizedEntries` and `SyncAuthorizedEntries` whenever the output mask includes `Downstream`.

This is a logic bug at a trust boundary (server -> agent/downstream consumer). It does not appear to directly bypass SPIRE Server authorization checks (which evaluate downstream/admin status server-side), but it can cause clients to make incorrect security decisions based on cached entry data.