### PR TITLE
fix: Adds gRPC conn release() method for common Agent-side client

### DIFF
--- a/cmd/spire-agent/cli/api/common.go
+++ b/cmd/spire-agent/cli/api/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
 	"github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/util"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -17,7 +18,12 @@ const commandTimeout = 5 * time.Second
 
 type workloadClient struct {
 	workload.SpiffeWorkloadAPIClient
+	conn    *grpc.ClientConn
 	timeout time.Duration
+}
+
+func (c *workloadClient) release() {
+	c.conn.Close()
 }
 
 type workloadClientMaker func(ctx context.Context, addr net.Addr, timeout time.Duration) (*workloadClient, error)
@@ -34,6 +40,7 @@ func newWorkloadClient(ctx context.Context, addr net.Addr, timeout time.Duration
 	}
 	return &workloadClient{
 		SpiffeWorkloadAPIClient: workload.NewSpiffeWorkloadAPIClient(conn),
+		conn:                    conn,
 		timeout:                 timeout,
 	}, nil
 }
@@ -105,6 +112,7 @@ func (a *adapter) Run(args []string) int {
 		_ = a.env.ErrPrintln(err)
 		return 1
 	}
+	defer clients.release()
 
 	if err := a.cmd.run(ctx, a.env, clients); err != nil {
 		_ = a.env.ErrPrintln(err)


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Agent management of gRPC connections is now `defer` closed via new `release()` method

**Description of change**

Out of interest, I was perusing the SPIRE codebase with Claude to identify any simple, uncontroversial improvements we could make in terms of quality etc. Noticed this wasn't being done by the Agent, so here's the change to ensure it closes the gRPC connections in a manner similar to the way the SPIRE Server does (albeit the Server does have different connection responsibilities).

There's no unit test for this, as we don't do anything equivalent on the Server - happy to add this if we think it'd be useful

**Which issue this PR fixes**

N/A

