### PR TITLE
Fix race between context cancellation and plugin error in workload attestor

### DIFF
--- a/pkg/agent/attestor/workload/workload.go
+++ b/pkg/agent/attestor/workload/workload.go
@@ -72,6 +72,10 @@ func (wla *attestor) Attest(ctx context.Context, pid int) ([]*common.Selector, e
 			selectors = append(selectors, s...)
 			wla.c.selectorHook(selectors)
 		case err := <-errChan:
+			if ctx.Err() != nil {
+				log.WithError(ctx.Err()).Error("Timed out collecting selectors for PID")
+				return nil, ctx.Err()
+			}
 			log.WithError(err).Error("Failed to collect all selectors for PID")
 		case <-ctx.Done():
 			log.WithError(ctx.Err()).Error("Timed out collecting selectors for PID")


### PR DESCRIPTION
When a workload client disconnects mid-attestation, the gRPC transport returns a codes.Canceled error for any in-flight plugin calls. This causes both errChan and ctx.Done() to become ready simultaneously, and Go's non-deterministic select could pick errChan, logging a misleading "Failed to collect all selectors" message and returning partial selectors with no error to the caller.

The fix checks ctx.Err() inside the errChan case. Because the gRPC cancellation error is a consequence of the context being cancelled, ctx.Err() is reliably set whenever this race occurs. When it is set, we treat the situation as a context cancellation: log "Timed out collecting selectors for PID" and return nil selectors with the context error, consistent with the ctx.Done() path.

This was flagged by a recent failure in the TestWorkloadAttestor during the execution of [unit-test (linux with race detection)](https://github.com/spiffe/spire/actions/runs/23448517833/job/68219076875?pr=6781#step:5:41)

```
--- FAIL: TestWorkloadAttestor (0.03s)
    --- FAIL: TestWorkloadAttestor/TestAttestLogsOnContextCancellation (0.01s)
        workload_test.go:179: 
            	Error Trace:	/home/runner/work/spire/spire/pkg/agent/attestor/workload/workload_test.go:179
            	Error:      	Expected nil, but got: []*common.Selector{(*common.Selector)(0xc0005da730)}
            	Test:       	TestWorkloadAttestor/TestAttestLogsOnContextCancellation
        workload_test.go:180: 
            	Error Trace:	/home/runner/work/spire/spire/pkg/agent/attestor/workload/workload_test.go:180
            	Error:      	An error is expected but got nil.
            	Test:       	TestWorkloadAttestor/TestAttestLogsOnContextCancellation
        workload_test.go:181: 
            	Error Trace:	/home/runner/work/spire/spire/test/spiretest/logs.go:19
            	            				/home/runner/work/spire/spire/pkg/agent/attestor/workload/workload_test.go:181
            	Error:      	Not equal: 
            	            	expected: []spiretest.LogEntry{spiretest.LogEntry{Level:0x2, Message:"Timed out collecting selectors for PID", Data:logrus.Fields{"error":"context canceled", "pid":"4"}}}
            	            	actual  : []spiretest.LogEntry{spiretest.LogEntry{Level:0x2, Message:"Failed to collect all selectors for PID", Data:logrus.Fields{"error":"workload attestor \"faketimeoutattestor\" failed: rpc error: code = Canceled desc = workloadattestor(faketimeoutattestor): context canceled", "pid":"4"}}}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -3,5 +3,5 @@
            	            	   Level: (logrus.Level) 2,
            	            	-  Message: (string) (len=38) "Timed out collecting selectors for PID",
            	            	+  Message: (string) (len=39) "Failed to collect all selectors for PID",
            	            	   Data: (logrus.Fields) (len=2) {
            	            	-   (string) (len=5) "error": (string) (len=16) "context canceled",
            	            	+   (string) (len=5) "error": (string) (len=137) "workload attestor \"faketimeoutattestor\" failed: rpc error: code = Canceled desc = workloadattestor(faketimeoutattestor): context canceled",
            	            	    (string) (len=3) "pid": (string) (len=1) "4"
            	Test:       	TestWorkloadAttestor/TestAttestLogsOnContextCancellation
            	Messages:   	unexpected logs
FAIL
FAIL	github.com/spiffe/spire/pkg/agent/attestor/workload	0.112s
```