### PR TITLE
Fix Dependabot auto-merge by exempting dependency manifests from code owner review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     interval: "daily"
     time: "09:00"
     timezone: "America/Los_Angeles"
+  # Wait for new releases to age before opening update PRs. Since
+  # Dependabot patch/minor updates are auto-merged once CI passes,
+  # the cooldown preserves a window for the ecosystem to detect and
+  # report compromised releases before they can land unattended.
+  cooldown:
+    default-days: 7
   groups:
     actions:
       patterns:
@@ -50,4 +56,10 @@ updates:
   directory: "/"
   schedule:
    interval: daily
+  # Let new action releases age before opening update PRs, so that a
+  # compromised release has a window to be detected and reported by the
+  # ecosystem before it is proposed for review (e.g. the March 2025
+  # tj-actions/changed-files compromise was reverted within days).
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 20

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -97,9 +97,23 @@ jobs:
 
           HEAD_SHA=$(echo "$COMMIT" | jq -r '.sha')
 
+          # Determine whether the PR touches only the dependency manifests.
+          # Only go.mod and go.sum are exempt from code owner review (see
+          # CODEOWNERS), so a PR touching any other file cannot be merged
+          # by this workflow. In particular, github-actions ecosystem
+          # updates modify workflow files and require maintainer review.
+          NON_MANIFEST_COUNT=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' | grep -cv -e '^go\.mod$' -e '^go\.sum$' || true)
+          if [ "$NON_MANIFEST_COUNT" = "0" ]; then
+            MANIFEST_ONLY=true
+          else
+            MANIFEST_ONLY=false
+          fi
+
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "update-type=${UPDATE_TYPE}" >> "$GITHUB_OUTPUT"
           echo "head-sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "manifest-only=${MANIFEST_ONLY}" >> "$GITHUB_OUTPUT"
 
       # Auto-merge all non-major updates. CI catches regressions regardless
       # of semver level, and major updates are excluded as they signal
