### PR TITLE
Fix flaky TestPublishJWTKey test in UpstreamAuthority `spire` plugin by notifying bundle subscribers immediately

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/spire.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire.go
@@ -87,12 +87,17 @@ type Plugin struct {
 	bundleMtx     sync.RWMutex
 	bundleVersion uint64
 	currentBundle *plugintypes.Bundle
+	// bundleUpdated is closed and replaced each time the bundle changes,
+	// allowing subscribers to be notified immediately rather than waiting for
+	// the internalPollFreq ticker.
+	bundleUpdated chan struct{}
 }
 
 func New() *Plugin {
 	return &Plugin{
 		clk:           clock.New(),
 		currentBundle: &plugintypes.Bundle{},
+		bundleUpdated: make(chan struct{}),
 	}
 }
 
@@ -230,6 +235,13 @@ func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLoca
 	ticker := p.clk.Ticker(internalPollFreq)
 	defer ticker.Stop()
 	for {
+		// Capture the notification channel before reading the bundle.
+		// If the bundle is updated after getBundleUpdateCh() returns but
+		// before the select below, the old channel will already be closed
+		// and the select will fire immediately rather than sleeping until
+		// the next internalPollFreq tick.
+		updateCh := p.getBundleUpdateCh()
+
 		newRootCAs := p.getBundle().X509Authorities
 		newJWTKeys := p.getBundle().JwtAuthorities
 		if !areRootsEqual(rootCAs, newRootCAs) || !arePublicKeysEqual(jwtKeys, newJWTKeys) {
@@ -244,6 +256,7 @@ func (p *Plugin) SubscribeToLocalBundle(req *upstreamauthorityv1.SubscribeToLoca
 		}
 		select {
 		case <-ticker.C:
+		case <-updateCh:
 		case <-stream.Context().Done():
 			return nil
 		}
@@ -326,6 +339,12 @@ func (p *Plugin) pollBundleUpdates(ctx context.Context) {
 	}
 }
 
+// setBundleIfVersionMatches updates currentBundle only when bundleVersion
+// still equals expectedVersion. This prevents a fetch that started before a
+// local mutation (setBundleJWTAuthorities / setBundleX509Authorities) from
+// overwriting the newer local state. bundleVersion is intentionally not
+// incremented here; it is only incremented by the local-mutation helpers so
+// that it remains a reliable guard against concurrent upstream fetches.
 func (p *Plugin) setBundleIfVersionMatches(b *types.Bundle, expectedVersion uint64) error {
 	p.bundleMtx.Lock()
 	defer p.bundleMtx.Unlock()
@@ -336,6 +355,7 @@ func (p *Plugin) setBundleIfVersionMatches(b *types.Bundle, expectedVersion uint
 			return err
 		}
 		p.currentBundle = currentBundle
+		p.signalBundleUpdate()
 	}
 
 	return nil
@@ -347,11 +367,28 @@ func (p *Plugin) getBundle() *plugintypes.Bundle {
 	return p.currentBundle
 }
 
+// getBundleUpdateCh returns the current bundle update notification channel.
+// When the bundle is updated, this channel is closed and a new one is created.
+func (p *Plugin) getBundleUpdateCh() <-chan struct{} {
+	p.bundleMtx.RLock()
+	defer p.bundleMtx.RUnlock()
+	return p.bundleUpdated
+}
+
+// signalBundleUpdate closes the current bundleUpdated channel and replaces it
+// with a new one, waking any goroutines waiting on the previous channel.
+// Must be called with bundleMtx write lock held.
+func (p *Plugin) signalBundleUpdate() {
+	close(p.bundleUpdated)
+	p.bundleUpdated = make(chan struct{})
+}
+
 func (p *Plugin) setBundleJWTAuthorities(keys []*plugintypes.JWTKey) {
 	p.bundleMtx.Lock()
 	defer p.bundleMtx.Unlock()
 	p.currentBundle.JwtAuthorities = keys
 	p.bundleVersion++
+	p.signalBundleUpdate()
 }
 
 func (p *Plugin) setBundleX509Authorities(rootCAs []*plugintypes.X509Certificate) {
@@ -359,6 +396,7 @@ func (p *Plugin) setBundleX509Authorities(rootCAs []*plugintypes.X509Certificate
 	defer p.bundleMtx.Unlock()
 	p.currentBundle.X509Authorities = rootCAs
 	p.bundleVersion++
+	p.signalBundleUpdate()
 }
 
 func (p *Plugin) getBundleVersion() uint64 {

--- a/pkg/server/plugin/upstreamauthority/spire/spire_test.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire_test.go
@@ -315,14 +315,13 @@ func TestMintX509CA(t *testing.T) {
 			// Verify X509CA has expected IDs
 			require.Equal(t, []string{"spiffe://example.org"}, certChainURIs(x509CA))
 
-			// Update bundle to trigger another response. Move time forward at
-			// the upstream poll frequency twice to ensure the plugin picks up
-			// the change to the bundle.
+			// Update bundle to trigger another response. Advance the clock
+			// past the upstream poll frequency to trigger a fetch; the plugin
+			// notifies SubscribeToLocalBundle immediately via bundleUpdated.
 			server.sAPIServer.appendRootCA(&types.X509Certificate{Asn1: serverCertUpdate[0].Raw})
 			server.sAPIServer.appendRootCA(&types.X509Certificate{Asn1: serverCertUpdateTainted[0].Raw, Tainted: true})
 			mockClock.Add(upstreamPollFreq)
 			mockClock.Add(upstreamPollFreq)
-			mockClock.Add(internalPollFreq)
 
 			// Get bundle update
 			bundleUpdateResp, _, err := stream.RecvLocalBundleUpdate()
@@ -386,13 +385,12 @@ func TestPublishJWTKey(t *testing.T) {
 	assert.Equal(t, upstreamJwtKeys[1].Kid, "gHTCunJbefYtnZnTctd84xeRWyMrEsWD")
 	assert.Equal(t, upstreamJwtKeys[2].Kid, "kid-2")
 
-	// Update bundle to trigger another response. Move time forward at the
-	// upstream poll frequency twice to ensure the plugin picks up the change
-	// to the bundle.
+	// Update bundle to trigger another response. Advance the clock past the
+	// upstream poll frequency to trigger a fetch; the plugin notifies
+	// SubscribeToLocalBundle immediately via bundleUpdated.
 	server.sAPIServer.appendKey(&types.JWTKey{KeyId: "kid-3", PublicKey: pkixBytes2})
 	mockClock.Add(upstreamPollFreq)
 	mockClock.Add(upstreamPollFreq)
-	mockClock.Add(internalPollFreq)
 
 	// Get bundle update
 	_, resp, err := stream.RecvLocalBundleUpdate()
@@ -453,12 +451,11 @@ func TestGetTrustBundle(t *testing.T) {
 	pkixBytes, err := x509.MarshalPKIXPublicKey(key.Public())
 	require.NoError(t, err)
 
-	// Update bundle to trigger another response. Move time forward at the
-	// upstream poll frequency twice to ensure the plugin picks up the change
-	// to the bundle.
+	// Update bundle to trigger another response. Advance the clock past the
+	// upstream poll frequency to trigger a fetch; the plugin notifies
+	// SubscribeToLocalBundle immediately via bundleUpdated.
 	server.sAPIServer.appendKey(&types.JWTKey{KeyId: "kid", PublicKey: pkixBytes})
 	mockClock.Add(upstreamPollFreq)
-	mockClock.Add(internalPollFreq)
 	mockClock.Add(upstreamPollFreq)
 
 	// Get bundle update


### PR DESCRIPTION
The SubscribeToLocalBundle loop polled for bundle changes on a 1-second ticker (internalPollFreq). When the upstream polling goroutine (pollBundleUpdates) fetched a new bundle and updated it via setBundleIfVersionMatches, there was a race: if the internal ticker had already fired and checked the bundle before the update landed, the loop would go back to sleep and wait a full second for the next tick. In tests using a mock clock, there was no automatic next tick, causing RecvLocalBundleUpdate to block until the 10-second context deadline.

This was surfaced through a failure running TestPublishJWTKey here: https://github.com/spiffe/spire/actions/runs/22989373622/job/66746907001?pr=6733#step:6:254

The fix introduces a bundleUpdated notification channel using the close-and-replace broadcast pattern. The loop captures the channel before reading the bundle state, so any update that arrives between the check and the select wakes it immediately rather than waiting for the next ticker cycle. This also improves production latency a little bit: upstream bundle changes now propagate to downstream servers without the up-to-1-second delay.

The tests are updated to remove the now-redundant mockClock.Add(internalPollFreq) advances and fix an inconsistent clock ordering in TestGetTrustBundle.