### PR TITLE
Fix Dependabot auto-merge to use squash merge

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -176,9 +176,14 @@ jobs:
 
           gh pr review --approve "$PR_URL"
 
-          # Use the merge API with the verified HEAD SHA so the merge is
-          # rejected if the branch was force-pushed between verification
-          # and this point.
-          gh api --method PUT "repos/${REPO}/pulls/${PR_NUMBER}/merge" \
-            --field merge_method=merge \
-            --field sha="${HEAD_SHA}"
+          # Verify the HEAD SHA has not changed since it was verified in
+          # the previous step. This closes the TOCTOU window where an
+          # attacker could force-push to the branch between verification
+          # and merge.
+          CURRENT_HEAD=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+          if [ "$CURRENT_HEAD" != "$HEAD_SHA" ]; then
+            echo "::error::PR HEAD changed between verification and merge (expected: ${HEAD_SHA}, got: ${CURRENT_HEAD}). Aborting."
+            exit 1
+          fi
+
+          gh pr merge --squash "$PR_URL"


### PR DESCRIPTION
- The raw merge API (`PUT /pulls/{number}/merge`) bypasses the merge queue and fails with `405 Merge commits are not allowed` because the repository only permits squash and rebase merges.
- Switch to `gh pr merge --squash`, which uses an allowed merge method and properly interacts with the merge queue.
- Preserve the TOCTOU protection by verifying the PR HEAD SHA has not changed right before merging, instead of relying on the raw API's `sha` parameter.