### PR TITLE
datastore: add DataConsistency param to FetchRegistrationEntries and FetchAttestedNode

### DIFF
--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -125,10 +125,10 @@ func (w metricsWrapper) DeleteRegistrationEntryEventForTesting(ctx context.Conte
 	return w.ds.DeleteRegistrationEntryEventForTesting(ctx, eventID)
 }
 
-func (w metricsWrapper) FetchAttestedNode(ctx context.Context, spiffeID string) (_ *common.AttestedNode, err error) {
+func (w metricsWrapper) FetchAttestedNode(ctx context.Context, spiffeID string, dataConsistency datastore.DataConsistency) (_ *common.AttestedNode, err error) {
 	callCounter := StartFetchNodeCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.FetchAttestedNode(ctx, spiffeID)
+	return w.ds.FetchAttestedNode(ctx, spiffeID, dataConsistency)
 }
 
 func (w metricsWrapper) FetchAttestedNodeEvent(ctx context.Context, eventID uint) (_ *datastore.AttestedNodeEvent, err error) {
@@ -155,10 +155,10 @@ func (w metricsWrapper) FetchRegistrationEntry(ctx context.Context, entryID stri
 	return w.ds.FetchRegistrationEntry(ctx, entryID)
 }
 
-func (w metricsWrapper) FetchRegistrationEntries(ctx context.Context, entryIDs []string) (_ map[string]*common.RegistrationEntry, err error) {
+func (w metricsWrapper) FetchRegistrationEntries(ctx context.Context, entryIDs []string, dataConsistency datastore.DataConsistency) (_ map[string]*common.RegistrationEntry, err error) {
 	callCounter := StartFetchRegistrationCall(w.m)
 	defer callCounter.Done(&err)
-	return w.ds.FetchRegistrationEntries(ctx, entryIDs)
+	return w.ds.FetchRegistrationEntries(ctx, entryIDs, dataConsistency)
 }
 
 func (w metricsWrapper) FetchRegistrationEntryEvent(ctx context.Context, eventID uint) (_ *datastore.RegistrationEntryEvent, err error) {

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -420,7 +420,7 @@ func (ds *fakeDataStore) DeleteRegistrationEntryEventForTesting(context.Context,
 	return ds.err
 }
 
-func (ds *fakeDataStore) FetchAttestedNode(context.Context, string) (*common.AttestedNode, error) {
+func (ds *fakeDataStore) FetchAttestedNode(context.Context, string, datastore.DataConsistency) (*common.AttestedNode, error) {
 	return &common.AttestedNode{}, ds.err
 }
 
@@ -444,7 +444,7 @@ func (ds *fakeDataStore) FetchRegistrationEntry(context.Context, string) (*commo
 	return &common.RegistrationEntry{}, ds.err
 }
 
-func (ds *fakeDataStore) FetchRegistrationEntries(context.Context, []string) (map[string]*common.RegistrationEntry, error) {
+func (ds *fakeDataStore) FetchRegistrationEntries(context.Context, []string, datastore.DataConsistency) (map[string]*common.RegistrationEntry, error) {
 	return map[string]*common.RegistrationEntry{}, ds.err
 }
 

--- a/pkg/server/api/agent/v1/service.go
+++ b/pkg/server/api/agent/v1/service.go
@@ -207,7 +207,7 @@ func (s *Service) GetAgent(ctx context.Context, req *agentv1.GetAgentRequest) (*
 	rpccontext.AddRPCAuditFields(ctx, logrus.Fields{telemetry.SPIFFEID: agentID.String()})
 
 	log = log.WithField(telemetry.SPIFFEID, agentID.String())
-	attestedNode, err := s.ds.FetchAttestedNode(ctx, agentID.String())
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, agentID.String(), datastore.RequireCurrent)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.Internal, "failed to fetch agent", err)
 	}
@@ -357,7 +357,7 @@ func (s *Service) AttestAgent(stream agentv1.Agent_AttestAgentServer) error {
 	}
 
 	// fetch the agent/node to check if it was already attested or banned
-	attestedNode, err := s.ds.FetchAttestedNode(ctx, agentID.String())
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, agentID.String(), datastore.RequireCurrent)
 	if err != nil {
 		return api.MakeErr(log, codes.Internal, "failed to fetch agent", err)
 	}
@@ -434,7 +434,7 @@ func (s *Service) RenewAgent(ctx context.Context, req *agentv1.RenewAgentRequest
 		return nil, api.MakeErr(log, codes.Internal, "caller ID missing from request context", nil)
 	}
 
-	attestedNode, err := s.ds.FetchAttestedNode(ctx, callerID.String())
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, callerID.String(), datastore.RequireCurrent)
 	if err != nil {
 		return nil, api.MakeErr(log, codes.Internal, "failed to fetch agent", err)
 	}

--- a/pkg/server/api/agent/v1/service_test.go
+++ b/pkg/server/api/agent/v1/service_test.go
@@ -1191,7 +1191,7 @@ func TestBanAgent(t *testing.T) {
 			if tt.expectCode != codes.OK {
 				require.Nil(t, banResp)
 
-				attestedNode, err := test.ds.FetchAttestedNode(ctx, node.SpiffeId)
+				attestedNode, err := test.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.RequireCurrent)
 				require.NoError(t, err)
 				require.NotNil(t, attestedNode)
 				require.NotZero(t, attestedNode.CertSerialNumber)
@@ -1202,7 +1202,7 @@ func TestBanAgent(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, banResp)
 
-			attestedNode, err := test.ds.FetchAttestedNode(ctx, idutil.RequireIDProtoString(tt.reqID))
+			attestedNode, err := test.ds.FetchAttestedNode(ctx, idutil.RequireIDProtoString(tt.reqID), datastore.RequireCurrent)
 			require.NoError(t, err)
 			require.NotNil(t, attestedNode)
 
@@ -1425,7 +1425,7 @@ func TestDeleteAgent(t *testing.T) {
 				spiretest.RequireGRPCStatus(t, err, tt.code, tt.err)
 
 				// Verify node was not deleted
-				attestedNode, err := test.ds.FetchAttestedNode(ctx, node1.SpiffeId)
+				attestedNode, err := test.ds.FetchAttestedNode(ctx, node1.SpiffeId, datastore.RequireCurrent)
 				require.NoError(t, err)
 				require.NotNil(t, attestedNode)
 
@@ -1437,7 +1437,7 @@ func TestDeleteAgent(t *testing.T) {
 
 			id := idutil.RequireIDFromProto(tt.req.Id)
 
-			attestedNode, err := test.ds.FetchAttestedNode(ctx, id.String())
+			attestedNode, err := test.ds.FetchAttestedNode(ctx, id.String(), datastore.RequireCurrent)
 			require.NoError(t, err)
 			require.Nil(t, attestedNode)
 		})
@@ -2044,7 +2044,7 @@ func TestRenewAgent(t *testing.T) {
 			require.Equal(t, []*url.URL{agentID.URL()}, x509Svid.URIs)
 
 			// Validate attested node in datastore
-			updatedNode, err := test.ds.FetchAttestedNode(ctx, agentID.String())
+			updatedNode, err := test.ds.FetchAttestedNode(ctx, agentID.String(), datastore.RequireCurrent)
 			require.NoError(t, err)
 			require.NotNil(t, updatedNode)
 			expectedNode := tt.createNode
@@ -2170,7 +2170,7 @@ func TestPostStatus(t *testing.T) {
 					require.NotNil(t, resp)
 
 					// Verify the agent version was updated in the datastore
-					node, err := test.ds.FetchAttestedNode(context.Background(), agentID.String())
+					node, err := test.ds.FetchAttestedNode(context.Background(), agentID.String(), datastore.RequireCurrent)
 					require.NoError(t, err)
 					require.NotNil(t, node)
 					require.Equal(t, tt.expectVersion, node.AgentVersion)
@@ -3503,7 +3503,7 @@ func (s *serviceTest) assertAttestAgentResult(t *testing.T, expectedID spiffeid.
 }
 
 func (s *serviceTest) assertAgentWasStored(t *testing.T, expectedID string, expectedSelectors []*common.Selector, expectedVersion string, agentSpiffeIdAsSelector bool) {
-	attestedAgent, err := s.ds.FetchAttestedNode(ctx, expectedID)
+	attestedAgent, err := s.ds.FetchAttestedNode(ctx, expectedID, datastore.RequireCurrent)
 	require.NoError(t, err)
 	require.NotNil(t, attestedAgent)
 	require.Equal(t, expectedID, attestedAgent.SpiffeId)

--- a/pkg/server/cache/nodecache/cache.go
+++ b/pkg/server/cache/nodecache/cache.go
@@ -68,7 +68,7 @@ func (c *Cache) LookupAttestedNode(id string) (*common.AttestedNode, time.Time) 
 }
 
 func (c *Cache) FetchAttestedNode(ctx context.Context, id string) (*common.AttestedNode, error) {
-	node, err := c.ds.FetchAttestedNode(ctx, id)
+	node, err := c.ds.FetchAttestedNode(ctx, id, datastore.RequireCurrent)
 	if err != nil {
 		c.RemoveAttestedNode(id)
 		return nil, err

--- a/pkg/server/datastore/datastore.go
+++ b/pkg/server/datastore/datastore.go
@@ -35,7 +35,7 @@ type DataStore interface {
 	CreateOrReturnRegistrationEntry(context.Context, *common.RegistrationEntry) (*common.RegistrationEntry, bool, error)
 	DeleteRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
 	FetchRegistrationEntry(ctx context.Context, entryID string) (*common.RegistrationEntry, error)
-	FetchRegistrationEntries(ctx context.Context, entryIDs []string) (map[string]*common.RegistrationEntry, error)
+	FetchRegistrationEntries(ctx context.Context, entryIDs []string, dataConsistency DataConsistency) (map[string]*common.RegistrationEntry, error)
 	ListRegistrationEntries(context.Context, *ListRegistrationEntriesRequest) (*ListRegistrationEntriesResponse, error)
 	PruneRegistrationEntries(ctx context.Context, expiresBefore time.Time) error
 	UpdateRegistrationEntry(context.Context, *common.RegistrationEntry, *common.RegistrationEntryMask) (*common.RegistrationEntry, error)
@@ -51,7 +51,7 @@ type DataStore interface {
 	CountAttestedNodes(context.Context, *CountAttestedNodesRequest) (int32, error)
 	CreateAttestedNode(context.Context, *common.AttestedNode) (*common.AttestedNode, error)
 	DeleteAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error)
-	FetchAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error)
+	FetchAttestedNode(ctx context.Context, spiffeID string, dataConsistency DataConsistency) (*common.AttestedNode, error)
 	ListAttestedNodes(context.Context, *ListAttestedNodesRequest) (*ListAttestedNodesResponse, error)
 	UpdateAttestedNode(context.Context, *common.AttestedNode, *common.AttestedNodeMask) (*common.AttestedNode, error)
 	PruneAttestedExpiredNodes(ctx context.Context, expiredBefore time.Time, includeNonReattestable bool) error

--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -307,14 +307,13 @@ func (ds *Plugin) CreateAttestedNode(ctx context.Context, node *common.AttestedN
 }
 
 // FetchAttestedNode fetches an existing attested node by SPIFFE ID
-func (ds *Plugin) FetchAttestedNode(ctx context.Context, spiffeID string) (attestedNode *common.AttestedNode, err error) {
-	if err = ds.withReadTx(ctx, func(tx *gorm.DB) (err error) {
-		attestedNode, err = fetchAttestedNode(tx, spiffeID)
-		return err
-	}); err != nil {
-		return nil, err
+func (ds *Plugin) FetchAttestedNode(ctx context.Context, spiffeID string,
+	dataConsistency datastore.DataConsistency,
+) (*common.AttestedNode, error) {
+	if dataConsistency == datastore.TolerateStale && ds.roDb != nil {
+		return fetchAttestedNode(ctx, ds.roDb, spiffeID)
 	}
-	return attestedNode, nil
+	return fetchAttestedNode(ctx, ds.db, spiffeID)
 }
 
 // CountAttestedNodes counts all attested nodes
@@ -523,8 +522,11 @@ func (ds *Plugin) FetchRegistrationEntry(ctx context.Context,
 
 // FetchRegistrationEntries fetches existing registrations by entry IDs
 func (ds *Plugin) FetchRegistrationEntries(ctx context.Context,
-	entryIDs []string,
+	entryIDs []string, dataConsistency datastore.DataConsistency,
 ) (map[string]*common.RegistrationEntry, error) {
+	if dataConsistency == datastore.TolerateStale && ds.roDb != nil {
+		return fetchRegistrationEntries(ctx, ds.roDb, entryIDs)
+	}
 	return fetchRegistrationEntries(ctx, ds.db, entryIDs)
 }
 
@@ -1633,7 +1635,13 @@ func createAttestedNode(tx *gorm.DB, node *common.AttestedNode) (*common.Atteste
 	return modelToAttestedNode(model), nil
 }
 
-func fetchAttestedNode(tx *gorm.DB, spiffeID string) (*common.AttestedNode, error) {
+func fetchAttestedNode(ctx context.Context, db *sqlDB, spiffeID string) (*common.AttestedNode, error) {
+	tx := db.BeginTx(ctx, nil)
+	if err := tx.Error; err != nil {
+		return nil, newWrappedSQLError(err)
+	}
+	defer tx.Rollback()
+
 	var model AttestedNode
 	err := tx.Find(&model, "spiffe_id = ?", spiffeID).Error
 	switch {

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -930,6 +930,41 @@ func (s *PluginSuite) TestFetchAttestedNodeMissing() {
 	s.Require().Nil(attestedNode)
 }
 
+func (s *PluginSuite) TestFetchAttestedNode_TolerateStale() {
+	node := &common.AttestedNode{
+		SpiffeId:            "spiffe://example.org/TolerateStale",
+		AttestationDataType: "aws-tag",
+		CertSerialNumber:    "badcafe",
+		CertNotAfter:        time.Now().Add(time.Hour).Unix(),
+	}
+
+	// Create the attested node and verify it exists on the primary.
+	createdNode, err := s.ds.CreateAttestedNode(ctx, node)
+	s.Require().NoError(err)
+	s.AssertProtoEqual(node, createdNode)
+
+	// Replica should eventually reflect the created node.
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		fetchedNode, err := s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.TolerateStale)
+		require.NoError(collect, err)
+		assert.True(collect, spiretest.CheckProtoEqual(s.T(), node, fetchedNode))
+	}, time.Second, 10*time.Millisecond)
+
+	// Delete the node and verify it is gone on the primary.
+	_, err = s.ds.DeleteAttestedNode(ctx, node.SpiffeId)
+	s.Require().NoError(err)
+	deletedNode, err := s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.RequireCurrent)
+	s.Require().NoError(err)
+	s.Nil(deletedNode)
+
+	// Replica should eventually reflect the deletion.
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		fetchedNode, err := s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.TolerateStale)
+		require.NoError(collect, err)
+		assert.Nil(collect, fetchedNode)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func (s *PluginSuite) TestListAttestedNodes() {
 	// Connection is never used, each test creates a connection to a different database
 	s.ds.Close()
@@ -2335,6 +2370,44 @@ func (s *PluginSuite) TestFetchRegistrationEntries() {
 			s.Require().False(ok)
 		})
 	}
+}
+
+func (s *PluginSuite) TestFetchRegistrationEntries_TolerateStale() {
+	entry, err := s.ds.CreateRegistrationEntry(ctx, &common.RegistrationEntry{
+		Selectors: []*common.Selector{
+			{Type: "TolerateStale", Value: "true"},
+		},
+		SpiffeId: "spiffe://example.org/tolerate-stale",
+		ParentId: "spiffe://example.org/parent",
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(entry)
+
+	// Replica should eventually reflect the created entry.
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		fetched, err := s.ds.FetchRegistrationEntries(ctx, []string{entry.EntryId}, datastore.TolerateStale)
+		require.NoError(collect, err)
+		fetchedEntry, ok := fetched[entry.EntryId]
+		assert.True(collect, ok)
+		assert.True(collect, spiretest.CheckProtoEqual(s.T(), entry, fetchedEntry))
+	}, time.Second, 10*time.Millisecond)
+
+	// Delete the entry and verify it is gone on the primary.
+	deletedEntry, err := s.ds.DeleteRegistrationEntry(ctx, entry.EntryId)
+	s.Require().NoError(err)
+	s.Require().NotNil(deletedEntry)
+	primary, err := s.ds.FetchRegistrationEntries(ctx, []string{entry.EntryId}, datastore.RequireCurrent)
+	s.Require().NoError(err)
+	_, ok := primary[entry.EntryId]
+	s.Require().False(ok)
+
+	// Replica should eventually reflect the deletion.
+	s.EventuallyWithT(func(collect *assert.CollectT) {
+		fetched, err := s.ds.FetchRegistrationEntries(ctx, []string{entry.EntryId}, datastore.TolerateStale)
+		require.NoError(collect, err)
+		_, ok := fetched[entry.EntryId]
+		assert.False(collect, ok)
+	}, time.Second, 10*time.Millisecond)
 }
 
 func (s *PluginSuite) TestPruneRegistrationEntries() {

--- a/pkg/server/datastore/sqlstore/sqlstore_test.go
+++ b/pkg/server/datastore/sqlstore/sqlstore_test.go
@@ -919,13 +919,13 @@ func (s *PluginSuite) TestCreateAttestedNode() {
 	s.Require().NoError(err)
 	s.AssertProtoEqual(node, attestedNode)
 
-	attestedNode, err = s.ds.FetchAttestedNode(ctx, node.SpiffeId)
+	attestedNode, err = s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.RequireCurrent)
 	s.Require().NoError(err)
 	s.AssertProtoEqual(node, attestedNode)
 }
 
 func (s *PluginSuite) TestFetchAttestedNodeMissing() {
-	attestedNode, err := s.ds.FetchAttestedNode(ctx, "missing")
+	attestedNode, err := s.ds.FetchAttestedNode(ctx, "missing", datastore.RequireCurrent)
 	s.Require().NoError(err)
 	s.Require().Nil(attestedNode)
 }
@@ -1440,7 +1440,7 @@ func (s *PluginSuite) TestUpdateAttestedNode() {
 			s.RequireProtoEqual(tt.expUpdatedNode, updatedNode)
 
 			// Check a fresh fetch shows the updated attested node
-			attestedNode, err := s.ds.FetchAttestedNode(ctx, tt.updateNode.SpiffeId)
+			attestedNode, err := s.ds.FetchAttestedNode(ctx, tt.updateNode.SpiffeId, datastore.RequireCurrent)
 			s.Require().NoError(err)
 			s.Require().NotNil(attestedNode)
 			s.RequireProtoEqual(tt.expUpdatedNode, attestedNode)
@@ -1500,7 +1500,7 @@ func (s *PluginSuite) TestPruneAttestedExpiredNodes() {
 
 		// check that none of the nodes gets deleted
 		for _, node := range nodes {
-			attestedNode, err := s.ds.FetchAttestedNode(ctx, node.SpiffeId)
+			attestedNode, err := s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.RequireCurrent)
 			s.Require().NoError(err)
 			s.NotNil(attestedNode)
 		}
@@ -1511,12 +1511,12 @@ func (s *PluginSuite) TestPruneAttestedExpiredNodes() {
 		s.Require().NoError(err)
 
 		// check that the unexpired node is present
-		attestedValidNode, err := s.ds.FetchAttestedNode(ctx, nodes["valid"].SpiffeId)
+		attestedValidNode, err := s.ds.FetchAttestedNode(ctx, nodes["valid"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.NotNil(attestedValidNode)
 
 		// check that the expired node and its selectors have been deleted
-		attestedExpiredNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired"].SpiffeId)
+		attestedExpiredNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.Nil(attestedExpiredNode)
 
@@ -1525,12 +1525,12 @@ func (s *PluginSuite) TestPruneAttestedExpiredNodes() {
 		s.Nil(deletedExpiredNodeSelectors)
 
 		// check that the expired node, which is also non-reattestable, has not been deleted
-		attestedNotReattestableNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-non-reattestable"].SpiffeId)
+		attestedNotReattestableNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-non-reattestable"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.NotNil(attestedNotReattestableNode)
 
 		// check that the banned node has not been deleted, even if it is expired
-		attestedBannedNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-banned"].SpiffeId)
+		attestedBannedNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-banned"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.NotNil(attestedBannedNode)
 	})
@@ -1540,12 +1540,12 @@ func (s *PluginSuite) TestPruneAttestedExpiredNodes() {
 		s.Require().NoError(err)
 
 		// check that the valid node is still present
-		attestedValidNode, err := s.ds.FetchAttestedNode(ctx, nodes["valid"].SpiffeId)
+		attestedValidNode, err := s.ds.FetchAttestedNode(ctx, nodes["valid"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.NotNil(attestedValidNode)
 
 		// check that the expired non-reattestable node and its selectors have been deleled
-		attestedNotReattestableNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-non-reattestable"].SpiffeId)
+		attestedNotReattestableNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-non-reattestable"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.Nil(attestedNotReattestableNode)
 
@@ -1554,7 +1554,7 @@ func (s *PluginSuite) TestPruneAttestedExpiredNodes() {
 		s.Nil(deletedExpiredNonReattestableNodeSelectors)
 
 		// check that the banned node has not been deleted
-		attestedBannedNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-banned"].SpiffeId)
+		attestedBannedNode, err := s.ds.FetchAttestedNode(ctx, nodes["expired-banned"].SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.NotNil(attestedBannedNode)
 	})
@@ -1587,7 +1587,7 @@ func (s *PluginSuite) TestDeleteAttestedNode() {
 		s.Require().NoError(err)
 		s.AssertProtoEqual(entryFoo, deletedNode)
 
-		attestedNode, err := s.ds.FetchAttestedNode(ctx, entryFoo.SpiffeId)
+		attestedNode, err := s.ds.FetchAttestedNode(ctx, entryFoo.SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.Nil(attestedNode)
 	})
@@ -1617,7 +1617,7 @@ func (s *PluginSuite) TestDeleteAttestedNode() {
 		s.Require().NoError(err)
 		s.AssertProtoEqual(entryFoo, deletedNode)
 
-		attestedNode, err := s.ds.FetchAttestedNode(ctx, deletedNode.SpiffeId)
+		attestedNode, err := s.ds.FetchAttestedNode(ctx, deletedNode.SpiffeId, datastore.RequireCurrent)
 		s.Require().NoError(err)
 		s.Nil(attestedNode)
 
@@ -2319,7 +2319,7 @@ func (s *PluginSuite) TestFetchRegistrationEntries() {
 			for _, entry := range tt.entries {
 				entryIds = append(entryIds, entry.EntryId)
 			}
-			fetchedRegistrationEntries, err := s.ds.FetchRegistrationEntries(ctx, append(entryIds, tt.deletedEntryId))
+			fetchedRegistrationEntries, err := s.ds.FetchRegistrationEntries(ctx, append(entryIds, tt.deletedEntryId), datastore.RequireCurrent)
 			s.Require().NoError(err)
 
 			// Make sure all entries we want to fetch are present
@@ -5272,7 +5272,7 @@ func (s *PluginSuite) TestRace() {
 
 		_, err := s.ds.CreateAttestedNode(ctx, node)
 		require.NoError(t, err)
-		_, err = s.ds.FetchAttestedNode(ctx, node.SpiffeId)
+		_, err = s.ds.FetchAttestedNode(ctx, node.SpiffeId, datastore.RequireCurrent)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/server/endpoints/authorized_entryfetcher_attested_nodes.go
+++ b/pkg/server/endpoints/authorized_entryfetcher_attested_nodes.go
@@ -212,7 +212,7 @@ func (a *attestedNodes) updateCache(ctx context.Context) error {
 
 func (a *attestedNodes) updateCachedNodes(ctx context.Context) error {
 	for spiffeId := range a.fetchNodes {
-		node, err := a.ds.FetchAttestedNode(ctx, spiffeId)
+		node, err := a.ds.FetchAttestedNode(ctx, spiffeId, datastore.TolerateStale)
 		if err != nil {
 			continue
 		}

--- a/pkg/server/endpoints/authorized_entryfetcher_registration_entries.go
+++ b/pkg/server/endpoints/authorized_entryfetcher_registration_entries.go
@@ -226,7 +226,7 @@ func (a *registrationEntries) updateCachedEntries(ctx context.Context) error {
 	entryIds := slices.Collect(maps.Keys(a.fetchEntries))
 	for pageStart := 0; pageStart < len(entryIds); pageStart += int(a.pageSize) {
 		fetchEntries := a.fetchEntriesPage(entryIds, pageStart)
-		commonEntries, err := a.ds.FetchRegistrationEntries(ctx, fetchEntries)
+		commonEntries, err := a.ds.FetchRegistrationEntries(ctx, fetchEntries, datastore.TolerateStale)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/endpoints/middleware_test.go
+++ b/pkg/server/endpoints/middleware_test.go
@@ -288,7 +288,7 @@ func TestAgentAuthorizer(t *testing.T) {
 				require.Fail(t, "unexpected error code")
 			}
 
-			attestedNode, err := ds.FetchAttestedNode(context.Background(), tt.node.SpiffeId)
+			attestedNode, err := ds.FetchAttestedNode(context.Background(), tt.node.SpiffeId, datastore.RequireCurrent)
 			require.NoError(t, err)
 			spiretest.RequireProtoEqual(t, tt.expectedNode, attestedNode)
 		})

--- a/pkg/server/hostservice/agentstore/agentstore.go
+++ b/pkg/server/hostservice/agentstore/agentstore.go
@@ -60,7 +60,7 @@ func (v1 *agentStoreV1) GetAgentInfo(ctx context.Context, req *agentstorev1.GetA
 		return nil, err
 	}
 
-	attestedNode, err := deps.DataStore.FetchAttestedNode(ctx, req.AgentId)
+	attestedNode, err := deps.DataStore.FetchAttestedNode(ctx, req.AgentId, datastore.RequireCurrent)
 	if err != nil {
 		return nil, err
 	}

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -141,11 +141,11 @@ func (s *DataStore) CreateAttestedNode(ctx context.Context, node *common.Atteste
 	return s.ds.CreateAttestedNode(ctx, node)
 }
 
-func (s *DataStore) FetchAttestedNode(ctx context.Context, spiffeID string) (*common.AttestedNode, error) {
+func (s *DataStore) FetchAttestedNode(ctx context.Context, spiffeID string, dataConsistency datastore.DataConsistency) (*common.AttestedNode, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.FetchAttestedNode(ctx, spiffeID)
+	return s.ds.FetchAttestedNode(ctx, spiffeID, dataConsistency)
 }
 
 func (s *DataStore) ListAttestedNodes(ctx context.Context, req *datastore.ListAttestedNodesRequest) (*datastore.ListAttestedNodesResponse, error) {
@@ -293,11 +293,11 @@ func (s *DataStore) FetchRegistrationEntry(ctx context.Context, entryID string) 
 	return s.ds.FetchRegistrationEntry(ctx, entryID)
 }
 
-func (s *DataStore) FetchRegistrationEntries(ctx context.Context, entryIDs []string) (map[string]*common.RegistrationEntry, error) {
+func (s *DataStore) FetchRegistrationEntries(ctx context.Context, entryIDs []string, dataConsistency datastore.DataConsistency) (map[string]*common.RegistrationEntry, error) {
 	if err := s.getNextError(); err != nil {
 		return nil, err
 	}
-	return s.ds.FetchRegistrationEntries(ctx, entryIDs)
+	return s.ds.FetchRegistrationEntries(ctx, entryIDs, dataConsistency)
 }
 
 func (s *DataStore) ListRegistrationEntries(ctx context.Context, req *datastore.ListRegistrationEntriesRequest) (*datastore.ListRegistrationEntriesResponse, error) {


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Events-driven entry cache reload (`AuthorizedEntryFetcherEvents`): the step that fetches changed entry and node data after detecting events via `ListRegistrationEntryEvents` / `ListAttestedNodeEvents`.

**Description of change**

`FetchRegistrationEntries` and `FetchAttestedNode` had no `DataConsistency` parameter and always queried the primary database. This is inconsistent with the rest of the events-based cache reload path, where `ListRegistrationEntryEvents`, `ListAttestedNodeEvents`, and `GetNodeSelectors` already route to the read-only replica via `DataConsistency: TolerateStale`.

This PR adds a `dataConsistency DataConsistency` trailing parameter to both methods (matching the existing `GetNodeSelectors` convention) and routes to the replica when `TolerateStale` is passed and `roDb` is configured. The two cache-updater call sites are updated to pass `TolerateStale`; all other callers pass `RequireCurrent` to preserve existing behavior.

`fetchAttestedNode` (inner function) is also refactored to accept `(ctx context.Context, db *sqlDB, spiffeID string)` so the request context propagates correctly to the SQL call, consistent with `fetchRegistrationEntries` and `getNodeSelectors`.

**Which issue this PR fixes**

N/A