### PR TITLE
Remove the unused kind configuration from the cert-manager integration test

### DIFF
--- a/test/integration/suites/upstream-authority-cert-manager/00-setup-kind
+++ b/test/integration/suites/upstream-authority-cert-manager/00-setup-kind
@@ -14,7 +14,7 @@ download-kind "${KIND_PATH}"
 download-kubectl "${KUBECTL_PATH}"
 
 # Start the kind cluster.
-start-kind-cluster "${KIND_PATH}" cert-manager-test ./conf/kind-config.yaml
+start-kind-cluster "${KIND_PATH}" cert-manager-test
 
 # Load the given images in the cluster.
 container_images=("spire-server:latest-local")

--- a/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
+++ b/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
@@ -1,4 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-- role: control-plane

--- a/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
+++ b/test/integration/suites/upstream-authority-cert-manager/conf/kind-config.yaml
@@ -2,4 +2,3 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6


### PR DESCRIPTION
The cert-manager integration test suite has a kind configuration whose only effect was pinning the node image to `kindest/node:v1.21.1`. That pin never took effect: `start-kind-cluster` always creates the cluster with `--image "${K8SIMAGE}"`, and kind's `--image` flag overrides the per-node image in the config, so the suite has been running on the version selected by `K8SIMAGE` (currently `v1.31.12`) all along. With the pin gone the configuration only declared a single `control-plane` node, which is kind's default.

This removes the configuration file entirely and drops the `--config` argument from the cluster creation. The suite now provisions its cluster the same way as the `k8s`, `key-manager-vault`, `upstream-authority-vault`, and `upstream-authority-ejbca` suites, which already create kind clusters without a config file.

I noticed the stale pin while adding image pull retries to `start-kind-cluster` in #7031.
