### PR TITLE
Keep CA journal in-memory state after datastore save failures

### DIFF
--- a/pkg/server/ca/manager/journal.go
+++ b/pkg/server/ca/manager/journal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -71,10 +72,7 @@ func (j *Journal) AppendX509CA(ctx context.Context, slotID string, issuedAt time
 
 	exceeded := len(j.entries.X509CAs) - journalCap
 	if exceeded > 0 {
-		// make a new slice so we keep growing the backing array to drop the first
-		x509CAs := make([]*journal.X509CAEntry, journalCap)
-		copy(x509CAs, j.entries.X509CAs[exceeded:])
-		j.entries.X509CAs = x509CAs
+		j.entries.X509CAs = slices.Clone(j.entries.X509CAs[exceeded:])
 	}
 
 	return j.save(ctx)
@@ -127,10 +125,7 @@ func (j *Journal) AppendJWTKey(ctx context.Context, slotID string, issuedAt time
 
 	exceeded := len(j.entries.JwtKeys) - journalCap
 	if exceeded > 0 {
-		// make a new slice so we keep growing the backing array to drop the first
-		jwtKeys := make([]*journal.JWTKeyEntry, journalCap)
-		copy(jwtKeys, j.entries.JwtKeys[exceeded:])
-		j.entries.JwtKeys = jwtKeys
+		j.entries.JwtKeys = slices.Clone(j.entries.JwtKeys[exceeded:])
 	}
 
 	return j.save(ctx)
@@ -180,10 +175,7 @@ func (j *Journal) AppendWITKey(ctx context.Context, slotID string, issuedAt time
 
 	exceeded := len(j.entries.WitKeys) - journalCap
 	if exceeded > 0 {
-		// make a new slice so we keep growing the backing array to drop the first
-		witKeys := make([]*journal.WITKeyEntry, journalCap)
-		copy(witKeys, j.entries.WitKeys[exceeded:])
-		j.entries.WitKeys = witKeys
+		j.entries.WitKeys = slices.Clone(j.entries.WitKeys[exceeded:])
 	}
 
 	return j.save(ctx)

--- a/pkg/server/ca/manager/journal.go
+++ b/pkg/server/ca/manager/journal.go
@@ -29,8 +29,8 @@ type journalConfig struct {
 	log logrus.FieldLogger
 }
 
-// Journal stores X509 CAs and JWT keys on disk as they are rotated by the
-// manager. The data format is a PEM encoded protocol buffer.
+// Journal stores X509 CAs, JWT keys, and WIT keys in the datastore as they are
+// rotated by the manager.
 type Journal struct {
 	config *journalConfig
 
@@ -212,9 +212,9 @@ func (j *Journal) setEntries(entries *journal.Entries) {
 }
 
 // saveInDatastore saves the provided marshaled entries in the datastore.
-// If caJournalID has not been defined yet (it's value is 0), it first finds
-// the CA journal records that corresponds to this server. In case that there is
-// no CA record for this server, it creates one.
+// If caJournalID has not been defined yet (its value is 0), it first finds
+// the CA journal record that corresponds to this server. In case there is no
+// CA record for this server, it creates one.
 // The ID of the CA journal record that was saved is returned, in addition to
 // the error (if any) of the operation.
 func (j *Journal) saveInDatastore(ctx context.Context, entriesBytes []byte) (caJournalID uint, err error) {
@@ -287,8 +287,7 @@ func (j *Journal) findCAJournal(ctx context.Context) (*datastore.CAJournal, erro
 	return nil, nil
 }
 
-// save saves the CA journal both on disk and in the datastore.
-// TODO: stop saving the CA journal on disk in v1.10.
+// save saves the CA journal in the datastore.
 func (j *Journal) save(ctx context.Context) error {
 	entriesBytes, err := proto.Marshal(j.entries)
 	if err != nil {

--- a/pkg/server/ca/manager/journal.go
+++ b/pkg/server/ca/manager/journal.go
@@ -58,7 +58,6 @@ func (j *Journal) AppendX509CA(ctx context.Context, slotID string, issuedAt time
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	backup := j.entries.X509CAs
 	j.entries.X509CAs = append(j.entries.X509CAs, &journal.X509CAEntry{
 		SlotId:              slotID,
 		IssuedAt:            issuedAt.Unix(),
@@ -78,12 +77,7 @@ func (j *Journal) AppendX509CA(ctx context.Context, slotID string, issuedAt time
 		j.entries.X509CAs = x509CAs
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.X509CAs = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 // UpdateX509CAStatus updates a stored X509CA entry to have the given status,
@@ -92,7 +86,6 @@ func (j *Journal) UpdateX509CAStatus(ctx context.Context, authorityID string, st
 	j.mu.Lock()
 	defer j.mu.Unlock()
 
-	backup := j.entries.X509CAs
 	var found bool
 	for i := len(j.entries.X509CAs) - 1; i >= 0; i-- {
 		entry := j.entries.X509CAs[i]
@@ -110,12 +103,7 @@ func (j *Journal) UpdateX509CAStatus(ctx context.Context, authorityID string, st
 		return fmt.Errorf("no journal entry found with authority ID %q", authorityID)
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.X509CAs = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 func (j *Journal) AppendJWTKey(ctx context.Context, slotID string, issuedAt time.Time, jwtKey *ca.JWTKey) error {
@@ -127,7 +115,6 @@ func (j *Journal) AppendJWTKey(ctx context.Context, slotID string, issuedAt time
 		return err
 	}
 
-	backup := j.entries.JwtKeys
 	j.entries.JwtKeys = append(j.entries.JwtKeys, &journal.JWTKeyEntry{
 		SlotId:      slotID,
 		IssuedAt:    issuedAt.Unix(),
@@ -146,12 +133,7 @@ func (j *Journal) AppendJWTKey(ctx context.Context, slotID string, issuedAt time
 		j.entries.JwtKeys = jwtKeys
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.JwtKeys = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 // UpdateJWTKeyStatus updates a stored JWTKey entry to have the given status,
@@ -159,8 +141,6 @@ func (j *Journal) AppendJWTKey(ctx context.Context, slotID string, issuedAt time
 func (j *Journal) UpdateJWTKeyStatus(ctx context.Context, authorityID string, status journal.Status) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-
-	backup := j.entries.JwtKeys
 
 	var found bool
 	for i := len(j.entries.JwtKeys) - 1; i >= 0; i-- {
@@ -176,12 +156,7 @@ func (j *Journal) UpdateJWTKeyStatus(ctx context.Context, authorityID string, st
 		return fmt.Errorf("no journal entry found with authority ID %q", authorityID)
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.JwtKeys = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 func (j *Journal) AppendWITKey(ctx context.Context, slotID string, issuedAt time.Time, witKey *ca.WITKey) error {
@@ -193,7 +168,6 @@ func (j *Journal) AppendWITKey(ctx context.Context, slotID string, issuedAt time
 		return err
 	}
 
-	backup := j.entries.WitKeys
 	j.entries.WitKeys = append(j.entries.WitKeys, &journal.WITKeyEntry{
 		SlotId:      slotID,
 		IssuedAt:    issuedAt.Unix(),
@@ -212,12 +186,7 @@ func (j *Journal) AppendWITKey(ctx context.Context, slotID string, issuedAt time
 		j.entries.WitKeys = witKeys
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.WitKeys = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 // UpdateWITKeyStatus updates a stored WITKey entry to have the given status,
@@ -225,8 +194,6 @@ func (j *Journal) AppendWITKey(ctx context.Context, slotID string, issuedAt time
 func (j *Journal) UpdateWITKeyStatus(ctx context.Context, authorityID string, status journal.Status) error {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-
-	backup := j.entries.WitKeys
 
 	var found bool
 	for i := len(j.entries.WitKeys) - 1; i >= 0; i-- {
@@ -242,12 +209,7 @@ func (j *Journal) UpdateWITKeyStatus(ctx context.Context, authorityID string, st
 		return fmt.Errorf("no journal entry found with authority ID %q", authorityID)
 	}
 
-	if err := j.save(ctx); err != nil {
-		j.entries.WitKeys = backup
-		return err
-	}
-
-	return nil
+	return j.save(ctx)
 }
 
 func (j *Journal) setEntries(entries *journal.Entries) {

--- a/pkg/server/ca/manager/journal_test.go
+++ b/pkg/server/ca/manager/journal_test.go
@@ -202,6 +202,51 @@ func TestAppendSetPreparedStatus(t *testing.T) {
 	require.Equal(t, journal.Status_PREPARED, lastJWTKey.Status)
 }
 
+func TestAppendKeepsEntriesOnSaveFailure(t *testing.T) {
+	test := setupJournalTest(t)
+	now := test.now()
+
+	testJournal := test.loadJournal(t)
+	testJournal.activeX509AuthorityID = getOneX509AuthorityID(ctx, t, test.jc.cat.GetKeyManager())
+
+	test.ds.SetNextError(errors.New("ds error"))
+	err := testJournal.AppendX509CA(ctx, "A", now, &ca.X509CA{
+		Signer:        kmKeys["X509-CA-A"],
+		Certificate:   rootCerts["X509-Root-A"],
+		UpstreamChain: testChain,
+	})
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+
+	test.ds.SetNextError(errors.New("ds error"))
+	err = testJournal.AppendJWTKey(ctx, "B", now, &ca.JWTKey{
+		Signer:   kmKeys["JWT-Signer-B"],
+		Kid:      "kid1",
+		NotAfter: now.Add(time.Hour),
+	})
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+
+	test.ds.SetNextError(errors.New("ds error"))
+	err = testJournal.AppendWITKey(ctx, "C", now, &ca.WITKey{
+		Signer:   kmKeys["WIT-Signer-C"],
+		Kid:      "kid1",
+		NotAfter: now.Add(time.Hour),
+	})
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+
+	// Journal save failures are non-fatal to callers. Keep the in-memory journal
+	// advanced so a later successful save persists the manager's current state.
+	entries := testJournal.getEntries()
+	require.Len(t, entries.X509CAs, 1)
+	require.Equal(t, "A", entries.X509CAs[0].SlotId)
+	require.Equal(t, journal.Status_PREPARED, entries.X509CAs[0].Status)
+	require.Len(t, entries.JwtKeys, 1)
+	require.Equal(t, "B", entries.JwtKeys[0].SlotId)
+	require.Equal(t, journal.Status_PREPARED, entries.JwtKeys[0].Status)
+	require.Len(t, entries.WitKeys, 1)
+	require.Equal(t, "C", entries.WitKeys[0].SlotId)
+	require.Equal(t, journal.Status_PREPARED, entries.WitKeys[0].Status)
+}
+
 func TestX509CAOverflow(t *testing.T) {
 	test := setupJournalTest(t)
 	now := test.now()
@@ -273,6 +318,31 @@ func TestUpdateX509CAStatus(t *testing.T) {
 	require.ErrorContains(t, err, fmt.Sprintf("no journal entry found with authority ID %q", nonExistingAuthorityID))
 }
 
+func TestUpdateX509CAStatusKeepsStatusOnSaveFailure(t *testing.T) {
+	test := setupJournalTest(t)
+	now := test.now()
+
+	testJournal := test.loadJournal(t)
+
+	err := testJournal.AppendX509CA(ctx, "A", now, &ca.X509CA{
+		Signer:      kmKeys["X509-CA-A"],
+		Certificate: rootCerts["X509-Root-A"],
+	})
+	require.NoError(t, err)
+
+	test.ds.SetNextError(errors.New("ds error"))
+	authorityIDA := x509util.SubjectKeyIDToString(rootCerts["X509-Root-A"].SubjectKeyId)
+	err = testJournal.UpdateX509CAStatus(ctx, authorityIDA, journal.Status_ACTIVE)
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+	require.Equal(t, authorityIDA, testJournal.activeX509AuthorityID)
+
+	// Activation proceeds even if journal persistence fails, so the in-memory
+	// journal should still reflect the active authority.
+	entries := testJournal.getEntries()
+	require.Len(t, entries.X509CAs, 1)
+	require.Equal(t, journal.Status_ACTIVE, entries.X509CAs[0].Status)
+}
+
 func TestUpdateJWTKeyStatus(t *testing.T) {
 	test := setupJournalTest(t)
 
@@ -320,6 +390,31 @@ func TestUpdateJWTKeyStatus(t *testing.T) {
 
 	err = testJournal.UpdateJWTKeyStatus(ctx, nonExistingAuthorityID, journal.Status_OLD)
 	require.ErrorContains(t, err, fmt.Sprintf("no journal entry found with authority ID %q", nonExistingAuthorityID))
+}
+
+func TestUpdateJWTKeyStatusKeepsStatusOnSaveFailure(t *testing.T) {
+	test := setupJournalTest(t)
+	now := test.now()
+
+	testJournal := test.loadJournal(t)
+	testJournal.activeX509AuthorityID = getOneX509AuthorityID(ctx, t, test.jc.cat.GetKeyManager())
+
+	err := testJournal.AppendJWTKey(ctx, "A", now, &ca.JWTKey{
+		Signer:   kmKeys["JWT-Signer-A"],
+		Kid:      "kid1",
+		NotAfter: now.Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	test.ds.SetNextError(errors.New("ds error"))
+	err = testJournal.UpdateJWTKeyStatus(ctx, "kid1", journal.Status_ACTIVE)
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+
+	// Status changes remain in memory after persistence errors because callers
+	// log the error and continue using the updated key.
+	entries := testJournal.getEntries()
+	require.Len(t, entries.JwtKeys, 1)
+	require.Equal(t, journal.Status_ACTIVE, entries.JwtKeys[0].Status)
 }
 
 func TestJWTKeyOverflow(t *testing.T) {
@@ -392,6 +487,31 @@ func TestUpdateWITKeyStatus(t *testing.T) {
 
 	err = testJournal.UpdateWITKeyStatus(ctx, nonExistingAuthorityID, journal.Status_OLD)
 	require.ErrorContains(t, err, fmt.Sprintf("no journal entry found with authority ID %q", nonExistingAuthorityID))
+}
+
+func TestUpdateWITKeyStatusKeepsStatusOnSaveFailure(t *testing.T) {
+	test := setupJournalTest(t)
+	now := test.now()
+
+	testJournal := test.loadJournal(t)
+	testJournal.activeX509AuthorityID = getOneX509AuthorityID(ctx, t, test.jc.cat.GetKeyManager())
+
+	err := testJournal.AppendWITKey(ctx, "A", now, &ca.WITKey{
+		Signer:   kmKeys["WIT-Signer-A"],
+		Kid:      "kid1",
+		NotAfter: now.Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	test.ds.SetNextError(errors.New("ds error"))
+	err = testJournal.UpdateWITKeyStatus(ctx, "kid1", journal.Status_ACTIVE)
+	require.EqualError(t, err, "could not save CA journal in the datastore: ds error")
+
+	// Status changes remain in memory after persistence errors because callers
+	// log the error and continue using the updated key.
+	entries := testJournal.getEntries()
+	require.Len(t, entries.WitKeys, 1)
+	require.Equal(t, journal.Status_ACTIVE, entries.WitKeys[0].Status)
 }
 
 func TestWITKeyOverflow(t *testing.T) {

--- a/pkg/server/ca/manager/journal_test.go
+++ b/pkg/server/ca/manager/journal_test.go
@@ -144,8 +144,8 @@ func TestJournalPersistence(t *testing.T) {
 	require.NotNil(t, journalDS)
 	spiretest.RequireProtoEqual(t, j.getEntries(), journalDS.getEntries())
 
-	// Append a new X.509 CA, which will make the CA journal to be stored
-	// on disk and in the datastore.
+	// Append a new X.509 CA, which will make the CA journal be stored in the
+	// datastore.
 	now = now.Add(time.Minute)
 	err = j.AppendX509CA(ctx, "C", now, &ca.X509CA{
 		Signer:        kmKeys["X509-CA-C"],
@@ -200,6 +200,18 @@ func TestAppendSetPreparedStatus(t *testing.T) {
 	lastJWTKey := testJournal.entries.JwtKeys[0]
 	require.Equal(t, "B", lastJWTKey.SlotId)
 	require.Equal(t, journal.Status_PREPARED, lastJWTKey.Status)
+
+	err = testJournal.AppendWITKey(ctx, "C", now, &ca.WITKey{
+		Signer:   kmKeys["WIT-Signer-C"],
+		Kid:      "KID",
+		NotAfter: now.Add(time.Hour),
+	})
+	require.NoError(t, err)
+
+	require.Len(t, testJournal.entries.WitKeys, 1)
+	lastWITKey := testJournal.entries.WitKeys[0]
+	require.Equal(t, "C", lastWITKey.SlotId)
+	require.Equal(t, journal.Status_PREPARED, lastWITKey.Status)
 }
 
 func TestAppendKeepsEntriesOnSaveFailure(t *testing.T) {


### PR DESCRIPTION
Callers of journal mutation methods (i.e. CA managers) treat journal save failures as non-fatal: they log the error and continue using the newly prepared or activated authority/key. Rolling back only the in-memory journal makes it diverge from the manager’s live slot state, and it does not fix the already-stale persisted journal.

Therefore, stop rolling back in-memory journal mutations when datastore saves fail. Keeping the in-memory journal advanced lets a later successful save persist the latest known manager state.

The previous rollback logic was actually flawed even on its own terms: the `backup` value used was only a reference, not its own independent copy. We also weren't restoring the `AuthorityId` field in `UpdateJWTKeyStatus` etc.

Also:
- simplify journal size trimming with `slices.Clone`
- update outdated journal comments and add missing journal test coverage for WITs