### PR TITLE
Add support for two more PQC curves

### DIFF
--- a/pkg/common/tlspolicy/tlspolicy.go
+++ b/pkg/common/tlspolicy/tlspolicy.go
@@ -34,6 +34,8 @@ func ApplyPolicy(config *tls.Config, policy Policy) error {
 		// List only known PQ-safe KEMs as valid curves.
 		config.CurvePreferences = []tls.CurveID{
 			tls.X25519MLKEM768,
+			tls.SecP256r1MLKEM768,
+			tls.SecP384r1MLKEM1024,
 		}
 
 		// Require TLS 1.3, as all PQ-safe KEMs require it anyway.

--- a/pkg/common/tlspolicy/tlspolicy_test.go
+++ b/pkg/common/tlspolicy/tlspolicy_test.go
@@ -30,6 +30,6 @@ func TestApplyPolicy(t *testing.T) {
 	})
 	require.NoError(err)
 
-	require.Equal(tlsConfig.CurvePreferences, []tls.CurveID{tls.X25519MLKEM768})
-	require.Equal(tlsConfig.MinVersion, uint16(tls.VersionTLS13))
+	require.Equal([]tls.CurveID{tls.X25519MLKEM768, tls.SecP256r1MLKEM768, tls.SecP384r1MLKEM1024}, tlsConfig.CurvePreferences)
+	require.Equal(uint16(tls.VersionTLS13), tlsConfig.MinVersion)
 }


### PR DESCRIPTION
Go 1.26 added support for these so we can allow using them

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

