### PR TITLE
Reject stale experimental sigstore config on upgrade

### DIFF
--- a/doc/plugin_agent_workloadattestor_docker.md
+++ b/doc/plugin_agent_workloadattestor_docker.md
@@ -12,6 +12,7 @@ then querying the container runtime API (Docker by default, or Podman when detec
 | docker_version                 | The API version of the docker daemon. If not specified                                         |                                  |
 | container_id_cgroup_matchers   | A list of patterns used to discover container IDs from cgroup entries (Unix)                   |                                  |
 | docker_host                    | The location of the Docker Engine API endpoint (Windows only)                                  | "npipe:////./pipe/docker_engine" |
+| sigstore                       | Sigstore options. See [Sigstore options](#sigstore-options). When set, enables verification of container image signatures and attestations. |                                  |
 | use_new_container_locator      | If true, enables the new container locator algorithm that has support for cgroups v2           | true                             |
 | verbose_container_locator_logs | If true, enables verbose logging of mountinfo and cgroup information used to locate containers | false                            |
 

--- a/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud.go
+++ b/pkg/agent/plugin/svidstore/gcpsecretmanager/gcloud.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 
@@ -62,15 +61,7 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		return nil
 	}
 
-	if len(newConfig.UnusedKeyPositions) != 0 {
-		var keys []string
-		for k := range newConfig.UnusedKeyPositions {
-			keys = append(keys, k)
-		}
-
-		sort.Strings(keys)
-		status.ReportErrorf("unknown configurations detected: %s", strings.Join(keys, ","))
-	}
+	pluginconf.ReportUnusedKeys(status, newConfig.UnusedKeyPositions)
 
 	return newConfig
 }

--- a/pkg/agent/plugin/workloadattestor/docker/docker.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"sync"
 
@@ -105,15 +104,7 @@ func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, stat
 		return nil
 	}
 
-	if len(newConfig.UnusedKeyPositions) > 0 {
-		var keys []string
-		for k := range newConfig.UnusedKeyPositions {
-			keys = append(keys, k)
-		}
-
-		sort.Strings(keys)
-		status.ReportErrorf("unknown configurations detected: %s", strings.Join(keys, ","))
-	}
+	pluginconf.ReportUnusedKeys(status, newConfig.UnusedKeyPositions)
 
 	newConfig.containerHelper = p.createHelper(newConfig, status)
 

--- a/pkg/agent/plugin/workloadattestor/docker/docker_test.go
+++ b/pkg/agent/plugin/workloadattestor/docker/docker_test.go
@@ -211,6 +211,18 @@ invalid2 = "/no/"`,
 			expectCode: codes.InvalidArgument,
 			expectMsg:  "unknown configurations detected: invalid1,invalid2",
 		},
+		{
+			name:        "stale experimental block is rejected",
+			trustDomain: "example.org",
+			config: `
+					experimental {
+						sigstore {
+							rekor_url = "https://rekor.sigstore.dev"
+						}
+					}`,
+			expectCode: codes.InvalidArgument,
+			expectMsg:  "unknown configurations detected: experimental",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			p := New()

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -20,6 +20,7 @@ import (
 	"github.com/andres-erbsen/clock"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
+	hcltoken "github.com/hashicorp/hcl/hcl/token"
 	workloadattestorv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/plugin/agent/workloadattestor/v1"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/agent/common/sigstore"
@@ -135,6 +136,8 @@ type HCLConfig struct {
 
 	// Sigstore contains sigstore specific configs.
 	Sigstore *sigstore.HCLConfig `hcl:"sigstore,omitempty"`
+
+	UnusedKeyPositions map[string][]hcltoken.Pos `hcl:",unusedKeyPositions"`
 }
 
 // k8sConfig holds the configuration distilled from HCL
@@ -166,6 +169,8 @@ func (p *Plugin) buildConfig(coreConfig catalog.CoreConfig, hclText string, stat
 		status.ReportErrorf("unable to decode configuration: %v", err)
 		return nil
 	}
+
+	pluginconf.ReportUnusedKeys(status, newConfig.UnusedKeyPositions)
 
 	// Determine max poll attempts with default
 	maxPollAttempts := newConfig.MaxPollAttempts

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -680,6 +680,28 @@ func (s *Suite) TestConfigureWithSigstore() {
 			`,
 			expectedError: "unable to decode configuration",
 		},
+		{
+			name:        "stale experimental block is rejected",
+			trustDomain: "example.org",
+			hcl: `
+				    skip_kubelet_verification = true
+					experimental {
+						sigstore {
+							rekor_url = "https://rekor.sigstore.dev"
+						}
+					}
+			`,
+			expectedError: "unknown configurations detected: experimental",
+		},
+		{
+			name:        "unknown top-level key is rejected",
+			trustDomain: "example.org",
+			hcl: `
+				    skip_kubelet_verification = true
+					bogus_key = "value"
+			`,
+			expectedError: "unknown configurations detected: bogus_key",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/common/pluginconf/pluginconf.go
+++ b/pkg/common/pluginconf/pluginconf.go
@@ -2,13 +2,30 @@ package pluginconf
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
+	"github.com/hashicorp/hcl/hcl/token"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	configv1 "github.com/spiffe/spire-plugin-sdk/proto/spire/service/common/config/v1"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ReportUnusedKeys reports an error on s listing any keys present in
+// unused. If unused is empty, no error is reported.
+func ReportUnusedKeys(s *Status, unused map[string][]token.Pos) {
+	if len(unused) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(unused))
+	for k := range unused {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	s.ReportErrorf("unknown configurations detected: %s", strings.Join(keys, ","))
+}
 
 type Status struct {
 	notes []string


### PR DESCRIPTION
The k8s workload attestor previously decoded its HCL config without an `unusedKeyPositions` map, so unknown top-level keys were silently accepted. This adds `UnusedKeyPositions` to `HCLConfig` and reports an `unknown configurations detected: ...` error when any are found, matching the behavior of the docker workload attestor.

In particular, a stale `experimental { sigstore { ... } }` block left over from the sigstore promotion (#6901) is now rejected, giving operators a clear signal that the `sigstore` block needs to move to the top level of `plugin_data`.

This PR also extracts the duplicated unused-key reporting from the docker and k8s workload attestors and the `gcp_secretmanager` SVID store into a new shared `pluginconf.ReportUnusedKeys` helper and adds the missing `sigstore` row to the docker workload attestor configuration table, so its docs match the k8s workload attestor.