### PR TITLE
Suppress RPC metrics for agent health check loopback calls

### DIFF
--- a/pkg/agent/endpoints/endpoints_test.go
+++ b/pkg/agent/endpoints/endpoints_test.go
@@ -89,13 +89,9 @@ func TestEndpoints(t *testing.T) {
 				{Type: fakemetrics.IncrCounterType, Key: []string{"workload_api", "connection"}, Val: 1},
 				{Type: fakemetrics.SetGaugeType, Key: []string{"workload_api", "connections"}, Val: 1},
 				{Type: fakemetrics.SetGaugeType, Key: []string{"workload_api", "connections"}, Val: 0},
-				// Call counter
-				{Type: fakemetrics.IncrCounterWithLabelsType, Key: []string{"rpc", "workload_api", "fetch_jwtsvid"}, Val: 1, Labels: []metrics.Label{
-					{Name: "status", Value: "OK"},
-				}},
-				{Type: fakemetrics.MeasureSinceWithLabelsType, Key: []string{"rpc", "workload_api", "fetch_jwtsvid", "elapsed_time"}, Val: 0, Labels: []metrics.Label{
-					{Name: "status", Value: "OK"},
-				}},
+				// RPC call counter is intentionally not emitted: the caller
+				// PID matches the agent PID (os.Getpid()), so the middleware
+				// discards per-call metrics to avoid health-check noise.
 			},
 		},
 		{
@@ -116,13 +112,9 @@ func TestEndpoints(t *testing.T) {
 				{Type: fakemetrics.IncrCounterType, Key: []string{"sds_api", "connection"}, Val: 1},
 				{Type: fakemetrics.SetGaugeType, Key: []string{"sds_api", "connections"}, Val: 1},
 				{Type: fakemetrics.SetGaugeType, Key: []string{"sds_api", "connections"}, Val: 0},
-				// Call counter
-				{Type: fakemetrics.IncrCounterWithLabelsType, Key: []string{"rpc", "sds", "v3", "fetch_secrets"}, Val: 1, Labels: []metrics.Label{
-					{Name: "status", Value: "OK"},
-				}},
-				{Type: fakemetrics.MeasureSinceWithLabelsType, Key: []string{"rpc", "sds", "v3", "fetch_secrets", "elapsed_time"}, Val: 0, Labels: []metrics.Label{
-					{Name: "status", Value: "OK"},
-				}},
+				// RPC call counter is intentionally not emitted: the caller
+				// PID matches the agent PID (os.Getpid()), so the middleware
+				// discards per-call metrics to avoid health-check noise.
 			},
 		},
 		{

--- a/pkg/agent/endpoints/metrics_test.go
+++ b/pkg/agent/endpoints/metrics_test.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -11,10 +12,13 @@ import (
 	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	debugv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/debug/v1"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 
 	"github.com/spiffe/spire/test/fakes/fakemetrics"
 	"github.com/spiffe/spire/test/grpctest"
@@ -143,6 +147,99 @@ func assertNoMisconfigurationLog(t *testing.T, hook *test.Hook) {
 	}
 }
 
+// TestAgentCallMetricsDiscarded verifies that RPC metrics are NOT emitted
+// when the caller is the agent itself (health check loopback), but ARE
+// emitted for external callers.
+// Regression test for https://github.com/spiffe/spire/issues/5335
+func TestAgentCallMetricsDiscarded(t *testing.T) {
+	workloadAPICtx := metadata.NewOutgoingContext(context.Background(),
+		metadata.Pairs("workload.spiffe.io", "true"))
+
+	t.Run("agent PID suppresses RPC metrics", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		metrics := fakemetrics.New()
+
+		server := grpctest.StartServer(t,
+			func(s grpc.ServiceRegistrar) {
+				workload_pb.RegisterSpiffeWorkloadAPIServer(s, &workload_pb.UnimplementedSpiffeWorkloadAPIServer{})
+			},
+			grpctest.Middleware(Middleware(log, metrics)),
+			grpctest.OverrideContext(func(ctx context.Context) context.Context {
+				return peer.NewContext(ctx, &peer.Peer{
+					AuthInfo: peertracker.AuthInfo{
+						Watcher: fakeWatcherWithPID(os.Getpid()),
+					},
+				})
+			}),
+		)
+
+		conn := server.NewGRPCClient(t)
+		client := workload_pb.NewSpiffeWorkloadAPIClient(conn)
+		_, _ = client.FetchJWTSVID(workloadAPICtx, &workload_pb.JWTSVIDRequest{})
+
+		for _, m := range metrics.AllMetrics() {
+			if m.Type == fakemetrics.IncrCounterWithLabelsType || m.Type == fakemetrics.MeasureSinceWithLabelsType {
+				assert.Fail(t, "RPC metrics should not be emitted for agent PID calls", "got metric: %v", m.Key)
+			}
+		}
+	})
+
+	t.Run("non-agent PID emits RPC metrics", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		metrics := fakemetrics.New()
+
+		server := grpctest.StartServer(t,
+			func(s grpc.ServiceRegistrar) {
+				workload_pb.RegisterSpiffeWorkloadAPIServer(s, &workload_pb.UnimplementedSpiffeWorkloadAPIServer{})
+			},
+			grpctest.Middleware(Middleware(log, metrics)),
+			grpctest.OverrideContext(func(ctx context.Context) context.Context {
+				return peer.NewContext(ctx, &peer.Peer{
+					AuthInfo: peertracker.AuthInfo{
+						Watcher: fakeWatcherWithPID(os.Getpid() + 1),
+					},
+				})
+			}),
+		)
+
+		conn := server.NewGRPCClient(t)
+		client := workload_pb.NewSpiffeWorkloadAPIClient(conn)
+		_, _ = client.FetchJWTSVID(workloadAPICtx, &workload_pb.JWTSVIDRequest{})
+
+		var foundRPCCounter bool
+		for _, m := range metrics.AllMetrics() {
+			if m.Type == fakemetrics.IncrCounterWithLabelsType && len(m.Key) > 0 && m.Key[0] == "rpc" {
+				foundRPCCounter = true
+			}
+		}
+		assert.True(t, foundRPCCounter, "RPC metrics should be emitted for non-agent PID calls")
+	})
+
+	t.Run("no peertracker emits RPC metrics", func(t *testing.T) {
+		log, _ := test.NewNullLogger()
+		metrics := fakemetrics.New()
+
+		server := grpctest.StartServer(t,
+			func(s grpc.ServiceRegistrar) {
+				workload_pb.RegisterSpiffeWorkloadAPIServer(s, &workload_pb.UnimplementedSpiffeWorkloadAPIServer{})
+			},
+			grpctest.Middleware(Middleware(log, metrics)),
+		)
+
+		conn := server.NewGRPCClient(t)
+		client := workload_pb.NewSpiffeWorkloadAPIClient(conn)
+		_, _ = client.FetchJWTSVID(workloadAPICtx, &workload_pb.JWTSVIDRequest{})
+
+		var foundRPCCounter bool
+		for _, m := range metrics.AllMetrics() {
+			if m.Type == fakemetrics.IncrCounterWithLabelsType && len(m.Key) > 0 && m.Key[0] == "rpc" {
+				foundRPCCounter = true
+			}
+		}
+		assert.True(t, foundRPCCounter, "RPC metrics should be emitted when no peertracker is present")
+	})
+}
+
 type fakeDebugServer struct {
 	debugv1.UnimplementedDebugServer
 }
