### PR TITLE
feat(oidc-discovery-provider): warn when allow_insecure_scheme is enabled

### DIFF
--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -38,7 +38,7 @@ The configuration file is **required** by the provider. It contains
 |-------------------------|---------|--------------------|------------------------------------------------------------------------|----------|
 | `acme`                  | section | required[1]        | Provides the ACME configuration.                                       |          |
 | `serving_cert_file`     | section | required\[1\]\[4\] | Provides the serving certificate configuration.                        |          |
-| `allow_insecure_scheme` | bool    | optional\[3\]      | Serves OIDC configuration response with HTTP url.                      | `false`  |
+| `allow_insecure_scheme` | bool    | optional\[3\]      | Serves OIDC configuration response with HTTP url. A warning is logged at startup when enabled. | `false`  |
 | `domains`               | strings | required           | One or more domains the provider is being served from.                 |          |
 | `experimental`          | section | optional           | The experimental options that are subject to change or removal.        |          |
 | `insecure_addr`         | string  | optional\[3\]      | Exposes the service on http.                                           |          |

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -63,6 +63,10 @@ func run(configPath string, expandEnv bool) error {
 	}
 	defer log.Close()
 
+	if config.AllowInsecureScheme {
+		log.Warn("allow_insecure_scheme is enabled. JWKS keys will be served over HTTP. This setting must only be used in development environments.")
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
OIDC Discovery Provider startup logging.

**Description of change**
Emit a startup warning when `allow_insecure_scheme=true` so operators have a runtime indication that JWKS keys are being served over HTTP. This implements the High Priority item from #6968 (the startup warning).

**Which issue this PR fixes**
fixes #6968
