### PR TITLE
Avoid race condition in k8s-sigstore integration test when copying signed image

### DIFF
--- a/test/integration/suites/k8s-sigstore/00-setup
+++ b/test/integration/suites/k8s-sigstore/00-setup
@@ -37,13 +37,27 @@ start-kind-cluster "${KIND_PATH}" k8stest ./conf/kind-config.yaml
 # Start local registry service connected to kind network
 docker-up registry
 
-# Copy signed images from public to local registry
-# Using official SPIRE images which are already signed with Cosign by the SPIRE project
-# Signed image: Use SPIRE agent 1.14.0 (signed by GitHub Actions with Sigstore)
+# Copy the signed image using crane, which pushes platform manifests before the
+# index (dependency order). This avoids the race condition in "cosign copy" where
+# the image index is pushed concurrently with its platform manifests, causing
+# MANIFEST_BLOB_UNKNOWN errors when the index references a platform manifest
+# that has not yet been committed.
 docker run --network="kind" \
     -v "${PWD}/conf/docker-registry/certs/domain.crt:/etc/ssl/certs/domain.crt" \
-    gcr.io/projectsigstore/cosign:latest \
+    gcr.io/go-containerregistry/crane:latest \
     copy ghcr.io/spiffe/spire-agent:1.14.0 "${REGISTRY_HTTP_ADDR}/workload:signed"
+
+# Copy the cosign signature tag separately, after the image is fully committed.
+# Cosign stores signatures as OCI tags with the format sha256-<hex-digest>.sig.
+signed_digest=$(docker run --rm --network="kind" \
+    -v "${PWD}/conf/docker-registry/certs/domain.crt:/etc/ssl/certs/domain.crt" \
+    gcr.io/go-containerregistry/crane:latest \
+    digest "${REGISTRY_HTTP_ADDR}/workload:signed")
+sig_tag="sha256-${signed_digest#sha256:}.sig"
+docker run --network="kind" \
+    -v "${PWD}/conf/docker-registry/certs/domain.crt:/etc/ssl/certs/domain.crt" \
+    gcr.io/go-containerregistry/crane:latest \
+    copy "ghcr.io/spiffe/spire-agent:${sig_tag}" "${REGISTRY_HTTP_ADDR}/workload:${sig_tag}"
 
 # For unsigned/skiplist workload testing, use a different SPIRE agent version (1.13.0)
 # This ensures unsigned variants have a different digest than the signed image (1.14.0)


### PR DESCRIPTION
The k8s-sigstore integration test was flaky because `cosign copy` uploads the multi-arch image index and its platform manifests concurrently. When the image index is pushed before one of its platform manifests is committed, the registry rejects it with MANIFEST_BLOB_UNKNOWN / DIGEST_INVALID.

An example of this is here: https://github.com/spiffe/spire/actions/runs/23011786300/job/66825690140?pr=6736#step:9:1669

The fix replaces `cosign copy` with two sequential `crane copy` steps: first the image (crane pushes platform manifests before the index, in dependency order), then the cosign signature tag separately. This eliminates the race entirely without relying on retries.