@@ -150,3 +247,9 @@ type fakeDebugServer struct {
 type fakeDelegatedIdentityServer struct {
 	delegatedidentityv1.UnimplementedDelegatedIdentityServer
 }
+
+type fakeWatcherWithPID int
+
+func (w fakeWatcherWithPID) Close()         {}
+func (w fakeWatcherWithPID) IsAlive() error { return nil }
+func (w fakeWatcherWithPID) PID() int32     { return int32(w) }

--- a/pkg/agent/endpoints/middleware.go
+++ b/pkg/agent/endpoints/middleware.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ func Middleware(log logrus.FieldLogger, metrics telemetry.Metrics) middleware.Mi
 		withPerServiceConnectionMetrics(metrics),
 		middleware.Preprocess(addWatcherPID),
 		middleware.Preprocess(verifySecurityHeader),
+		middleware.Postprocess(discardAgentCallMetrics),
 	)
 }
 
@@ -52,4 +54,17 @@ func isWorkloadAPIMethod(fullMethod string) bool {
 func hasSecurityHeader(ctx context.Context) bool {
 	md, ok := metadata.FromIncomingContext(ctx)
 	return ok && len(md["workload.spiffe.io"]) == 1 && md["workload.spiffe.io"][0] == "true"
+}
+
+// discardAgentCallMetrics prevents RPC metrics from being emitted for calls
+// made by the agent itself (e.g. health check loopback calls to the Workload
+// API). This runs in Postprocess before the metrics middleware finalizes the
+// call counter, so discarding here prevents the counter from emitting.
+func discardAgentCallMetrics(ctx context.Context, _ string, _ bool, _ error) {
+	watcher, ok := peertracker.WatcherFromContext(ctx)
+	if ok && int(watcher.PID()) == os.Getpid() {
+		if counter, ok := rpccontext.CallCounter(ctx).(*telemetry.CallCounter); ok {
+			counter.Discard()
+		}
+	}
 }

--- a/pkg/common/telemetry/call.go
+++ b/pkg/common/telemetry/call.go
@@ -51,6 +51,13 @@ func (c *CallCounter) AddLabel(name, value string) {
 	c.mu.Unlock()
 }
 
+// Discard marks the call counter as done without emitting any metrics.
+// This is used to silently drop metrics for calls that should not be
+// tracked (e.g. the agent's own health check loopback calls).
+func (c *CallCounter) Discard() {
+	c.done = true
+}
+
 // Done finishes the "call" and emits metrics. No other calls to the CallCounter
 // should be done during or after the call to Done. In other words, it is not
 // thread-safe and is intended to be the final call to the CallCounter struct.


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Agent RPC metrics for Workload API calls made by the agent's own health check (both the gRPC Health/Check service and the HTTP `/ready` `/live` endpoints). These internal loopback calls no longer emit per-call RPC metrics (counter and elapsed_time). Connection metrics are unaffected. Metrics for calls from real workloads are unaffected.

**Description of change**

- Added `Discard()` method to `telemetry.CallCounter` that marks the counter as done without emitting metrics
- Added `discardAgentCallMetrics` postprocess middleware step in the agent endpoint middleware chain that checks the caller PID via peertracker; when the caller is the agent itself, the RPC call counter is discarded
- Updated existing integration tests to reflect that agent-PID calls no longer emit RPC metrics
- Added regression test `TestAgentCallMetricsDiscarded` with three cases: agent PID (suppressed), non-agent PID (emitted), and no peertracker (emitted)

**Which issue this PR fixes**

Fixes #5335