### PR TITLE
agent: treat failure of all attestation plugins as overall failure & return Unavailable

### DIFF
--- a/pkg/agent/api/delegatedidentity/v1/service.go
+++ b/pkg/agent/api/delegatedidentity/v1/service.go
@@ -85,7 +85,7 @@ func (s *Service) isCallerAuthorized(ctx context.Context, log logrus.FieldLogger
 		callerSelectors, err = s.peerAttestor.Attest(ctx)
 		if err != nil {
 			log.WithError(err).Error("Workload attestation failed")
-			return nil, status.Error(codes.Internal, "workload attestation failed")
+			return nil, workloadAttestationFailedError(ctx)
 		}
 	}
 
@@ -112,6 +112,13 @@ func (s *Service) isCallerAuthorized(ctx context.Context, log logrus.FieldLogger
 	}).Error("Permission denied; caller not configured as an authorized delegate.")
 
 	return nil, status.Error(codes.PermissionDenied, "caller not configured as an authorized delegate")
+}
+
+func workloadAttestationFailedError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return status.Error(codes.Unavailable, "workload attestation failed")
 }
 
 func (s *Service) constructValidSelectorsFromReq(ctx context.Context, log logrus.FieldLogger, reqPid int32, reqSelectors []*types.Selector) ([]*common.Selector, error) {
@@ -142,7 +149,8 @@ func (s *Service) constructValidSelectorsFromReq(ctx context.Context, log logrus
 		// Delegate authorized, use PID the delegate gave us to try and attest on-behalf-of
 		selectors, err = s.delegateWorkloadAttestor.Attest(ctx, int(reqPid))
 		if err != nil {
-			return nil, err
+			log.WithError(err).Error("Workload attestation failed")
+			return nil, workloadAttestationFailedError(ctx)
 		}
 	}
 

--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -85,7 +85,7 @@ func TestSubscribeToX509SVIDs(t *testing.T) {
 		{
 			testName:   "attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Internal,
+			expectCode: codes.Unavailable,
 			expectMsg:  "workload attestation failed",
 		},
 		{
@@ -378,7 +378,7 @@ func TestSubscribeToX509Bundles(t *testing.T) {
 		{
 			testName:   "Attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Internal,
+			expectCode: codes.Unavailable,
 			expectMsg:  "workload attestation failed",
 		},
 		{
@@ -480,6 +480,7 @@ func TestFetchJWTSVIDs(t *testing.T) {
 		expectCode   codes.Code
 		expectMsg    string
 		attestErr    error
+		delegateErr  error
 		managerErr   error
 		expectResp   *delegatedidentityv1.FetchJWTSVIDsResponse
 	}{
@@ -492,7 +493,7 @@ func TestFetchJWTSVIDs(t *testing.T) {
 			testName:   "Attest error",
 			attestErr:  errors.New("ohno"),
 			audience:   []string{"AUDIENCE"},
-			expectCode: codes.Internal,
+			expectCode: codes.Unavailable,
 			expectMsg:  "workload attestation failed",
 		},
 		{
@@ -573,6 +574,18 @@ func TestFetchJWTSVIDs(t *testing.T) {
 			},
 			expectCode: codes.InvalidArgument,
 			expectMsg:  "could not parse provided selectors",
+		},
+		{
+			testName:     "delegate workload attest error",
+			authSpiffeID: []string{"spiffe://example.org/one"},
+			pid:          447,
+			audience:     []string{"AUDIENCE"},
+			identities: []cache.Identity{
+				identities[0],
+			},
+			delegateErr: errors.New("ohno"),
+			expectCode:  codes.Unavailable,
+			expectMsg:   "workload attestation failed",
 		},
 		{
 			testName:     "success with one identity",
@@ -742,6 +755,7 @@ func TestFetchJWTSVIDs(t *testing.T) {
 				Identities:   tt.identities,
 				AuthSpiffeID: tt.authSpiffeID,
 				AttestErr:    tt.attestErr,
+				DelegateErr:  tt.delegateErr,
 				ManagerErr:   tt.managerErr,
 				JwtSVIDS:     tt.jwtSVIDsResp,
 			}
@@ -786,7 +800,7 @@ func TestSubscribeToJWTBundles(t *testing.T) {
 		{
 			testName:   "Attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Internal,
+			expectCode: codes.Unavailable,
 			expectMsg:  "workload attestation failed",
 		},
 		{
@@ -870,6 +884,7 @@ type testParams struct {
 	JwtSVIDS     map[spiffeid.ID]*client.JWTSVID
 	AuthSpiffeID []string
 	AttestErr    error
+	DelegateErr  error
 	ManagerErr   error
 	Metrics      *fakemetrics.FakeMetrics
 }
@@ -900,7 +915,7 @@ func runTest(t *testing.T, params testParams, fn func(ctx context.Context, clien
 	}
 
 	service.delegateWorkloadAttestor = FakeWorkloadPIDAttestor{
-		err: params.AttestErr,
+		err: params.DelegateErr,
 	}
 
 	unaryInterceptor, streamInterceptor := middleware.Interceptors(middleware.WithLogger(log))

--- a/pkg/agent/attestor/workload/workload.go
+++ b/pkg/agent/attestor/workload/workload.go
@@ -2,6 +2,7 @@ package attestor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -42,11 +43,12 @@ type Config struct {
 	selectorHook func([]*common.Selector)
 }
 
-// Attest invokes all workload attestor plugins against the provided PID. If an error
-// is encountered, it is logged and selectors from the failing plugin are discarded.
-func (wla *attestor) Attest(ctx context.Context, pid int) ([]*common.Selector, error) {
+// Attest invokes all workload attestor plugins against the provided PID. If some
+// attestors fail, the errors are logged and selectors from the failing plugins
+// are discarded. If all attestors fail, the combined error is returned.
+func (wla *attestor) Attest(ctx context.Context, pid int) (_ []*common.Selector, retErr error) {
 	counter := telemetry_workload.StartAttestationCall(wla.c.Metrics)
-	defer counter.Done(nil)
+	defer counter.Done(&retErr)
 
 	log := wla.c.Log.WithField(telemetry.PID, pid)
 
@@ -55,17 +57,18 @@ func (wla *attestor) Attest(ctx context.Context, pid int) ([]*common.Selector, e
 	errChan := make(chan error)
 
 	for _, p := range plugins {
-		go func(p workloadattestor.WorkloadAttestor) {
+		go func() {
 			if selectors, err := wla.invokeAttestor(ctx, p, pid); err == nil {
 				sChan <- selectors
 			} else {
 				errChan <- err
 			}
-		}(p)
+		}()
 	}
 
 	// Collect the results
-	selectors := []*common.Selector{}
+	var selectors []*common.Selector
+	var errs []error
 	for range plugins {
 		select {
 		case s := <-sChan:
@@ -76,14 +79,23 @@ func (wla *attestor) Attest(ctx context.Context, pid int) ([]*common.Selector, e
 				log.WithError(ctx.Err()).Error("Timed out collecting selectors for PID")
 				return nil, ctx.Err()
 			}
-			log.WithError(err).Error("Failed to collect all selectors for PID")
+			errs = append(errs, err)
 		case <-ctx.Done():
 			log.WithError(ctx.Err()).Error("Timed out collecting selectors for PID")
 			return nil, ctx.Err()
 		}
 	}
 
+	if len(plugins) > 0 && len(errs) == len(plugins) {
+		return nil, errors.Join(errs...)
+	}
+
+	if len(errs) > 0 {
+		log.WithError(errors.Join(errs...)).Error("Failed to collect all selectors for PID")
+	}
+
 	telemetry_workload.AddDiscoveredSelectorsSample(wla.c.Metrics, float32(len(selectors)))
+
 	// The agent health check currently exercises the Workload API. Since this
 	// can happen with some frequency, it has a tendency to fill up logs with
 	// hard-to-filter details if we're not careful (e.g. issue #1537). Only log
@@ -91,6 +103,7 @@ func (wla *attestor) Attest(ctx context.Context, pid int) ([]*common.Selector, e
 	if pid != os.Getpid() {
 		log.WithField(telemetry.Selectors, selectors).Debug("PID attested to have selectors")
 	}
+
 	return selectors, nil
 }
 

--- a/pkg/agent/attestor/workload/workload_test.go
+++ b/pkg/agent/attestor/workload/workload_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -36,6 +37,7 @@ var (
 		2: nil,
 		3: {"baz"},
 		4: {"baz"},
+		// 5: attestor2 cannot attest process 5
 	}
 )
 
@@ -71,28 +73,55 @@ func (s *WorkloadAttestorTestSuite) TestAttestWorkload() {
 
 	// both attestors succeed but with no selectors
 	selectors, err := s.attestor.Attest(ctx, 1)
-	s.Assert().Nil(err)
+	s.Nil(err)
 	s.Empty(selectors)
 
 	// attestor1 has selectors, but not attestor2
 	selectors, err = s.attestor.Attest(ctx, 2)
-	s.Assert().Nil(err)
+	s.Nil(err)
 	spiretest.AssertProtoListEqual(s.T(), selectors1, selectors)
 
 	// attestor2 has selectors, attestor1 fails
 	selectors, err = s.attestor.Attest(ctx, 3)
-	s.Assert().Nil(err)
+	s.Nil(err)
 	spiretest.AssertProtoListEqual(s.T(), selectors2, selectors)
 
 	// both have selectors
 	selectors, err = s.attestor.Attest(ctx, 4)
-	s.Assert().Nil(err)
+	s.Nil(err)
 	util.SortSelectors(selectors)
-	combined := make([]*common.Selector, 0, len(selectors1)+len(selectors2))
-	combined = append(combined, selectors1...)
-	combined = append(combined, selectors2...)
+	combined := slices.Concat(selectors1, selectors2)
 	util.SortSelectors(combined)
 	spiretest.AssertProtoListEqual(s.T(), combined, selectors)
+
+	// neither attestor can attest the workload
+	selectors, err = s.attestor.Attest(ctx, 5)
+	spiretest.AssertErrorContains(s.T(), err, `workload attestor "fake1" failed`)
+	spiretest.AssertErrorContains(s.T(), err, `workloadattestor(fake1): cannot attest pid 5`)
+	spiretest.AssertErrorContains(s.T(), err, `workload attestor "fake2" failed`)
+	spiretest.AssertErrorContains(s.T(), err, `workloadattestor(fake2): cannot attest pid 5`)
+	s.Nil(selectors)
+}
+
+func (s *WorkloadAttestorTestSuite) TestAttestLogsOnPartialFailure() {
+	s.catalog.SetWorkloadAttestors(
+		fakeworkloadattestor.New(s.T(), "fake1", attestor1Pids),
+		fakeworkloadattestor.New(s.T(), "fake2", attestor2Pids),
+	)
+
+	selectors, err := s.attestor.Attest(ctx, 3)
+	s.Nil(err)
+	spiretest.AssertProtoListEqual(s.T(), selectors2, selectors)
+	spiretest.AssertLogs(s.T(), s.loggerHook.AllEntries(), []spiretest.LogEntry{
+		{
+			Level:   logrus.ErrorLevel,
+			Message: "Failed to collect all selectors for PID",
+			Data: logrus.Fields{
+				telemetry.PID:   "3",
+				logrus.ErrorKey: `workload attestor "fake1" failed: rpc error: code = Unknown desc = workloadattestor(fake1): cannot attest pid 3`,
+			},
+		},
+	})
 }
 
 func (s *WorkloadAttestorTestSuite) TestAttestWorkloadMetrics() {
@@ -106,7 +135,7 @@ func (s *WorkloadAttestorTestSuite) TestAttestWorkloadMetrics() {
 	s.attestor.c.Metrics = metrics
 
 	selectors, err := s.attestor.Attest(ctx, 2)
-	s.Assert().Nil(err)
+	s.Nil(err)
 
 	// Create expected metrics
 	expected := fakemetrics.New()
@@ -124,7 +153,8 @@ func (s *WorkloadAttestorTestSuite) TestAttestWorkloadMetrics() {
 
 	// No selectors expected
 	selectors, err = s.attestor.Attest(ctx, 3)
-	s.Assert().Nil(err)
+	spiretest.AssertErrorContains(s.T(), err, `workload attestor "fake1" failed`)
+	spiretest.AssertErrorContains(s.T(), err, `workloadattestor(fake1): cannot attest pid 3`)
 	s.Empty(selectors)
 
 	// Create expected metrics with error key
@@ -132,9 +162,8 @@ func (s *WorkloadAttestorTestSuite) TestAttestWorkloadMetrics() {
 	err = errors.New("some error")
 	attestorCounter = telemetry_workload.StartAttestorCall(expected, "fake1")
 	attestorCounter.Done(&err)
-	telemetry_workload.AddDiscoveredSelectorsSample(expected, float32(0))
 	attestationCounter = telemetry_workload.StartAttestationCall(expected)
-	attestationCounter.Done(nil)
+	attestationCounter.Done(&err)
 
 	s.Require().Equal(expected.AllMetrics(), metrics.AllMetrics())
 }
@@ -162,10 +191,10 @@ func (s *WorkloadAttestorTestSuite) TestAttestLogsOnContextCancellation() {
 	ctx, cancel := context.WithCancel(context.Background())
 	var selectors []*common.Selector
 	var attestErr error
-	go func(innerCtx context.Context, pid int) {
-		selectors, attestErr = s.attestor.Attest(innerCtx, pid)
+	go func() {
+		selectors, attestErr = s.attestor.Attest(ctx, pid)
 		attestCh <- struct{}{}
-	}(ctx, pid)
+	}()
 
 	// Wait for one of the plugins to return selectors
 	<-selectorC
@@ -176,8 +205,8 @@ func (s *WorkloadAttestorTestSuite) TestAttestLogsOnContextCancellation() {
 	// Wait for attestation goroutine to complete execution
 	<-attestCh
 
-	s.Assert().Nil(selectors)
-	s.Assert().Error(attestErr)
+	s.Nil(selectors)
+	s.Error(attestErr)
 	spiretest.AssertLogs(s.T(), s.loggerHook.AllEntries(), []spiretest.LogEntry{
 		{
 			Level:   logrus.ErrorLevel,

--- a/pkg/agent/endpoints/sdsv3/handler.go
+++ b/pkg/agent/endpoints/sdsv3/handler.go
@@ -70,7 +70,7 @@ func (h *Handler) StreamSecrets(stream secret_v3.SecretDiscoveryService_StreamSe
 	selectors, err := h.c.Attestor.Attest(stream.Context())
 	if err != nil {
 		log.WithError(err).Error("Failed to attest the workload")
-		return err
+		return workloadAttestationFailedError(stream.Context())
 	}
 
 	sub, err := h.c.Manager.SubscribeToCacheChanges(stream.Context(), selectors)
@@ -224,13 +224,20 @@ func (h *Handler) DeltaSecrets(secret_v3.SecretDiscoveryService_DeltaSecretsServ
 	return status.Error(codes.Unimplemented, "Method is not implemented")
 }
 
+func workloadAttestationFailedError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return status.Error(codes.Unavailable, "workload attestation failed")
+}
+
 func (h *Handler) FetchSecrets(ctx context.Context, req *discovery_v3.DiscoveryRequest) (*discovery_v3.DiscoveryResponse, error) {
 	log := rpccontext.Logger(ctx).WithField(telemetry.ResourceNames, req.ResourceNames)
 
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		log.WithError(err).Error("Failed to attest the workload")
-		return nil, err
+		return nil, workloadAttestationFailedError(ctx)
 	}
 
 	upd := h.c.Manager.FetchWorkloadUpdate(selectors)

--- a/pkg/agent/endpoints/workload/handler.go
+++ b/pkg/agent/endpoints/workload/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) FetchJWTSVID(ctx context.Context, req *workload.JWTSVIDRequest
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		loggerWithContextInfo(ctx, log, start, err).Error("Workload attestation failed")
-		return nil, err
+		return nil, workloadAttestationFailedError(ctx)
 	}
 
 	log = log.WithField(telemetry.Registered, true)
@@ -123,7 +123,7 @@ func (h *Handler) FetchJWTBundles(_ *workload.JWTBundlesRequest, stream workload
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		loggerWithContextInfo(ctx, log, start, err).Error("Workload attestation failed")
-		return err
+		return workloadAttestationFailedError(ctx)
 	}
 
 	subscriber, err := h.c.Manager.SubscribeToCacheChanges(ctx, selectors)
@@ -164,7 +164,7 @@ func (h *Handler) ValidateJWTSVID(ctx context.Context, req *workload.ValidateJWT
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		loggerWithContextInfo(ctx, log, start, err).Error("Workload attestation failed")
-		return nil, err
+		return nil, workloadAttestationFailedError(ctx)
 	}
 
 	bundles := h.getWorkloadBundles(selectors)
@@ -222,7 +222,7 @@ func (h *Handler) FetchX509SVID(_ *workload.X509SVIDRequest, stream workload.Spi
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		loggerWithContextInfo(ctx, log, start, err).Error("Workload attestation failed")
-		return err
+		return workloadAttestationFailedError(ctx)
 	}
 
 	subscriber, err := h.c.Manager.SubscribeToCacheChanges(ctx, selectors)
@@ -254,7 +254,7 @@ func (h *Handler) FetchX509Bundles(_ *workload.X509BundlesRequest, stream worklo
 	selectors, err := h.c.Attestor.Attest(ctx)
 	if err != nil {
 		loggerWithContextInfo(ctx, log, start, err).Error("Workload attestation failed")
-		return err
+		return workloadAttestationFailedError(ctx)
 	}
 
 	subscriber, err := h.c.Manager.SubscribeToCacheChanges(ctx, selectors)
@@ -284,6 +284,13 @@ func (h *Handler) FetchWITSVID(_ *workload.WITSVIDRequest, stream workload.Spiff
 
 func (h *Handler) FetchWITBundles(_ *workload.WITBundlesRequest, stream workload.SpiffeWorkloadAPI_FetchWITBundlesServer) error {
 	return status.Error(codes.Unimplemented, "fetching WIT bundles is not implemented")
+}
+
+func workloadAttestationFailedError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return status.Error(codes.Unavailable, "workload attestation failed")
 }
 
 func (h *Handler) fetchJWTSVID(ctx context.Context, log logrus.FieldLogger, entry *common.RegistrationEntry, audience []string, start time.Time) (*workload.JWTSVID, error) {

--- a/pkg/agent/endpoints/workload/handler_test.go
+++ b/pkg/agent/endpoints/workload/handler_test.go
@@ -166,8 +166,8 @@ func TestFetchX509SVID(t *testing.T) {
 		{
 			name:       "attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Unknown,
-			expectMsg:  "ohno",
+			expectCode: codes.Unavailable,
+			expectMsg:  "workload attestation failed",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
@@ -407,8 +407,8 @@ func TestFetchX509Bundles(t *testing.T) {
 		{
 			testName:   "attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Unknown,
-			expectMsg:  "ohno",
+			expectCode: codes.Unavailable,
+			expectMsg:  "workload attestation failed",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
@@ -804,8 +804,8 @@ func TestFetchJWTSVID(t *testing.T) {
 			name:       "attest error",
 			audience:   []string{"AUDIENCE"},
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Unknown,
-			expectMsg:  "ohno",
+			expectCode: codes.Unavailable,
+			expectMsg:  "workload attestation failed",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
@@ -1049,8 +1049,8 @@ func TestFetchJWTBundles(t *testing.T) {
 		{
 			name:       "attest error",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Unknown,
-			expectMsg:  "ohno",
+			expectCode: codes.Unavailable,
+			expectMsg:  "workload attestation failed",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,
@@ -1432,8 +1432,8 @@ func TestValidateJWTSVID(t *testing.T) {
 			svid:       "BAD",
 			audience:   "AUDIENCE",
 			attestErr:  errors.New("ohno"),
-			expectCode: codes.Unknown,
-			expectMsg:  "ohno",
+			expectCode: codes.Unavailable,
+			expectMsg:  "workload attestation failed",
 			expectLogs: []spiretest.LogEntry{
 				{
 					Level:   logrus.ErrorLevel,


### PR DESCRIPTION
Two changes here in separate commits:

1. Treat failure from all attestation plugins as an overall workload attestation failure, instead of trying and failing to find a matching registration entry.
    - The main point here is to log a better error, e.g. "Workload attestation failed" with the underlying attestation plugin error instead of "No identity issued" with a misleading "registered=false" field.
3. More controversially, return [gRPC code](https://grpc.io/docs/guides/status-codes/) ~`UNAUTHENTICATED`~ `UNAVAILABLE` when workload attestation fails.
    - This seems to make more sense than relying on what would otherwise happen, which is that we'd return whatever gRPC error the failed plugin(s) returned, which isn't always sensible (e.g. several plugins return `INTERNAL` when a dependency isn't available).
    - Alternatively, we could return `PERMISSION_DENIED` since that's what would have happened previously, but it seems a little less correct.