### PR TITLE
fix: use structured logger for rebootstrap messages and fix typos

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -181,7 +181,7 @@ func (a *Agent) Run(ctx context.Context) error {
 
 			if x509util.IsUnknownAuthorityError(err) {
 				if a.c.TrustBundleSources.IsBootstrap() {
-					a.c.Log.Info("Trust Bundle and Server dont agree.... bootstrapping again")
+					a.c.Log.Info("Trust Bundle and Server don't agree, bootstrapping again")
 				} else if a.c.RebootstrapMode != RebootstrapNever {
 					startTime, err := a.c.TrustBundleSources.GetStartTime()
 					if err != nil {
@@ -190,10 +190,10 @@ func (a *Agent) Run(ctx context.Context) error {
 					seconds := time.Since(startTime)
 					if seconds < a.c.RebootstrapDelay {
 						a.c.Log.WithFields(logrus.Fields{
-							"time left": a.c.RebootstrapDelay - seconds,
-						}).Info("Trust Bundle and Server dont agree.... Ignoring for now.")
+							"time_left": a.c.RebootstrapDelay - seconds,
+						}).Info("Trust Bundle and Server don't agree, ignoring for now")
 					} else {
-						a.c.Log.Warn("Trust Bundle and Server dont agree.... rebootstrapping")
+						a.c.Log.Warn("Trust Bundle and Server don't agree, rebootstrapping")
 						err = sto.StoreBundle(nil)
 						if err != nil {
 							return err
@@ -392,10 +392,10 @@ func (a *Agent) newManager(ctx context.Context, sto storage.Storage, cat catalog
 			seconds := time.Since(startTime)
 			if seconds < a.c.RebootstrapDelay {
 				a.c.Log.WithFields(logrus.Fields{
-					"time left": a.c.RebootstrapDelay - seconds,
-				}).Info("Trust Bundle and Server dont agree.... Ignoring for now.")
+					"time_left": a.c.RebootstrapDelay - seconds,
+				}).Info("Trust Bundle and Server don't agree, ignoring for now")
 			} else {
-				a.c.Log.Info("Trust Bundle and Server dont agree.... rebootstrapping")
+				a.c.Log.Info("Trust Bundle and Server don't agree, rebootstrapping")
 				err = a.c.TrustBundleSources.SetForceRebootstrap()
 				if err != nil {
 					return nil, err

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -365,9 +365,9 @@ func (m *manager) runSynchronizer(ctx context.Context) error {
 			}
 			seconds := time.Since(startTime)
 			if seconds < m.c.RebootstrapDelay {
-				fmt.Printf("Trust Bandle and Server dont agree.... Ignoring for now. Rebootstrap timeout left: %s\n", m.c.RebootstrapDelay-seconds)
+				m.c.Log.WithField("time_left", m.c.RebootstrapDelay-seconds).Info("Trust Bundle and Server don't agree, ignoring for now")
 			} else {
-				fmt.Printf("Trust Bandle and Server dont agree.... rebootstrapping")
+				m.c.Log.Warn("Trust Bundle and Server don't agree, rebootstrapping")
 				err = m.c.TrustBundleSources.SetForceRebootstrap()
 				if err != nil {
 					return err


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Rebootstrap log messages in `pkg/agent/manager/manager.go` and `pkg/agent/agent.go`.

**Description of change**

`manager.runSynchronizer` was using `fmt.Printf` instead of `m.c.Log` for trust bundle mismatch messages. Those messages get dropped in any prod setup that captures structured logs -- which is basically all of them. Also fixes "Bandle" typo and "dont"/"time left" field key inconsistencies in both files.

- replace `fmt.Printf` with `m.c.Log.Info`/`m.c.Log.Warn` in `manager.go`
- fix "Trust Bandle" -> "Trust Bundle" typo
- fix "dont agree" -> "don't agree" in both files
- normalize log field key "time left" -> "time_left" in `agent.go`

**How to reproduce**

Set `rebootstrap_mode` to anything other than `never`, cause a trust bundle mismatch (e.g. rotate the server bundle). The agent hits `IsUnknownAuthorityError` in `runSynchronizer` -- with the bug the messages never appear in the structured log.

**Which issue this PR fixes**

n/a