### PR TITLE
Update golangci-lint version + add `modernize` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,7 @@ linters:
       - linters:
           - gosec
         path: (.*_test\.go$)|(^test/.*)
-        text: integer overflow conversion
+        text: "G115: integer overflow conversion|G101: Potential hardcoded credentials|via taint analysis"
       - linters:
           - revive
         text: Import alias "v1" is redundant

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - intrange
     - mirror
     - misspell
+    - modernize
     - nakedret
     - nilerr
     - nilnesserr

--- a/.spire-tool-versions
+++ b/.spire-tool-versions
@@ -1,3 +1,3 @@
-golangci-lint v2.9.0
+golangci-lint v2.12.2
 markdown_lint v0.39.0
 protoc 32.1

--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -949,23 +949,23 @@ type FakeManager struct {
 	updates     []*cache.WorkloadUpdate
 	cacheUpdate map[spiffeid.TrustDomain]*cache.Bundle
 
-	subscribers int32
+	subscribers atomic.Int32
 	err         error
 }
 
 func (m *FakeManager) Subscribers() int {
-	return int(atomic.LoadInt32(&m.subscribers))
+	return int(m.subscribers.Load())
 }
 
 func (m *FakeManager) subscriberDone() {
-	atomic.AddInt32(&m.subscribers, -1)
+	m.subscribers.Add(-1)
 }
 
 func (m *FakeManager) SubscribeToCacheChanges(context.Context, cache.Selectors) (cache.Subscriber, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	atomic.AddInt32(&m.subscribers, 1)
+	m.subscribers.Add(1)
 	return newFakeSubscriber(m, m.updates), nil
 }
 

