### PR TITLE
Handle Debug service in agent connection metrics middleware

### DIFF
--- a/doc/telemetry/telemetry.md
+++ b/doc/telemetry/telemetry.md
@@ -104,6 +104,8 @@ The following metrics are emitted:
 | Call Counter | `workload_api`, `workload_attestor`                                      | `attestor`                   | The Workload API is invoking a given attestor.                                        |
 | Gauge        | `started`                                                                | `version`, `trust_domain_id` | Information about the Agent.                                                          |
 | Gauge        | `uptime_in_ms`                                                           |                              | The uptime of the Agent in milliseconds.                                              |
+| Counter      | `debug_api`, `connection`                                                |                              | The Debug API has successfully established a connection.                              |
+| Gauge        | `debug_api`, `connections`                                               |                              | The number of active connections that the Debug API has.                              |
 | Counter      | `delegated_identity_api`, `connection`                                   |                              | The Delegated Identity API has successfully established a connection.                 |
 | Gauge        | `delegated_identity_api`, `connections`                                  |                              | The number of active connection that the Delegated Identity API has.                  |
 | Latency      | `delegated_identity_api`, `subscribe_x509_svid` `first_x509_svid_update` |                              | The latency fetching first X.509-SVID in Delegated Identity API.                      |

--- a/pkg/agent/endpoints/metrics.go
+++ b/pkg/agent/endpoints/metrics.go
@@ -37,8 +37,8 @@ func (m *connectionMetrics) Preprocess(ctx context.Context, _ string, _ any) (co
 		case middleware.DelegatedIdentityServiceName:
 			adminapi.IncrDelegatedIdentityAPIConnectionCounter(m.metrics)
 			adminapi.SetDelegatedIdentityAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.delegatedIdentityAPIConns, 1))
-		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
-			// Intentionally not emitting metrics for health and reflection services
+		case middleware.DebugServiceName, middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
+			// Intentionally not emitting metrics for debug, health, and reflection services
 		default:
 			middleware.LogMisconfiguration(ctx, "unrecognized service for connection metrics: "+names.Service)
 		}
@@ -55,8 +55,8 @@ func (m *connectionMetrics) Postprocess(ctx context.Context, _ string, _ bool, _
 			sdsAPITelemetry.SetSDSAPIConnectionTotalGauge(m.metrics, atomic.AddInt32(&m.sdsAPIConns, -1))
 		case middleware.DelegatedIdentityServiceName:
 			adminapi.SetDelegatedIdentityAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.delegatedIdentityAPIConns, -1))
-		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
-			// Intentionally not emitting metrics for health and reflection services
+		case middleware.DebugServiceName, middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
+			// Intentionally not emitting metrics for debug, health, and reflection services
 		default:
 			middleware.LogMisconfiguration(ctx, "unrecognized service for connection metrics: "+names.Service)
 		}

--- a/pkg/agent/endpoints/metrics.go
+++ b/pkg/agent/endpoints/metrics.go
@@ -22,6 +22,7 @@ type connectionMetrics struct {
 	metrics                   telemetry.Metrics
 	workloadAPIConns          int32
 	sdsAPIConns               int32
+	debugAPIConns             int32
 	delegatedIdentityAPIConns int32
 }
 
@@ -37,8 +38,11 @@ func (m *connectionMetrics) Preprocess(ctx context.Context, _ string, _ any) (co
 		case middleware.DelegatedIdentityServiceName:
 			adminapi.IncrDelegatedIdentityAPIConnectionCounter(m.metrics)
 			adminapi.SetDelegatedIdentityAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.delegatedIdentityAPIConns, 1))
-		case middleware.DebugServiceName, middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
-			// Intentionally not emitting metrics for debug, health, and reflection services
+		case middleware.DebugServiceName:
+			adminapi.IncrDebugAPIConnectionCounter(m.metrics)
+			adminapi.SetDebugAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.debugAPIConns, 1))
+		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
+			// Intentionally not emitting metrics for health and reflection services
 		default:
 			middleware.LogMisconfiguration(ctx, "unrecognized service for connection metrics: "+names.Service)
 		}
