### PR TITLE
Prevent nil bundleClient panic possibility in spire upstream authority plugin when polling restarts

### DIFF
--- a/pkg/server/plugin/upstreamauthority/spire/spire.go
+++ b/pkg/server/plugin/upstreamauthority/spire/spire.go
@@ -423,19 +423,16 @@ func (p *Plugin) unsubscribeToPolling() {
 	defer p.pollMtx.Unlock()
 	p.currentPollSubscribers--
 	if p.currentPollSubscribers == 0 {
-		// TODO: may we release server here?
 		p.stopPolling()
+		// Wait for the polling goroutine to fully exit so its deferred
+		// release() call — which nils out bundleClient — cannot race with
+		// a future startPolling call.
+		<-p.pollDone
+		p.pollDone = nil
 	}
 }
 
 func (p *Plugin) startPolling(streamCtx context.Context) error {
-	// Wait for the previous polling goroutine to finish before starting a
-	// new one. This ensures its deferred release() call — which nils out
-	// bundleClient — cannot race with the new goroutine calling getBundle().
-	if p.pollDone != nil {
-		<-p.pollDone
-	}
-
 	var pollCtx context.Context
 	pollCtx, p.stopPolling = context.WithCancel(context.Background())
 


### PR DESCRIPTION
A race in startPolling could cause a nil pointer dereference in pollBundleUpdates. When all subscribers disconnected and a new one arrived quickly, the old polling goroutine's deferred release() could fire after the new goroutine had already started, zeroing out the bundleClient the new goroutine was using.

I saw this recently in a CI run:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0xaaae98]

goroutine 804 [running]:
github.com/spiffe/spire/pkg/server/plugin/upstreamauthority/spire.(*serverClient).getBundle(0x3e34356cc0a0, {0xd53c30, 0x3e343533c280})
	/home/runner/work/spire/spire/pkg/server/plugin/upstreamauthority/spire/spire_server_client.go:159 +0xb8
github.com/spiffe/spire/pkg/server/plugin/upstreamauthority/spire.(*Plugin).pollBundleUpdates(0x3e34355a2000, {0xd53c30, 0x3e343533c280})
	/home/runner/work/spire/spire/pkg/server/plugin/upstreamauthority/spire/spire.go:324 +0x13b
created by github.com/spiffe/spire/pkg/server/plugin/upstreamauthority/spire.(*Plugin).startPolling in goroutine 791
	/home/runner/work/spire/spire/pkg/server/plugin/upstreamauthority/spire/spire.go:438 +0xdc
FAIL	github.com/spiffe/spire/pkg/server/plugin/upstreamauthority/spire	0.100s
```

In production this is extremely unlikely: it requires all downstream servers to disconnect simultaneously and one to reconnect before the scheduler runs the old goroutine even once. In unit tests the mock clock can hold the old goroutine alive indefinitely, making the race easy to trigger. This was surfaced by the test changes in #6734.

The fix adds a pollDone channel so startPolling waits for the previous goroutine to fully exit before calling serverClient.start().