--- a/pkg/agent/attestor/node/node.go
+++ b/pkg/agent/attestor/node/node.go
@@ -273,7 +273,7 @@ func (a *attestor) serverConn(bundle *spiffebundle.Bundle) (*grpc.ClientConn, er
 	// reached what appears to be the right trust domain server.
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true, //nolint: gosec // this is required in order to do non-hostname based verification
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error { //nolint:gosec // we don't need SessionTicketsDisabled
 			a.c.Log.Warn("Insecure bootstrap enabled; skipping server certificate verification")
 			if len(rawCerts) == 0 {
 				// This is not really possible without a catastrophic bug

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -1558,7 +1558,7 @@ type FakeManager struct {
 	ca          *testca.CA
 	identities  []cache.Identity
 	updates     []*cache.WorkloadUpdate
-	subscribers int32
+	subscribers atomic.Int32
 	err         error
 }
 
@@ -1589,7 +1589,7 @@ func (m *FakeManager) SubscribeToCacheChanges(context.Context, cache.Selectors) 
 	if m.err != nil {
 		return nil, m.err
 	}
-	atomic.AddInt32(&m.subscribers, 1)
+	m.subscribers.Add(1)
 	return newFakeSubscriber(m, m.updates), nil
 }
 
@@ -1601,11 +1601,11 @@ func (m *FakeManager) FetchWorkloadUpdate([]*common.Selector) *cache.WorkloadUpd
 }
 
 func (m *FakeManager) Subscribers() int {
-	return int(atomic.LoadInt32(&m.subscribers))
+	return int(m.subscribers.Load())
 }
 
 func (m *FakeManager) subscriberDone() {
-	atomic.AddInt32(&m.subscribers, -1)
+	m.subscribers.Add(-1)
 }
 
 type fakeSubscriber struct {

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -1879,8 +1879,8 @@ type mockAPI struct {
 	svid []*x509.Certificate
 
 	// Counts the number of requests received from clients
-	getAuthorizedEntriesCount int32
-	batchNewX509SVIDCount     int32
+	getAuthorizedEntriesCount atomic.Int32
+	batchNewX509SVIDCount     atomic.Int32
 
 	// Last agent version received via PostStatus
 	lastAgentVersion string
@@ -1964,7 +1964,7 @@ func (h *mockAPI) PostStatus(_ context.Context, req *agentv1.PostStatusRequest) 
 }
 
 func (h *mockAPI) GetAuthorizedEntries(_ context.Context, req *entryv1.GetAuthorizedEntriesRequest) (*entryv1.GetAuthorizedEntriesResponse, error) {
-	count := atomic.AddInt32(&h.getAuthorizedEntriesCount, 1)
+	count := h.getAuthorizedEntriesCount.Add(1)
 	if h.c.getAuthorizedEntries != nil {
 		return h.c.getAuthorizedEntries(h, count, req)
 	}
@@ -1972,7 +1972,7 @@ func (h *mockAPI) GetAuthorizedEntries(_ context.Context, req *entryv1.GetAuthor
 }
 
 func (h *mockAPI) BatchNewX509SVID(_ context.Context, req *svidv1.BatchNewX509SVIDRequest) (*svidv1.BatchNewX509SVIDResponse, error) {
-	count := atomic.AddInt32(&h.batchNewX509SVIDCount, 1)
+	count := h.batchNewX509SVIDCount.Add(1)
 
 	var entries map[string]*common.RegistrationEntry
 	if h.c.batchNewX509SVIDEntries != nil {

--- a/pkg/agent/plugin/nodeattestor/awsiid/iid_test.go
+++ b/pkg/agent/plugin/nodeattestor/awsiid/iid_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	apiTokenPath                 = "/latest/api/token"   //nolint: gosec // false positive
-	staticToken                  = "It's just some data" //nolint: gosec // false positive
+	apiTokenPath                 = "/latest/api/token"
+	staticToken                  = "It's just some data"
 	defaultIdentityDocumentPath  = "/latest/dynamic/instance-identity/document"
 	identitySignatureRSA1024Path = "/latest/dynamic/instance-identity/signature"
 	identitySignatureRSA2048Path = "/latest/dynamic/instance-identity/rsa2048"

--- a/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/agent/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -209,7 +209,7 @@ func (p *Plugin) serveNonce(ctx context.Context, l net.Listener, agentName strin
 		fmt.Fprintln(w, nonce)
 	})
 
-	go func() {
+	go func() { //nolint:gosec // G118: complaint about context.Background()
 		<-ctx.Done()
 		_ = s.Shutdown(context.Background())
 	}()

--- a/pkg/agent/plugin/nodeattestor/v1_test.go
+++ b/pkg/agent/plugin/nodeattestor/v1_test.go
@@ -186,7 +186,7 @@ func (plugin *fakeV1Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_Ai
 func challengeResponses(ss ...[]byte) map[string]string {
 	set := make(map[string]string)
 	for i := 0; i < len(ss); i += 2 {
-		set[string(ss[i])] = string(ss[i+1])
+		set[string(ss[i])] = string(ss[i+1]) //nolint:gosec // incorrect "G602: slice index out of range" finding
 	}
 	return set
 }

--- a/pkg/agent/plugin/nodeattestor/v1_test.go
+++ b/pkg/agent/plugin/nodeattestor/v1_test.go
@@ -184,9 +184,12 @@ func (plugin *fakeV1Plugin) AidAttestation(stream nodeattestorv1.NodeAttestor_Ai
 }
 
 func challengeResponses(ss ...[]byte) map[string]string {
-	set := make(map[string]string)
-	for i := 0; i < len(ss); i += 2 {
-		set[string(ss[i])] = string(ss[i+1]) //nolint:gosec // incorrect "G602: slice index out of range" finding
+	if len(ss)%2 != 0 {
+		panic(fmt.Sprintf("challengeResponse: arg len (%d) must be even", len(ss)))
 	}
-	return set
+	result := make(map[string]string)
+	for i := 0; i < len(ss); i += 2 {
+		result[string(ss[i])] = string(ss[i+1]) //nolint:gosec // silence "G602: slice index out of range" finding
+	}
+	return result
 }

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -516,6 +516,7 @@ func (p *Plugin) reloadKubeletClient(config *k8sConfig) (err error) {
 	// with the raw kubelet certs that we can verify directly.
 	case config.NodeName == "":
 		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.SessionTicketsDisabled = true
 		tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			var certs []*x509.Certificate
 			for _, rawCert := range rawCerts {

--- a/pkg/common/api/middleware/middleware.go
+++ b/pkg/common/api/middleware/middleware.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"slices"
 )
 
 type PreprocessFunc = func(ctx context.Context, fullMethod string, req any) (context.Context, error)
@@ -102,7 +103,7 @@ func (ms middlewares) Preprocess(ctx context.Context, fullMethod string, req any
 }
 
 func (ms middlewares) Postprocess(ctx context.Context, fullMethod string, handlerInvoked bool, rpcErr error) {
-	for i := len(ms) - 1; i >= 0; i-- {
-		ms[i].Postprocess(ctx, fullMethod, handlerInvoked, rpcErr)
+	for _, m := range slices.Backward(ms) {
+		m.Postprocess(ctx, fullMethod, handlerInvoked, rpcErr)
 	}
 }

--- a/pkg/common/catalog/closers.go
+++ b/pkg/common/catalog/closers.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"errors"
 	"io"
+	"slices"
 	"time"
 
 	"google.golang.org/grpc"
@@ -13,8 +14,8 @@ type closerGroup []io.Closer
 func (cs closerGroup) Close() error {
 	// Close in reverse order.
 	var errs error
-	for i := len(cs) - 1; i >= 0; i-- {
-		errs = errors.Join(errs, cs[i].Close())
+	for _, c := range slices.Backward(cs) {
+		errs = errors.Join(errs, c.Close())
 	}
 
 	return errs

--- a/pkg/common/catalog/external.go
+++ b/pkg/common/catalog/external.go
@@ -166,7 +166,7 @@ func (p *hcClientPlugin) GRPCClient(ctx context.Context, b *goplugin.GRPCBroker,
 		}
 	})
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx) //nolint:gosec // G118: false complaint about cancel not being called
 	wg.Go(func() {
 		<-ctx.Done()
 		if !gracefulStopWithTimeout(server) {

--- a/pkg/common/container/process/helper.go
+++ b/pkg/common/container/process/helper.go
@@ -74,8 +74,12 @@ func (h *helper) GetContainerIDByProcess(pID int32, log hclog.Logger) (string, e
 
 	var jobNames []string
 	for _, handle := range handles {
+		pidUint32, err := util.CheckedCast[uint32](handle.UniqueProcessID)
+		if err != nil {
+			return "", fmt.Errorf("invalid value for PID: %w", err)
+		}
 		// Filter all handles related with vmcompute processes
-		if !isVmcomputeProcess(uint32(handle.UniqueProcessID)) {
+		if !isVmcomputeProcess(pidUint32) {
 			continue
 		}
 
@@ -139,7 +143,11 @@ func (h *helper) searchProcessByExeFile(exeFile string, log hclog.Logger) ([]uin
 
 func (h *helper) getJobName(handle SystemHandleInformationExItem, currentProcess windows.Handle, childProcessHandle windows.Handle, log hclog.Logger) (string, error) {
 	// Open the handle associated with the process ID, with permissions to duplicate the handle
-	hProcess, err := h.wapi.OpenProcess(windows.PROCESS_DUP_HANDLE, false, uint32(handle.UniqueProcessID))
+	pidUint32, err := util.CheckedCast[uint32](handle.UniqueProcessID)
+	if err != nil {
+		return "", fmt.Errorf("invalid value for PID: %w", err)
+	}
+	hProcess, err := h.wapi.OpenProcess(windows.PROCESS_DUP_HANDLE, false, pidUint32)
 	if err != nil {
 		if errors.Is(err, windows.ERROR_ACCESS_DENIED) {
 			// This is expected when trying to open process as a non admin user

--- a/pkg/common/container/process/winapi.go
+++ b/pkg/common/container/process/winapi.go
@@ -68,8 +68,7 @@ type API interface {
 	Process32Next(snapshot windows.Handle, procEntry *windows.ProcessEntry32) error
 }
 
-type api struct {
-}
+type api struct{}
 
 func (a *api) IsProcessInJob(procHandle windows.Handle, jobHandle windows.Handle, result *bool) error {
 	if procIsProcessInJobErr != nil {
@@ -228,25 +227,31 @@ func (u UnicodeString) String() string {
 	return windows.UTF16ToString(data)
 }
 
-func ntQueryObject(handle windows.Handle, objectInformationClass uint32, objectInformation *byte, objectInformationLength uint32, returnLength *uint32) (ntStatus windows.NTStatus) {
+func ntQueryObject(handle windows.Handle, objectInformationClass uint32, objectInformation *byte, objectInformationLength uint32, returnLength *uint32) windows.NTStatus {
 	if procNtQueryObjectErr != nil {
 		return windows.STATUS_PROCEDURE_NOT_FOUND
 	}
 	r0, _, _ := syscall.SyscallN(procNtQueryObject.Addr(), uintptr(handle), uintptr(objectInformationClass), uintptr(unsafe.Pointer(objectInformation)), uintptr(objectInformationLength), uintptr(unsafe.Pointer(returnLength)), 0)
-	if r0 != 0 {
-		ntStatus = windows.NTStatus(r0)
-	}
-	return
+
+	return ntStatusFromSyscall(r0)
 }
 
-func ntQuerySystemInformation(sysInfoClass int32, sysInfo unsafe.Pointer, sysInfoLen uint32, retLen *uint32) (ntstatus windows.NTStatus) {
+func ntQuerySystemInformation(sysInfoClass int32, sysInfo unsafe.Pointer, sysInfoLen uint32, retLen *uint32) windows.NTStatus {
 	if procNtQuerySystemInformationErr != nil {
 		return windows.STATUS_PROCEDURE_NOT_FOUND
 	}
-	r0, _, _ := syscall.SyscallN(procNtQuerySystemInformation.Addr(), uintptr(sysInfoClass), uintptr(sysInfo), uintptr(sysInfoLen), uintptr(unsafe.Pointer(retLen)), 0, 0)
-	if r0 != 0 {
-		ntstatus = windows.NTStatus(r0)
+	sysInfoClassUIP, err := util.CheckedCast[uintptr](sysInfoClass)
+	if err != nil {
+		return windows.STATUS_INTEGER_OVERFLOW
 	}
+	r0, _, _ := syscall.SyscallN(procNtQuerySystemInformation.Addr(), sysInfoClassUIP, uintptr(sysInfo), uintptr(sysInfoLen), uintptr(unsafe.Pointer(retLen)), 0, 0)
+	return ntStatusFromSyscall(r0)
+}
 
-	return
+func ntStatusFromSyscall(r0 uintptr) windows.NTStatus {
+	// NTSTATUS is a 32-bit Windows ABI value even though syscall.SyscallN
+	// returns it in a uintptr-sized register. Preserve the low 32 bits instead
+	// of treating wider uintptr values as overflow; this keeps statuses with
+	// the high bit set intact even if a platform sign-extends the register.
+	return windows.NTStatus(uint32(r0)) //nolint:gosec // G115: intentional ABI conversion from syscall return value.
 }

--- a/pkg/common/cryptoutil/keys.go
+++ b/pkg/common/cryptoutil/keys.go
@@ -9,30 +9,12 @@ import (
 	"github.com/go-jose/go-jose/v4"
 )
 
-func RSAPublicKeyEqual(a, b *rsa.PublicKey) bool {
-	return a.E == b.E && a.N.Cmp(b.N) == 0
-}
-
-func ECDSAPublicKeyEqual(a, b *ecdsa.PublicKey) bool {
-	return a.Curve == b.Curve && a.X.Cmp(b.X) == 0 && a.Y.Cmp(b.Y) == 0
-}
-
-func ECDSAKeyMatches(privateKey *ecdsa.PrivateKey, publicKey *ecdsa.PublicKey) bool {
-	return ECDSAPublicKeyEqual(&privateKey.PublicKey, publicKey)
-}
-
-func RSAKeyMatches(privateKey *rsa.PrivateKey, publicKey *rsa.PublicKey) bool {
-	return RSAPublicKeyEqual(&privateKey.PublicKey, publicKey)
-}
-
 func PublicKeyEqual(a, b crypto.PublicKey) (bool, error) {
 	switch a := a.(type) {
 	case *rsa.PublicKey:
-		rsaPublicKey, ok := b.(*rsa.PublicKey)
-		return ok && RSAPublicKeyEqual(a, rsaPublicKey), nil
+		return a.Equal(b), nil
 	case *ecdsa.PublicKey:
-		ecdsaPublicKey, ok := b.(*ecdsa.PublicKey)
-		return ok && ECDSAPublicKeyEqual(a, ecdsaPublicKey), nil
+		return a.Equal(b), nil
 	default:
 		return false, fmt.Errorf("unsupported public key type %T", a)
 	}
@@ -41,11 +23,9 @@ func PublicKeyEqual(a, b crypto.PublicKey) (bool, error) {
 func KeyMatches(privateKey crypto.PrivateKey, publicKey crypto.PublicKey) (bool, error) {
 	switch privateKey := privateKey.(type) {
 	case *rsa.PrivateKey:
-		rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
-		return ok && RSAKeyMatches(privateKey, rsaPublicKey), nil
+		return privateKey.PublicKey.Equal(publicKey), nil
 	case *ecdsa.PrivateKey:
-		ecdsaPublicKey, ok := publicKey.(*ecdsa.PublicKey)
-		return ok && ECDSAKeyMatches(privateKey, ecdsaPublicKey), nil
+		return privateKey.PublicKey.Equal(publicKey), nil
 	default:
 		return false, fmt.Errorf("unsupported private key type %T", privateKey)
 	}

--- a/pkg/common/entrypoint/entrypoint_windows.go
+++ b/pkg/common/entrypoint/entrypoint_windows.go
@@ -103,7 +103,7 @@ func isWindowsService() (bool, error) {
 			return false, err
 		}
 	}
-	for ; ; parentProcess = (*windows.SYSTEM_PROCESS_INFORMATION)(unsafe.Pointer(uintptr(unsafe.Pointer(parentProcess)) + uintptr(parentProcess.NextEntryOffset))) {
+	for ; ; parentProcess = (*windows.SYSTEM_PROCESS_INFORMATION)(unsafe.Add(unsafe.Pointer(parentProcess), parentProcess.NextEntryOffset)) {
 		if parentProcess.UniqueProcessID == currentProcess.InheritedFromUniqueProcessId {
 			return strings.EqualFold("services.exe", parentProcess.ImageName.String()), nil
 		}

--- a/pkg/common/util/cast.go
+++ b/pkg/common/util/cast.go
@@ -3,7 +3,7 @@ package util
 import "fmt"
 
 type Int interface {
-	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
 }
 
 func CheckedCast[To, From Int](v From) (To, error) {

--- a/pkg/server/authorizedentries/cache_test.go
+++ b/pkg/server/authorizedentries/cache_test.go
@@ -340,10 +340,10 @@ func makeWorkload(parent spiffeid.ID) *types.Entry {
 	}
 }
 
-var nextEntryIDPrefix int32
+var nextEntryIDPrefix atomic.Int32
 
 func makeEntryIDPrefix() int32 {
-	return atomic.AddInt32(&nextEntryIDPrefix, 1)
+	return nextEntryIDPrefix.Add(1)
 }
 
 func buildCacheForBenchmark() *cacheTest {

--- a/pkg/server/bundle/client/sources.go
+++ b/pkg/server/bundle/client/sources.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"maps"
+	"slices"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -64,8 +65,8 @@ func MergeTrustDomainConfigSources(sources ...TrustDomainConfigSource) TrustDoma
 	return TrustDomainConfigSourceFunc(func(ctx context.Context) (map[spiffeid.TrustDomain]TrustDomainConfig, error) {
 		merged := make(map[spiffeid.TrustDomain]TrustDomainConfig)
 		// merge in reverse order
-		for i := len(sources) - 1; i >= 0; i-- {
-			configs, err := sources[i].GetTrustDomainConfigs(ctx)
+		for _, source := range slices.Backward(sources) {
+			configs, err := source.GetTrustDomainConfigs(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/ca/manager/journal.go
+++ b/pkg/server/ca/manager/journal.go
@@ -85,8 +85,7 @@ func (j *Journal) UpdateX509CAStatus(ctx context.Context, authorityID string, st
 	defer j.mu.Unlock()
 
 	var found bool
-	for i := len(j.entries.X509CAs) - 1; i >= 0; i-- {
-		entry := j.entries.X509CAs[i]
+	for _, entry := range slices.Backward(j.entries.X509CAs) {
 		if authorityID == entry.AuthorityId {
 			found = true
 			entry.Status = status
@@ -138,8 +137,7 @@ func (j *Journal) UpdateJWTKeyStatus(ctx context.Context, authorityID string, st
 	defer j.mu.Unlock()
 
 	var found bool
-	for i := len(j.entries.JwtKeys) - 1; i >= 0; i-- {
-		entry := j.entries.JwtKeys[i]
+	for _, entry := range slices.Backward(j.entries.JwtKeys) {
 		if authorityID == entry.AuthorityId {
 			found = true
 			entry.Status = status
@@ -188,8 +186,7 @@ func (j *Journal) UpdateWITKeyStatus(ctx context.Context, authorityID string, st
 	defer j.mu.Unlock()
 
 	var found bool
-	for i := len(j.entries.WitKeys) - 1; i >= 0; i-- {
-		entry := j.entries.WitKeys[i]
+	for _, entry := range slices.Backward(j.entries.WitKeys) {
 		if authorityID == entry.AuthorityId {
 			found = true
 			entry.Status = status

--- a/pkg/server/ca/manager/slot.go
+++ b/pkg/server/ca/manager/slot.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -136,8 +137,8 @@ func (s *SlotLoader) getX509CASlots(ctx context.Context, entries []*journal.X509
 	var next *x509CASlot
 
 	// Search from oldest
-	for i := len(entries) - 1; i >= 0; i-- {
-		slot, err := s.tryLoadX509CASlotFromEntry(ctx, entries[i])
+	for _, entry := range slices.Backward(entries) {
+		slot, err := s.tryLoadX509CASlotFromEntry(ctx, entry)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -198,8 +199,8 @@ func (s *SlotLoader) getJWTKeysSlots(ctx context.Context, entries []*journal.JWT
 	var next *jwtKeySlot
 
 	// Search from oldest
-	for i := len(entries) - 1; i >= 0; i-- {
-		slot, err := s.tryLoadJWTKeySlotFromEntry(ctx, entries[i])
+	for _, entry := range slices.Backward(entries) {
+		slot, err := s.tryLoadJWTKeySlotFromEntry(ctx, entry)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -260,8 +261,8 @@ func (s *SlotLoader) getWITKeysSlots(ctx context.Context, entries []*journal.WIT
 	var next *witKeySlot
 
 	// Search from oldest
-	for i := len(entries) - 1; i >= 0; i-- {
-		slot, err := s.tryLoadWITKeySlotFromEntry(ctx, entries[i])
+	for _, entry := range slices.Backward(entries) {
+		slot, err := s.tryLoadWITKeySlotFromEntry(ctx, entry)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/server/datastore/sqldriver/awsrds/awsrds_test.go
+++ b/pkg/server/datastore/sqldriver/awsrds/awsrds_test.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	fakeSQLDriverName  = "fake-sql-driver"
-	token              = "aws-rds-host:1234?Action=connect&DBUser=test_user&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=TESTTESTTESTTESTTEST%2F20240116%2Fus-east-2%2Frds-db%2Faws4_request&X-Amz-Date=20240116T150146Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" //nolint: gosec // for testing
+	token              = "aws-rds-host:1234?Action=connect&DBUser=test_user&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=TESTTESTTESTTESTTEST%2F20240116%2Fus-east-2%2Frds-db%2Faws4_request&X-Amz-Date=20240116T150146Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	mysqlConnString    = "test_user:@tcp(aws-rds-host:1234)/spire?parseTime=true&allowCleartextPasswords=1&tls=true"
 	postgresConnString = "dbname=postgres user=postgres host=the-host sslmode=require"
 )

--- a/pkg/server/datastore/sqlstore/mysql.go
+++ b/pkg/server/datastore/sqlstore/mysql.go
@@ -125,7 +125,7 @@ func configureConnection(cfg *configuration, isReadOnly bool) (*mysql.Config, er
 
 	// MySQL still allows, and in some places requires, older TLS versions. For example, when built with yaSSL, it is limited to TLSv1 and TLSv1.1.
 	// TODO: consider making this more secure by default
-	tlsConf := tls.Config{} //nolint: gosec // see above
+	tlsConf := tls.Config{}
 
 	// load and configure Root CA if it exists
 	if len(cfg.RootCAPath) > 0 {

--- a/pkg/server/datastore/sqlstore/mysql.go
+++ b/pkg/server/datastore/sqlstore/mysql.go
@@ -123,9 +123,7 @@ func configureConnection(cfg *configuration, isReadOnly bool) (*mysql.Config, er
 		return mysqlConfig, nil
 	}
 
-	// MySQL still allows, and in some places requires, older TLS versions. For example, when built with yaSSL, it is limited to TLSv1 and TLSv1.1.
-	// TODO: consider making this more secure by default
-	tlsConf := tls.Config{}
+	var tlsConf tls.Config
 
 	// load and configure Root CA if it exists
 	if len(cfg.RootCAPath) > 0 {

--- a/pkg/server/endpoints/endpoints.go
+++ b/pkg/server/endpoints/endpoints.go
@@ -303,7 +303,7 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 }
 
 func (e *Endpoints) createTCPServer(ctx context.Context, unaryInterceptor grpc.UnaryServerInterceptor, streamInterceptor grpc.StreamServerInterceptor) *grpc.Server {
-	tlsConfig := &tls.Config{ //nolint: gosec // False positive, getTLSConfig is setting MinVersion
+	tlsConfig := &tls.Config{
 		GetConfigForClient: e.getTLSConfig(ctx),
 		// Disable session ticket resumption so that VerifyPeerCertificate is
 		// called on every connection, ensuring the peer certificate chain is
@@ -468,6 +468,7 @@ func (e *Endpoints) getTLSConfig(ctx context.Context) func(*tls.ClientHelloInfo)
 		spiffeTLSConfig.MinVersion = tls.VersionTLS12
 		spiffeTLSConfig.NextProtos = []string{http2.NextProtoTLS}
 		spiffeTLSConfig.VerifyPeerCertificate = e.serverSpiffeVerificationFunc(bundleSrc)
+		spiffeTLSConfig.SessionTicketsDisabled = true
 
 		err := tlspolicy.ApplyPolicy(spiffeTLSConfig, e.TLSPolicy)
 		if err != nil {

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	// Defaults used for testing
-	validAccessKeyID     = "AKIAIOSFODNN7EXAMPLE" //nolint:gosec // This is a fake access key ID only used as test input
+	validAccessKeyID     = "AKIAIOSFODNN7EXAMPLE"
 	validSecretAccessKey = "secret"
 	validRegion          = "us-west-2"
 	validServerIDFile    = "server_id_test"

--- a/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/azure_key_vault_test.go
@@ -54,8 +54,6 @@ var (
 	refreshedDate = unixEpoch.Add(6 * time.Hour)
 )
 
-func toPtr[T any](v T) *T { return &v }
-
 type pluginTest struct {
 	plugin    *Plugin
 	kmsClient *kmsClientFake
@@ -1010,7 +1008,7 @@ func TestKeyVaultKeyToRawKey(t *testing.T) {
 			name: "RSA-HSM normalized to RSA",
 			jwk: func() *azkeys.JSONWebKey {
 				k := toRSAKey(rsa2048Key.Public(), fakeKID, keyOps)
-				k.Kty = toPtr(azkeys.KeyTypeRSAHSM)
+				k.Kty = new(azkeys.KeyTypeRSAHSM)
 				return k
 			}(),
 			assertKey: func(t *testing.T, got any) {
@@ -1049,19 +1047,19 @@ func TestKeyTypeFromKeySpec(t *testing.T) {
 
 	makeRSABundle := func(kty azkeys.KeyType, keySize int) azkeys.KeyBundle {
 		return azkeys.KeyBundle{Key: &azkeys.JSONWebKey{
-			Kty:    toPtr(kty),
+			Kty:    new(kty),
 			N:      make([]byte, keySize/8),
 			E:      []byte{1, 0, 1},
-			KID:    toPtr(azkeys.ID(fakeKID)),
+			KID:    new(azkeys.ID(fakeKID)),
 			KeyOps: keyOps,
 		}}
 	}
 
 	makeECBundle := func(kty azkeys.KeyType, crv azkeys.CurveName) azkeys.KeyBundle {
 		return azkeys.KeyBundle{Key: &azkeys.JSONWebKey{
-			Kty:    toPtr(kty),
-			Crv:    toPtr(crv),
-			KID:    toPtr(azkeys.ID(fakeKID)),
+			Kty:    new(kty),
+			Crv:    new(crv),
+			KID:    new(azkeys.ID(fakeKID)),
 			KeyOps: keyOps,
 		}}
 	}

--- a/pkg/server/plugin/keymanager/azurekeyvault/client_fake.go
+++ b/pkg/server/plugin/keymanager/azurekeyvault/client_fake.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"path"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -109,6 +110,7 @@ func (k *kmsClientFake) setCreateKeyErr(fakeError string) {
 		k.createKeyErr = errors.New(fakeError)
 	}
 }
+
 func (k *kmsClientFake) setGetKeyErr(fakeError string) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
@@ -384,8 +386,8 @@ func (k *kmsClientFake) Sign(_ context.Context, keyName, _ string, parameters az
 
 func toRSAKey(publicKey crypto.PublicKey, kmsKeyID string, keyOperations []*azkeys.KeyOperation) *azkeys.JSONWebKey {
 	rsaKey := publicKey.(*rsa.PublicKey)
-	var s = big.NewInt(int64(rsaKey.E))
-	var e = s.Bytes()
+	s := big.NewInt(int64(rsaKey.E))
+	e := s.Bytes()
 	key := &azkeys.JSONWebKey{
 		N:      rsaKey.N.Bytes(),
 		E:      e,
@@ -398,14 +400,30 @@ func toRSAKey(publicKey crypto.PublicKey, kmsKeyID string, keyOperations []*azke
 
 func toECKey(publicKey crypto.PublicKey, keyName string, curveName azkeys.CurveName, keyOperations []*azkeys.KeyOperation) *azkeys.JSONWebKey {
 	ecdsaKey := publicKey.(*ecdsa.PublicKey)
+	encodedPoint, err := ecdsaKey.Bytes()
+	if err != nil {
+		panic(fmt.Sprintf("invalid ECDSA public key: %v", err))
+	}
+	if encodedPoint[0] != 0x04 {
+		panic(fmt.Sprintf(
+			"invalid ECDSA public key: public key byte 0 = %#x != 0x04", encodedPoint[0]))
+	}
+	// ecdsa.PublicKey.Bytes returns an uncompressed point encoded per SEC 1
+	// v2.0 Section 2.3.3: 0x04 || X || Y.
+	// Here, X and Y are encoded as defined in Section 2.3.5 of SEC 1.
+	// JWK EC "x" and "y" are defined by RFC 7518 to use that same Section
+	// 2.3.5 encoding.
+	// Therefore, accessing encodedPoint sub-slices below is correct.
+	// Note that accessing ecdsaKey.X and ecdsaKey.Y would also work, but is
+	// deprecated.
+	coordinateLength := (len(encodedPoint) - 1) / 2
 	key := &azkeys.JSONWebKey{
-		Crv: new(curveName),
-		//D:      ecdsaKey.D.Bytes(),
+		Crv:    new(curveName),
 		KID:    new(azkeys.ID(keyName)),
 		KeyOps: keyOperations,
 		Kty:    new(azkeys.KeyTypeEC),
-		X:      ecdsaKey.X.Bytes(),
-		Y:      ecdsaKey.Y.Bytes(),
+		X:      slices.Clone(encodedPoint[1 : 1+coordinateLength]),
+		Y:      slices.Clone(encodedPoint[1+coordinateLength:]),
 	}
 	return key
 }

--- a/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
+++ b/pkg/server/plugin/notifier/k8sbundle/k8sbundle.go
@@ -238,23 +238,23 @@ func (p *Plugin) updateBundles(ctx context.Context) (err error) {
 	for _, client := range clients {
 		list, err := client.GetList(ctx)
 		if err != nil {
-			updateErrs.WriteString(fmt.Sprintf("unable to get list: %v, ", err))
+			fmt.Fprintf(&updateErrs, "unable to get list: %v, ", err)
 			continue
 		}
 		listItems, err := meta.ExtractList(list)
 		if err != nil {
-			updateErrs.WriteString(fmt.Sprintf("unable to extract list items: %v, ", err))
+			fmt.Fprintf(&updateErrs, "unable to extract list items: %v, ", err)
 			continue
 		}
 		for _, item := range listItems {
 			itemMeta, err := meta.Accessor(item)
 			if err != nil {
-				updateErrs.WriteString(fmt.Sprintf("unable to extract metadata for item: %v, ", err))
+				fmt.Fprintf(&updateErrs, "unable to extract metadata for item: %v, ", err)
 				continue
 			}
 			err = p.updateBundle(ctx, client, itemMeta.GetNamespace(), itemMeta.GetName())
 			if err != nil && status.Code(err) != codes.AlreadyExists {
-				updateErrs.WriteString(fmt.Sprintf("%s: %v, ", namespacedName(itemMeta), err))
+				fmt.Fprintf(&updateErrs, "%s: %v, ", namespacedName(itemMeta), err)
 			}
 		}
 	}

--- a/test/integration/setup/adminclient/client.go
+++ b/test/integration/setup/adminclient/client.go
@@ -128,7 +128,7 @@ func run() string {
 
 	var msg strings.Builder
 	for _, failure := range failures {
-		msg.WriteString(fmt.Sprintf("RPC %q: %v\n", failure.name, failure.err))
+		fmt.Fprintf(&msg, "RPC %q: %v\n", failure.name, failure.err)
 	}
 
 	return msg.String()

--- a/test/integration/setup/downstreamclient/client.go
+++ b/test/integration/setup/downstreamclient/client.go
@@ -59,7 +59,7 @@ func run() string {
 
 	var msg strings.Builder
 	for rpcName, err := range failures {
-		msg.WriteString(fmt.Sprintf("RPC %q: %v\n", rpcName, err))
+		fmt.Fprintf(&msg, "RPC %q: %v\n", rpcName, err)
 	}
 
 	return msg.String()

--- a/test/integration/setup/svidstore/plugin/disk.go
+++ b/test/integration/setup/svidstore/plugin/disk.go
@@ -97,7 +97,7 @@ func (p *Plugin) updateFile(op func(map[string]*svidstorev1.X509SVID)) error {
 
 	op(p.svids)
 
-	data, err := json.Marshal(p.svids)
+	data, err := json.Marshal(p.svids) //nolint:gosec // G117: complaint about marshaling PrivateKey field
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to marshal json: %s", err.Error())
 	}


### PR DESCRIPTION
- Bump `golangci-lint` to latest version (2.12.2) and address findings (or in some cases, suppress them when they occur in test code).
- Add [`modernize`](https://golangci-lint.run/docs/linters/configuration/#modernize) linter. This uses the official https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/modernize so hopefully is uncontroversial to enable.

Fixes: #7076