### PR TITLE
Add deprecation warning log markers

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -476,7 +476,10 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 
 	ac.UseSyncAuthorizedEntries = true
 	if c.Agent.Experimental.UseSyncAuthorizedEntries != nil {
-		ac.Log.Warn("The 'use_sync_authorized_entries' configuration is deprecated. The option to disable it will be removed in SPIRE 1.13.")
+		ac.Log.WithFields(logrus.Fields{
+			telemetry.Alert:     true,
+			telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+		}).Warn("The 'use_sync_authorized_entries' configuration is deprecated. The option to disable it will be removed in SPIRE 1.13.")
 		ac.UseSyncAuthorizedEntries = *c.Agent.Experimental.UseSyncAuthorizedEntries
 	}
 

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/workloadkey"
 	"github.com/spiffe/spire/pkg/common/log"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/assert"
@@ -871,6 +872,37 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 			test: func(t *testing.T, c *agent.Config) {
 				require.Nil(t, c)
+			},
+		},
+		{
+			msg: "use_sync_authorized_entries logs deprecation alert",
+			input: func(c *Config) {
+				useSyncAuthorizedEntries := false
+				c.Agent.Experimental.UseSyncAuthorizedEntries = &useSyncAuthorizedEntries
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "The 'use_sync_authorized_entries' configuration is deprecated. The option to disable it will be removed in SPIRE 1.13.",
+									Data: logrus.Fields{
+										telemetry.Alert:     "true",
+										telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+									},
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.False(t, c.UseSyncAuthorizedEntries)
 			},
 		},
 		{

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -804,7 +804,10 @@ func setBundleEndpointConfigProfile(config *bundleEndpointConfig, dataDir string
 		return nil
 
 	case config.Profile == nil:
-		log.Warn("Bundle endpoint is configured but has no profile set, using https_spiffe as default; please configure a profile explicitly. This will be fatal in a future release.")
+		log.WithFields(logrus.Fields{
+			telemetry.Alert:     true,
+			telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+		}).Warn("Bundle endpoint is configured but has no profile set, using https_spiffe as default; please configure a profile explicitly. This will be fatal in a future release.")
 		return nil
 	}
 

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -757,7 +757,10 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 	}
 
 	if c.Server.Experimental.SQLTransactionTimeout != "" {
-		sc.Log.Warn("experimental.sql_transaction_timeout is deprecated, use experimental.event_timeout instead")
+		sc.Log.WithFields(logrus.Fields{
+			telemetry.Alert:     true,
+			telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+		}).Warn("experimental.sql_transaction_timeout is deprecated, use experimental.event_timeout instead")
 		interval, err := time.ParseDuration(c.Server.Experimental.SQLTransactionTimeout)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse SQL transaction timeout interval: %w", err)
@@ -793,7 +796,10 @@ func setBundleEndpointConfigProfile(config *bundleEndpointConfig, dataDir string
 		return errors.New("either bundle endpoint 'acme' or 'profile' can be set, but not both")
 
 	case config.ACME != nil:
-		log.Warn("ACME configuration within the bundle_endpoint is deprecated. Please use ACME configuration as part of the https_web profile instead.")
+		log.WithFields(logrus.Fields{
+			telemetry.Alert:     true,
+			telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+		}).Warn("ACME configuration within the bundle_endpoint is deprecated. Please use ACME configuration as part of the https_web profile instead.")
 		federationConfig.BundleEndpoint.ACME = configToACMEConfig(config.ACME, dataDir)
 		return nil
 

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/log"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/pkg/server"
 	bundleClient "github.com/spiffe/spire/pkg/server/bundle/client"
 	"github.com/spiffe/spire/pkg/server/credtemplate"
@@ -731,6 +732,27 @@ func TestNewServerConfig(t *testing.T) {
 					},
 				}
 			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "ACME configuration within the bundle_endpoint is deprecated. Please use ACME configuration as part of the https_web profile instead.",
+									Data: logrus.Fields{
+										telemetry.Alert:     "true",
+										telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+									},
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
 			test: func(t *testing.T, c *server.Config) {
 				expectACME := &bundle.ACMEConfig{
 					DirectoryURL: "somepath.tt",
@@ -1216,6 +1238,27 @@ func TestNewServerConfig(t *testing.T) {
 			msg: "sql_transaction_timeout is correctly parsed",
 			input: func(c *Config) {
 				c.Server.Experimental.SQLTransactionTimeout = "1m"
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "experimental.sql_transaction_timeout is deprecated, use experimental.event_timeout instead",
+									Data: logrus.Fields{
+										telemetry.Alert:     "true",
+										telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+									},
+								},
+							})
+						})
+						return nil
+					},
+				}
 			},
 			test: func(t *testing.T, c *server.Config) {
 				require.Equal(t, time.Minute, c.EventTimeout)

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -712,6 +712,16 @@ func TestNewServerConfig(t *testing.T) {
 					},
 				}
 			},
