### PR TITLE
Instruct sigstore to cache data in memory in tests

### DIFF
--- a/pkg/agent/plugin/workloadattestor/docker/docker_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_test.go
@@ -157,6 +157,10 @@ func TestDockerErrorContextCancel(t *testing.T) {
 }
 
 func TestDockerConfig(t *testing.T) {
+	// Make sure sigstore caches things in memory instead of trying
+	// to cache them to some directory.
+	t.Setenv("SIGSTORE_NO_CACHE", "true")
+
 	for _, tt := range []struct {
 		name               string
 		trustDomain        string

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -629,6 +629,10 @@ func (s *Suite) TestConfigure() {
 }
 
 func (s *Suite) TestConfigureWithSigstore() {
+	// Make sure sigstore caches things in memory instead of trying
+	// to cache them to some directory.
+	s.T().Setenv("SIGSTORE_NO_CACHE", "true")
+
 	cases := []struct {
 		name          string
 		trustDomain   string


### PR DESCRIPTION
Otherwise it tries to cache them somewhere else which sometimes leads to flaky tests