### PR TITLE
Add disable_group_name_selectors option to Windows workload attestor

### DIFF
--- a/doc/plugin_agent_workloadattestor_windows.md
+++ b/doc/plugin_agent_workloadattestor_windows.md
@@ -3,10 +3,11 @@
 The `windows` plugin generates Windows-based selectors for workloads calling the agent.
 It does so by opening an access token associated with the workload process. The system is then interrogated to retrieve user and group account information from that access token.
 
-| Configuration            | Description                                                                                                                                                | Default |
-|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `discover_workload_path` | If true, the workload path will be discovered by the plugin and used to provide additional selectors                                                       | false   |
-| `workload_size_limit`    | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash. | 0       |
+| Configuration                  | Description                                                                                                                                                                                                            | Default |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `discover_workload_path`       | If true, the workload path will be discovered by the plugin and used to provide additional selectors                                                                                                                   | false   |
+| `workload_size_limit`          | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash.                                                             | 0       |
+| `disable_group_name_selectors` | If true, skips resolving group SIDs to human-readable names, avoiding expensive Domain Controller lookups. Group SID selectors (`group_sid`) are always collected regardless. Only `group_name` selectors are affected. | false   |
 
 ## Workload Selectors
 

--- a/doc/plugin_agent_workloadattestor_windows.md
+++ b/doc/plugin_agent_workloadattestor_windows.md
@@ -3,10 +3,10 @@
 The `windows` plugin generates Windows-based selectors for workloads calling the agent.
 It does so by opening an access token associated with the workload process. The system is then interrogated to retrieve user and group account information from that access token.
 
-| Configuration                  | Description                                                                                                                                                                                                            | Default |
-|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| `discover_workload_path`       | If true, the workload path will be discovered by the plugin and used to provide additional selectors                                                                                                                   | false   |
-| `workload_size_limit`          | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash.                                                             | 0       |
+| Configuration                  | Description                                                                                                                                                                                                                                                          | Default |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `discover_workload_path`       | If true, the workload path will be discovered by the plugin and used to provide additional selectors                                                                                                                                                                 | false   |
+| `workload_size_limit`          | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash.                                                                                                           | 0       |
 | `disable_group_name_selectors` | If true, skips resolving group SIDs to human-readable names, avoiding potentially expensive account name resolution (e.g. against a Domain Controller). Group SID selectors (`group_sid`) are always collected regardless. Only `group_name` selectors are affected. | false   |
 
 ## Workload Selectors

--- a/doc/plugin_agent_workloadattestor_windows.md
+++ b/doc/plugin_agent_workloadattestor_windows.md
@@ -7,7 +7,7 @@ It does so by opening an access token associated with the workload process. The 
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `discover_workload_path`       | If true, the workload path will be discovered by the plugin and used to provide additional selectors                                                                                                                   | false   |
 | `workload_size_limit`          | The limit of workload binary sizes when calculating certain selectors (e.g. sha256). If zero, no limit is enforced. If negative, never calculate the hash.                                                             | 0       |
-| `disable_group_name_selectors` | If true, skips resolving group SIDs to human-readable names, avoiding expensive Domain Controller lookups. Group SID selectors (`group_sid`) are always collected regardless. Only `group_name` selectors are affected. | false   |
+| `disable_group_name_selectors` | If true, skips resolving group SIDs to human-readable names, avoiding potentially expensive account name resolution (e.g. against a Domain Controller). Group SID selectors (`group_sid`) are always collected regardless. Only `group_name` selectors are affected. | false   |
 
 ## Workload Selectors
 
@@ -47,6 +47,8 @@ Defenses against this are:
 - An enabled group in a token is a group that has the [SE_GROUP_ENABLED](https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-attributes-in-an-access-token) attribute.
 
 - User and group account names are expressed using the [down-level logon name format](https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name).
