### PR TITLE
Retry container image pulls in integration tests to reduce CI flakiness

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -31,13 +31,42 @@ fail-now() {
     exit 1
 }
 
+# retry runs the given command, retrying with exponential backoff if it fails.
+# It is intended to harden steps against transient registry/network errors
+# (e.g. Docker Hub image pull timeouts) that would otherwise cause spurious CI
+# failures. The number of attempts and the initial backoff (in seconds) can be
+# tuned via the RETRY_ATTEMPTS and RETRY_DELAY environment variables.
+retry() {
+    local attempts="${RETRY_ATTEMPTS:-5}"
+    local delay="${RETRY_DELAY:-5}"
+    local max_delay=60
+    local attempt=1
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if [ "${attempt}" -ge "${attempts}" ]; then
+            log-warn "command failed after ${attempt} attempt(s): $*"
+            return 1
+        fi
+        log-warn "command failed (attempt ${attempt}/${attempts}), retrying in ${delay}s: $*"
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+        if [ "${delay}" -gt "${max_delay}" ]; then
+            delay="${max_delay}"
+        fi
+    done
+}
+
 docker-up() {
     if [ $# -eq 0 ]; then
         log-debug "bringing up services..."
     else
         log-debug "bringing up $*..."
     fi
-    docker compose up -d "$@" || fail-now "failed to bring up services."
+    # Retry to harden against transient image pull failures during startup.
+    retry docker compose up -d "$@" || fail-now "failed to bring up services."
 }
 
 docker-wait-for-healthy() {
@@ -206,7 +235,8 @@ ENTRYPOINT ["/usr/bin/dumb-init", "supervisord", "--nodaemon", "--configuration"
 CMD []
 EOF
 
-    docker build --target envoy-agent-mashup -t envoy-agent-mashup .
+    # Retry to harden against transient pulls of the envoy base image.
+    retry docker build --target envoy-agent-mashup -t envoy-agent-mashup .
 }
 
 curl-with-retry() {
@@ -338,6 +368,11 @@ start-kind-cluster() {
     local kind_path=$1
     local kind_name=$2
     local kind_config_path=$3
+
+    # Pre-pull the node image with retry to harden against transient Docker Hub
+    # failures. kind uses the locally cached image when present, so it won't
+    # attempt its own (un-retried) pull during cluster creation.
+    retry docker pull "${K8SIMAGE}" || fail-now "unable to pull node image ${K8SIMAGE}"
 
     log-info "starting cluster..."
     "${kind_path}" create cluster --name "${kind_name}" --config "${kind_config_path}" --image "${K8SIMAGE}" || fail-now "unable to create cluster"

--- a/test/integration/common
+++ b/test/integration/common
@@ -34,11 +34,10 @@ fail-now() {
 # retry runs the given command, retrying with exponential backoff if it fails.
 # It is intended to harden steps against transient registry/network errors
 # (e.g. Docker Hub image pull timeouts) that would otherwise cause spurious CI
-# failures. The number of attempts and the initial backoff (in seconds) can be
-# tuned via the RETRY_ATTEMPTS and RETRY_DELAY environment variables.
+# failures.
 retry() {
-    local attempts="${RETRY_ATTEMPTS:-5}"
-    local delay="${RETRY_DELAY:-5}"
+    local attempts=5
+    local delay=5
     local max_delay=60
     local attempt=1
     while true; do

--- a/test/integration/suites/datastore-mysql-replication/00-setup
+++ b/test/integration/suites/datastore-mysql-replication/00-setup
@@ -16,4 +16,4 @@ log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .
 
 log-debug "pulling mysql docker images..."
-docker compose pull
+retry docker compose pull

--- a/test/integration/suites/datastore-mysql/00-setup
+++ b/test/integration/suites/datastore-mysql/00-setup
@@ -13,4 +13,4 @@ log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .
 
 log-debug "pulling mysql docker images..."
-docker compose pull
+retry docker compose pull

--- a/test/integration/suites/datastore-postgres-replication/00-setup
+++ b/test/integration/suites/datastore-postgres-replication/00-setup
@@ -13,4 +13,4 @@ log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .
 
 log-debug "pulling postgres docker images..."
-docker compose pull
+retry docker compose pull

--- a/test/integration/suites/datastore-postgres/00-setup
+++ b/test/integration/suites/datastore-postgres/00-setup
@@ -13,4 +13,4 @@ log-debug "copying over test data..."
 cp -r "${PKGDIR}"/testdata .
 
 log-debug "pulling postgres docker images..."
-docker compose pull
+retry docker compose pull

--- a/test/integration/suites/force-rotation-self-signed/00-setup
+++ b/test/integration/suites/force-rotation-self-signed/00-setup
@@ -24,4 +24,4 @@ mkdir -p -m 777 shared/intermediateBSocket
 # leafB certificates
 "${ROOTDIR}/setup/x509pop/setup.sh" leafB/server leafB/agent
 
-docker build --target nested-agent-alpine -t nested-agent-alpine .
+retry docker build --target nested-agent-alpine -t nested-agent-alpine .

--- a/test/integration/suites/ghostunnel-federation/00-setup
+++ b/test/integration/suites/ghostunnel-federation/00-setup
@@ -5,4 +5,4 @@ set -e
 "${ROOTDIR}/setup/x509pop/setup.sh" conf/downstream/server conf/downstream/agent
 "${ROOTDIR}/setup/x509pop/setup.sh" conf/upstream/server conf/upstream/agent
 
-docker build --target socat-ghostunnel-agent-mashup -t socat-ghostunnel-agent-mashup .
+retry docker build --target socat-ghostunnel-agent-mashup -t socat-ghostunnel-agent-mashup .

--- a/test/integration/suites/nested-rotation/00-setup
+++ b/test/integration/suites/nested-rotation/00-setup
@@ -30,4 +30,4 @@ mkdir -p -m 777 shared/intermediateB/data
 # leafB certificates
 "${ROOTDIR}/setup/x509pop/setup.sh" leafB/server leafB/agent
 
-docker build --target nested-agent-alpine -t nested-agent-alpine .
+retry docker build --target nested-agent-alpine -t nested-agent-alpine .

--- a/test/integration/suites/spire-server-cli/01-start-server
+++ b/test/integration/suites/spire-server-cli/01-start-server
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker build --target spire-server-alpine -t spire-server-alpine .
+retry docker build --target spire-server-alpine -t spire-server-alpine .
 docker-spire-server-up spire-server
 


### PR DESCRIPTION
Integration test suites pull container base images directly from Docker Hub at test time (`kindest/node` for kind clusters, `postgres`, `alpine`, and the Envoy base image), and none of these pulls are retried. When Docker Hub is briefly unavailable or rate-limits the runner, the pull times out and the whole suite fails. This shows up as CI flakiness, including in the merge queue where the code has already been approved and a transient `registry-1.docker.io ... context deadline exceeded` is enough to block a merge.

This PR adds a `retry` helper to the integration test `common` library that retries a command with exponential backoff, and wraps the image-pull operations with it.

Changes:
- `start-kind-cluster` now pre-pulls the node image with retry before creating the cluster. kind uses the locally cached image when present, so it no longer performs its own un-retried pull during cluster creation.
- `docker-up` and `build-mashup-image` retry `docker compose up` and the Envoy `docker build`.
- The datastore suites retry `docker compose pull`, and the suites that build from `alpine` (`nested-rotation`, `force-rotation-self-signed`, `spire-server-cli`, `ghostunnel-federation`) retry their `docker build`.

The retry uses 5 attempts with exponential backoff (5s initial delay, capped at 60s).

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/26865939226
