### PR TITLE
Document URISanSelectors for agent SPIFFE ID template

### DIFF
--- a/doc/plugin_server_nodeattestor_x509pop.md
+++ b/doc/plugin_server_nodeattestor_x509pop.md
@@ -74,11 +74,12 @@ Details about the template engine are available [here](template_engine.md).
 
 Some useful values are:
 
-| Value                 | Description                                                                                  |
-|-----------------------|----------------------------------------------------------------------------------------------|
-| .PluginName           | The name of the plugin                                                                       |
-| .Fingerprint          | The SHA1 fingerprint of the agent's x509 certificate                                         |
-| .TrustDomain          | The configured trust domain                                                                  |
-| .Subject.CommonName   | The common name field of the agent's x509 certificate                                        |
-| .SerialNumberHex      | The serial number field of the agent's x509 certificate represented as lowercase hexadecimal |
-| .SVIDPathTrimmed      | The SVID Path after trimming off the SVID prefix                                             |
+| Value                  | Description                                                                                  |
+|------------------------|----------------------------------------------------------------------------------------------|
+| .PluginName            | The name of the plugin                                                                       |
+| .Fingerprint           | The SHA1 fingerprint of the agent's x509 certificate                                         |
+| .TrustDomain           | The configured trust domain                                                                  |
+| .Subject.CommonName    | The common name field of the agent's x509 certificate                                        |
+| .SerialNumberHex       | The serial number field of the agent's x509 certificate represented as lowercase hexadecimal |
+| .SVIDPathTrimmed       | The SVID Path after trimming off the SVID prefix                                             |
+| .URISanSelectors.<key> | The value of the URI San selector with key <key>                                             |

--- a/doc/plugin_server_nodeattestor_x509pop.md
+++ b/doc/plugin_server_nodeattestor_x509pop.md
@@ -74,11 +74,12 @@ Details about the template engine are available [here](template_engine.md).
 
 Some useful values are:
 
-| Value                 | Description                                                                                  |
-|-----------------------|----------------------------------------------------------------------------------------------|
-| .PluginName           | The name of the plugin                                                                       |
-| .Fingerprint          | The SHA1 fingerprint of the agent's x509 certificate                                         |
-| .TrustDomain          | The configured trust domain                                                                  |
-| .Subject.CommonName   | The common name field of the agent's x509 certificate                                        |
-| .SerialNumberHex      | The serial number field of the agent's x509 certificate represented as lowercase hexadecimal |
-| .SVIDPathTrimmed      | The SVID Path after trimming off the SVID prefix                                             |
+| Value                       | Description                                                                                  |
+|-----------------------------|----------------------------------------------------------------------------------------------|
+| .PluginName                 | The name of the plugin                                                                       |
+| .Fingerprint                | The SHA1 fingerprint of the agent's x509 certificate                                         |
+| .TrustDomain                | The configured trust domain                                                                  |
+| .Subject.CommonName         | The common name field of the agent's x509 certificate                                        |
+| .SerialNumberHex            | The serial number field of the agent's x509 certificate represented as lowercase hexadecimal |
+| .SVIDPathTrimmed            | The SVID Path after trimming off the SVID prefix                                             |
+| .URISanSelectors.&lt;key&gt;| The value of the URI San selector with key `<key>`                                           |


### PR DESCRIPTION
Looks like you can use these URI SAN selectors in the x509pop agent SPIFFE ID template, but we never documented it.