@@ -114,6 +128,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           HEAD_SHA: ${{ steps.pr.outputs.head-sha }}
+          MANIFEST_ONLY: ${{ steps.pr.outputs.manifest-only }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -174,6 +189,17 @@ jobs:
           gh api --method PATCH "repos/${REPO}/issues/${PR_NUMBER}" \
             --field "milestone=${MILESTONE_NUMBER}"
 
+          # PRs touching files beyond go.mod/go.sum (e.g. github-actions
+          # ecosystem updates, which modify workflow files) require code
+          # owner review and cannot be merged by this workflow. Stop after
+          # the milestone assignment and leave review and merge to the
+          # maintainers.
+          if [ "$MANIFEST_ONLY" != "true" ]; then
+            echo "PR #${PR_NUMBER} touches files other than go.mod/go.sum: leaving review and merge to maintainers."
+            echo ":information_source: **Dependabot auto-merge skipped:** PR #${PR_NUMBER} touches files beyond the dependency manifests and requires maintainer review." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           gh pr review --approve "$PR_URL"
 
           # Verify the HEAD SHA has not changed since it was verified in
@@ -186,4 +212,18 @@ jobs:
             exit 1
           fi
 
-          gh pr merge --squash "$PR_URL"
+          # At this point the PR meets all branch protection requirements
+          # (CI passed, DCO passed, approved above, and go.mod/go.sum have
+          # no code owner), so gh adds it directly to the merge queue, the
+          # same as clicking "Merge when ready". The queue revalidates CI
+          # before the PR lands. Retry briefly because GitHub recomputes
+          # the mergeability state asynchronously after the approval.
+          for attempt in 1 2 3; do
+            if gh pr merge --squash "$PR_URL"; then
+              exit 0
+            fi
+            echo "Merge attempt ${attempt} failed; retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::Could not add PR #${PR_NUMBER} to the merge queue."
+          exit 1

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -102,8 +102,13 @@ jobs:
           # CODEOWNERS), so a PR touching any other file cannot be merged
           # by this workflow. In particular, github-actions ecosystem
           # updates modify workflow files and require maintainer review.
-          NON_MANIFEST_COUNT=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
-            --jq '.[].filename' | grep -cv -e '^go\.mod$' -e '^go\.sum$' || true)
+          # Fetch the file list separately from counting so that an API
+          # failure aborts the step (fails closed) instead of being masked
+          # by the || true that only covers the expected grep exit code
+          # when the count is zero.
+          PR_FILES=$(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename')
+          NON_MANIFEST_COUNT=$(echo "$PR_FILES" | grep -cv -e '^go\.mod$' -e '^go\.sum$' || true)
           if [ "$NON_MANIFEST_COUNT" = "0" ]; then
             MANIFEST_ONLY=true
           else

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -62,6 +62,17 @@ jobs:
         run: make lint
       - name: Tidy check
         run: make tidy-check
+      # go.mod and go.sum have no code owner (see CODEOWNERS) so that
+      # Dependabot updates can be auto-merged. Reject replace/exclude
+      # directives so a go.mod-only PR cannot redirect a module to a
+      # different source repository without maintainer review.
+      - name: Module directive check
+        run: |
+          directives=$(go mod edit -json | jq '[.Replace, .Exclude] | map(length) | add')
+          if [ "$directives" != "0" ]; then
+            echo "::error file=go.mod::go.mod must not contain replace or exclude directives"
+            exit 1
+          fi
       - name: Generate check
         run: make generate-check
       - name: Shell check

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,13 @@
 * @evan2645 @amartinezfayo @sorindumitru @MarcosDY @rturner3
 
+# The dependency manifests have no code owner so that Dependabot
+# patch/minor updates can be auto-merged once CI passes (see
+# .github/workflows/dependabot_automerge.yml). PRs touching any other
+# file still require maintainer review. CI rejects replace/exclude
+# directives in go.mod, so these files cannot redirect module sources.
+/go.mod
+/go.sum
+
 ##########################################
 # Maintainers
 ##########################################


### PR DESCRIPTION
The Dependabot auto-merge workflow has never successfully merged a PR. After CI passes, the workflow assigns the milestone and approves, but the merge step fails with `GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`. An example of a failure is here: https://github.com/spiffe/spire/actions/runs/26658532935

The root cause is that `go.mod` and `go.sum` fall under the `*` rule in `CODEOWNERS`, so the "require review from code owners" branch protection requirement is never satisfied by the workflow's `github-actions[bot]` approval. Because the PR can never become merge-ready, `gh pr merge` falls back to enabling auto-merge, which is a feature that is intentionally disabled on this repository.

This PR exempts `/go.mod` and `/go.sum` from code owner review using the documented CODEOWNERS pattern of leaving the owners empty. With that, a verified Dependabot PR meets all branch protection requirements as soon as the workflow approves it, and `gh pr merge` adds it directly to the merge queue, the same as clicking "Merge when ready". The "Allow auto-merge" repository setting remains disabled and the review process for every other PR is unchanged. The merge step now also retries briefly, since GitHub recomputes the mergeability state asynchronously after the approval is submitted.

The workflow now only approves and merges PRs whose changed files are limited to `go.mod` and `go.sum`. For other Dependabot PRs, such as `github-actions` ecosystem updates that modify workflow files, it assigns the milestone and leaves review and merge to the maintainers instead of failing at the merge step.

Security considerations:

- No significant new attack vector is created for human-authored PRs. The workflow only approves and merges PRs that were opened by `dependabot[bot]` and contain exactly one commit cryptographically signed by Dependabot. A regular PR touching only `go.mod` and `go.sum` still requires an approving review from a collaborator with write access, and only a collaborator can add it to the merge queue. A PR touching `go.mod` together with any other file still requires code owner review, since ownership applies per file.
- A new `Module directive check` step in the lint job rejects `replace` and `exclude` directives in `go.mod`, so a `go.mod`-only PR cannot redirect a module to a different source repository. This closes the one meaningful capability that removing the code owner requirement would otherwise add.
- A 7-day Dependabot `cooldown` lets new upstream releases age before an update PR is opened, preserving a window for the ecosystem to detect and report a compromised release before it can land unattended. This mitigates the main residual supply chain exposure (a malicious version published upstream), which exists today as well, since routine version bumps are typically merged within a day or two of being opened. The cooldown applies to both the `gomod` and `github-actions` ecosystems.
- The merge queue still revalidates CI before any PR lands, and the workflow re-verifies that the PR head SHA has not changed between commit verification and merge.
