### PR TITLE
chore: fix typos in common package

### DIFF
--- a/pkg/common/fflag/fflag.go
+++ b/pkg/common/fflag/fflag.go
@@ -18,7 +18,7 @@ type Flag string
 // representations. It is loaded directly from the config file.
 type RawConfig []string
 
-// To add a feature flag, decleare it here along with its config name.
+// To add a feature flag, declare it here along with its config name.
 // Then, add it to the `flags` package-level singleton map below, setting the
 // appropriate default value. Flags should always be opt-in and default to
 // false, with the only exception being flags that are in the process of being

--- a/pkg/common/plugin/x509pop/x509pop_test.go
+++ b/pkg/common/plugin/x509pop/x509pop_test.go
@@ -128,7 +128,7 @@ func TestMakeAgentID(t *testing.T) {
 			expectID:     "spiffe://example.org/spire/agent/foo/us-east-1/production/path/to/value",
 		},
 		{
-			desc:      "custom template with nonexistant fields",
+			desc:      "custom template with nonexistent fields",
 			template:  agentpathtemplate.MustParse("/{{ .Foo }}"),
 			expectErr: `template: agent-path:1:4: executing "agent-path" at <.Foo>: can't evaluate field Foo in type x509pop.agentPathTemplateData`,
 		},

--- a/pkg/common/x509util/cert.go
+++ b/pkg/common/x509util/cert.go
@@ -75,7 +75,7 @@ func RawCertsFromCertificates(certs []*x509.Certificate) [][]byte {
 	return rawCerts
 }
 
-// IsUnknownAuthorityError returns tru if the Server returned an unknown authority error when verifying
+// IsUnknownAuthorityError returns true if the Server returned an unknown authority error when verifying
 // presented SVID
 func IsUnknownAuthorityError(err error) bool {
 	if err == nil {

--- a/pkg/common/x509util/dns_test.go
+++ b/pkg/common/x509util/dns_test.go
@@ -82,7 +82,7 @@ func TestValidateAndNormalize(t *testing.T) {
 			wantErr: x509util.ErrNameMustBeASCII,
 		},
 		{
-			name: "hypen is ok",
+			name: "hyphen is ok",
 			dns:  "a-hello.com",
 		},
 		{


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
This PR fixes minor typos in the `pkg/common` directory, specifically in comments and test strings. No logical functionality or behavior is affected.

**Description of change**
<!-- Please provide a description of the change -->
- Fixed `decleare` -> `declare` in `pkg/common/fflag/fflag.go` comment
- Fixed `hypen is ok` -> `hyphen is ok` in `pkg/common/x509util/dns_test.go` test case name
- Fixed `returns tru if` -> `returns true if` in `pkg/common/x509util/cert.go` comment
- Fixed `nonexistant` -> `nonexistent` in `pkg/common/plugin/x509pop/x509pop_test.go` test case description

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

