### PR TITLE
Fix azure_imds node attestation for standalone VMs

### DIFF
--- a/pkg/server/plugin/nodeattestor/azureimds/client.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/client.go
@@ -168,7 +168,7 @@ func (c *azureClient) getNetworkInterfaces(ctx context.Context, vmId string, sub
 	query := fmt.Sprintf(`
 	Resources
 	| where type == "microsoft.network/networkinterfaces"
-	| where properties.virtualMachine.id == "%s"
+	| where tolower(properties.virtualMachine.id) == tolower("%s")
 	| mv-expand ipConfig = properties.ipConfigurations
 	| extend subnetId = tostring(ipConfig.properties.subnet.id)
 	| extend vnetName = extract(@"virtualNetworks/([^/]+)", 1, subnetId)
@@ -178,10 +178,10 @@ func (c *azureClient) getNetworkInterfaces(ctx context.Context, vmId string, sub
 	| extend nsgRg = extract(@"resourceGroups/([^/]+)",1,nsgId)
 	| extend nsgName = extract(@"networkSecurityGroups/([^/]+)",1,nsgId)
 	| extend securityGroup = bag_pack("resourceGroup", nsgRg, "name",nsgName)
-	| summarize 
+	| summarize
 		subnets = make_list(subnetObj)
-		by id, name, resourceGroup, tostring(securityGroup)
-	| project name, resourceGroup, subnets, securityGroup`, vmId)
+		by id, name, resourceGroup, securityGroup_str = tostring(securityGroup)
+	| project name, resourceGroup, subnets, securityGroup = todynamic(securityGroup_str)`, vmId)
 	options := &armresourcegraph.QueryRequestOptions{
 		ResultFormat: new(armresourcegraph.ResultFormatObjectArray),
 	}


### PR DESCRIPTION
**Affected functionality**

`azure_imds` node attestation for standalone Azure VMs.

**Description of change**

The standalone VM NIC query converts `securityGroup` to a string for grouping (`summarize ... by tostring(securityGroup)`), but never converts it back to an object before returning. The Go unmarshaler expects an object (`azureimds.SecurityGroup`), not a string, causing attestation to fail with:

      json: cannot unmarshal string into Go struct field
      NetworkInterface.securityGroup of type azureimds.SecurityGroup

**Note:** VMSS nodes are unaffected (different ARG query path).

fixes https://github.com/spiffe/spire/issues/6806

