### PR TITLE
Stop wrapping objects in slices when printing

### DIFF
--- a/cmd/spire-server/cli/agent/agent_test.go
+++ b/cmd/spire-server/cli/agent/agent_test.go
@@ -561,10 +561,10 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 Error             : rpc error: code = Internal desc = some error when deleting agent
 `,
 			expectedStdoutJSON: fmt.Sprintf(
-				`[{"expired_agents":[
+				`{"expired_agents":[
 {"agent_id":"%s","deleted":false,"error":"rpc error: code = Internal desc = some error when deleting agent"},
 {"agent_id":"%s","deleted":false,"error":"rpc error: code = Internal desc = some error when deleting agent"}
-]}]`,
+]}`,
 				spiffeid.RequireFromPath(td, expiredAgents[1].Id.Path).String(),
 				spiffeid.RequireFromPath(td, expiredAgents[2].Id.Path).String(),
 			),
@@ -586,7 +586,7 @@ Agents purged:
 SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 `,
 			expectedStdoutJSON: fmt.Sprintf(
-				`[{"expired_agents":[{"agent_id":"%s","deleted":true}]}]`,
+				`{"expired_agents":[{"agent_id":"%s","deleted":true}]}`,
 				spiffeid.RequireFromPath(td, expiredAgents[2].Id.Path).String(),
 			),
 		},
@@ -611,7 +611,7 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent2
 SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 `,
 			expectedStdoutJSON: fmt.Sprintf(
-				`[{"expired_agents":[{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true}]}]`,
+				`{"expired_agents":[{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true}]}`,
 				spiffeid.RequireFromPath(td, expiredAgents[0].Id.Path).String(),
 				spiffeid.RequireFromPath(td, expiredAgents[1].Id.Path).String(),
 				spiffeid.RequireFromPath(td, expiredAgents[2].Id.Path).String(),
@@ -636,7 +636,7 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent2
 SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 `,
 			expectedStdoutJSON: fmt.Sprintf(
-				`[{"expired_agents":[{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true}]}]`,
+				`{"expired_agents":[{"agent_id":"%s","deleted":true},{"agent_id":"%s","deleted":true}]}`,
 				spiffeid.RequireFromPath(td, expiredAgents[1].Id.Path).String(),
 				spiffeid.RequireFromPath(td, expiredAgents[2].Id.Path).String(),
 			),
@@ -650,7 +650,7 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 				OutputMask: &types.AgentMask{X509SvidExpiresAt: true},
 			},
 			expectedStdoutPretty: `No agents to purge.`,