+			logOptions: assertLogsContainEntries([]spiretest.LogEntry{
+				{
+					Level:   logrus.WarnLevel,
+					Message: "Bundle endpoint is configured but has no profile set, using https_spiffe as default; please configure a profile explicitly. This will be fatal in a future release.",
+					Data: logrus.Fields{
+						telemetry.Alert:     "true",
+						telemetry.AlertType: telemetry.DeprecatedConfigAlertType,
+					},
+				},
+			}),
 			test: func(t *testing.T, c *server.Config) {
 				require.Equal(t, "192.168.1.1", c.Federation.BundleEndpoint.Address.IP.String())
 				require.Equal(t, 1337, c.Federation.BundleEndpoint.Address.Port)

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -47,6 +47,10 @@ SPIRE cannot make any guarantees around configuration or behavior compatibility 
 
 When a breaking change is introduced to a plugin interface, existing plugins compiled against the old interface will still continue to function for one minor version release cycle to give operators time to adopt requisite changes. SPIRE will log warnings to make operators aware of the change.
 
+#### Deprecation Log Markers
+
+Deprecation warnings include structured fields to make them easier to find and alert on. All deprecation alerts include `alert=true`. Configuration deprecation warnings include `alert_type=deprecated_config`, and deprecated plugin service warnings include `alert_type=deprecated_service`.
+
 ## Supported Upgrade Paths
 
 The supported version skew between SPIRE Servers and agents has implications on the order in which they must be upgraded. SPIRE Servers must be upgraded before SPIRE Agents, and is limited to a jump of at most one minor version (regardless of patch version). Upgrades that jump two or more minor versions (e.g. 1.1.1 to 1.3.0) are not supported.

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -47,10 +47,6 @@ SPIRE cannot make any guarantees around configuration or behavior compatibility 
 
 When a breaking change is introduced to a plugin interface, existing plugins compiled against the old interface will still continue to function for one minor version release cycle to give operators time to adopt requisite changes. SPIRE will log warnings to make operators aware of the change.
 
-#### Deprecation Log Markers
-
-Deprecation warnings include structured fields to make them easier to find and alert on. All deprecation alerts include `alert=true`. Configuration deprecation warnings include `alert_type=deprecated_config`, and deprecated plugin service warnings include `alert_type=deprecated_service`.
-
 ## Supported Upgrade Paths
 
 The supported version skew between SPIRE Servers and agents has implications on the order in which they must be upgraded. SPIRE Servers must be upgraded before SPIRE Agents, and is limited to a jump of at most one minor version (regardless of patch version). Upgrades that jump two or more minor versions (e.g. 1.1.1 to 1.3.0) are not supported.

--- a/pkg/common/catalog/catalog_test.go
+++ b/pkg/common/catalog/catalog_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/catalog/testplugin"
 	"github.com/spiffe/spire/pkg/common/plugin"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,6 +197,26 @@ func testPlugin(t *testing.T, pluginPath string) {
 		testLoad(t, pluginPath, loadTest{
 			expectPluginClient:  true,
 			expectServiceClient: true,
+		})
+	})
+	t.Run("deprecated service logs alert", func(t *testing.T) {
+		testLoad(t, pluginPath, loadTest{
+			mutateServiceRepo: func(serviceRepo *ServiceRepo) {
+				serviceRepo.versions = []catalog.Version{SomeServiceVersion{deprecated: true}}
+			},
+			expectPluginClient:  true,
+			expectServiceClient: true,
+			expectLogEntries: []spiretest.LogEntry{
+				{
+					Level:   logrus.WarnLevel,
+					Message: "Service is deprecated and will be removed in a future release",
+					Data: logrus.Fields{
+						telemetry.Alert:                 "true",
+						telemetry.AlertType:             telemetry.DeprecatedServiceAlertType,
+						telemetry.DeprecatedServiceName: SomeServiceVersion{}.New().GRPCServiceName(),
+					},
+				},
+			},
 		})
 	})
 	t.Run("unknown type", func(t *testing.T) {

--- a/pkg/common/catalog/plugin.go
+++ b/pkg/common/catalog/plugin.go
@@ -155,7 +155,11 @@ func (p *pluginImpl) bindRepo(repo bindableServiceRepo, grpcServiceNames map[str
 
 func warnIfDeprecated(log logrus.FieldLogger, thisVersion, latestVersion Version) {
 	if thisVersion.Deprecated() {
-		log = log.WithField(telemetry.DeprecatedServiceName, thisVersion.New().GRPCServiceName())
+		log = log.WithFields(logrus.Fields{
+			telemetry.Alert:                 true,
+			telemetry.AlertType:             telemetry.DeprecatedServiceAlertType,
+			telemetry.DeprecatedServiceName: thisVersion.New().GRPCServiceName(),
+		})
 		if !latestVersion.Deprecated() {
 			log = log.WithField(telemetry.PreferredServiceName, latestVersion.New().GRPCServiceName())
 		}

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -14,6 +14,12 @@ const (
 	// should be used with other tags to add clarity
 	Activate = "activate"
 
+	// Alert tags log events that should be easy for operators to alert on.
+	Alert = "alert"
+
+	// AlertType tags the category of an alert log event.
+	AlertType = "alert_type"
+
 	// Append functionality related to appending some element (such as part of a bundle);
 	// should be used with other tags to add clarity
 	Append = "append"
@@ -21,6 +27,12 @@ const (
 	// Attest functionality related to attesting; should be used with other tags
 	// to add clarity
 	Attest = "attest"
+
+	// DeprecatedConfigAlertType tags alerts for deprecated configuration settings.
+	DeprecatedConfigAlertType = "deprecated_config"
+
+	// DeprecatedServiceAlertType tags alerts for deprecated plugin services.
+	DeprecatedServiceAlertType = "deprecated_service"
 
 	// Create functionality related to creating some entity; should be used with other tags
 	// to add clarity

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -13,13 +13,6 @@ const (
 	// Activate functionality related to activating some element (such as X509 CA manager);
 	// should be used with other tags to add clarity
 	Activate = "activate"
-
-	// Alert tags log events that should be easy for operators to alert on.
-	Alert = "alert"
-
-	// AlertType tags the category of an alert log event.
-	AlertType = "alert_type"
-
 	// Append functionality related to appending some element (such as part of a bundle);
 	// should be used with other tags to add clarity
 	Append = "append"
@@ -27,13 +20,6 @@ const (
 	// Attest functionality related to attesting; should be used with other tags
 	// to add clarity
 	Attest = "attest"
-
-	// DeprecatedConfigAlertType tags alerts for deprecated configuration settings.
-	DeprecatedConfigAlertType = "deprecated_config"
-
-	// DeprecatedServiceAlertType tags alerts for deprecated plugin services.
-	DeprecatedServiceAlertType = "deprecated_service"
-
 	// Create functionality related to creating some entity; should be used with other tags
 	// to add clarity
 	Create = "create"
@@ -271,6 +257,18 @@ const (
 
 	// DatabaseType labels a database type (MySQL, postgres...)
 	DatabaseType = "db_type"
+
+	// Alert tags log events that should be easy for operators to alert on.
+	Alert = "alert"
+
+	// AlertType tags the category of an alert log event.
+	AlertType = "alert_type"
+
+	// DeprecatedConfigAlertType tags alerts for deprecated configuration settings.
+	DeprecatedConfigAlertType = "deprecated_config"
+
+	// DeprecatedServiceAlertType tags alerts for deprecated plugin services.
+	DeprecatedServiceAlertType = "deprecated_service"
 
 	// DeprecatedServiceName tags the deprecated service name
 	DeprecatedServiceName = "deprecated_service_name"

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -13,6 +13,7 @@ const (
 	// Activate functionality related to activating some element (such as X509 CA manager);
 	// should be used with other tags to add clarity
 	Activate = "activate"
+
 	// Append functionality related to appending some element (such as part of a bundle);
 	// should be used with other tags to add clarity
 	Append = "append"
@@ -20,6 +21,7 @@ const (
 	// Attest functionality related to attesting; should be used with other tags
 	// to add clarity
 	Attest = "attest"
+
 	// Create functionality related to creating some entity; should be used with other tags
 	// to add clarity
 	Create = "create"


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Deprecation warning logs emitted by agent and server configuration handling, and deprecated plugin service binding.

**Description of change**

Adds structured alert fields to deprecation warnings so operators can reliably find and alert on them. Configuration deprecation warnings now include `alert=true` and `alert_type=deprecated_config`; deprecated plugin service warnings include `alert=true` and `alert_type=deprecated_service`.

The upgrade guide documents these fields, and focused tests cover the affected warning sites.

**Which issue this PR fixes**

fixes #5905