+
+- Enabling `disable_group_name_selectors` will cause existing workload registration entries that use `group_name` selectors to stop matching. Operators should audit those entries and switch them to `group_sid` selectors before enabling this flag.
 
 ## Configuration
 

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -188,7 +188,7 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames boo
 		}
 	}
 	if !disableGroupNames {
-		p.log.Debug("lookupAccount (groups) completed", "count", len(groups), "elapsed_ms", time.Since(start).Milliseconds())
+		p.log.Debug("Group account name lookups completed", "count", len(groups), "duration_ms", time.Since(start).Milliseconds())
 	}
 
 	if queryPath {

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -211,7 +211,7 @@ func (p *Plugin) Configure(_ context.Context, req *configv1.ConfigureRequest) (*
 	p.config = newConfig
 
 	if newConfig.DisableGroupNameSelectors {
-		p.log.Info("group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced")
+		p.log.Info("Group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced")
 	}
 
 	return &configv1.ConfigureResponse{}, nil

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
@@ -33,8 +34,9 @@ func New() *Plugin {
 }
 
 type Configuration struct {
-	DiscoverWorkloadPath bool  `hcl:"discover_workload_path"`
-	WorkloadSizeLimit    int64 `hcl:"workload_size_limit"`
+	DiscoverWorkloadPath      bool  `hcl:"discover_workload_path"`
+	WorkloadSizeLimit         int64 `hcl:"workload_size_limit"`
+	DisableGroupNameSelectors bool  `hcl:"disable_group_name_selectors"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Configuration {
@@ -77,7 +79,7 @@ func (p *Plugin) Attest(_ context.Context, req *workloadattestorv1.AttestRequest
 		return nil, err
 	}
 
-	process, err := p.newProcessInfo(req.Pid, config.DiscoverWorkloadPath)
+	process, err := p.newProcessInfo(req.Pid, config.DiscoverWorkloadPath, config.DisableGroupNameSelectors)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to get process information: %v", err)
 	}
@@ -119,7 +121,7 @@ func (p *Plugin) AttestReference(_ context.Context, _ *workloadattestorv1.Attest
 	return nil, status.Error(codes.Unimplemented, "AttestReference not implemented")
 }
 
-func (p *Plugin) newProcessInfo(pid int32, queryPath bool) (*processInfo, error) {
+func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames bool) (*processInfo, error) {
 	p.log = p.log.With(telemetry.PID, pid)
 
 	h, err := p.q.OpenProcess(pid)
@@ -174,13 +176,18 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool) (*processInfo, error)
 		// https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-attributes-in-an-access-token
 		enabledSelector := getGroupEnabledSelector(group.Attributes)
 		processInfo.groupsSIDs = append(processInfo.groupsSIDs, enabledSelector+":"+group.Sid.String())
-		groupAccount, groupDomain, err := p.q.LookupAccount(group.Sid)
-		if err != nil {
-			p.log.Warn("failed to lookup account from group SID", "sid", group.Sid, "error", err)
-			continue
+		if !disableGroupNames {
+			start := time.Now()
+			groupAccount, groupDomain, err := p.q.LookupAccount(group.Sid)
+			elapsed := time.Since(start).Milliseconds()
+			if err != nil {
+				p.log.Warn("failed to lookup account from group SID", "sid", group.Sid, "error", err)
+				continue
+			}
+			p.log.Debug("lookupAccount (group) completed", "sid", group.Sid, "elapsed_ms", elapsed)
+			// If the LookupAccount call succeeded, we know that groupAccount is not empty
+			processInfo.groups = append(processInfo.groups, enabledSelector+":"+parseAccount(groupAccount, groupDomain))
 		}
-		// If the LookupAccount call succeeded, we know that groupAccount is not empty
-		processInfo.groups = append(processInfo.groups, enabledSelector+":"+parseAccount(groupAccount, groupDomain))
 	}
 
 	if queryPath {

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -211,7 +211,7 @@ func (p *Plugin) Configure(_ context.Context, req *configv1.ConfigureRequest) (*
 	p.config = newConfig
 
 	if newConfig.DisableGroupNameSelectors {
-		p.log.Info("Group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced")
+		p.log.Info("Group name selectors disabled; only group_sid selectors will be produced for groups")
 	}
 
 	return &configv1.ConfigureResponse{}, nil

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -169,6 +169,7 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames boo
 	}
 	groups := p.q.AllGroups(tokenGroups)
 
+	start := time.Now()
 	for _, group := range groups {
 		// Each group has a set of attributes that control how
 		// the system uses the SID in an access check.
@@ -177,17 +178,17 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames boo
 		enabledSelector := getGroupEnabledSelector(group.Attributes)
 		processInfo.groupsSIDs = append(processInfo.groupsSIDs, enabledSelector+":"+group.Sid.String())
 		if !disableGroupNames {
-			start := time.Now()
 			groupAccount, groupDomain, err := p.q.LookupAccount(group.Sid)
-			elapsed := time.Since(start).Milliseconds()
 			if err != nil {
 				p.log.Warn("failed to lookup account from group SID", "sid", group.Sid, "error", err)
 				continue
 			}
-			p.log.Debug("lookupAccount (group) completed", "sid", group.Sid, "elapsed_ms", elapsed)
 			// If the LookupAccount call succeeded, we know that groupAccount is not empty
 			processInfo.groups = append(processInfo.groups, enabledSelector+":"+parseAccount(groupAccount, groupDomain))
 		}
+	}
+	if !disableGroupNames {
+		p.log.Debug("lookupAccount (groups) completed", "count", len(groups), "elapsed_ms", time.Since(start).Milliseconds())
 	}
 
 	if queryPath {
@@ -208,6 +209,10 @@ func (p *Plugin) Configure(_ context.Context, req *configv1.ConfigureRequest) (*
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.config = newConfig
+
+	if newConfig.DisableGroupNameSelectors {
+		p.log.Info("group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced")
+	}
 
 	return &configv1.ConfigureResponse{}, nil
 }

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -116,6 +116,26 @@ func TestAttest(t *testing.T) {
 			expectCode: codes.OK,
 		},
 		{
+			name:        "successful with groups, group name selectors disabled",
+			trustDomain: "example.org",
+			config:      "disable_group_name_selectors = true",
+			pq: &fakeProcessQuery{
+				handle:           windows.InvalidHandle,
+				tokenUser:        &windows.Tokenuser{User: windows.SIDAndAttributes{Sid: sidUser}},
+				tokenGroups:      &windows.Tokengroups{Groups: [1]windows.SIDAndAttributes{sidAndAttrGroup1}},
+				account:          "user1",
+				domain:           "domain1",
+				sidAndAttributes: []windows.SIDAndAttributes{sidAndAttrGroup1, sidAndAttrGroup3},
+			},
+			expectSelectors: []string{
+				"windows:user_name:domain1\\user1",
+				"windows:user_sid:" + sidUser.String(),
+				"windows:group_sid:se_group_enabled:true:" + sidGroup1.String(),
+				"windows:group_sid:se_group_enabled:true:" + sidGroup3.String(),
+			},
+			expectCode: codes.OK,
+		},
+		{
 			name:        "successful getting path and hashing process binary",
 			trustDomain: "example.org",
 			pq: &fakeProcessQuery{

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -134,6 +134,12 @@ func TestAttest(t *testing.T) {
 				"windows:group_sid:se_group_enabled:true:" + sidGroup3.String(),
 			},
 			expectCode: codes.OK,
+			expectLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced",
+				},
+			},
 		},
 		{
 			name:        "successful getting path and hashing process binary",

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -137,7 +137,7 @@ func TestAttest(t *testing.T) {
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.InfoLevel,
-					Message: "group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced",
+					Message: "Group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced",
 				},
 			},
 		},

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -137,7 +137,7 @@ func TestAttest(t *testing.T) {
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.InfoLevel,
-					Message: "Group name selectors disabled; skipping LookupAccount for groups, only group_sid selectors will be produced",
+					Message: "Group name selectors disabled; only group_sid selectors will be produced for groups",
 				},
 			},
 		},


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Windows workload attestor group SID resolution.

**Description of change**
Adds a `disable_group_name_selectors` boolean configuration option (default: `false`) to the Windows workload attestor. When enabled, the attestor skips resolving group SIDs to human-readable names via `LookupAccountSid`, avoiding timeouts for workloads whose principals belong to many groups (~88ms per group, 44+ seconds for 500+ groups). Group SID selectors (`group_sid`) are always collected regardless of this setting, only `group_name` selectors are skipped.

Also adds debug-level timing instrumentation to the group name lookup path so operators can observe lookup latency without enabling the flag.

**Which issue this PR fixes**
fixes #6902