### PR TITLE
Makefile: go-check: allow suffixed Go versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -502,7 +502,7 @@ dev-shell: | go-check
 # execute on the go binary and also need the right path in order to locate the
 # correct go binary.
 go-check:
-ifeq (go$(go_version), $(shell $(go_path) go version 2>/dev/null | cut -f3 -d' '))
+ifeq (go$(go_version), $(firstword $(subst -, ,$(word 3,$(shell $(go_path) go version 2>/dev/null)))))
 else ifeq ($(os1),windows)
 	@echo "Installing go$(go_version)..."
 	$(E)rm -rf $(dir $(go_dir))


### PR DESCRIPTION
Some Go toolchains report a version suffix, for example `go1.26.3-X:nodwarf5` on my Arch Linux machine. Strip any dash suffix before comparing the installed Go version against the required version from `.go-version`.

This avoid unnecessary Go toolchain downloads.