### PR TITLE
integration: wait for both TCP and UDS server endpoints

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -106,6 +106,7 @@ check-server-started() {
   for ((i=1;i<=MAXCHECKS;i++)); do
       log-info "checking for starting server APIs ($i of $MAXCHECKS max)..."
       docker compose logs "$1"
+      # The server emits the below log twice: TCP and UDS listener
       if [ "$(docker compose logs "$1" | grep -c "Starting Server APIs")" -ge 2 ]; then
           return 0
       fi

--- a/test/integration/common
+++ b/test/integration/common
@@ -106,7 +106,7 @@ check-server-started() {
   for ((i=1;i<=MAXCHECKS;i++)); do
       log-info "checking for starting server APIs ($i of $MAXCHECKS max)..."
       docker compose logs "$1"
-      if docker compose logs "$1" | grep "Starting Server APIs"; then
+      if [ "$(docker compose logs "$1" | grep -c "Starting Server APIs")" -ge 2 ]; then
           return 0
       fi
       sleep "${CHECKINTERVAL}"


### PR DESCRIPTION
Noticed in the envoy suite that even though the server was ready we still failed to fetch bundle for bootstrapping the agent:

```
downstream-federated-spire-server-1  | time="2026-05-24T06:43:57Z" level=info msg="Starting Server APIs" address="[::]:8081" network=tcp subsystem_name=endpoints
[2026-05-24T06:43:57Z] bootstrapping downstream federated agent...
Error: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix ///tmp/spire-server/private/api.sock: connect: no such file or directory"
[2026-05-24T06:43:57Z] step 00-test-envoy-releases.sh failed
```

Since the CLI uses the UDS socket, it still failed even if the TCP endpoint was available. Wait for both TCP and UDS before continuing.