-			expectedStdoutJSON:   `[{"expired_agents":[]}]`,
+			expectedStdoutJSON:   `{"expired_agents":[]}`,
 		},
 		{
 			name:           "using dry run",
@@ -668,7 +668,7 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent2
 SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 `,
 			expectedStdoutJSON: fmt.Sprintf(
-				`[{"expired_agents":[{"agent_id":"%s","deleted":false},{"agent_id":"%s","deleted":false}]}]`,
+				`{"expired_agents":[{"agent_id":"%s","deleted":false},{"agent_id":"%s","deleted":false}]}`,
 				spiffeid.RequireFromPath(td, expiredAgents[1].Id.Path).String(),
 				spiffeid.RequireFromPath(td, expiredAgents[2].Id.Path).String(),
 			),
@@ -682,7 +682,7 @@ SPIFFE ID         : spiffe://example.org/spire/agent/agent3
 				OutputMask: &types.AgentMask{X509SvidExpiresAt: true},
 			},
 			expectedStdoutPretty: `No agents to purge.`,
-			expectedStdoutJSON:   `[{"expired_agents":[]}]`,
+			expectedStdoutJSON:   `{"expired_agents":[]}`,
 		},
 	} {
 		for _, format := range availableFormats {

--- a/cmd/spire-server/cli/agent/purge.go
+++ b/cmd/spire-server/cli/agent/purge.go
@@ -96,7 +96,7 @@ type expiredAgent struct {
 }
 
 func (c *purgeCommand) prettyPrintPurgeResult(env *commoncli.Env, results ...any) error {
-	if expAgents, ok := results[0].([]any)[0].(*expiredAgents); ok {
+	if expAgents, ok := results[0].(*expiredAgents); ok {
 		if len(expAgents.Agents) == 0 {
 			env.Println("No agents to purge.")
 			return nil

--- a/cmd/spire-server/cli/wit/mint.go
+++ b/cmd/spire-server/cli/wit/mint.go
@@ -194,12 +194,7 @@ func ttlToSeconds(ttl time.Duration) (int32, error) {
 }
 
 func prettyPrintMint(env *commoncli.Env, results ...any) error {
-	resultInterface, ok := results[0].([]any)
-	if !ok {
-		return cliprinter.ErrInternalCustomPrettyFunc
-	}
-
-	if wit, ok := resultInterface[0].(*mintResult); ok {
+	if wit, ok := results[0].(*mintResult); ok {
 		errToken := env.Println(wit.Svid.Token)
 		errKey := env.Println(wit.PrivateKey)
 		return errors.Join(errToken, errKey)

--- a/cmd/spire-server/cli/wit/mint_test.go
+++ b/cmd/spire-server/cli/wit/mint_test.go
@@ -188,7 +188,7 @@ func TestMintRun(t *testing.T) {
 				},
 			},
 			expStdoutPretty: token + "\n",
-			expStdoutJSON: fmt.Sprintf(`[{
+			expStdoutJSON: fmt.Sprintf(`{
   "svid": {
     "token": "%s",
     "id": {
@@ -199,7 +199,7 @@ func TestMintRun(t *testing.T) {
     "issued_at": 1628500000
   },
   "private_key": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"0cYDPbnY4FIsWUx8INUzmKXRZFWQKHZZnQk2N7axDfo\",\"y\":\"lehH6R5xLJkVy-NgFo0P2Y4-xIcIBzkAC0U9AX-PQf8\",\"d\":\"WItUvS9niefekUhGVVYGK3UtPzVn5-LS2bmAahx7-iw\"}"
-}]`, token),
+}`, token),
 		},
 		{
 			name:     "write on invalid path",
@@ -233,12 +233,12 @@ func TestMintRun(t *testing.T) {
 				},
 			},
 			expStdoutPretty: "malformed token\n",
-			expStdoutJSON: `[{
+			expStdoutJSON: `{
   "svid": {
     "token": "malformed token"
   },
   "private_key": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"0cYDPbnY4FIsWUx8INUzmKXRZFWQKHZZnQk2N7axDfo\",\"y\":\"lehH6R5xLJkVy-NgFo0P2Y4-xIcIBzkAC0U9AX-PQf8\",\"d\":\"WItUvS9niefekUhGVVYGK3UtPzVn5-LS2bmAahx7-iw\"}"
-}]`,
+}`,
 			expStderr: "Unable to determine WIT-SVID lifetime: go-jose/go-jose: compact JWS format must have three parts\n",
 		},
 		{
@@ -261,7 +261,7 @@ func TestMintRun(t *testing.T) {
 				},
 			},
 			expStdoutPretty: expiredToken + "\n",
-			expStdoutJSON: fmt.Sprintf(`[{
+			expStdoutJSON: fmt.Sprintf(`{
   "svid": {
     "token": "%s",
     "id": {
@@ -272,7 +272,7 @@ func TestMintRun(t *testing.T) {
     "issued_at": 1628600000
   },
   "private_key": "{\"kty\":\"EC\",\"crv\":\"P-256\",\"x\":\"0cYDPbnY4FIsWUx8INUzmKXRZFWQKHZZnQk2N7axDfo\",\"y\":\"lehH6R5xLJkVy-NgFo0P2Y4-xIcIBzkAC0U9AX-PQf8\",\"d\":\"WItUvS9niefekUhGVVYGK3UtPzVn5-LS2bmAahx7-iw\"}"
-}]`, expiredToken),
+}`, expiredToken),
 			expStderr: fmt.Sprintf("WIT-SVID lifetime was capped shorter than specified ttl; expires %q\n", expiredAt.UTC().Format(time.RFC3339)),
 		},
 		{

--- a/cmd/spire-server/cli/x509/mint.go
+++ b/cmd/spire-server/cli/x509/mint.go
@@ -184,24 +184,20 @@ type mintResult struct {
 }
 
 func (c *mintCommand) prettyPrintMint(env *commoncli.Env, results ...any) error {
-	if resultInterface, ok := results[0].([]any); ok {
-		result, ok := resultInterface[0].(*mintResult)
-		if !ok {
-			return errors.New("unexpected type")
-		}
-
-		svidPEM, keyPEM, bundlePEM := convertSVIDResultToPEM(result.PrivateKey, result.X509SVID, result.RootCAs)
-
-		if err := env.Printf("X509-SVID:\n%s\n", svidPEM.String()); err != nil {
-			return err
-		}
-		if err := env.Printf("Private key:\n%s\n", keyPEM.String()); err != nil {
-			return err
-		}
-		return env.Printf("Root CAs:\n%s\n", bundlePEM.String())
+	result, ok := results[0].(*mintResult)
+	if !ok {
+		return errors.New("unexpected type")
 	}
 
-	return cliprinter.ErrInternalCustomPrettyFunc
+	svidPEM, keyPEM, bundlePEM := convertSVIDResultToPEM(result.PrivateKey, result.X509SVID, result.RootCAs)
+
+	if err := env.Printf("X509-SVID:\n%s\n", svidPEM.String()); err != nil {
+		return err
+	}
+	if err := env.Printf("Private key:\n%s\n", keyPEM.String()); err != nil {
+		return err
+	}
+	return env.Printf("Root CAs:\n%s\n", bundlePEM.String())
 }
 
 func convertSVIDResultToPEM(privateKey []byte, svidCertChain, rootCAs [][]byte) (*bytes.Buffer, *bytes.Buffer, *bytes.Buffer) {

--- a/cmd/spire-server/cli/x509/mint_test.go
+++ b/cmd/spire-server/cli/x509/mint_test.go
@@ -243,17 +243,15 @@ Private key:
 Root CAs:
 %s
 `, certDerPem.String(), testKeyPEM, rootCaPem.String()),
-			expStdoutJSON: fmt.Sprintf(`[
-  {
-    "x509_svid": [
-      "%s"
-    ],
-    "private_key": "%s",
-    "root_cas": [
-      "%s"
-    ]
-  }
-]`, base64.StdEncoding.EncodeToString(certDER), privateKeyBase64, base64.StdEncoding.EncodeToString(x509Authority.Raw)),
+			expStdoutJSON: fmt.Sprintf(`{
+  "x509_svid": [
+    "%s"
+  ],
+  "private_key": "%s",
+  "root_cas": [
+    "%s"
+  ]
+}`, base64.StdEncoding.EncodeToString(certDER), privateKeyBase64, base64.StdEncoding.EncodeToString(x509Authority.Raw)),
 		},
 		{
 			name:     "success with ttl and dnsnames, written to directory",

--- a/pkg/common/cliprinter/cliprinter.go
+++ b/pkg/common/cliprinter/cliprinter.go
@@ -60,7 +60,7 @@ func (p *printer) PrintProto(msg ...proto.Message) error {
 
 // PrintStruct prints a struct and applies the configured formatting.
 func (p *printer) PrintStruct(msg ...any) error {
-	return p.printStruct(msg)
+	return p.printStruct(msg...)
 }
 
 func (p *printer) printError(err error) error {

--- a/pkg/common/cliprinter/cliprinter_test.go
+++ b/pkg/common/cliprinter/cliprinter_test.go
@@ -13,7 +13,7 @@ import (
 func TestPrintError(t *testing.T) {
 	p, stdout, stderr := newTestPrinter()
 
-	err := p.printError(errors.New("red alert"))
+	err := p.PrintError(errors.New("red alert"))
 	if err != nil {
 		t.Errorf("failed to print error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestPrintError(t *testing.T) {
 	}
 
 	p = newTestPrinterWithWriter(badWriter{}, badWriter{})
-	err = p.printError(errors.New("red alert"))
+	err = p.PrintError(errors.New("red alert"))
 	if err == nil {
 		t.Errorf("did not return error after bad write")
 	}
@@ -36,7 +36,7 @@ func TestPrintError(t *testing.T) {
 func TestPrintProto(t *testing.T) {
 	p, stdout, stderr := newTestPrinter()
 
-	err := p.printProto(new(agentapi.CountAgentsResponse))
+	err := p.PrintProto(new(agentapi.CountAgentsResponse))
 	if err != nil {
 		t.Errorf("failed to print proto: %v", err)
 	}
@@ -48,7 +48,7 @@ func TestPrintProto(t *testing.T) {
 	}
 
 	p = newTestPrinterWithWriter(badWriter{}, badWriter{})
-	err = p.printProto(new(agentapi.CountAgentsResponse))
+	err = p.PrintProto(new(agentapi.CountAgentsResponse))
 	if err == nil {
 		t.Errorf("did not return error after bad write")
 	}
@@ -63,7 +63,7 @@ func TestPrintStruct(t *testing.T) {
 		Name: "boaty",
 	}
 
-	err := p.printStruct(msg)
+	err := p.PrintStruct(msg)
 	if err != nil {
 		t.Errorf("failed to print struct: %v", err)
 	}
@@ -76,8 +76,14 @@ func TestPrintStruct(t *testing.T) {
 		t.Error("did not print struct")
 	}
 
+	expectedOutput := "Name: boaty\n\n"
+	actualOutput := stdout.String()
+	if actualOutput != expectedOutput {
+		t.Errorf("output expected to be %q but got %q", expectedOutput, actualOutput)
+	}
+
 	p = newTestPrinterWithWriter(badWriter{}, badWriter{})
-	err = p.printStruct(msg)
+	err = p.PrintStruct(msg)
 	if err == nil {
 		t.Errorf("did not return error after bad write")
 	}


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated? (not affected)

**Affected functionality**
CLI printing when using JSON output.

**Description of change**
Stops the cliprinter `PrintStruct` from wrapping its inputs as a slice of one item before printing them. Currently it seems the behaviour is that all JSON output is wrapped as an array of one item, which makes it more awkward to consume. Also changes the tests for the cliprinter to call the exported methods rather than the internal ones and adds an assertion on the output to stop this regressing (unclear if tests where meant to be on the exported or internal methods - if they were originally on the exported methods this would have shown up there).

**Which issue this PR fixes**
Fixes #6654