### PR TITLE
Retry image builds to tolerate transient base image pull failures

### DIFF
--- a/.github/workflows/scripts/retry.sh
+++ b/.github/workflows/scripts/retry.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# retry runs the given command, retrying with exponential backoff if it fails.
+# It is intended to harden CI steps against transient registry/network errors
+# (e.g. Docker Hub image pull timeouts during a `docker buildx build`) that
+# would otherwise cause spurious build failures.
+
+set -u
+
+attempts=5
+delay=5
+max_delay=60
+attempt=1
+
+if [ "$#" -eq 0 ]; then
+    echo "retry: no command given" >&2
+    exit 2
+fi
+
+while true; do
+    if "$@"; then
+        exit 0
+    fi
+    if [ "${attempt}" -ge "${attempts}" ]; then
+        echo "retry: command failed after ${attempt} attempt(s): $*" >&2
+        exit 1
+    fi
+    echo "retry: command failed (attempt ${attempt}/${attempts}), retrying in ${delay}s: $*" >&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+    if [ "${delay}" -gt "${max_delay}" ]; then
+        delay="${max_delay}"
+    fi
+done

--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,8 @@ define image_rule
 .PHONY: $1
 $1: $3 container-builder
 	@echo Building docker image $2 $(PLATFORM)…
-	$(E)docker buildx build \
+	$(E).github/workflows/scripts/retry.sh \
+		docker buildx build \
 		--platform $(PLATFORMS) \
 		--build-arg goversion=$(go_version) \
 		--build-arg TAG=$(TAG) \


### PR DESCRIPTION
The images CI job builds the SPIRE container images with `make images-no-load`, which runs `docker buildx build` for each image. Those builds pull base images from Docker Hub (`golang:<version>-alpine`, `alpine`, and `tonistiigi/xx`). When Docker Hub is briefly unavailable or rate-limits the runner, the `FROM` pull times out and the build fails. Like the integration test suites, this causes CI flakiness, including in the merge queue where the code has already been approved.

This PR adds a small `retry.sh` helper under `.github/workflows/scripts` that retries a command with exponential backoff, and wraps the `docker buildx build` invocation in the Makefile `image_rule` with it. On a transient failure the build is retried, and BuildKit reuses the layers it already produced, so a retry resumes past the base images that were already pulled. Only the build command is wrapped: the `container-builder` buildx instance creation stays outside the retry, because re-creating an already existing builder would itself fail.

Because the retry lives in the shared `image_rule`, it also applies to the `images` builds in the nightly and release workflows, not only the PR build. The Windows image build is left unchanged.

This applies the same approach as #7031, which adds image pull retries to the integration tests.

The retry uses 5 attempts with exponential backoff (5s initial delay, capped at 60s).

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/26865938677
