### PR TITLE
Fix for flaky rotation integration test

### DIFF
--- a/test/integration/suites/rotation/05-check-svids
+++ b/test/integration/suites/rotation/05-check-svids
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# 45 seconds should be enough for the server to prepare and rotate into a new
+# 60 seconds should be enough for the server to prepare and rotate into a new
 # CA and mint a new SVID with the new CA. Check every three seconds that the
-# is valid.
-NUMCHECKS=15
+# SVID is valid.
+NUMCHECKS=20
 CHECKINTERVAL=3
 for ((i=1;i<=NUMCHECKS;i++)); do
     log-info "checking X509-SVID ($i of $NUMCHECKS)..."

--- a/test/integration/suites/rotation/conf/server/server.conf
+++ b/test/integration/suites/rotation/conf/server/server.conf
@@ -4,8 +4,8 @@ server {
 	trust_domain = "domain.test"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"
-    ca_ttl = "1m"
-	default_x509_svid_ttl = "10s"
+    ca_ttl = "3m"
+	default_x509_svid_ttl = "20s"
 }
 
 plugins {


### PR DESCRIPTION
The `rotation` integration test was intermittently failing on ARM64 runners with an SVID expiry error. The root cause was `default_x509_svid_ttl = "10s"` combined with the server's hardcoded `NotBeforeCushion = 10s`: this makes `halfLife = (10s + 10s) / 2 = 10s`, equal to the SVID's remaining TTL at creation, so the agent triggered SVID renewal immediately. On slow runners, the renewal took long enough that the old SVID expired before the new one was stored in cache.

Example of a failure: https://github.com/spiffe/spire/actions/runs/24084022811/job/70253527959

This PR
- Raises `ca_ttl` to `3m` (`MaxSVIDTTLForCATTL` goes from 10s to 30s, preventing SVID truncation near CA rotation).
- Raises `default_x509_svid_ttl` to `20s` (renewal now triggers 3–7s after issuance, leaving 13–17s to complete).
- Raises `NUMCHECKS` from 15 to 20 to keep a CA rotation observable during the check step.