### PR TITLE
Fix assign-reviewer not setting an assignee on open

### DIFF
--- a/.github/workflows/assign_reviewer.yaml
+++ b/.github/workflows/assign_reviewer.yaml
@@ -40,10 +40,15 @@ on:
   pull_request_review:
     types: [submitted]
 
-# Serialize runs per PR so overlapping events don't race on assignee/label
-# state. Don't cancel in-progress runs; each event must be processed.
+# Serialize runs per PR and per event action so overlapping events don't race
+# on assignee/label state. The action is part of the group on purpose: when a
+# PR opens, GitHub fires the "opened" event together with a burst of CODEOWNERS
+# "review_requested" events, and a single group plus cancel-in-progress: false
+# makes GitHub cancel all but the latest pending run, which can drop the
+# "opened" run that assigns the reviewer. Keeping each action in its own group
+# lets "opened" run on its own while same-action bursts still collapse safely.
 concurrency:
-  group: assign-reviewer-${{ github.event.pull_request.number }}
+  group: assign-reviewer-${{ github.event.pull_request.number }}-${{ github.event_name }}-${{ github.event.action }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
The `assign-reviewer` workflow is supposed to set a rotated maintainer as the assignee when a pull request is opened, but in practice the assignee was never set, because of a concurrency interaction.

When a PR is opened, GitHub fires the `opened` event together with a burst of `review_requested` events from the `CODEOWNERS` auto-request (one per code owner). All of these ran in a single per-PR concurrency group with `cancel-in-progress: false`, which makes GitHub cancel all but the latest pending run in the group. The `opened` run, the one that actually assigns the maintainer, was getting cancelled, while the surviving `review_requested` runs are no-ops on a fresh PR (they only act once the ball is in the author's court, signalled by the `awaiting-author` label). The net result was that no assignee was set on open.

This includes the event name and action in the concurrency group so each action runs in its own group. The `opened` run is no longer cancelled by the `review_requested` burst, while same-action bursts still collapse safely and overlapping different actions remain serialized per PR.
