### PR TITLE
implementing optional tls config for prometheus scraping

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -528,7 +528,7 @@ plugins {
 #         tls {
 #             cert_file = "/path/to/cert.pem"
 #             key_file = "/path/to/key.pem"
-#             ca_file = "/path/to/ca.pem" # optional CA file for mTLS
+#             client_ca_file = "/path/to/ca.pem" # optional CA file for mTLS
 #         }
 #     }
 

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -1003,7 +1003,7 @@ plugins {
 #         tls {
 #             cert_file = "/path/to/cert.pem"
 #             key_file = "/path/to/key.pem"
-#             ca_file = "/path/to/ca.pem" # optional CA file for mTLS
+#             client_ca_file = "/path/to/ca.pem" # optional CA file for mTLS
 #         }
 #     }
 

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -385,7 +385,7 @@ telemetry {
         tls {
             cert_file = "/path/to/cert.pem"
             key_file = "/path/to/key.pem"
-            ca_file = "/path/to/ca.pem" # optional CA file for mTLS
+            client_ca_file = "/path/to/ca.pem" # optional CA file for mTLS
         }
     }
 }

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -825,7 +825,7 @@ telemetry {
         tls {
             cert_file = "/path/to/cert.pem"
             key_file = "/path/to/key.pem"
-            ca_file = "/path/to/ca.pem" # optional CA file for mTLS
+            client_ca_file = "/path/to/ca.pem" # optional CA file for mTLS
         }
     }
 }

--- a/doc/telemetry/telemetry_config.md
+++ b/doc/telemetry/telemetry_config.md
@@ -68,7 +68,7 @@ telemetry {
             tls {
                 cert_file = "/path/to/cert.pem"
                 key_file = "/path/to/key.pem"
-                ca_file = "/path/to/ca.pem" # optional CA file for mTLS
+                client_ca_file = "/path/to/ca.pem" # optional CA file for mTLS
             }
         }
 

--- a/pkg/common/telemetry/config.go
+++ b/pkg/common/telemetry/config.go
@@ -44,9 +44,9 @@ type PrometheusConfig struct {
 }
 
 type TLSConfig struct {
-	CertFile string `hcl:"cert_file"`
-	KeyFile  string `hcl:"key_file"`
-	CAFile   string `hcl:"ca_file"` // optional
+	CertFile     string `hcl:"cert_file"`
+	KeyFile      string `hcl:"key_file"`
+	ClientCAFile string `hcl:"client_ca_file"` // optional
 }
 
 type StatsdConfig struct {

--- a/pkg/common/telemetry/prometheus.go
+++ b/pkg/common/telemetry/prometheus.go
@@ -135,8 +135,8 @@ func (p *prometheusRunner) newTLSConfig() (*tls.Config, error) {
 	}
 
 	var caCertPool *x509.CertPool
-	if p.c.TLS.CAFile != "" {
-		caCertPool, err = util.LoadCertPool(p.c.TLS.CAFile)
+	if p.c.TLS.ClientCAFile != "" {
+		caCertPool, err = util.LoadCertPool(p.c.TLS.ClientCAFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/common/telemetry/prometheus_test.go
+++ b/pkg/common/telemetry/prometheus_test.go
@@ -126,9 +126,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 			setupTLS: func(t *testing.T) *TLSConfig {
 				certFile, keyFile := createTestCertAndKey(t)
 				return &TLSConfig{
-					CertFile: certFile,
-					KeyFile:  keyFile,
-					CAFile:   "", // No CA file
+					CertFile:     certFile,
+					KeyFile:      keyFile,
+					ClientCAFile: "", // No CA file
 				}
 			},
 			expectError: false,
@@ -148,9 +148,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 				certFile, keyFile := createTestCertAndKey(t)
 				caFile := createTestCA(t)
 				return &TLSConfig{
-					CertFile: certFile,
-					KeyFile:  keyFile,
-					CAFile:   caFile,
+					CertFile:     certFile,
+					KeyFile:      keyFile,
+					ClientCAFile: caFile,
 				}
 			},
 			expectError: false,
@@ -168,9 +168,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 			name: "testing TLS with missing cert file",
 			setupTLS: func(t *testing.T) *TLSConfig {
 				return &TLSConfig{
-					CertFile: "/nonexistent/cert.pem",
-					KeyFile:  "/nonexistent/key.pem",
-					CAFile:   "",
+					CertFile:     "/nonexistent/cert.pem",
+					KeyFile:      "/nonexistent/key.pem",
+					ClientCAFile: "",
 				}
 			},
 			expectError: true,
@@ -185,9 +185,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 				certFile := createTempFile(t, []byte("invalid cert data"))
 				keyFile := createTempFile(t, []byte("invalid key data"))
 				return &TLSConfig{
-					CertFile: certFile,
-					KeyFile:  keyFile,
-					CAFile:   "",
+					CertFile:     certFile,
+					KeyFile:      keyFile,
+					ClientCAFile: "",
 				}
 			},
 			expectError:      true,
@@ -198,9 +198,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 			setupTLS: func(t *testing.T) *TLSConfig {
 				certFile, _ := createTestCertAndKey(t)
 				return &TLSConfig{
-					CertFile: certFile,
-					KeyFile:  "/nonexistent/key.pem",
-					CAFile:   "",
+					CertFile:     certFile,
+					KeyFile:      "/nonexistent/key.pem",
+					ClientCAFile: "",
 				}
 			},
 			expectError: true,
@@ -214,9 +214,9 @@ func TestPrometheusTLSConfig(t *testing.T) {
 				certFile, keyFile := createTestCertAndKey(t)
 				invalidCAFile := createTempFile(t, []byte("invalid CA data"))
 				return &TLSConfig{
-					CertFile: certFile,
-					KeyFile:  keyFile,
-					CAFile:   invalidCAFile,
+					CertFile:     certFile,
+					KeyFile:      keyFile,
+					ClientCAFile: invalidCAFile,
 				}
 			},
 			expectError:      true,


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->Changes introduce optional tls config for prometheus metrics scraping. Backward compatible.


**Description of change**
<!-- Please provide a description of the change --> Updated the common prometheus config to accept tls certificates and then start the prometheus runner with tls (if provided)


**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged --> fixes #6680
Closes #6680 