@@ -55,8 +59,10 @@ func (m *connectionMetrics) Postprocess(ctx context.Context, _ string, _ bool, _
 			sdsAPITelemetry.SetSDSAPIConnectionTotalGauge(m.metrics, atomic.AddInt32(&m.sdsAPIConns, -1))
 		case middleware.DelegatedIdentityServiceName:
 			adminapi.SetDelegatedIdentityAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.delegatedIdentityAPIConns, -1))
-		case middleware.DebugServiceName, middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
-			// Intentionally not emitting metrics for debug, health, and reflection services
+		case middleware.DebugServiceName:
+			adminapi.SetDebugAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.debugAPIConns, -1))
+		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
+			// Intentionally not emitting metrics for health and reflection services
 		default:
 			middleware.LogMisconfiguration(ctx, "unrecognized service for connection metrics: "+names.Service)
 		}

--- a/pkg/agent/endpoints/metrics_test.go
+++ b/pkg/agent/endpoints/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	debugv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/debug/v1"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -46,12 +47,25 @@ func TestDebugServiceConnectionMetrics(t *testing.T) {
 		}
 	}
 
-	for _, m := range metrics.AllMetrics() {
-		for _, key := range m.Key {
-			assert.NotContains(t, key, "spire",
-				"Metric keys should use the short name 'debug', not the raw service path")
+	// Verify connection metrics are emitted with the correct metric key
+	allMetrics := metrics.AllMetrics()
+	require.NotEmpty(t, allMetrics)
+
+	var foundConnectionCounter, foundGaugeUp, foundGaugeDown bool
+	for _, m := range allMetrics {
+		if m.Type == fakemetrics.IncrCounterType && assert.ObjectsAreEqual([]string{"debug_api", "connection"}, m.Key) {
+			foundConnectionCounter = true
+		}
+		if m.Type == fakemetrics.SetGaugeType && assert.ObjectsAreEqual([]string{"debug_api", "connections"}, m.Key) && m.Val == 1 {
+			foundGaugeUp = true
+		}
+		if m.Type == fakemetrics.SetGaugeType && assert.ObjectsAreEqual([]string{"debug_api", "connections"}, m.Key) && m.Val == 0 {
+			foundGaugeDown = true
 		}
 	}
+	assert.True(t, foundConnectionCounter, "Expected debug_api connection counter metric")
+	assert.True(t, foundGaugeUp, "Expected debug_api connections gauge to increment")
+	assert.True(t, foundGaugeDown, "Expected debug_api connections gauge to decrement")
 }
 
 // TestAllAgentServicesHandledByConnectionMetrics registers every gRPC service
@@ -117,8 +131,6 @@ func TestAllAgentServicesHandledByConnectionMetrics(t *testing.T) {
 		_, _ = client.FetchJWTSVIDs(ctx, &delegatedidentityv1.FetchJWTSVIDsRequest{})
 		assertNoMisconfigurationLog(t, hook)
 	})
