### PR TITLE
Disable TLS session ticket resumption on server TCP endpoint

### DIFF
--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -301,6 +301,10 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 func (e *Endpoints) createTCPServer(ctx context.Context, unaryInterceptor grpc.UnaryServerInterceptor, streamInterceptor grpc.StreamServerInterceptor) *grpc.Server {
 	tlsConfig := &tls.Config{ //nolint: gosec // False positive, getTLSConfig is setting MinVersion
 		GetConfigForClient: e.getTLSConfig(ctx),
+		// Disable session ticket resumption so that VerifyPeerCertificate is
+		// called on every connection, ensuring the peer certificate chain is
+		// always validated against the current trust bundle.
+		SessionTicketsDisabled: true,
 	}
 
 	return grpc.NewServer(


### PR DESCRIPTION
TLS session resumption via session tickets skips the VerifyPeerCertificate callback, which is where SPIRE performs SPIFFE certificate chain validation against the current trust bundle. This means that if a certificate is removed from the bundle (or a federation relationship is removed), a peer that had previously established a TLS session could resume it without their certificate chain being re-validated, until the session ticket expires.

This is particularly relevant for admin callers from federated trust domains, which rely solely on TLS-level certificate chain validation with no secondary per-RPC datastore check. Agent connections are additionally protected by a per-RPC serial number check against the datastore.

In practice, session resumption is unlikely to be active: Go only enables it on the client side when ClientSessionCache is non-nil, which SPIRE agents do not set. Disabling session tickets on the server is nonetheless a safe defense-in-depth improvement that ensures VerifyPeerCertificate runs on every connection.