### PR TITLE
Avoid race condition in TestCachePeriodicRebuild

### DIFF
--- a/pkg/server/cache/nodecache/cache_test.go
+++ b/pkg/server/cache/nodecache/cache_test.go
@@ -145,8 +145,10 @@ func TestCachePeriodicRebuild(t *testing.T) {
 
 	clk.Add(rebuildInterval)
 
-	cachedSecondAgent, _ = cache.LookupAttestedNode(secondAgent.SpiffeId)
-	require.NotNil(t, cachedSecondAgent)
+	require.Eventually(t, func() bool {
+		cachedSecondAgent, _ = cache.LookupAttestedNode(secondAgent.SpiffeId)
+		return cachedSecondAgent != nil
+	}, time.Second, time.Millisecond)
 
 	cachedThirdAgent, _ := cache.LookupAttestedNode(thirdAgent.SpiffeId)
 	require.Nil(t, cachedThirdAgent)
@@ -159,8 +161,10 @@ func TestCachePeriodicRebuild(t *testing.T) {
 
 	clk.Add(rebuildInterval)
 
-	cachedThirdAgent, _ = cache.LookupAttestedNode(thirdAgent.SpiffeId)
-	require.NotNil(t, cachedThirdAgent)
+	require.Eventually(t, func() bool {
+		cachedThirdAgent, _ = cache.LookupAttestedNode(thirdAgent.SpiffeId)
+		return cachedThirdAgent != nil
+	}, time.Second, time.Millisecond)
 
 	cncl()
 	<-done


### PR DESCRIPTION
The test was advancing the mock clock to trigger the periodic rebuild ticker, then immediately asserting that the rebuilt cache contained the newly added nodes. This created a race: the `PeriodicRebuild` goroutine had to be scheduled, receive the tick, and complete `Rebuild` before the assertion ran, which was not guaranteed, especially under race detection.

An example of a failure in a "unit-test (linux with race detection)" run is here: https://github.com/spiffe/spire/actions/runs/23211981035/job/67462977242#step:5:179

Fixed by replacing the immediate `require.NotNil` assertions after each `clk.Add(rebuildInterval)` call with `require.Eventually`, polling until the cache reflects the rebuild.