### PR TITLE
Experimental External CA mode

### DIFF
--- a/cmd/spire-server/cli/run/external_ca_test.go
+++ b/cmd/spire-server/cli/run/external_ca_test.go
@@ -1,0 +1,98 @@
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseConfigExternalCA verifies the experimental external_ca / pkcs11 HCL
+// block is decoded into the config struct.
+func TestParseConfigExternalCA(t *testing.T) {
+	hclConfig := `
+server {
+	bind_address = "127.0.0.1"
+	bind_port = "8081"
+	trust_domain = "example.org"
+	data_dir = "."
+
+	experimental {
+		external_ca {
+			enabled = true
+			root_cert_file_path = "/opt/spire/certs/root-cert.pem"
+			cert_file_path = "/opt/spire/certs/intermediate-cert.pem"
+			pkcs11 {
+				pkcs11_uri = "pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so;token=SPIRE;pin-value=1234"
+				pkcs11_object = "pkcs11:object=intermediate-ca-key"
+			}
+		}
+	}
+}
+plugins {}
+`
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "server.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(hclConfig), 0o600))
+
+	c, err := ParseFile(confPath, false)
+	require.NoError(t, err)
+
+	extCA := c.Server.Experimental.ExternalCA
+	require.NotNil(t, extCA)
+	require.True(t, extCA.Enabled)
+	require.Equal(t, "/opt/spire/certs/root-cert.pem", extCA.RootCertFilePath)
+	require.Equal(t, "/opt/spire/certs/intermediate-cert.pem", extCA.CertFilePath)
+	require.NotNil(t, extCA.PKCS11)
+	require.Equal(t, "pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so;token=SPIRE;pin-value=1234", extCA.PKCS11.Pkcs11URI)
+	require.Equal(t, "pkcs11:object=intermediate-ca-key", extCA.PKCS11.Pkcs11Object)
+}
+
+// TestNewServerConfigExternalCA verifies the external_ca config is plumbed into
+// the server.Config when enabled, and ignored when disabled.
+func TestNewServerConfigExternalCA(t *testing.T) {
+	logOptions := []log.Option{}
+
+	t.Run("enabled", func(t *testing.T) {
+		c := defaultValidConfig()
+		c.Server.Experimental.ExternalCA = &externalCAConfig{
+			Enabled:          true,
+			RootCertFilePath: "/root.pem",
+			CertFilePath:     "/intermediate.pem",
+			PKCS11: &pkcs11Config{
+				Pkcs11URI:    "pkcs11:token=SPIRE;pin-value=1234",
+				Pkcs11Object: "pkcs11:object=intermediate-ca-key",
+			},
+		}
+
+		sc, err := NewServerConfig(c, logOptions, false)
+		require.NoError(t, err)
+		require.True(t, sc.ExternalCA.Enabled)
+		require.Equal(t, "/root.pem", sc.ExternalCA.RootCertFilePath)
+		require.Equal(t, "/intermediate.pem", sc.ExternalCA.CertFilePath)
+		require.NotNil(t, sc.ExternalCA.PKCS11)
+		require.Equal(t, "pkcs11:token=SPIRE;pin-value=1234", sc.ExternalCA.PKCS11.PKCS11URI)
+		require.Equal(t, "pkcs11:object=intermediate-ca-key", sc.ExternalCA.PKCS11.PKCS11Object)
+	})
+
+	t.Run("disabled leaves external CA unset", func(t *testing.T) {
+		c := defaultValidConfig()
+		c.Server.Experimental.ExternalCA = &externalCAConfig{Enabled: false}
+
+		sc, err := NewServerConfig(c, logOptions, false)
+		require.NoError(t, err)
+		require.False(t, sc.ExternalCA.Enabled)
+		require.Nil(t, sc.ExternalCA.PKCS11)
+	})
+
+	t.Run("absent leaves external CA unset", func(t *testing.T) {
+		c := defaultValidConfig()
+
+		sc, err := NewServerConfig(c, logOptions, false)
+		require.NoError(t, err)
+		require.False(t, sc.ExternalCA.Enabled)
+		require.Nil(t, sc.ExternalCA.PKCS11)
+	})
+}

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -118,6 +118,7 @@ type experimentalConfig struct {
 	RequirePQKEM            bool                        `hcl:"require_pq_kem"`
 	WITKeyType              string                      `hcl:"wit_key_type"`
 	WITIssuer               string                      `hcl:"wit_issuer"`
+	ExternalCA              *externalCAConfig           `hcl:"external_ca"`
 
 	Flags fflag.RawConfig `hcl:"feature_flags"`
 
@@ -131,6 +132,18 @@ type caSubjectConfig struct {
 	Organization       []string               `hcl:"organization"`
 	CommonName         string                 `hcl:"common_name"`
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
+}
+
+type externalCAConfig struct {
+	Enabled          bool          `hcl:"enabled"`
+	RootCertFilePath string        `hcl:"root_cert_file_path"`
+	CertFilePath     string        `hcl:"cert_file_path"`
+	PKCS11           *pkcs11Config `hcl:"pkcs11"`
+}
+
+type pkcs11Config struct {
+	Pkcs11URI    string `hcl:"pkcs11_uri"`
+	Pkcs11Object string `hcl:"pkcs11_object"`
 }
 
 type federationConfig struct {
@@ -785,6 +798,20 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 
 	for _, f := range c.Server.Experimental.Flags {
 		sc.Log.Warnf("Developer feature flag %q has been enabled", f)
+	}
+
+	if c.Server.Experimental.ExternalCA != nil && c.Server.Experimental.ExternalCA.Enabled {
+		sc.ExternalCA = server.ExternalCAConfig{
+			Enabled:          c.Server.Experimental.ExternalCA.Enabled,
+			RootCertFilePath: c.Server.Experimental.ExternalCA.RootCertFilePath,
+			CertFilePath:     c.Server.Experimental.ExternalCA.CertFilePath,
+		}
+		if c.Server.Experimental.ExternalCA.PKCS11 != nil {
+			sc.ExternalCA.PKCS11 = &server.PKCS11Config{
+				PKCS11URI:    c.Server.Experimental.ExternalCA.PKCS11.Pkcs11URI,
+				PKCS11Object: c.Server.Experimental.ExternalCA.PKCS11.Pkcs11Object,
+			}
+		}
 	}
 
 	return sc, nil

--- a/doc/external_ca_hsm.md
+++ b/doc/external_ca_hsm.md
@@ -1,0 +1,340 @@
+# Using an External CA with HSM (Experimental)
+
+This document describes how to configure SPIRE Server to use an existing Certificate Authority (CA) from a Hardware Security Module (HSM) instead of generating its own intermediate CA.
+
+## Overview
+
+By default, SPIRE Server generates and manages its own X.509 intermediate CA, rotating it automatically according to configured TTLs. However, in some enterprise environments, organizations need to:
+
+- Use existing PKI infrastructure
+- Store CA keys in Hardware Security Modules (HSMs) for enhanced security
+- Maintain compliance with policies requiring hardware-backed key storage
+- Integrate SPIRE into established certificate hierarchies
+
+The External CA feature allows SPIRE Server to use a pre-existing intermediate CA certificate with its private key stored in an HSM, accessed via PKCS#11.
+
+## How It Works
+
+When external CA mode is enabled:
+
+1. **X.509 CA**: SPIRE loads an existing intermediate CA certificate and uses the HSM for signing operations
+2. **JWT Keys**: Continue to rotate normally using the configured key manager
+3. **Trust Bundle**: Contains both the root CA and intermediate CA certificates
+4. **Rotation**: X.509 CA rotation is disabled; the external CA remains static
+
+## Architecture Changes
+
+### Normal SPIRE CA Management
+```
+┌─────────────────────────────────────┐
+│  SPIRE Server                       │
+│  ┌────────────────────────────────┐ │
+│  │  CA Manager                    │ │
+│  │  - Generates Intermediate CA   │ │
+│  │  - Rotates CA automatically    │ │
+│  │  - Stores keys in KeyManager   │ │
+│  └────────────────────────────────┘ │
+└─────────────────────────────────────┘
+```
+
+### External CA Mode
+```
+┌─────────────────────────────────────┐
+│  SPIRE Server                       │
+│  ┌────────────────────────────────┐ │
+│  │  CA Manager                    │ │
+│  │  - Loads existing cert         │ │
+│  │  - Uses HSM for signing        │ │
+│  │  - No X.509 CA rotation        │ │
+│  └────────────┬───────────────────┘ │
+└────────────────┼─────────────────────┘
+                 │ PKCS#11
+                 ▼
+        ┌──────────────────┐
+        │  HSM             │
+        │  - Stores CA key │
+        │  - Signs SVIDs   │
+        └──────────────────┘
+```
+
+## Configuration
+
+### Prerequisites
+
+1. **Root CA Certificate**: PEM-encoded root certificate
+2. **Intermediate CA Certificate**: PEM-encoded intermediate certificate signed by the root
+3. **HSM Access**: PKCS#11-accessible HSM with the intermediate CA private key
+4. **PKCS#11 URI**: Connection details for the HSM
+
+### Configuration Example
+
+```hcl
+server {
+    trust_domain = "example.org"
+    data_dir = "/opt/spire/data"
+
+    experimental {
+        external_ca {
+            enabled = true
+            root_cert_file_path = "/opt/spire/conf/root-ca.pem"
+            cert_file_path = "/opt/spire/conf/intermediate-ca.pem"
+            pkcs11 {
+                pkcs11_uri = "pkcs11:token=MyHSM;pin-value=1234"
+                pkcs11_object = "spire-intermediate-key"
+            }
+        }
+    }
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "postgres"
+            connection_string = "postgresql://user:pass@localhost/spire"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    # KeyManager still used for JWT keys
+    KeyManager "disk" {
+        plugin_data {
+            keys_path = "/opt/spire/.data/keys.json"
+        }
+    }
+}
+```
+
+### Configuration Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `enabled` | Enable external CA mode | Yes |
+| `root_cert_file_path` | Path to root CA certificate (PEM) | Yes |
+| `cert_file_path` | Path to intermediate CA certificate (PEM) | Yes |
+| `pkcs11.pkcs11_uri` | PKCS#11 URI for HSM connection | Yes |
+| `pkcs11.pkcs11_object` | Object name/ID of the private key in HSM | Yes |
+
+### PKCS#11 URI Format
+
+The PKCS#11 URI should follow the format:
+```
+pkcs11:token=<token-name>;pin-value=<pin>
+```
+
+Additional attributes can be included:
+```
+pkcs11:token=MyToken;slot-id=0;pin-value=1234
+pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so;token=MyToken;pin-value=secret
+```
+
+Refer to [RFC 7512](https://tools.ietf.org/html/rfc7512) for complete URI specification.
+
+## Certificate Requirements
+
+### Root Certificate
+- Must be a valid X.509 CA certificate
+- Should have appropriate KeyUsage (keyCertSign, cRLSign)
+- Must be trusted by all SPIRE components
+
+### Intermediate Certificate
+- Must be signed by the root certificate
+- Must have `BasicConstraints: CA=TRUE`
+- Must have appropriate KeyUsage (digitalSignature, keyCertSign, cRLSign)
+- Public key must match the private key stored in the HSM
+- Should have a validity period appropriate for your environment
+
+### Validation Checks
+
+SPIRE Server performs the following validations on startup:
+
+1. **Chain Verification**: Verifies intermediate is signed by root
+2. **CA Constraints**: Checks that intermediate has `CA:TRUE`
+3. **Key Matching**: Verifies HSM key matches certificate public key
+
+If any validation fails, SPIRE Server will not start and will log the specific error.
+
+## Certificate Lifecycle
+
+### Initial Setup
+
+1. Generate or obtain root and intermediate certificates from your PKI
+2. Import the intermediate private key into your HSM
+3. Configure SPIRE Server with paths to certificates and HSM details
+4. Start SPIRE Server
+
+### Certificate Renewal
+
+When the intermediate certificate approaches expiration:
+
+1. SPIRE logs a warning 30 days before expiration
+2. Generate a new intermediate certificate with the same key
+3. Update the `cert_file_path` to point to the new certificate
+4. Restart SPIRE Server
+
+**Important**: The private key in the HSM remains the same; only the certificate is renewed.
+
+### Monitoring
+
+Monitor the following:
+- Certificate expiration dates
+- HSM availability and connectivity
+- SPIRE Server logs for expiration warnings
+
+## Operational Considerations
+
+### JWT Key Rotation
+
+JWT keys continue to rotate normally using the configured KeyManager. This ensures JWT-SVIDs can be refreshed even though the X.509 CA is static.
+
+### High Availability
+
+For HA deployments:
+- All SPIRE servers must be configured identically
+- All servers must have access to the same HSM
+- Certificate files must be available on all nodes
+- HSM must support concurrent access from multiple servers
+
+### Backup and Recovery
+
+**Critical**: The intermediate CA private key in the HSM is the root of trust. Ensure:
+- HSM backup procedures are in place
+- Recovery procedures are tested
+- Certificate files are backed up
+- PKCS#11 credentials are securely stored
+
+### Performance
+
+HSM signing operations may have different performance characteristics compared to software signing:
+- Latency may be higher for each signing operation
+- Throughput depends on HSM capabilities
+- Consider HSM capacity when sizing your deployment
+
+## Security Considerations
+
+### Key Security
+- The intermediate CA key never leaves the HSM
+- All signing operations occur within the HSM
+- PIN/credentials should be protected (consider using environment variables)
+
+### Access Control
+- Restrict file system access to certificate files
+- Use HSM access controls to limit who can use the signing key
+- Audit HSM access logs
+
+### Credential Management
+- **Do not** hardcode PINs in configuration files
+- Use environment variable expansion: `pin-value=$HSM_PIN`
+- Rotate HSM PINs according to your security policy
+
+## Troubleshooting
+
+### Common Issues
+
+**Error: "intermediate CA certificate is not signed by root CA"**
+- Verify the intermediate certificate is actually signed by the root
+- Check that you're using the correct root certificate file
+- Use `openssl verify` to validate the chain
+
+**Error: "HSM signer public key does not match intermediate certificate public key"**
+- The key in the HSM doesn't match the certificate
+- Verify you're referencing the correct key object in the HSM
+- Check the certificate was generated from the HSM key
+
+**Error: "failed to initialize PKCS#11"**
+- HSM is not accessible
+- PKCS#11 URI is incorrect
+- HSM driver/library not installed
+- Check HSM connectivity and credentials
+
+**Warning: "External CA certificate is approaching expiration"**
+- Certificate expires in less than 30 days
+- Renew the certificate soon
+- No immediate action required, but plan renewal
+
+### Debugging
+
+Enable debug logging:
+```hcl
+server {
+    log_level = "DEBUG"
+}
+```
+
+Check logs for:
+- Certificate loading messages
+- HSM connection details
+- Validation results
+- Expiration warnings
+
+### Testing HSM Connectivity
+
+Before configuring SPIRE, test HSM access:
+```bash
+# List available tokens
+pkcs11-tool --list-tokens
+
+# List objects on a specific token
+pkcs11-tool --token "MyToken" --login --list-objects
+
+# Test signing operation
+pkcs11-tool --token "MyToken" --login --sign --id <key-id>
+```
+
+## Migration
+
+### From Standard SPIRE to External CA
+
+1. **Generate or obtain certificates** from your PKI
+2. **Import intermediate key** to HSM
+3. **Stop SPIRE Server**
+4. **Add external_ca configuration**
+5. **Start SPIRE Server**
+
+Note: This is a one-way migration. Reverting requires reconfiguring all workloads.
+
+### Testing the Migration
+
+1. Set up a test environment mirroring production
+2. Configure external CA in test
+3. Verify workload SVIDs are issued correctly
+4. Check agent connectivity
+5. Monitor for any errors over several rotation cycles
+
+## Limitations
+
+- X.509 CA certificates must be renewed manually
+- The feature is experimental and subject to change
+- HSM must support PKCS#11
+- Certificate chain validation is performed on startup only
+- Root CA cannot be rotated without recreating the trust domain
+
+## Example: Using SoftHSM for Testing
+
+For testing purposes, you can use SoftHSM:
+
+```bash
+# Install SoftHSM
+apt-get install softhsm2
+
+# Initialize token
+softhsm2-util --init-token --slot 0 --label "TestToken" --pin 1234 --so-pin 5678
+
+# Import private key
+softhsm2-util --import intermediate-key.pem --slot 0 --label "spire-ca" --id 01 --pin 1234
+
+# Configure SPIRE
+pkcs11_uri = "pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so;token=TestToken;pin-value=1234"
+pkcs11_object = "spire-ca"
+```
+
+**Warning**: SoftHSM provides no real security benefits and should only be used for testing.
+
+## Further Reading
+
+- [PKCS#11 Specification](http://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html)
+- [RFC 7512: PKCS#11 URI](https://tools.ietf.org/html/rfc7512)
+- [SPIRE Server Configuration Reference](/doc/spire_server.md)
+- [X.509 Certificate and CRL Profile (RFC 5280)](https://tools.ietf.org/html/rfc5280)

--- a/doc/external_ca_hsm.md
+++ b/doc/external_ca_hsm.md
@@ -85,26 +85,7 @@ server {
         }
     }
 }
-
-plugins {
-    DataStore "sql" {
-        plugin_data {
-            database_type = "postgres"
-            connection_string = "postgresql://user:pass@localhost/spire"
-        }
-    }
-
-    NodeAttestor "join_token" {
-        plugin_data {}
-    }
-
-    # KeyManager still used for JWT keys
-    KeyManager "disk" {
-        plugin_data {
-            keys_path = "/opt/spire/.data/keys.json"
-        }
-    }
-}
+...
 ```
 
 ### Configuration Parameters
@@ -192,8 +173,7 @@ JWT keys continue to rotate normally using the configured KeyManager. This ensur
 ### High Availability
 
 For HA deployments:
-- All SPIRE servers must be configured identically
-- All servers must have access to the same HSM
+- All SPIRE servers can either share an HSM (network) or use different ones so long as the root CA is shared
 - Certificate files must be available on all nodes
 - HSM must support concurrent access from multiple servers
 
@@ -282,26 +262,6 @@ pkcs11-tool --token "MyToken" --login --list-objects
 # Test signing operation
 pkcs11-tool --token "MyToken" --login --sign --id <key-id>
 ```
-
-## Migration
-
-### From Standard SPIRE to External CA
-
-1. **Generate or obtain certificates** from your PKI
-2. **Import intermediate key** to HSM
-3. **Stop SPIRE Server**
-4. **Add external_ca configuration**
-5. **Start SPIRE Server**
-
-Note: This is a one-way migration. Reverting requires reconfiguring all workloads.
-
-### Testing the Migration
-
-1. Set up a test environment mirroring production
-2. Configure external CA in test
-3. Verify workload SVIDs are issued correctly
-4. Check agent connectivity
-5. Monitor for any errors over several rotation cycles
 
 ## Limitations
 

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -96,18 +96,8 @@ This may be useful for templating configuration files, for example across differ
 | `organization`              | Array of `Organization` values |                |
 | `common_name`               | The `CommonName` value         |                |
 
-| experimental                  | Description                                                                                                                                                                                                            | Default                            |
-|:------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|
-| `agent_spiffe_id_as_selector` | Enable adding the agent spiffe_id to the list of node selectors automatically.                                                                                                                                         | false                              |
-| `cache_reload_interval`       | The amount of time between two reloads of the in-memory entry cache. Increasing this will mitigate high database load for extra large deployments, but will also slow propagation of new or updated entries to agents. | 5s                                 |
-| `full_cache_reload_interval`  | How often to a full reload of the cache from the database when using the events based cache.                                                                                                                           | 24h                                |
-| `events_based_cache`          | Use events to update the cache with what's changed since the last update. Enabling this will reduce overhead on the database.                                                                                          | false                              |
-| `prune_events_older_than`     | How old an event can be before being deleted. Used with events based cache. Decreasing this will keep the events table smaller, but will increase risk of missing an event if connection to the database is down.      | 12h                                |
-| `event_timeout`               | Maximum time to wait for an event to come in before giving up.                                                                                                                                                         | 15m                                |
-| `auth_opa_policy_engine`      | The [auth opa_policy engine](/doc/authorization_policy_engine.md) used for authorization decisions                                                                                                                     | default SPIRE authorization policy |
-| `named_pipe_name`             | Pipe name of the SPIRE Server API named pipe (Windows only)                                                                                                                                                            | \spire-server\private\api          |
-| `require_pq_kem`              | Require use of a post-quantum-safe key exchange method for TLS handshakes                                                                                                                                              | false                              |
 | `wit_issuer`                  | The issuer claim used when minting WIT-SVIDs                                                                                                                                                                           |                                    |
+| `external_ca`                 | Configuration for using an existing CA from an HSM (see [External CA Configuration](#external-ca-configuration))                                                                                                       |                                    |
 
 | ratelimit     | Description                                                                                                                                        | Default |
 |:--------------|----------------------------------------------------------------------------------------------------------------------------------------------------|---------|
@@ -122,6 +112,62 @@ This may be useful for templating configuration files, for example across differ
 |:------------------------------|-------------------------------------------------------------------------------------------|----------------|
 | `rego_path`                   | File to retrieve OPA rego policy for authorization.                                       |                |
 | `policy_data_path`            | File to retrieve databindings for policy evaluation.                                      |                |
+
+### External CA Configuration
+
+The `external_ca` configuration allows SPIRE Server to use an existing Certificate Authority from an HSM (Hardware Security Module) instead of generating its own intermediate CA. This is useful for integrating SPIRE with existing PKI infrastructure where CA keys are stored in hardware security modules.
+
+When enabled, SPIRE will:
+- Load an existing intermediate CA certificate and use the corresponding private key from an HSM for signing operations
+- Skip X.509 CA rotation (the external CA remains static)
+- Continue normal JWT key rotation for JWT-SVID signing
+
+**Important Notes:**
+- This is an experimental feature and may change in future releases
+- The intermediate CA certificate must be renewed manually before expiration
+- SPIRE will log a warning when the certificate is within 30 days of expiration
+- The HSM must be accessible via PKCS#11
+
+For detailed information, see the [External CA with HSM documentation](/doc/external_ca_hsm.md).
+
+| external_ca         | Description                                                                                | Required |
+|:--------------------|--------------------------------------------------------------------------------------------|----------|
+| `enabled`           | Enable external CA mode                                                                    | Yes      |
+| `root_cert_file_path` | Path to the root CA certificate (PEM format)                                              | Yes      |
+| `cert_file_path`    | Path to the intermediate CA certificate (PEM format)                                      | Yes      |
+| `pkcs11`            | PKCS#11 configuration for accessing the HSM                                                | Yes      |
+
+| pkcs11       | Description                                                                                           | Required |
+|:-------------|-------------------------------------------------------------------------------------------------------|----------|
+| `pkcs11_uri` | PKCS#11 URI for connecting to the HSM (e.g., "pkcs11:token=MyToken;pin-value=1234")                  | Yes      |
+| `pkcs11_object` | Name or identifier of the private key object in the HSM                                            | Yes      |
+
+**Example Configuration:**
+
+```hcl
+server {
+    trust_domain = "example.org"
+    data_dir = "/opt/spire/data"
+
+    experimental {
+        external_ca {
+            enabled = true
+            root_cert_file_path = "/opt/spire/conf/root-ca.pem"
+            cert_file_path = "/opt/spire/conf/intermediate-ca.pem"
+            pkcs11 {
+                pkcs11_uri = "pkcs11:token=MyHSM;pin-value=secret"
+                pkcs11_object = "intermediate-ca-key"
+            }
+        }
+    }
+}
+```
+
+**Certificate Requirements:**
+- The intermediate certificate must be signed by the root certificate
+- The intermediate certificate must have `CA:TRUE` in BasicConstraints
+- The private key in the HSM must correspond to the intermediate certificate's public key
+- Both certificates must be in PEM format
 
 ### Profiling Names
 
@@ -822,6 +868,19 @@ server {
         organization = ["SPIRE"]
         common_name = ""
     }
+
+    # Experimental: Use an external CA from an HSM
+    # experimental {
+    #     external_ca {
+    #         enabled = true
+    #         root_cert_file_path = "/opt/spire/conf/root-ca.pem"
+    #         cert_file_path = "/opt/spire/conf/intermediate-ca.pem"
+    #         pkcs11 {
+    #             pkcs11_uri = "pkcs11:token=MyHSM;pin-value=secret"
+    #             pkcs11_object = "intermediate-ca-key"
+    #         }
+    #     }
+    # }
 }
 
 telemetry {

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/uber-go/tally/v4 v4.1.17
 	github.com/valyala/fastjson v1.6.10
+	go.step.sm/crypto v0.77.7
 	golang.org/x/crypto v0.52.0
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93
 	golang.org/x/net v0.55.0
@@ -122,6 +123,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
+	github.com/ThalesIgnite/crypto11 v1.2.5 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -242,6 +244,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/miekg/pkcs11 v1.1.2 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
@@ -284,6 +287,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
+	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/theupdateframework/go-tuf v0.7.0 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.1 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSC
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
+github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
+github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -630,6 +632,9 @@ github.com/mattn/go-sqlite3 v1.14.44/go.mod h1:pjEuOr8IwzLJP2MfGeTb0A35jauH+C2kb
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
 github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
+github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.2 h1:/VxmeAX5qU6Q3EwafypogwWbYryHFmF2RpkJmw3m4MQ=
+github.com/miekg/pkcs11 v1.1.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=
 github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -829,6 +834,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tchap/go-patricia/v2 v2.3.3 h1:xfNEsODumaEcCcY3gI0hYPZ/PcpVv5ju6RMAhgwZDDc=
 github.com/tchap/go-patricia/v2 v2.3.3/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=
+github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
+github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.7.0 h1:CqbQFrWo1ae3/I0UCblSbczevCCbS31Qvs5LdxRWqRI=
 github.com/theupdateframework/go-tuf v0.7.0/go.mod h1:uEB7WSY+7ZIugK6R1hiBMBjQftaFzn7ZCDJcp1tCUug=
 github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4+coG1iNURAGCw=

--- a/pkg/server/ca/manager/external_ca_test.go
+++ b/pkg/server/ca/manager/external_ca_test.go
@@ -1,0 +1,140 @@
+package manager
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/test/testca"
+	"github.com/stretchr/testify/require"
+)
+
+// writeCertFile PEM-encodes cert and writes it to a file in dir, returning the
+// path.
+func writeCertFile(t *testing.T, dir, name string, certPEM []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, certPEM, 0o600))
+	return path
+}
+
+// TestNewManagerExternalCAValidation covers the configuration and certificate
+// validation performed by NewManager when external X.509 CA mode is enabled.
+// These checks run before any PKCS#11 module is loaded, so they can be
+// exercised without an HSM.
+func TestNewManagerExternalCAValidation(t *testing.T) {
+	dir := t.TempDir()
+
+	// A valid root -> intermediate chain.
+	root := testca.New(t, testTrustDomain)
+	intermediate := root.ChildCA()
+	rootPEM := pemutil.EncodeCertificate(root.X509Authorities()[0])
+	// A leaf created by the intermediate yields the chain [leaf, intermediateCA];
+	// the last element is the intermediate CA certificate itself.
+	intermediateChain, _ := intermediate.CreateX509Certificate()
+	intermediateCAPEM := pemutil.EncodeCertificate(intermediateChain[len(intermediateChain)-1])
+
+	validRootPath := writeCertFile(t, dir, "root.pem", rootPEM)
+	validIntermediatePath := writeCertFile(t, dir, "intermediate.pem", intermediateCAPEM)
+
+	// A self-signed CA not signed by the root (different root).
+	otherRoot := testca.New(t, testTrustDomain)
+	unsignedIntermediatePEM := pemutil.EncodeCertificate(otherRoot.X509Authorities()[0])
+	unsignedIntermediatePath := writeCertFile(t, dir, "unsigned-intermediate.pem", unsignedIntermediatePEM)
+
+	// A non-CA certificate signed by the root.
+	nonCACerts, _ := root.CreateX509Certificate()
+	nonCAPEM := pemutil.EncodeCertificate(nonCACerts[0])
+	nonCAPath := writeCertFile(t, dir, "non-ca.pem", nonCAPEM)
+
+	baseConfig := func(t *testing.T) Config {
+		mt := setupTest(t)
+		c := mt.selfSignedConfig()
+		c.UseExternalX509CA = true
+		c.RootCertPath = validRootPath
+		c.IntermediateCertPath = validIntermediatePath
+		c.PKCS11URI = "pkcs11:module-path=/does/not/matter;token=SPIRE;pin-value=1234"
+		c.PKCS11SigningKey = "pkcs11:object=intermediate-ca-key"
+		return c
+	}
+
+	t.Run("missing root_cert_file_path", func(t *testing.T) {
+		c := baseConfig(t)
+		c.RootCertPath = ""
+		_, err := NewManager(context.Background(), c)
+		require.EqualError(t, err, "external CA mode requires root_cert_file_path to be configured")
+	})
+
+	t.Run("missing cert_file_path", func(t *testing.T) {
+		c := baseConfig(t)
+		c.IntermediateCertPath = ""
+		_, err := NewManager(context.Background(), c)
+		require.EqualError(t, err, "external CA mode requires cert_file_path to be configured")
+	})
+
+	t.Run("missing pkcs11_uri", func(t *testing.T) {
+		c := baseConfig(t)
+		c.PKCS11URI = ""
+		_, err := NewManager(context.Background(), c)
+		require.EqualError(t, err, "external CA mode requires pkcs11_uri to be configured")
+	})
+
+	t.Run("missing pkcs11_object", func(t *testing.T) {
+		c := baseConfig(t)
+		c.PKCS11SigningKey = ""
+		_, err := NewManager(context.Background(), c)
+		require.EqualError(t, err, "external CA mode requires pkcs11_object to be configured")
+	})
+
+	t.Run("root certificate file does not exist", func(t *testing.T) {
+		c := baseConfig(t)
+		c.RootCertPath = filepath.Join(dir, "missing-root.pem")
+		_, err := NewManager(context.Background(), c)
+		require.ErrorContains(t, err, "failed to load root CA certificate")
+	})
+
+	t.Run("intermediate certificate file does not exist", func(t *testing.T) {
+		c := baseConfig(t)
+		c.IntermediateCertPath = filepath.Join(dir, "missing-intermediate.pem")
+		_, err := NewManager(context.Background(), c)
+		require.ErrorContains(t, err, "failed to load intermediate CA certificate")
+	})
+
+	t.Run("intermediate not signed by root", func(t *testing.T) {
+		c := baseConfig(t)
+		c.IntermediateCertPath = unsignedIntermediatePath
+		_, err := NewManager(context.Background(), c)
+		require.ErrorContains(t, err, "intermediate CA certificate is not signed by root CA")
+	})
+
+	t.Run("intermediate is not a CA certificate", func(t *testing.T) {
+		c := baseConfig(t)
+		c.IntermediateCertPath = nonCAPath
+		_, err := NewManager(context.Background(), c)
+		require.ErrorContains(t, err, "intermediate certificate is not a CA certificate")
+	})
+
+	t.Run("valid chain proceeds to PKCS11 initialization", func(t *testing.T) {
+		// With a valid configuration and chain, validation passes and the
+		// manager attempts to load the PKCS#11 module. Since the module path is
+		// bogus, it fails at PKCS#11 initialization rather than at any of the
+		// validation checks above, proving the validation gate was cleared.
+		c := baseConfig(t)
+		_, err := NewManager(context.Background(), c)
+		require.ErrorContains(t, err, "PKCS#11")
+	})
+}
+
+func TestPublicKeysEqual(t *testing.T) {
+	root := testca.New(t, testTrustDomain)
+	other := testca.New(t, testTrustDomain)
+
+	rootKey := root.X509Authorities()[0].PublicKey
+	otherKey := other.X509Authorities()[0].PublicKey
+
+	require.True(t, publicKeysEqual(rootKey, rootKey))
+	require.False(t, publicKeysEqual(rootKey, otherKey))
+	require.False(t, publicKeysEqual(rootKey, nil))
+}

--- a/pkg/server/ca/manager/journal.go
+++ b/pkg/server/ca/manager/journal.go
@@ -208,6 +208,15 @@ func (j *Journal) setEntries(entries *journal.Entries) {
 	j.entries = entries
 }
 
+// SetActiveX509AuthorityID sets the active X.509 authority ID for external CA usage.
+// This is used when the CA is managed externally (e.g., via HSM) and not tracked in the journal.
+func (j *Journal) SetActiveX509AuthorityID(authorityID string) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	j.activeX509AuthorityID = authorityID
+}
+
 // saveInDatastore saves the provided marshaled entries in the datastore.
 // If caJournalID has not been defined yet (its value is 0), it first finds
 // the CA journal record that corresponds to this server. In case there is no

--- a/pkg/server/ca/manager/manager.go
+++ b/pkg/server/ca/manager/manager.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/backoff"
 	"github.com/spiffe/spire/pkg/common/coretypes/x509certificate"
+	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
 	telemetry_server "github.com/spiffe/spire/pkg/common/telemetry/server"
 	"github.com/spiffe/spire/pkg/common/x509util"
@@ -28,6 +30,8 @@ import (
 	"github.com/spiffe/spire/pkg/server/plugin/notifier"
 	"github.com/spiffe/spire/proto/private/server/journal"
 	"github.com/spiffe/spire/proto/spire/common"
+	"go.step.sm/crypto/kms/apiv1"
+	"go.step.sm/crypto/kms/pkcs11"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -82,20 +86,25 @@ type AuthorityManager interface {
 }
 
 type Config struct {
-	CredBuilder     *credtemplate.Builder
-	CredValidator   *credvalidator.Validator
-	CA              ManagedCA
-	Catalog         catalog.Catalog
-	TrustDomain     spiffeid.TrustDomain
-	X509CAKeyType   keymanager.KeyType
-	DisableJWTSVIDs bool
-	DisableWITSVIDs bool
-	JWTKeyType      keymanager.KeyType
-	WITKeyType      keymanager.KeyType
-	Dir             string
-	Log             logrus.FieldLogger
-	Metrics         telemetry.Metrics
-	Clock           clock.Clock
+	CredBuilder          *credtemplate.Builder
+	CredValidator        *credvalidator.Validator
+	CA                   ManagedCA
+	Catalog              catalog.Catalog
+	TrustDomain          spiffeid.TrustDomain
+	X509CAKeyType        keymanager.KeyType
+	DisableJWTSVIDs      bool
+	DisableWITSVIDs      bool
+	JWTKeyType           keymanager.KeyType
+	WITKeyType           keymanager.KeyType
+	Dir                  string
+	Log                  logrus.FieldLogger
+	Metrics              telemetry.Metrics
+	Clock                clock.Clock
+	UseExternalX509CA    bool
+	RootCertPath         string
+	IntermediateCertPath string
+	PKCS11URI            string
+	PKCS11SigningKey     string
 }
 
 type Manager struct {
@@ -125,6 +134,22 @@ type Manager struct {
 
 	// Used for testing backoff, must not be set in regular code
 	triggerBackOffCh chan error
+	// pkcs11KMS to avoid resource leaks
+	pkcs11KMS io.Closer
+}
+
+// publicKeysEqual compares two public keys for equality.
+// Supports RSA, ECDSA, and Ed25519 keys.
+func publicKeysEqual(a, b crypto.PublicKey) bool {
+	aBytes, err := x509.MarshalPKIXPublicKey(a)
+	if err != nil {
+		return false
+	}
+	bBytes, err := x509.MarshalPKIXPublicKey(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aBytes, bBytes)
 }
 
 func NewManager(ctx context.Context, c Config) (*Manager, error) {
@@ -161,6 +186,102 @@ func NewManager(ctx context.Context, c Config) (*Manager, error) {
 		Catalog:        c.Catalog,
 		UpstreamClient: m.upstreamClient,
 	}
+	if c.UseExternalX509CA {
+		// Validate configuration
+		if c.RootCertPath == "" {
+			return nil, fmt.Errorf("external CA mode requires root_cert_file_path to be configured")
+		}
+		if c.IntermediateCertPath == "" {
+			return nil, fmt.Errorf("external CA mode requires cert_file_path to be configured")
+		}
+		if c.PKCS11URI == "" {
+			return nil, fmt.Errorf("external CA mode requires pkcs11_uri to be configured")
+		}
+		if c.PKCS11SigningKey == "" {
+			return nil, fmt.Errorf("external CA mode requires pkcs11_object to be configured")
+		}
+
+		// Load certificates
+		rootCA, err := pemutil.LoadCertificate(c.RootCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load root CA certificate: %w", err)
+		}
+
+		intermediateCA, err := pemutil.LoadCertificate(c.IntermediateCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load intermediate CA certificate: %w", err)
+		}
+
+		// Validate certificate chain
+		if err := intermediateCA.CheckSignatureFrom(rootCA); err != nil {
+			return nil, fmt.Errorf("intermediate CA certificate is not signed by root CA: %w", err)
+		}
+
+		// Verify intermediate has CA constraints
+		if !intermediateCA.IsCA {
+			return nil, fmt.Errorf("intermediate certificate is not a CA certificate (BasicConstraints.CA is false)")
+		}
+
+		if _, err := m.appendBundle(ctx, []*x509.Certificate{rootCA, intermediateCA}, nil, nil); err != nil {
+			return nil, fmt.Errorf("failed to append certs to bundle: %w", err)
+		}
+
+		// Load signer from HSM
+		p11, err := pkcs11.New(ctx, apiv1.Options{
+			Type: "pkcs11",
+			URI:  c.PKCS11URI,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize PKCS#11: %w", err)
+		}
+		m.pkcs11KMS = p11
+		signer, err := p11.CreateSigner(&apiv1.CreateSignerRequest{
+			SigningKey: c.PKCS11SigningKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create signer from HSM: %w", err)
+		}
+
+		// Verify signer's public key matches the intermediate certificate's public key
+		if !publicKeysEqual(signer.Public(), intermediateCA.PublicKey) {
+			return nil, fmt.Errorf("HSM signer public key does not match intermediate certificate public key")
+		}
+
+		x509CA := &ca.X509CA{
+			Signer:      signer,
+			Certificate: intermediateCA,
+		}
+
+		m.currentX509CA = &x509CASlot{
+			id:                  c.PKCS11SigningKey,
+			x509CA:              x509CA,
+			issuedAt:            intermediateCA.NotBefore,
+			status:              journal.Status_ACTIVE,
+			authorityID:         x509util.SubjectKeyIDToString(intermediateCA.SubjectKeyId),
+			upstreamAuthorityID: x509util.SubjectKeyIDToString(intermediateCA.AuthorityKeyId),
+			publicKey:           intermediateCA.PublicKey,
+			notAfter:            intermediateCA.NotAfter,
+		}
+
+		// Initialize nextX509CA as an empty slot to prevent nil pointer issues with the rotator
+		m.nextX509CA = &x509CASlot{}
+
+		m.c.CA.SetX509CA(x509CA)
+
+		// Log certificate info and warn if approaching expiration
+		timeUntilExpiry := time.Until(intermediateCA.NotAfter)
+		m.c.Log.WithFields(logrus.Fields{
+			"authority_id": m.currentX509CA.authorityID,
+			"not_before":   intermediateCA.NotBefore,
+			"not_after":    intermediateCA.NotAfter,
+			"expires_in":   timeUntilExpiry.String(),
+		}).Info("Loaded external X.509 CA from HSM")
+
+		// Warn if certificate is approaching expiration
+		if timeUntilExpiry < 30*24*time.Hour {
+			m.c.Log.WithField("expires_in", timeUntilExpiry.String()).Warn("External CA certificate is approaching expiration")
+		}
+	}
 
 	journal, slots, err := loader.load(ctx)
 	if err != nil {
@@ -169,13 +290,20 @@ func NewManager(ctx context.Context, c Config) (*Manager, error) {
 
 	now := m.c.Clock.Now()
 	m.journal = journal
-	if currentX509CA, ok := slots[CurrentX509CASlot]; ok {
-		m.currentX509CA = currentX509CA.(*x509CASlot)
 
-		if !currentX509CA.IsEmpty() && !currentX509CA.ShouldActivateNext(now) {
-			// activate the X509CA immediately if it is set and not within
-			// activation time of the next X509CA.
-			m.activateX509CA(ctx)
+	// Set the active X.509 authority ID in the journal when using external CA
+	if c.UseExternalX509CA {
+		m.journal.SetActiveX509AuthorityID(m.currentX509CA.authorityID)
+	}
+	if !c.UseExternalX509CA {
+		if currentX509CA, ok := slots[CurrentX509CASlot]; ok {
+			m.currentX509CA = currentX509CA.(*x509CASlot)
+
+			if !currentX509CA.IsEmpty() && !currentX509CA.ShouldActivateNext(now) {
+				// activate the X509CA immediately if it is set and not within
+				// activation time of the next X509CA.
+				m.activateX509CA(ctx)
+			}
 		}
 	}
 
@@ -221,6 +349,13 @@ func (m *Manager) Close() {
 	if m.upstreamClient != nil {
 		_ = m.upstreamClient.Close()
 	}
+	if m.pkcs11KMS != nil {
+		_ = m.pkcs11KMS.Close()
+	}
+}
+
+func (m *Manager) IsStaticX509CA() bool {
+	return m.c.UseExternalX509CA
 }
 
 func (m *Manager) NotifyTaintedX509Authority(ctx context.Context, authorityID string) error {
@@ -327,6 +462,10 @@ func (m *Manager) IsUpstreamAuthority() bool {
 func (m *Manager) ActivateX509CA(ctx context.Context) {
 	m.x509CAMutex.RLock()
 	defer m.x509CAMutex.RUnlock()
+	if m.c.UseExternalX509CA {
+		m.c.Log.Debug("Static X.509 CA mode: skipping ActivateX509CA")
+		return
+	}
 
 	m.activateX509CA(ctx)
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -153,6 +153,10 @@ type Config struct {
 
 	// DisableWITSVIDs, if true, WIT-SVID profile is disabled
 	DisableWITSVIDs bool
+
+	// ExternalCA configures the server to use an external CA for X.509 SVID
+	// signing.
+	ExternalCA ExternalCAConfig
 }
 
 type ExperimentalConfig struct {
@@ -166,6 +170,24 @@ type FederationConfig struct {
 	// FederatesWith holds the federation configuration for trust domains this
 	// server federates with.
 	FederatesWith map[spiffeid.TrustDomain]bundle_client.TrustDomainConfig
+}
+
+type ExternalCAConfig struct {
+	// Enabled indicates whether to use an external CA for X.509 SVID signing.
+	Enabled bool
+	// RootCertFilePath is the path to the root certificate file of the external CA.
+	RootCertFilePath string
+	// CertFilePath is the path to the certificate file of the external CA.
+	CertFilePath string
+	// PKCS11 contains the PKCS#11 configuration for accessing the external CA's private key.
+	PKCS11 *PKCS11Config
+}
+
+type PKCS11Config struct {
+	// PKCS11URI is the PKCS#11 URI used to locate the external CA's private key.
+	PKCS11URI string
+	// PKCS11Object is the PKCS#11 object label or ID used to identify the external CA's private key.
+	PKCS11Object string
 }
 
 func New(config Config) *Server {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -227,6 +227,7 @@ func (s *Server) run(ctx context.Context) (err error) {
 		registrationManager.Run,
 		bundlePublishingManager.Run,
 		catalog.ReconfigureTask(s.config.Log.WithField(telemetry.SubsystemName, "reconfigurer"), cat),
+		healthChecker.ListenAndServe,
 	}
 
 	if s.config.LogReopener != nil {
@@ -355,7 +356,7 @@ func (s *Server) newCA(metrics telemetry.Metrics, credBuilder *credtemplate.Buil
 }
 
 func (s *Server) newCAManager(ctx context.Context, cat catalog.Catalog, metrics telemetry.Metrics, serverCA *ca.CA, credBuilder *credtemplate.Builder, credValidator *credvalidator.Validator) (*manager.Manager, error) {
-	caManager, err := manager.NewManager(ctx, manager.Config{
+	managerConfig := manager.Config{
 		CA:              serverCA,
 		Catalog:         cat,
 		TrustDomain:     s.config.TrustDomain,
@@ -369,7 +370,19 @@ func (s *Server) newCAManager(ctx context.Context, cat catalog.Catalog, metrics 
 		DisableWITSVIDs: s.config.DisableWITSVIDs,
 		JWTKeyType:      s.config.JWTKeyType,
 		WITKeyType:      s.config.WITKeyType,
-	})
+	}
+	// Configure external CA if enabled
+	if s.config.ExternalCA.Enabled {
+		managerConfig.UseExternalX509CA = true
+		managerConfig.RootCertPath = s.config.ExternalCA.RootCertFilePath
+		managerConfig.IntermediateCertPath = s.config.ExternalCA.CertFilePath
+		if s.config.ExternalCA.PKCS11 != nil {
+			managerConfig.PKCS11URI = s.config.ExternalCA.PKCS11.PKCS11URI
+			managerConfig.PKCS11SigningKey = s.config.ExternalCA.PKCS11.PKCS11Object
+		}
+	}
+
+	caManager, err := manager.NewManager(ctx, managerConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -378,6 +391,9 @@ func (s *Server) newCAManager(ctx context.Context, cat catalog.Catalog, metrics 
 }
 
 func (s *Server) newCASync(ctx context.Context, healthChecker health.Checker, caManager *manager.Manager) (*rotator.Rotator, error) {
+	if caManager.IsStaticX509CA() {
+		s.config.Log.Info("Using static X.509 CA. X.509 CA rotation will be disabled, but JWT key rotation will continue normally.")
+	}
 	caSync := rotator.NewRotator(rotator.Config{
 		Log:           s.config.Log.WithField(telemetry.SubsystemName, telemetry.CAManager),
 		Manager:       caManager,

--- a/test/integration/suites/external-ca-hsm/00-setup
+++ b/test/integration/suites/external-ca-hsm/00-setup
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+log-info "Setting up certificates and HSM..."
+
+# Create directories
+mkdir -p certs
+
+# Generate root CA private key
+log-debug "Generating root CA..."
+openssl ecparam -name prime256v1 -genkey -noout -out certs/root-key.pem
+
+# Generate root CA certificate using config to avoid duplicate extensions
+openssl req -new -x509 -key certs/root-key.pem -out certs/root-cert.pem -days 365 \
+    -subj "/C=US/O=SPIRE/CN=Root CA" \
+    -extensions v3_ca \
+    -config <(cat <<EOF
+[req]
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints=critical,CA:TRUE
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+EOF
+) || fail-now "Failed to generate root CA"
+
+# Generate intermediate CA private key in unencrypted PKCS#8 form.
+# SoftHSM's --import only accepts PKCS#8 ("BEGIN PRIVATE KEY"); the SEC1 output
+# of `openssl ecparam -genkey` ("BEGIN EC PRIVATE KEY") is rejected.
+log-debug "Generating intermediate CA..."
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 \
+    -out certs/intermediate-key.pem || fail-now "Failed to generate intermediate key"
+
+# Generate intermediate CA CSR
+openssl req -new -key certs/intermediate-key.pem -out certs/intermediate.csr \
+    -subj "/C=US/O=SPIRE/CN=Intermediate CA" || fail-now "Failed to generate intermediate CSR"
+
+# Sign intermediate CA with root CA
+openssl x509 -req -in certs/intermediate.csr -CA certs/root-cert.pem -CAkey certs/root-key.pem \
+    -CAcreateserial -out certs/intermediate-cert.pem -days 180 \
+    -extfile <(cat <<EOF
+basicConstraints=critical,CA:TRUE,pathlen:0
+keyUsage=critical,digitalSignature,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always
+EOF
+) || fail-now "Failed to sign intermediate CA"
+
+# Extract public key from intermediate cert to verify later
+openssl x509 -in certs/intermediate-cert.pem -noout -pubkey > certs/intermediate-pubkey.pem
+
+# Create SoftHSM configuration
+log-debug "Configuring SoftHSM..."
+cat > conf/server/softhsm2.conf <<EOF
+directories.tokendir = /var/lib/softhsm/tokens
+objectstore.backend = file
+log.level = INFO
+EOF
+
+# Initialize SoftHSM token (will be done in container)
+# For now, just prepare the configuration
+
+# Setup x509pop for agent attestation
+"${ROOTDIR}/setup/x509pop/setup.sh" conf/server conf/agent
+
+log-success "Setup complete"

--- a/test/integration/suites/external-ca-hsm/01-init-hsm
+++ b/test/integration/suites/external-ca-hsm/01-init-hsm
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+log-info "Initializing HSM and importing keys..."
+
+# Initialize the SoftHSM token and import the intermediate CA key BEFORE the
+# server runs. The server's entrypoint is "spire-server run" with a PKCS#11
+# external CA config, so if it starts before the token exists it crashes with
+# "could not open PKCS#11". We override the entrypoint to "sh" and run a
+# throwaway container; the token persists to the host via the ./softhsm volume.
+log-debug "Initializing SoftHSM token and importing intermediate CA key..."
+docker compose run --rm -T --entrypoint sh spire-server -c '
+    set -e
+    softhsm2-util --init-token --slot 0 --label "SPIRE" --so-pin 5678 --pin 1234
+    # Select the token by label, not slot: SoftHSM assigns a new random slot id
+    # after init, so "--slot 0" may no longer point at the token we created.
+    softhsm2-util --import /opt/spire/certs/intermediate-key.pem \
+        --token "SPIRE" \
+        --label "intermediate-ca-key" \
+        --id 01 \
+        --pin 1234
+    softhsm2-util --show-slots
+' || fail-now "Failed to initialize HSM and import key"
+
+log-success "HSM initialized and key imported"

--- a/test/integration/suites/external-ca-hsm/02-start-server
+++ b/test/integration/suites/external-ca-hsm/02-start-server
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+log-info "Starting SPIRE server with external CA..."
+
+# Stop and restart server to pick up configuration
+docker-stop spire-server
+docker compose up -d spire-server
+
+# Check that server started successfully
+check-server-started spire-server
+
+# Verify server is using external CA
+log-debug "Checking server logs for external CA messages..."
+docker compose logs spire-server | grep -q "Loaded external X.509 CA from HSM" || \
+    fail-now "Server did not log external CA initialization"
+
+log-success "Server started with external CA"

--- a/test/integration/suites/external-ca-hsm/03-bootstrap-agent
+++ b/test/integration/suites/external-ca-hsm/03-bootstrap-agent
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+log-info "Bootstrapping agent..."
+
+# Create registration entry for the agent
+docker compose exec -T spire-server \
+    /opt/spire/bin/spire-server entry create \
+    -parentID "spiffe://domain.test/spire/server" \
+    -spiffeID "spiffe://domain.test/agent" \
+    -selector "x509pop:subject:cn:agent" \
+    -node || fail-now "Failed to create agent entry"
+
+log-success "Agent bootstrapped"

--- a/test/integration/suites/external-ca-hsm/04-start-agent
+++ b/test/integration/suites/external-ca-hsm/04-start-agent
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+log-info "Starting SPIRE agent..."
+
+docker-up spire-agent
+
+# Give the agent time to attest
+sleep 5
+
+log-success "Agent started"

--- a/test/integration/suites/external-ca-hsm/05-create-workload-entry
+++ b/test/integration/suites/external-ca-hsm/05-create-workload-entry
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+log-info "Creating workload registration entry..."
+
+# Create a workload registration entry
+docker compose exec -T spire-server \
+    /opt/spire/bin/spire-server entry create \
+    -parentID "spiffe://domain.test/agent" \
+    -spiffeID "spiffe://domain.test/workload" \
+    -selector "unix:uid:0" \
+    -x509SVIDTTL 60 || fail-now "Failed to create workload entry"
+
+log-success "Workload entry created"

--- a/test/integration/suites/external-ca-hsm/06-check-svids
+++ b/test/integration/suites/external-ca-hsm/06-check-svids
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+log-info "Checking that X509-SVIDs can be fetched..."
+
+# Entry propagation to the agent is asynchronous, so retry the fetch until the
+# SVID is issued instead of failing on the first "no identity issued".
+# Write into the bind-mounted agent conf dir so the files are visible on the
+# host (the spire-agent image is FROM scratch: no shell/openssl in-container).
+MAXCHECKS=30
+INTERVAL=1
+for ((i=1;i<=MAXCHECKS;i++)); do
+    log-info "fetching X509-SVID ($i of $MAXCHECKS max)..."
+    if docker compose exec -T spire-agent \
+        /opt/spire/bin/spire-agent api fetch x509 -write /opt/spire/conf/agent; then
+        break
+    fi
+    if [ "$i" -eq "$MAXCHECKS" ]; then
+        fail-now "Failed to fetch X509-SVID"
+    fi
+    sleep "${INTERVAL}"
+done
+
+# Verify the SVID chain on the host (openssl is available here).
+log-debug "Verifying SVID chain..."
+test -f conf/agent/svid.0.pem || fail-now "SVID file was not written"
+test -f conf/agent/bundle.0.pem || fail-now "bundle file was not written"
+openssl verify -CAfile conf/agent/bundle.0.pem conf/agent/svid.0.pem \
+    || fail-now "SVID chain verification failed"
+
+log-success "X509-SVIDs are working correctly"

--- a/test/integration/suites/external-ca-hsm/07-verify-ca-static
+++ b/test/integration/suites/external-ca-hsm/07-verify-ca-static
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+log-info "Verifying X.509 CA remains static..."
+
+# Get the current intermediate CA authority ID from server logs
+AUTHORITY_ID_1=$(docker compose logs spire-server | grep "Loaded external X.509 CA from HSM" | grep -o 'authority_id=[^ ]*' | cut -d= -f2 | tail -1)
+
+if [ -z "$AUTHORITY_ID_1" ]; then
+    fail-now "Could not extract authority ID from logs"
+fi
+
+log-debug "Initial authority ID: $AUTHORITY_ID_1"
+
+# Wait for longer than the normal CA rotation period would be
+# In standard mode with 1m CA TTL, rotation would happen
+# With external CA, it should NOT rotate
+log-info "Waiting 90 seconds to ensure no CA rotation occurs..."
+sleep 90
+
+# Check logs again - should still show the same authority ID
+# and should NOT show any CA rotation messages. Capture logs to a variable and
+# grep here-strings: piping `docker compose logs` into `grep -q` trips
+# SIGPIPE+pipefail and would mask a real rotation.
+SERVER_LOGS=$(docker compose logs spire-server)
+
+grep -q "Preparing X.509 CA" <<< "$SERVER_LOGS" && \
+    fail-now "ERROR: X.509 CA rotation occurred when it should be static"
+
+grep "X.509 CA activated" <<< "$SERVER_LOGS" | grep -qv "Loaded external" && \
+    fail-now "ERROR: X.509 CA activation occurred when it should be static"
+
+# Verify authority ID is still the same
+AUTHORITY_ID_2=$(grep "Loaded external X.509 CA from HSM" <<< "$SERVER_LOGS" | grep -o 'authority_id=[^ ]*' | cut -d= -f2 | tail -1)
+
+if [ "$AUTHORITY_ID_1" != "$AUTHORITY_ID_2" ]; then
+    fail-now "Authority ID changed! Expected: $AUTHORITY_ID_1, Got: $AUTHORITY_ID_2"
+fi
+
+# Verify SVIDs still work
+log-debug "Verifying SVIDs still work after waiting period..."
+docker compose exec -T spire-agent \
+    /opt/spire/bin/spire-agent api fetch x509 || fail-now "SVID fetch failed after wait period"
+
+log-success "X.509 CA correctly remains static"

--- a/test/integration/suites/external-ca-hsm/08-verify-jwt-rotation
+++ b/test/integration/suites/external-ca-hsm/08-verify-jwt-rotation
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+log-info "Verifying JWT keys still rotate..."
+
+# Fetch a JWT-SVID to confirm JWT signing works under the external X.509 CA.
+log-debug "Fetching JWT-SVID..."
+docker compose exec -T spire-agent \
+    /opt/spire/bin/spire-agent api fetch jwt -audience test \
+    -spiffeID spiffe://domain.test/workload -output json \
+    || fail-now "Failed to fetch JWT-SVID"
+
+# JWT keys rotate independently of the static X.509 CA. Confirm the server is
+# preparing/activating JWT keys (rotation is alive). Capture logs to a variable
+# and grep a here-string: piping `docker compose logs` into `grep -q` trips
+# SIGPIPE+pipefail (grep exits early on match, killing the upstream writer) and
+# would false-fail this step.
+SERVER_LOGS=$(docker compose logs spire-server)
+grep -q "JWT key prepared" <<< "$SERVER_LOGS" \
+    || fail-now "No JWT key preparation found in logs"
+grep -q "JWT key activated" <<< "$SERVER_LOGS" \
+    || fail-now "No JWT key activation found in logs"
+
+log-success "JWT keys are rotating correctly"

--- a/test/integration/suites/external-ca-hsm/09-test-validation
+++ b/test/integration/suites/external-ca-hsm/09-test-validation
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+log-info "Testing certificate validation..."
+
+# Stop the server
+docker-stop spire-server
+
+# Test 1: Invalid certificate chain (intermediate not signed by root)
+log-debug "Test: Invalid certificate chain..."
+cp certs/intermediate-cert.pem certs/intermediate-cert.pem.backup
+
+# Create a self-signed intermediate (not signed by root). Use -config with an
+# explicit extensions section instead of -addext: the default openssl.cnf
+# already injects basicConstraints, so -addext produces a DUPLICATE extension
+# (OID 2.5.29.19) that fails to parse before the signature check is reached.
+openssl req -new -x509 -key certs/intermediate-key.pem -out certs/intermediate-cert.pem -days 1 \
+    -subj "/C=US/O=INVALID/CN=Bad Intermediate" \
+    -extensions v3_ca \
+    -config <(cat <<EOF
+[req]
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[v3_ca]
+basicConstraints=critical,CA:TRUE
+keyUsage=critical,keyCertSign,cRLSign
+subjectKeyIdentifier=hash
+EOF
+)
+
+# Try to start server - should fail
+docker compose up -d spire-server
+sleep 5
+
+# Capture logs to a variable and grep a here-string: piping `docker compose
+# logs` into `grep -q` trips SIGPIPE+pipefail (grep exits early on match,
+# killing the upstream writer) and would false-fail this step.
+grep -q "intermediate CA certificate is not signed by root CA" <<< "$(docker compose logs spire-server)" || \
+    fail-now "Server should have rejected invalid certificate chain"
+
+log-debug "✓ Correctly rejected invalid certificate chain"
+
+# Restore valid certificate
+cp certs/intermediate-cert.pem.backup certs/intermediate-cert.pem
+docker-stop spire-server
+
+# Test 2: Non-CA certificate
+log-debug "Test: Non-CA certificate..."
+openssl x509 -req -in certs/intermediate.csr -CA certs/root-cert.pem -CAkey certs/root-key.pem \
+    -CAcreateserial -out certs/intermediate-cert.pem -days 180 \
+    -extfile <(cat <<EOF
+basicConstraints=critical,CA:FALSE
+keyUsage=critical,digitalSignature
+EOF
+)
+
+docker compose up -d spire-server
+sleep 5
+
+grep -q "intermediate certificate is not a CA certificate" <<< "$(docker compose logs spire-server)" || \
+    fail-now "Server should have rejected non-CA certificate"
+
+log-debug "✓ Correctly rejected non-CA certificate"
+
+# Restore valid certificate for remaining tests
+cp certs/intermediate-cert.pem.backup certs/intermediate-cert.pem
+
+log-success "Certificate validation working correctly"

--- a/test/integration/suites/external-ca-hsm/Dockerfile
+++ b/test/integration/suites/external-ca-hsm/Dockerfile
@@ -1,0 +1,25 @@
+# The canonical spire-server:latest-local image ships a FULLY STATIC musl
+# binary, which cannot dlopen() shared objects. The PKCS#11 KeyManager loads
+# the SoftHSM module via dlopen at runtime, so the static binary fails with
+# "could not open PKCS#11". This image instead compiles a DYNAMICALLY-linked
+# spire-server so dlopen works. Build context must be the repo root.
+ARG goversion=1.25.6
+FROM golang:${goversion}-alpine3.22 AS builder
+
+# build-base provides gcc/musl-dev for cgo (go-sqlite3 etc.).
+RUN apk add --no-cache build-base git
+
+WORKDIR /spire
+COPY go.* ./
+RUN go mod download
+COPY . .
+# Dynamic link (no -extldflags "-static"); CGO on so the binary can dlopen.
+RUN CGO_ENABLED=1 go build -o /spire-server ./cmd/spire-server
+
+FROM alpine:3.18 AS spire-server-hsm
+RUN apk add --no-cache softhsm bash
+RUN mkdir -p /var/lib/softhsm/tokens
+
+COPY --from=builder /spire-server /opt/spire/bin/spire-server
+
+ENTRYPOINT ["/opt/spire/bin/spire-server", "run"]

--- a/test/integration/suites/external-ca-hsm/Dockerfile
+++ b/test/integration/suites/external-ca-hsm/Dockerfile
@@ -3,7 +3,7 @@
 # the SoftHSM module via dlopen at runtime, so the static binary fails with
 # "could not open PKCS#11". This image instead compiles a DYNAMICALLY-linked
 # spire-server so dlopen works. Build context must be the repo root.
-ARG goversion=1.25.6
+ARG goversion=1.26.4
 FROM golang:${goversion}-alpine3.22 AS builder
 
 # build-base provides gcc/musl-dev for cgo (go-sqlite3 etc.).

--- a/test/integration/suites/external-ca-hsm/README.md
+++ b/test/integration/suites/external-ca-hsm/README.md
@@ -1,0 +1,20 @@
+# External CA HSM Suite
+
+## Description
+
+This suite tests the experimental external CA feature, which allows SPIRE Server to use an existing Certificate Authority from an HSM (Hardware Security Module) instead of generating its own intermediate CA.
+
+The test:
+1. Sets up SoftHSM as a test HSM
+2. Generates a root CA and intermediate CA
+3. Imports the intermediate CA private key into the HSM
+4. Configures SPIRE Server to use the external CA
+5. Verifies that workload X509-SVIDs can be issued correctly
+6. Verifies that the X.509 CA remains static (does not rotate)
+7. Verifies that JWT keys continue to rotate normally
+8. Tests certificate validation (chain verification, key matching)
+
+## Requirements
+
+- SoftHSM2 package installed in the container
+- OpenSSL for certificate generation

--- a/test/integration/suites/external-ca-hsm/conf/agent/agent.conf
+++ b/test/integration/suites/external-ca-hsm/conf/agent/agent.conf
@@ -1,0 +1,28 @@
+agent {
+    data_dir = "/opt/spire/data/agent"
+    log_level = "DEBUG"
+    trust_domain = "domain.test"
+    server_address = "spire-server"
+    server_port = "8081"
+
+    insecure_bootstrap = true
+}
+
+plugins {
+    NodeAttestor "x509pop" {
+        plugin_data {
+            private_key_path = "/opt/spire/conf/agent/agent.key.pem"
+            certificate_path = "/opt/spire/conf/agent/agent.crt.pem"
+        }
+    }
+
+    KeyManager "disk" {
+        plugin_data {
+            directory = "/opt/spire/data/agent"
+        }
+    }
+
+    WorkloadAttestor "unix" {
+        plugin_data {}
+    }
+}

--- a/test/integration/suites/external-ca-hsm/conf/server/server.conf
+++ b/test/integration/suites/external-ca-hsm/conf/server/server.conf
@@ -1,0 +1,41 @@
+server {
+    bind_address = "0.0.0.0"
+    bind_port = "8081"
+    trust_domain = "domain.test"
+    data_dir = "/opt/spire/data/server"
+    log_level = "DEBUG"
+    default_x509_svid_ttl = "30s"
+    default_jwt_svid_ttl = "30s"
+
+    experimental {
+        external_ca {
+            enabled = true
+            root_cert_file_path = "/opt/spire/certs/root-cert.pem"
+            cert_file_path = "/opt/spire/certs/intermediate-cert.pem"
+            pkcs11 {
+                pkcs11_uri = "pkcs11:module-path=/usr/lib/softhsm/libsofthsm2.so;token=SPIRE;pin-value=1234"
+                pkcs11_object = "pkcs11:object=intermediate-ca-key"
+            }
+        }
+    }
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "/opt/spire/data/server/datastore.sqlite3"
+        }
+    }
+
+    NodeAttestor "x509pop" {
+        plugin_data {
+            ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
+        }
+    }
+
+    # KeyManager is still used for JWT keys
+    KeyManager "memory" {
+        plugin_data = {}
+    }
+}

--- a/test/integration/suites/external-ca-hsm/docker-compose.yaml
+++ b/test/integration/suites/external-ca-hsm/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  spire-server:
+    build:
+      context: ${REPODIR}
+      dockerfile: test/integration/suites/external-ca-hsm/Dockerfile
+    image: spire-server-hsm:latest-local
+    hostname: spire-server
+    volumes:
+      - ./conf/server:/opt/spire/conf/server
+      - ./certs:/opt/spire/certs
+      - softhsm-tokens:/var/lib/softhsm
+    environment:
+      - SOFTHSM2_CONF=/opt/spire/conf/server/softhsm2.conf
+    command: ["-config", "/opt/spire/conf/server/server.conf"]
+
+  spire-agent:
+    image: spire-agent:latest-local
+    hostname: spire-agent
+    depends_on: ["spire-server"]
+    volumes:
+      - ./conf/agent:/opt/spire/conf/agent
+    command: ["-config", "/opt/spire/conf/agent/agent.conf"]
+volumes:
+  softhsm-tokens:

--- a/test/integration/suites/external-ca-hsm/teardown
+++ b/test/integration/suites/external-ca-hsm/teardown
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -z "${SUCCESS}" ]; then
+    log-warn "Test suite failed. Dumping server logs:"
+    docker compose logs spire-server
+
+    log-warn "Agent logs:"
+    docker compose logs spire-agent
+fi
+
+docker-cleanup


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md
- [x] Proper tests/regressions included
- [x] Documentation updated

**Affected functionality**
Adding an experimental feature which allows to configure `spire-server` to use an existing intermediate CA with signing happening via pkcs11 in a HSM.

**Description of change**
Allow SPIRE Server to sign X.509-SVIDs directly with a pre-existing,
long-lived intermediate CA instead of generating and rotating its own.
The intermediate certificate (and its root) are supplied by the operator
and the signing key is accessed through a crypto.Signer, with PKCS#11 as
the first supported backend (covers HSM and SoftHSM).

When external CA mode is enabled:
  * the supplied intermediate is used as the active X.509 signing authority
  * the root and intermediate are published in the trust bundle
  * X.509 CA rotation is disabled (the external CA is static)
  * JWT key rotation continues normally
  * startup validates that the intermediate is signed by the root and is a
    CA certificate, failing fast otherwise
 
**Which issue this PR fixes**
Fixes #7018
