### PR TITLE
fix: handle nil NSG in VMSS NIC parseNetworkInterfaceConfig

### DIFF
--- a/pkg/server/plugin/nodeattestor/azureimds/client.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/client.go
@@ -127,13 +127,23 @@ func (c *azureClient) GetVMSSInstance(ctx context.Context, vmId, subscriptionID,
 		}
 
 		for _, instance := range page.Value {
-			if *instance.Properties.VMID == vmId {
-				vm, err := buildVirtualMachineFromVMSSInstance(instance, info.ResourceGroup)
-				if err != nil {
-					return nil, err
-				}
-				return vm, nil
+			if instance == nil {
+				continue
 			}
+			if instance.Properties == nil {
+				continue
+			}
+			if instance.Properties.VMID == nil {
+				continue
+			}
+			if *instance.Properties.VMID != vmId {
+				continue
+			}
+			vm, err := buildVirtualMachineFromVMSSInstance(instance, info.ResourceGroup)
+			if err != nil {
+				return nil, err
+			}
+			return vm, nil
 		}
 	}
 	return nil, status.Errorf(codes.Internal, "VMSS instance %q not found", vmId)
@@ -205,6 +215,21 @@ func buildVirtualMachineFromVMSSInstance(instance *armcompute.VirtualMachineScal
 	if instance == nil {
 		return nil, status.Error(codes.Internal, "vmss instance is nil")
 	}
+	if instance.ID == nil {
+		return nil, status.Error(codes.Internal, "vmss instance ID is nil")
+	}
+	if instance.Name == nil {
+		return nil, status.Error(codes.Internal, "vmss instance name is nil")
+	}
+	if instance.Location == nil {
+		return nil, status.Error(codes.Internal, "vmss instance location is nil")
+	}
+	if instance.Properties == nil {
+		return nil, status.Error(codes.Internal, "vmss instance properties are nil")
+	}
+	if instance.Properties.VMID == nil {
+		return nil, status.Error(codes.Internal, "vmss instance VM ID is nil")
+	}
 
 	v := &VirtualMachine{
 		ID:            *instance.ID,
@@ -220,6 +245,10 @@ func buildVirtualMachineFromVMSSInstance(instance *armcompute.VirtualMachineScal
 		for key, value := range instance.Tags {
 			v.Tags[key] = value
 		}
+	}
+
+	if instance.Properties.NetworkProfileConfiguration == nil {
+		return v, nil
 	}
 
 	for _, interfaceConfig := range instance.Properties.NetworkProfileConfiguration.NetworkInterfaceConfigurations {
@@ -239,6 +268,9 @@ func parseNetworkInterfaceConfig(interfaceConfig *armcompute.VirtualMachineScale
 	if interfaceConfig == nil {
 		return nil, status.Error(codes.Internal, "network interface configuration is nil")
 	}
+	if interfaceConfig.Name == nil {
+		return nil, status.Error(codes.Internal, "network interface configuration name is nil")
+	}
 
 	ni := &NetworkInterface{
 		Name: *interfaceConfig.Name,
@@ -248,19 +280,23 @@ func parseNetworkInterfaceConfig(interfaceConfig *armcompute.VirtualMachineScale
 		return ni, nil
 	}
 
-	if interfaceConfig.Properties.NetworkSecurityGroup != nil && interfaceConfig.Properties.NetworkSecurityGroup.ID != nil {
-		nsgResourceGroup, nsgName, err := parseNetworkSecurityGroupID(*interfaceConfig.Properties.NetworkSecurityGroup.ID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "unable to parse network security group ID: %v", err)
-		}
-		ni.SecurityGroup = SecurityGroup{
-			ResourceGroup: nsgResourceGroup,
-			Name:          nsgName,
-		}
+	sg, err := parseSecurityGroup(interfaceConfig.Properties.NetworkSecurityGroup)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "unable to parse network security group ID: %v", err)
 	}
+	ni.SecurityGroup = sg
 
 	for _, ipconfig := range interfaceConfig.Properties.IPConfigurations {
-		if ipconfig == nil || ipconfig.Properties == nil || ipconfig.Properties.Subnet == nil || ipconfig.Properties.Subnet.ID == nil {
+		if ipconfig == nil {
+			continue
+		}
+		if ipconfig.Properties == nil {
+			continue
+		}
+		if ipconfig.Properties.Subnet == nil {
+			continue
+		}
+		if ipconfig.Properties.Subnet.ID == nil {
 			continue
 		}
 
@@ -272,6 +308,23 @@ func parseNetworkInterfaceConfig(interfaceConfig *armcompute.VirtualMachineScale
 	}
 
 	return ni, nil
+}
+
+func parseSecurityGroup(nsg *armcompute.SubResource) (SecurityGroup, error) {
+	if nsg == nil {
+		return SecurityGroup{}, nil
+	}
+	if nsg.ID == nil {
+		return SecurityGroup{}, nil
+	}
+	resourceGroup, name, err := parseNetworkSecurityGroupID(*nsg.ID)
+	if err != nil {
+		return SecurityGroup{}, err
+	}
+	return SecurityGroup{
+		ResourceGroup: resourceGroup,
+		Name:          name,
+	}, nil
 }
 
 func extractArmResourceGraphItems[T any](resp armresourcegraph.ClientResourcesResponse) ([]*T, error) {

--- a/pkg/server/plugin/nodeattestor/azureimds/client_test.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/client_test.go
@@ -1,0 +1,199 @@
+package azureimds
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNetworkInterfaceConfigNoNSG(t *testing.T) {
+	nicName := "test-nic"
+	subnetID := "/subscriptions/sub-123/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-1/subnets/subnet-1"
+	config := &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+		Name: &nicName,
+		Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+			IPConfigurations: []*armcompute.VirtualMachineScaleSetIPConfiguration{
+				{
+					Properties: &armcompute.VirtualMachineScaleSetIPConfigurationProperties{
+						Subnet: &armcompute.APIEntityReference{
+							ID: &subnetID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ni, err := parseNetworkInterfaceConfig(config)
+	require.NoError(t, err)
+	require.Equal(t, nicName, ni.Name)
+	require.Equal(t, SecurityGroup{}, ni.SecurityGroup)
+	require.Len(t, ni.Subnets, 1)
+	require.Equal(t, "vnet-1", ni.Subnets[0].VNet)
+	require.Equal(t, "subnet-1", ni.Subnets[0].SubnetName)
+}
+
+func TestParseNetworkInterfaceConfigNoSubnets(t *testing.T) {
+	nicName := "test-nic"
+	nsgID := "/subscriptions/sub-123/resourceGroups/rg-1/providers/Microsoft.Network/networkSecurityGroups/nsg-1"
+
+	tests := []struct {
+		name   string
+		config *armcompute.VirtualMachineScaleSetNetworkConfiguration
+	}{
+		{
+			name: "nil ip configurations",
+			config: &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+				Name: &nicName,
+				Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					NetworkSecurityGroup: &armcompute.SubResource{ID: &nsgID},
+				},
+			},
+		},
+		{
+			name: "empty ip configurations",
+			config: &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+				Name: &nicName,
+				Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					NetworkSecurityGroup: &armcompute.SubResource{ID: &nsgID},
+					IPConfigurations:     []*armcompute.VirtualMachineScaleSetIPConfiguration{},
+				},
+			},
+		},
+		{
+			name: "ip config with nil subnet",
+			config: &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+				Name: &nicName,
+				Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
+					NetworkSecurityGroup: &armcompute.SubResource{ID: &nsgID},
+					IPConfigurations: []*armcompute.VirtualMachineScaleSetIPConfiguration{
+						{
+							Properties: &armcompute.VirtualMachineScaleSetIPConfigurationProperties{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "nil properties",
+			config: &armcompute.VirtualMachineScaleSetNetworkConfiguration{
+				Name: &nicName,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ni, err := parseNetworkInterfaceConfig(tc.config)
+			require.NoError(t, err)
+			require.Equal(t, nicName, ni.Name)
+			require.Empty(t, ni.Subnets)
+		})
+	}
+}
+
+func TestBuildVirtualMachineFromVMSSInstanceNilFields(t *testing.T) {
+	id := "vm-id"
+	name := "vm-name"
+	location := "westus"
+	vmID := "vm-guid"
+
+	tests := []struct {
+		name     string
+		instance *armcompute.VirtualMachineScaleSetVM
+		errMsg   string
+	}{
+		{
+			name:     "nil instance",
+			instance: nil,
+			errMsg:   "vmss instance is nil",
+		},
+		{
+			name: "nil ID",
+			instance: &armcompute.VirtualMachineScaleSetVM{
+				Name:     &name,
+				Location: &location,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					VMID: &vmID,
+				},
+			},
+			errMsg: "vmss instance ID is nil",
+		},
+		{
+			name: "nil name",
+			instance: &armcompute.VirtualMachineScaleSetVM{
+				ID:       &id,
+				Location: &location,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					VMID: &vmID,
+				},
+			},
+			errMsg: "vmss instance name is nil",
+		},
+		{
+			name: "nil location",
+			instance: &armcompute.VirtualMachineScaleSetVM{
+				ID:   &id,
+				Name: &name,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+					VMID: &vmID,
+				},
+			},
+			errMsg: "vmss instance location is nil",
+		},
+		{
+			name: "nil properties",
+			instance: &armcompute.VirtualMachineScaleSetVM{
+				ID:       &id,
+				Name:     &name,
+				Location: &location,
+			},
+			errMsg: "vmss instance properties are nil",
+		},
+		{
+			name: "nil VMID",
+			instance: &armcompute.VirtualMachineScaleSetVM{
+				ID:         &id,
+				Name:       &name,
+				Location:   &location,
+				Properties: &armcompute.VirtualMachineScaleSetVMProperties{},
+			},
+			errMsg: "vmss instance VM ID is nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vm, err := buildVirtualMachineFromVMSSInstance(tc.instance, "rg")
+			require.Error(t, err)
+			require.Nil(t, vm)
+			require.Contains(t, err.Error(), tc.errMsg)
+		})
+	}
+}
+
+func TestBuildVirtualMachineFromVMSSInstanceNoNetworkProfile(t *testing.T) {
+	id := "vm-id"
+	name := "vm-name"
+	location := "westus"
+	vmID := "vm-guid"
+
+	instance := &armcompute.VirtualMachineScaleSetVM{
+		ID:       &id,
+		Name:     &name,
+		Location: &location,
+		Properties: &armcompute.VirtualMachineScaleSetVMProperties{
+			VMID: &vmID,
+		},
+	}
+
+	vm, err := buildVirtualMachineFromVMSSInstance(instance, "rg")
+	require.NoError(t, err)
+	require.Equal(t, id, vm.ID)
+	require.Equal(t, name, vm.Name)
+	require.Equal(t, location, vm.Location)
+	require.Equal(t, vmID, vm.VMID)
+	require.Equal(t, "rg", vm.ResourceGroup)
+	require.Empty(t, vm.Interfaces)
+}

--- a/pkg/server/plugin/nodeattestor/azureimds/imds.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/imds.go
@@ -427,7 +427,10 @@ func buildSelectors(ctx context.Context, tenant *tenantConfig, vmssName *string,
 
 	// add network interface selectors
 	for _, networkInterface := range vm.Interfaces {
-		selectorMap[selectorValue("network-security-group", networkInterface.SecurityGroup.ResourceGroup, networkInterface.SecurityGroup.Name)] = true
+		sg := networkInterface.SecurityGroup
+		if sg.ResourceGroup != "" || sg.Name != "" {
+			selectorMap[selectorValue("network-security-group", sg.ResourceGroup, sg.Name)] = true
+		}
 		for _, subnet := range networkInterface.Subnets {
 			selectorMap[selectorValue("virtual-network", subnet.VNet)] = true
 			selectorMap[selectorValue("virtual-network-subnet", subnet.VNet, subnet.SubnetName)] = true

--- a/pkg/server/plugin/nodeattestor/azureimds/imds_test.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/imds_test.go
@@ -270,6 +270,55 @@ func (s *IMDSAttestorSuite) TestAttestSuccessWithVMSS() {
 	s.RequireProtoListEqual(expected, resp.Selectors)
 }
 
+func (s *IMDSAttestorSuite) TestAttestSuccessWithVMSSNoNSG() {
+	s.setVMSSInstance(&VirtualMachine{
+		Name:          "VIRTUALMACHINE",
+		Location:      "westus",
+		ResourceGroup: "RESOURCEGROUP",
+		Interfaces: []*NetworkInterface{
+			{
+				Name: "nic-1",
+				Subnets: []Subnet{
+					{VNet: "vnet-1", SubnetName: "subnet-1"},
+				},
+			},
+		},
+	})
+
+	agentID := fmt.Sprintf("spiffe://example.org/spire/agent/azure_imds/%s/%s/%s", testTenantID, testSubscriptionID, testVMID)
+
+	selectorValues := slices.Clone(testVMSelectors)
+	selectorValues = append(selectorValues,
+		fmt.Sprintf("vmss-name:%s", testVMSSName),
+		"virtual-network:vnet-1",
+		"virtual-network-subnet:vnet-1:subnet-1",
+	)
+	sort.Strings(selectorValues)
+
+	var expected []*common.Selector
+	for _, selectorValue := range selectorValues {
+		expected = append(expected, &common.Selector{
+			Type:  "azure_imds",
+			Value: selectorValue,
+		})
+	}
+
+	vmssChallengeHandler := makeChallengeHandlerWithNonceCapture(&s.sharedNonce, func(ctx context.Context, challenge []byte) ([]byte, error) {
+		nonce := string(challenge)
+		vmssName := testVMSSName
+		return makeAttestPayloadWithNonce(testVMID, testSubscriptionID, nonce, testTenantDomain, &vmssName), nil
+	})
+
+	attestor := s.loadPluginWithChallengeHandler(vmssChallengeHandler, nil)
+
+	payload := []byte("initial")
+	resp, err := attestor.Attest(context.Background(), payload, vmssChallengeHandler)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+	s.Require().Equal(agentID, resp.AgentID)
+	s.RequireProtoListEqual(expected, resp.Selectors)
+}
+
 func (s *IMDSAttestorSuite) TestAttestSuccessWithRestrictedSubscription() {
 	s.setVirtualMachine(&VirtualMachine{
 		Name:          "VIRTUALMACHINE",

--- a/pkg/server/plugin/nodeattestor/azureimds/utils_test.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/stretchr/testify/require"
 )
 
@@ -528,33 +527,6 @@ func TestValidateVMSSName(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestParseNetworkInterfaceConfigNoNSG(t *testing.T) {
-	nicName := "test-nic"
-	subnetID := "/subscriptions/sub-123/resourceGroups/rg-1/providers/Microsoft.Network/virtualNetworks/vnet-1/subnets/subnet-1"
-	config := &armcompute.VirtualMachineScaleSetNetworkConfiguration{
-		Name: &nicName,
-		Properties: &armcompute.VirtualMachineScaleSetNetworkConfigurationProperties{
-			IPConfigurations: []*armcompute.VirtualMachineScaleSetIPConfiguration{
-				{
-					Properties: &armcompute.VirtualMachineScaleSetIPConfigurationProperties{
-						Subnet: &armcompute.APIEntityReference{
-							ID: &subnetID,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	ni, err := parseNetworkInterfaceConfig(config)
-	require.NoError(t, err)
-	require.Equal(t, nicName, ni.Name)
-	require.Equal(t, SecurityGroup{}, ni.SecurityGroup)
-	require.Len(t, ni.Subnets, 1)
-	require.Equal(t, "vnet-1", ni.Subnets[0].VNet)
-	require.Equal(t, "subnet-1", ni.Subnets[0].SubnetName)
 }
 
 func TestValidateUUID(t *testing.T) {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Azure IMDS node attestation for VMSS instances.

**Description of change**

VMSS NICs don't always have a Network Security Group attached. `parseNetworkInterfaceConfig` was dereferencing `NetworkSecurityGroup.ID` unconditionally, causing a plugin panic when attesting VMSS nodes with no NSG on their NIC.

added nil checks for `Properties`, `NetworkSecurityGroup`, and `NetworkSecurityGroup.ID`. if there's no NSG the `SecurityGroup` field is left as zero-value. also guard `ipconfig.Properties` and `Subnet` against nil in the IP config loop.

added a test case for the no-NSG path in `utils_test.go`.

**Which issue this PR fixes**

fixes #6630