### PR TITLE
Add TLS support for Prometheus telemetry endpoint

### DIFF
--- a/pkg/common/telemetry/config.go
+++ b/pkg/common/telemetry/config.go
@@ -36,9 +36,17 @@ type DogStatsdConfig struct {
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
+type PrometheusTLSConfig struct {
+	CertFile           string                 `hcl:"cert_file"`
+	KeyFile            string                 `hcl:"key_file"`
+	CAFile             string                 `hcl:"ca_file"`
+	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
+}
+
 type PrometheusConfig struct {
 	Host               string                 `hcl:"host"`
 	Port               int                    `hcl:"port"`
+	TLS                *PrometheusTLSConfig   `hcl:"tls"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 


### PR DESCRIPTION
Adds TLS support for the Prometheus metrics endpoint. Configuration is optional and backward compatible, so no breaking changes. Supports certificate/key pairs and optional CA validation.

Closes #6680