### PR TITLE
DO NOT MERGE: assign-reviewer workflow smoke test

### DIFF
--- a/ASSIGN_REVIEWER_SMOKE_TEST.md
+++ b/ASSIGN_REVIEWER_SMOKE_TEST.md
@@ -1,0 +1,4 @@
+# assign-reviewer smoke test
+
+Throwaway file to open a test PR that exercises the assign-reviewer workflow
+on the default branch. Safe to delete. Do not merge.


### PR DESCRIPTION
Throwaway PR to verify the assign-reviewer workflow runs with a write token on the default branch and sets an assignee. Will be closed once verified. Do not merge.