### PR TITLE
test(common/idutil): Expand IDFromProto coverage

### DIFF
--- a/pkg/common/idutil/safety_test.go
+++ b/pkg/common/idutil/safety_test.go
@@ -64,29 +64,64 @@ func TestIDProtoFromString(t *testing.T) {
 }
 
 func TestIDFromProto(t *testing.T) {
-	assert := assert.New(t)
+	for _, tt := range []struct {
+		name      string
+		proto     *types.SPIFFEID
+		expected  string
+		expectErr string
+	}{
+		{
+			name:      "empty proto",
+			proto:     &types.SPIFFEID{},
+			expectErr: "trust domain is missing",
+		},
+		{
+			name:     "valid trust domain",
+			proto:    &types.SPIFFEID{TrustDomain: "example.org"},
+			expected: "spiffe://example.org",
+		},
+		{
+			name:     "valid trust domain and path",
+			proto:    &types.SPIFFEID{TrustDomain: "example.org", Path: "/workload"},
+			expected: "spiffe://example.org/workload",
+		},
+		{
+			name:      "trailing slash in path",
+			proto:     &types.SPIFFEID{TrustDomain: "example.org", Path: "/"},
+			expectErr: "path cannot have a trailing slash",
+		},
+		{
+			name:      "missing leading slash in path",
+			proto:     &types.SPIFFEID{TrustDomain: "example.org", Path: "workload"},
+			expectErr: "path must have a leading slash",
+		},
+		{
+			name:      "invalid characters in path",
+			proto:     &types.SPIFFEID{TrustDomain: "example.org", Path: "/workload/%41%42%43"},
+			expectErr: "path segment characters are limited to letters, numbers, dots, dashes, and underscores",
+		},
+		{
+			name:      "invalid characters in trust domain",
+			proto:     &types.SPIFFEID{TrustDomain: "example.org/path"},
+			expectErr: "trust domain characters are limited to lowercase letters, numbers, dots, dashes, and underscores",
+		},
+		{
+			name:      "trust domain with space",
+			proto:     &types.SPIFFEID{TrustDomain: "example .org"},
+			expectErr: "trust domain characters are limited to lowercase letters, numbers, dots, dashes, and underscores",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
 
-	id, err := IDFromProto(&types.SPIFFEID{})
-	assert.EqualError(err, "trust domain is missing")
-	assert.Empty(id)
-
-	id, err = IDFromProto(&types.SPIFFEID{TrustDomain: "example.org"})
-	assert.NoError(err)
-	assert.Equal("spiffe://example.org", id.String())
-
-	id, err = IDFromProto(&types.SPIFFEID{TrustDomain: "example.org", Path: "/"})
-	assert.EqualError(err, "path cannot have a trailing slash")
-	assert.Empty(id)
-
-	id, err = IDFromProto(&types.SPIFFEID{TrustDomain: "example.org", Path: "workload"})
-	assert.EqualError(err, "path must have a leading slash")
-	assert.Empty(id)
-
-	id, err = IDFromProto(&types.SPIFFEID{TrustDomain: "example.org", Path: "/workload"})
-	assert.NoError(err)
-	assert.Equal("spiffe://example.org/workload", id.String())
-
-	id, err = IDFromProto(&types.SPIFFEID{TrustDomain: "example.org", Path: "/workload/%41%42%43"})
-	assert.EqualError(err, "path segment characters are limited to letters, numbers, dots, dashes, and underscores")
-	assert.Empty(id)
+			id, err := IDFromProto(tt.proto)
+			if tt.expectErr != "" {
+				assert.EqualError(err, tt.expectErr)
+				assert.Empty(id)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tt.expected, id.String())
+		})
+	}
 }


### PR DESCRIPTION
## Summary

This updates `TestIDFromProto` to use table-driven test cases and expands coverage for invalid trust domain values.

The existing path validation cases are preserved, and the new cases cover trust domains containing invalid characters such as paths and spaces.

## Testing

- `go test ./pkg/common/idutil`