-
-	_ = metrics
 }
 
 func assertNoMisconfigurationLog(t *testing.T, hook *test.Hook) {

--- a/pkg/agent/endpoints/metrics_test.go
+++ b/pkg/agent/endpoints/metrics_test.go
@@ -1,0 +1,140 @@
+package endpoints
+
+import (
+	"context"
+	"testing"
+
+	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	debugv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/debug/v1"
+	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
+	"github.com/spiffe/spire/test/grpctest"
+)
+
+// TestDebugServiceConnectionMetrics verifies that Debug API calls going through
+// the agent middleware do NOT produce misconfiguration error logs.
+// Regression test for https://github.com/spiffe/spire/issues/5183
+func TestDebugServiceConnectionMetrics(t *testing.T) {
+	log, hook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+	metrics := fakemetrics.New()
+
+	server := grpctest.StartServer(t,
+		func(s grpc.ServiceRegistrar) {
+			debugv1.RegisterDebugServer(s, &fakeDebugServer{})
+		},
+		grpctest.Middleware(Middleware(log, metrics)),
+	)
+
+	conn := server.NewGRPCClient(t)
+	client := debugv1.NewDebugClient(conn)
+
+	_, _ = client.GetInfo(context.Background(), &debugv1.GetInfoRequest{})
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel {
+			assert.NotContains(t, entry.Message, "unrecognized service for connection metrics",
+				"Debug service should be recognized by connection metrics middleware")
+		}
+	}
+
+	for _, m := range metrics.AllMetrics() {
+		for _, key := range m.Key {
+			assert.NotContains(t, key, "spire",
+				"Metric keys should use the short name 'debug', not the raw service path")
+		}
+	}
+}
+
+// TestAllAgentServicesHandledByConnectionMetrics registers every gRPC service
+// that the agent exposes (across both the Workload API and Admin API servers),
+// makes a call to each one through the middleware, and asserts that none
+// produce an "unrecognized service" misconfiguration log.
+//
+// IMPORTANT: When adding a new gRPC service to the agent, add it to this test.
+// If a service is missing from the connectionMetrics switch in metrics.go, this
+// test will catch it.
+func TestAllAgentServicesHandledByConnectionMetrics(t *testing.T) {
+	log, hook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+	metrics := fakemetrics.New()
+
+	server := grpctest.StartServer(t,
+		func(s grpc.ServiceRegistrar) {
+			workload_pb.RegisterSpiffeWorkloadAPIServer(s, &workload_pb.UnimplementedSpiffeWorkloadAPIServer{})
+			secret_v3.RegisterSecretDiscoveryServiceServer(s, &secret_v3.UnimplementedSecretDiscoveryServiceServer{})
+			grpc_health_v1.RegisterHealthServer(s, &grpc_health_v1.UnimplementedHealthServer{})
+			debugv1.RegisterDebugServer(s, &fakeDebugServer{})
+			delegatedidentityv1.RegisterDelegatedIdentityServer(s, &fakeDelegatedIdentityServer{})
+		},
+		grpctest.Middleware(Middleware(log, metrics)),
+	)
+
+	conn := server.NewGRPCClient(t)
+	ctx := context.Background()
+
+	// Call each agent service to exercise it through the middleware.
+	// The connectionMetrics switch must handle every service listed here.
+	t.Run("WorkloadAPI", func(t *testing.T) {
+		hook.Reset()
+		client := workload_pb.NewSpiffeWorkloadAPIClient(conn)
+		_, _ = client.FetchJWTSVID(ctx, &workload_pb.JWTSVIDRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	t.Run("SDS", func(t *testing.T) {
+		hook.Reset()
+		client := secret_v3.NewSecretDiscoveryServiceClient(conn)
+		_, _ = client.FetchSecrets(ctx, &discovery_v3.DiscoveryRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	t.Run("Health", func(t *testing.T) {
+		hook.Reset()
+		client := grpc_health_v1.NewHealthClient(conn)
+		_, _ = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	t.Run("Debug", func(t *testing.T) {
+		hook.Reset()
+		client := debugv1.NewDebugClient(conn)
+		_, _ = client.GetInfo(ctx, &debugv1.GetInfoRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	t.Run("DelegatedIdentity", func(t *testing.T) {
+		hook.Reset()
+		client := delegatedidentityv1.NewDelegatedIdentityClient(conn)
+		_, _ = client.FetchJWTSVIDs(ctx, &delegatedidentityv1.FetchJWTSVIDsRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	_ = metrics
+}
+
+func assertNoMisconfigurationLog(t *testing.T, hook *test.Hook) {
+	t.Helper()
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel {
+			assert.NotContains(t, entry.Message, "unrecognized service for connection metrics",
+				"Service should be recognized by the connection metrics middleware")
+		}
+	}
+}
+
+type fakeDebugServer struct {
+	debugv1.UnimplementedDebugServer
+}
+
+type fakeDelegatedIdentityServer struct {
+	delegatedidentityv1.UnimplementedDelegatedIdentityServer
+}

--- a/pkg/common/api/middleware/names.go
+++ b/pkg/common/api/middleware/names.go
@@ -21,6 +21,8 @@ const (
 	HealthServiceShortName             = "Health"
 	LoggerServiceName                  = "logger.v1.Logger"
 	LoggerServiceShortName             = "Logger"
+	DebugServiceName                   = "spire.agent.debug.v1.Debug"
+	DebugServiceShortName              = "Debug"
 	DelegatedIdentityServiceName       = "spire.api.agent.delegatedidentity.v1.DelegatedIdentity"
 	DelegatedIdentityServiceShortName  = "DelegatedIdentity"
 	ServerReflectionServiceName        = "grpc.reflection.v1.ServerReflection"
@@ -36,6 +38,7 @@ var (
 		EnvoySDSv3ServiceName, EnvoySDSv3ServiceShortName,
 		HealthServiceName, HealthServiceShortName,
 		LoggerServiceName, LoggerServiceShortName,
+		DebugServiceName, DebugServiceShortName,
 		DelegatedIdentityServiceName, DelegatedIdentityServiceShortName,
 	)
 

--- a/pkg/common/telemetry/agent/adminapi/debugapi.go
+++ b/pkg/common/telemetry/agent/adminapi/debugapi.go
@@ -1,0 +1,20 @@
+package adminapi
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Counters (literal increments, not call counters)
+
+// IncrDebugAPIConnectionCounter indicate Debug
+// API connection (some connection is made, running total count)
+func IncrDebugAPIConnectionCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.DebugAPI, telemetry.Connection}, 1)
+}
+
+// SetDebugAPIConnectionGauge sets the number of active Debug API connections
+func SetDebugAPIConnectionGauge(m telemetry.Metrics, connections int32) {
+	m.SetGauge([]string{telemetry.DebugAPI, telemetry.Connections}, float32(connections))
+}
+
+// End Counters


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Agent metrics middleware (`pkg/agent/endpoints/metrics.go`), service name constants (`pkg/common/api/middleware/names.go`), and Debug API telemetry helpers (`pkg/common/telemetry/agent/adminapi/debugapi.go`).

**Description of change**

The agent's `connectionMetrics` middleware did not have a case for the Debug service (`spire.agent.debug.v1.Debug`) in its `Preprocess`/`Postprocess` switch statements. This caused a misconfiguration error to be logged every time the Debug API was called:

```
unrecognized service for connection metrics: spire.agent.debug.v1.Debug
```

Since the Debug API is typically polled on a schedule (e.g., by monitoring tools), this produced recurring error noise every minute.

Changes:
- Add `DebugServiceName` and `DebugServiceShortName` constants in `names.go`, with a `serviceReplacer` mapping so logs and metrics use the clean short name `"Debug"` instead of the full proto path
- Add `IncrDebugAPIConnectionCounter` and `SetDebugAPIConnectionGauge` telemetry helpers in `debugapi.go`, following the same pattern as the DelegatedIdentity helpers
- Handle `DebugServiceName` in the `Preprocess`/`Postprocess` switch, emitting connection counter and gauge metrics (consistent with other agent services like DelegatedIdentity)
- Add a focused regression test (`TestDebugServiceConnectionMetrics`) that verifies no misconfiguration error is logged and connection metrics are emitted
- Add a guard-rail test (`TestAllAgentServicesHandledByConnectionMetrics`) that exercises every agent gRPC service through the middleware to catch similar issues in the future

**Which issue this PR fixes**

Fixes #5183
