### PR TITLE
Specify a read buffer size for agent WorkloadAPI server

### DIFF
--- a/pkg/agent/endpoints/endpoints.go
+++ b/pkg/agent/endpoints/endpoints.go
@@ -20,6 +20,10 @@ import (
 	"github.com/spiffe/spire/pkg/common/telemetry"
 )
 
+const (
+	readBufferSize = 4096
+)
+
 type Server interface {
 	ListenAndServe(ctx context.Context) error
 	WaitForListening(listening chan struct{})
@@ -107,6 +111,7 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 		grpc.Creds(peertracker.NewCredentials()),
 		grpc.UnaryInterceptor(unaryInterceptor),
 		grpc.StreamInterceptor(streamInterceptor),
+		grpc.ReadBufferSize(readBufferSize),
 	)
 
 	workload_pb.RegisterSpiffeWorkloadAPIServer(server, e.workloadAPIServer)


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Hopefully none, but it may lead to multiple read() calls when reading large requests for WorkloadAPI, SDSv3 and gRPC Healthcheck.

**Description of change**
gRPC allocates a 32KB buffer per active connection for reading data from callers. This is excessive since we don't usually have large incoming requests.

In a testing setup this dropped the memory usage of spire-agent from ~340MB to ~200MB

In the case where we have larger incoming payloads, we would end up making multiple read() calls to read the incoming data, so no functionality is affected but if there are larger requests (maybe for the SDSv3 API?) incoming we could have some performance degradation.

