### PR TITLE
Increase TestRenewTokenFailed timeout in TestRenewTokenFailed to avoid flakiness 

### DIFF
--- a/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
+++ b/pkg/server/plugin/upstreamauthority/vault/vault_client_test.go
@@ -467,7 +467,7 @@ func TestRenewTokenFailed(t *testing.T) {
 
 	select {
 	case <-renewCh:
-	case <-time.After(1 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Error("renewChan did not close in the expected time")
 	}
 }


### PR DESCRIPTION
The TestRenewTokenFailed test was flaky on slow CI. The test waited up to 1 second for renewCh to close after a failed token renewal, but this proved too tight.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/23130770440/job/67183528830?pr=6747#step:6:255 (Windows runners are usually slower)

Increased the timeout to 10 seconds to make the test more reliable.