### PR TITLE
Update the review ball-in-court on fork PRs via workflow_run

### DIFF
--- a/.github/reviewer-pool.json
+++ b/.github/reviewer-pool.json
@@ -1,0 +1,7 @@
+{
+  "reviewers": [
+    "amartinezfayo",
+    "sorindumitru",
+    "MarcosDY"
+  ]
+}

--- a/.github/workflows/assign_reviewer.yaml
+++ b/.github/workflows/assign_reviewer.yaml
@@ -4,45 +4,36 @@ name: assign-reviewer
 #
 # This workflow does not request reviewers: the repository's CODEOWNERS file
 # already requests the maintainers on every PR. Instead it designates a single
-# maintainer as the PR *assignee* to show who owns the next action
-# ("ball in court"), and keeps that up to date as the review progresses:
+# maintainer as the PR assignee to show who owns the next action ("ball in
+# court"), and keeps that up to date as the review progresses:
 #   - opened / ready_for_review -> a maintainer is chosen at random from the
 #     pool and set as the assignee.
-#   - that maintainer requests changes or comments -> ball to the author.
-#   - that maintainer approves -> they stay assigned (a maintainer merges).
 #   - a human re-requests a review while the ball is with the author -> the
 #     assignee flips to the requested maintainer.
 #
-# The assignee is picked at random from the pool, which evens out over time and
-# avoids the bias of mapping the shared PR/issue number namespace onto the pool.
+# Review submissions (the flip to the author on changes requested, and the
+# reviewer staying assigned on approval) are handled by the companion
+# assign-reviewer-review-capture and assign-reviewer-review-apply workflows.
+# That split exists because review handling needs a write token on PRs from
+# forks, which the pull_request_review event does not provide; see those files.
+#
+# The maintainer is picked at random from the pool, which evens out over time.
 # The selection is stateless: no persisted index or external state. The pool is
-# an explicit list below, separate from CODEOWNERS,
-# so it can be adjusted for availability (leave, inactivity) without touching
-# ownership.
+# an explicit list below, separate from CODEOWNERS, so it can be adjusted for
+# availability (leave, inactivity) without touching ownership.
 #
-# The author holding the ball is shown with the "awaiting-author" label rather
-# than an assignee, because external contributors generally cannot be set as
-# assignees (only the author after commenting, collaborators with write access,
-# or org members with read access are eligible), so an assignee would be
-# silently dropped. The label has no such restriction and is created
-# automatically if missing.
-#
-# pull_request_target and pull_request_review are used (instead of
-# pull_request) so the workflow has a write-scoped token on PRs opened from
-# forks, which is the common case for external contributions. This is safe
-# here because the job never checks out or executes any code from the PR; it
-# only reads PR metadata and calls the assignee / label APIs, never
+# This runs on pull_request_target, which has a write-scoped token even for PRs
+# from forks. It is safe because the job never checks out or executes any code
+# from the PR; it only reads PR metadata and calls the assignee API, never
 # interpolating PR-controlled text into a shell.
 
 on:
   pull_request_target:
     types: [opened, ready_for_review, review_requested]
-  pull_request_review:
-    types: [submitted]
 
 # Serialize runs per PR and per event action so overlapping events don't race
-# on assignee/label state. The action is part of the group on purpose: when a
-# PR opens, GitHub fires the "opened" event together with a burst of CODEOWNERS
+# on the assignee. The action is part of the group on purpose: when a PR opens,
+# GitHub fires the "opened" event together with a burst of CODEOWNERS
 # "review_requested" events, and a single group plus cancel-in-progress: false
 # makes GitHub cancel all but the latest pending run, which can drop the
 # "opened" run that assigns the reviewer. Keeping each action in its own group
@@ -58,71 +49,40 @@ jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
     permissions:
+      contents: read       # read .github/reviewer-pool.json
       pull-requests: write # manage assignees
-      issues: write        # create and apply the awaiting-author label
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            // Rotation pool, separate from CODEOWNERS. Edit this list to adjust
-            // who participates according to availability.
-            const POOL = [
-              'amartinezfayo',
-              'sorindumitru',
-              'MarcosDY',
-            ];
-
-            // Label used to show that the ball is in the author's court.
-            const AUTHOR_LABEL = 'awaiting-author';
-
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
-            const eventName = context.eventName;
             const action = context.payload.action;
             const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
             const assignees = () => (pr.assignees || []).map(a => a.login);
-            const labels = () => (pr.labels || []).map(l => l.name);
+
+            // The reviewer pool lives in .github/reviewer-pool.json so it has a
+            // single, discoverable source of truth shared with
+            // assign-reviewer-review-apply.yaml. Read it from the default branch
+            // (the API default ref) so a PR from a fork cannot substitute its
+            // own pool.
+            const { data: poolFile } = await github.rest.repos.getContent({
+              owner, repo, path: '.github/reviewer-pool.json',
+            });
+            const POOL = JSON.parse(
+              Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
+            ).reviewers;
             const inPool = (login) => POOL.some(p => eq(p, login));
-            const authorHoldsBall = () => labels().some(n => eq(n, AUTHOR_LABEL));
+            const authorHoldsBall = () => assignees().some(a => eq(a, pr.user.login));
 
-            // Ensure the awaiting-author label exists (addLabels does not
-            // create missing labels), then apply it.
-            async function addAuthorLabel() {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name: AUTHOR_LABEL });
-              } catch (e) {
-                if (e.status !== 404) throw e;
-                try {
-                  await github.rest.issues.createLabel({
-                    owner, repo, name: AUTHOR_LABEL, color: 'fbca04',
-                    description: 'Waiting on the PR author to address review feedback',
-                  });
-                } catch (err) {
-                  // 422: another run for a different PR created the label
-                  // first (benign race); proceed to apply it.
-                  if (err.status !== 422) throw err;
-                }
-              }
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: pr.number, labels: [AUTHOR_LABEL],
-              });
-            }
-
-            async function removeAuthorLabel() {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: pr.number, name: AUTHOR_LABEL,
-                });
-              } catch (e) {
-                if (e.status !== 404) throw e; // 404: label not applied; fine
-              }
-            }
-
-            // Ball in a maintainer's court: make them the sole pool assignee
-            // and clear the author label. Non-pool assignees are left intact.
-            async function setMaintainerCourt(login) {
+            // Make `login` the sole ball-in-court assignee among flow
+            // participants (the pool members and the PR author), leaving any
+            // unrelated, manually-added assignees untouched.
+            async function setCourt(login) {
+              const flow = [...POOL, pr.user.login];
               const current = assignees();
-              const toRemove = current.filter(a => inPool(a) && !eq(a, login));
+              const toRemove = current.filter(a =>
+                flow.some(f => eq(f, a)) && !eq(a, login));
               if (toRemove.length > 0) {
                 await github.rest.issues.removeAssignees({
                   owner, repo, issue_number: pr.number, assignees: toRemove,
@@ -133,34 +93,18 @@ jobs:
                   owner, repo, issue_number: pr.number, assignees: [login],
                 });
               }
-              await removeAuthorLabel();
-              core.info(`Ball in court: ${login} (maintainer), PR #${pr.number}.`);
-            }
-
-            // Ball in the author's court: clear pool assignees and apply the
-            // awaiting-author label.
-            async function setAuthorCourt() {
-              const toRemove = assignees().filter(a => inPool(a));
-              if (toRemove.length > 0) {
-                await github.rest.issues.removeAssignees({
-                  owner, repo, issue_number: pr.number, assignees: toRemove,
-                });
-              }
-              await addAuthorLabel();
-              core.info(`Ball in court: ${pr.user.login} (author), PR #${pr.number}.`);
+              core.info(`Ball in court: ${login}, PR #${pr.number}.`);
             }
 
             // Skip bot-authored PRs (for example Dependabot). These are handled
-            // by the auto-merge workflow and do not take part in the review
-            // rotation.
+            // by the auto-merge workflow and do not take part in the rotation.
             if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
               core.info(`PR #${pr.number} authored by bot ${pr.user.login}; skipping.`);
               return;
             }
 
             // 1) New PR (or draft promoted to ready): pick a random pool member.
-            if (eventName === 'pull_request_target' &&
-                (action === 'opened' || action === 'ready_for_review')) {
+            if (action === 'opened' || action === 'ready_for_review') {
               if (pr.draft) {
                 core.info(`PR #${pr.number} is a draft; skipping.`);
                 return;
@@ -174,17 +118,15 @@ jobs:
               }
               const reviewer = candidates[Math.floor(Math.random() * candidates.length)];
               core.info(`Selected assignee for PR #${pr.number}: ${reviewer}.`);
-              await setMaintainerCourt(reviewer);
+              await setCourt(reviewer);
               return;
             }
 
             // 2) A review was (re-)requested. Move the ball to that maintainer,
             //    but only when the ball is currently in the author's court (the
-            //    awaiting-author label is present). This restricts the path to
-            //    genuine re-requests after feedback, so the CODEOWNERS
-            //    auto-request that fires when a PR is opened cannot override the
-            //    rotated assignee regardless of how the events are ordered.
-            if (eventName === 'pull_request_target' && action === 'review_requested') {
+            //    author is the assignee). This keeps the CODEOWNERS auto-request
+            //    that fires on open from overriding the rotated assignee.
+            if (action === 'review_requested') {
               const reviewer = context.payload.requested_reviewer;
               if (!reviewer || reviewer.type === 'Bot' || !inPool(reviewer.login)) {
                 core.info('Review request is not for a pool member; skipping.');
@@ -194,30 +136,6 @@ jobs:
                 core.info(`Ball is not in the author's court on PR #${pr.number}; not overriding the rotation.`);
                 return;
               }
-              await setMaintainerCourt(reviewer.login);
-              return;
-            }
-
-            // 3) A review was submitted: move the ball based on the verdict.
-            // Only reviews from pool members drive the ball-in-court state, so
-            // a drive-by review from a non-pool user cannot clear the assigned
-            // maintainer or, on approval, be set as a (possibly non-assignable)
-            // assignee.
-            if (eventName === 'pull_request_review' && action === 'submitted') {
-              const submitter = context.payload.review.user.login;
-              if (!inPool(submitter)) {
-                core.info(`Review by ${submitter} is not from a pool member; leaving court unchanged.`);
-                return;
-              }
-              const state = (context.payload.review.state || '').toLowerCase();
-              if (state === 'approved') {
-                // Reviewer stays assigned (a maintainer merges).
-                await setMaintainerCourt(submitter);
-              } else if (state === 'changes_requested' || state === 'commented') {
-                // Ball back to the author to address feedback.
-                await setAuthorCourt();
-              }
-              // Any other review state leaves whose court the ball is in
-              // unchanged.
+              await setCourt(reviewer.login);
               return;
             }

--- a/.github/workflows/assign_reviewer.yaml
+++ b/.github/workflows/assign_reviewer.yaml
@@ -19,8 +19,8 @@ name: assign-reviewer
 #
 # The maintainer is picked at random from the pool, which evens out over time.
 # The selection is stateless: no persisted index or external state. The pool is
-# an explicit list below, separate from CODEOWNERS, so it can be adjusted for
-# availability (leave, inactivity) without touching ownership.
+# defined in .github/reviewer-pool.json, separate from CODEOWNERS, so it can be
+# adjusted for availability (leave, inactivity) without touching ownership.
 #
 # This runs on pull_request_target, which has a write-scoped token even for PRs
 # from forks. It is safe because the job never checks out or executes any code
@@ -50,7 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read       # read .github/reviewer-pool.json
-      pull-requests: write # manage assignees
+      issues: write        # add/remove assignees (the issues API endpoint)
+      pull-requests: write # add/remove assignees on the pull request
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -62,10 +63,10 @@ jobs:
             const assignees = () => (pr.assignees || []).map(a => a.login);
 
             // The reviewer pool lives in .github/reviewer-pool.json so it has a
-            // single, discoverable source of truth shared with
-            // assign-reviewer-review-apply.yaml. Read it from the default branch
-            // (the API default ref) so a PR from a fork cannot substitute its
-            // own pool.
+            // single, discoverable source of truth shared with the apply
+            // workflow (assign_reviewer_review_apply.yaml). Read it from the
+            // default branch (the API default ref) so a PR from a fork cannot
+            // substitute its own pool.
             const { data: poolFile } = await github.rest.repos.getContent({
               owner, repo, path: '.github/reviewer-pool.json',
             });

--- a/.github/workflows/assign_reviewer.yaml
+++ b/.github/workflows/assign_reviewer.yaml
@@ -74,7 +74,15 @@ jobs:
               Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
             ).reviewers;
             const inPool = (login) => POOL.some(p => eq(p, login));
-            const authorHoldsBall = () => assignees().some(a => eq(a, pr.user.login));
+            // The ball is in the author's court only when the author is assigned
+            // and no pool member other than the author also is, so a re-request
+            // does not override a maintainer who is still (for example,
+            // manually) co-assigned.
+            const authorHoldsBall = () => {
+              const current = assignees();
+              return current.some(a => eq(a, pr.user.login)) &&
+                !current.some(a => inPool(a) && !eq(a, pr.user.login));
+            };
 
             // Make `login` the sole ball-in-court assignee among flow
             // participants (the pool members and the PR author), leaving any

--- a/.github/workflows/assign_reviewer_review_apply.yaml
+++ b/.github/workflows/assign_reviewer_review_apply.yaml
@@ -18,8 +18,10 @@ name: assign-reviewer-review-apply
 # number is a positive integer and the review state is one of the known values,
 # binds the artifact to the triggering PR by requiring the re-fetched PR head to
 # equal the run's head SHA (so a forged pr_number cannot target a victim PR),
-# only ever assigns a login that is in the pool or is the PR author re-fetched
-# from the API, and never interpolates artifact data into a shell.
+# confirms via the API that the named reviewer actually submitted a review in
+# that state (so a forged artifact cannot fabricate one), skips bot-authored
+# PRs, only ever assigns a login that is in the pool or is the PR author
+# re-fetched from the API, and never interpolates artifact data into a shell.
 
 on:
   workflow_run:

--- a/.github/workflows/assign_reviewer_review_apply.yaml
+++ b/.github/workflows/assign_reviewer_review_apply.yaml
@@ -1,0 +1,136 @@
+name: assign-reviewer-review-apply
+
+# Privileged half of the review ball-in-court update.
+#
+# Triggered by the completion of assign-reviewer-review-capture via
+# workflow_run. A workflow_run run executes from the default branch with a
+# write-scoped token even when the originating review was on a PR from a fork,
+# which is what lets it move the assignee where the pull_request_review event
+# could not.
+#
+# Ball-in-court rules applied here:
+#   - reviewer approves  -> the reviewer stays assigned (a maintainer merges).
+#   - changes requested or comment -> the author is assigned (their court).
+#
+# Security: this never checks out or runs any PR code. The only thing it
+# consumes from the (fork-triggered) capture run is a small JSON artifact, which
+# it treats as untrusted: it validates the PR number is a positive integer and
+# the review state is one of the known values, only ever assigns a login that is
+# in the pool or is the PR author (re-fetched from the API), and never
+# interpolates artifact data into a shell.
+
+on:
+  workflow_run:
+    workflows: [assign-reviewer-review-capture]
+    types: [completed]
+
+# Serialize applies for the same commit so close-together reviews don't race on
+# the assignee. The PR number is not in the workflow_run context for fork PRs,
+# so the head SHA is used as the grouping key.
+concurrency:
+  group: assign-reviewer-review-apply-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    # Only act when the capture run succeeded (so the artifact exists).
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read       # read .github/reviewer-pool.json
+      pull-requests: write # manage assignees
+      actions: read        # download the artifact from the capture run
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: assign-reviewer-review
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+
+            const { owner, repo } = context.repo;
+            const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+            // The reviewer pool lives in .github/reviewer-pool.json so it has a
+            // single, discoverable source of truth shared with
+            // assign_reviewer.yaml. This workflow_run job already runs from the
+            // default branch, so the default ref is the trusted pool.
+            const { data: poolFile } = await github.rest.repos.getContent({
+              owner, repo, path: '.github/reviewer-pool.json',
+            });
+            const POOL = JSON.parse(
+              Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
+            ).reviewers;
+            const inPool = (login) => POOL.some(p => eq(p, login));
+
+            // The artifact comes from a fork-triggered run; treat it as
+            // untrusted and validate every field before use.
+            let raw;
+            try {
+              raw = JSON.parse(fs.readFileSync('review.json', 'utf8'));
+            } catch (e) {
+              core.warning(`Could not read captured review data: ${e.message}`);
+              return;
+            }
+            const prNumber = Number(raw.pr_number);
+            const state = String(raw.review_state || '').toLowerCase();
+            const submitter = String(raw.submitter || '');
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.warning('Captured pr_number is not a positive integer; ignoring.');
+              return;
+            }
+            if (!['approved', 'changes_requested', 'commented'].includes(state)) {
+              core.info(`Review state "${state}" does not change the court; nothing to do.`);
+              return;
+            }
+            // Only reviews from pool members drive the ball-in-court state.
+            if (!inPool(submitter)) {
+              core.info(`Review by ${submitter} is not from a pool member; leaving court unchanged.`);
+              return;
+            }
+
+            // Re-fetch the PR so we act on its current author and assignees.
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+            const author = pr.user.login;
+            const current = (pr.assignees || []).map(a => a.login);
+
+            // The apply is asynchronous, so the PR may have closed in between.
+            if (pr.state !== 'open') {
+              core.info(`PR #${prNumber} is ${pr.state}; leaving court unchanged.`);
+              return;
+            }
+            // A pool member can leave a comment review on their own PR; don't
+            // assign them to it (the open handler excludes the author too).
+            if (eq(submitter, author)) {
+              core.info(`Self-review by ${submitter} on PR #${prNumber}; leaving court unchanged.`);
+              return;
+            }
+
+            // Approve keeps the reviewer assigned; otherwise the author owns it.
+            const target = state === 'approved' ? submitter : author;
+
+            // Make `target` the sole ball-in-court assignee among flow
+            // participants (pool members and the author), leaving unrelated,
+            // manually-added assignees untouched.
+            const flow = [...POOL, author];
+            const toRemove = current.filter(a =>
+              flow.some(f => eq(f, a)) && !eq(a, target));
+            if (toRemove.length > 0) {
+              await github.rest.issues.removeAssignees({
+                owner, repo, issue_number: prNumber, assignees: toRemove,
+              });
+            }
+            if (!current.some(a => eq(a, target))) {
+              await github.rest.issues.addAssignees({
+                owner, repo, issue_number: prNumber, assignees: [target],
+              });
+            }
+            core.info(`Ball in court: ${target}, PR #${prNumber}.`);

--- a/.github/workflows/assign_reviewer_review_apply.yaml
+++ b/.github/workflows/assign_reviewer_review_apply.yaml
@@ -12,12 +12,14 @@ name: assign-reviewer-review-apply
 #   - reviewer approves  -> the reviewer stays assigned (a maintainer merges).
 #   - changes requested or comment -> the author is assigned (their court).
 #
-# Security: this never checks out or runs any PR code. The only thing it
-# consumes from the (fork-triggered) capture run is a small JSON artifact, which
-# it treats as untrusted: it validates the PR number is a positive integer and
-# the review state is one of the known values, only ever assigns a login that is
-# in the pool or is the PR author (re-fetched from the API), and never
-# interpolates artifact data into a shell.
+# Security: this never checks out or runs any PR code. The capture artifact is
+# treated as untrusted (a fork PR can run a modified capture, since
+# pull_request_review uses the PR's own workflow copy): it validates the PR
+# number is a positive integer and the review state is one of the known values,
+# binds the artifact to the triggering PR by requiring the re-fetched PR head to
+# equal the run's head SHA (so a forged pr_number cannot target a victim PR),
+# only ever assigns a login that is in the pool or is the PR author re-fetched
+# from the API, and never interpolates artifact data into a shell.
 
 on:
   workflow_run:
@@ -103,6 +105,27 @@ jobs:
             const author = pr.user.login;
             const current = (pr.assignees || []).map(a => a.login);
 
+            // Bind the artifact to the PR that actually triggered the capture
+            // run. pull_request_review runs the PR's own copy of the capture
+            // workflow, so a fork can ship a modified capture that uploads an
+            // arbitrary pr_number; the field validation above only checks it is
+            // a positive integer. Requiring the re-fetched PR's head to equal
+            // the triggering run's head SHA limits any forged artifact to the
+            // attacker's own PR (whose head is the only one that can match),
+            // rather than letting it act on a victim PR. A legitimate apply that
+            // races a fresh push is skipped and reconciles on the next event.
+            if (pr.head.sha !== context.payload.workflow_run.head_sha) {
+              core.info(`PR #${prNumber} head does not match the capture run head; ignoring (forged or stale artifact).`);
+              return;
+            }
+
+            // Skip bot-authored PRs (for example Dependabot); they are owned by
+            // the auto-merge workflow and do not take part in the rotation.
+            if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
+              core.info(`PR #${prNumber} authored by bot ${pr.user.login}; skipping.`);
+              return;
+            }
+
             // The apply is asynchronous, so the PR may have closed in between.
             if (pr.state !== 'open') {
               core.info(`PR #${prNumber} is ${pr.state}; leaving court unchanged.`);
@@ -112,6 +135,21 @@ jobs:
             // assign them to it (the open handler excludes the author too).
             if (eq(submitter, author)) {
               core.info(`Self-review by ${submitter} on PR #${prNumber}; leaving court unchanged.`);
+              return;
+            }
+
+            // Confirm the claimed review actually exists. The capture is
+            // fork-modifiable, so without this a forged artifact could fabricate
+            // a pool member's review on the attacker's own PR. Require a real
+            // review by `submitter` in `state` before acting on it.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const reviewExists = reviews.some(r =>
+              r.user && eq(r.user.login, submitter) &&
+              (r.state || '').toLowerCase() === state);
+            if (!reviewExists) {
+              core.info(`No ${state} review by ${submitter} on PR #${prNumber}; ignoring (forged or stale artifact).`);
               return;
             }
 

--- a/.github/workflows/assign_reviewer_review_apply.yaml
+++ b/.github/workflows/assign_reviewer_review_apply.yaml
@@ -41,7 +41,8 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read       # read .github/reviewer-pool.json
-      pull-requests: write # manage assignees
+      issues: write        # add/remove assignees (the issues API endpoint)
+      pull-requests: write # add/remove assignees on the pull request
       actions: read        # download the artifact from the capture run
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/assign_reviewer_review_capture.yaml
+++ b/.github/workflows/assign_reviewer_review_capture.yaml
@@ -12,8 +12,9 @@ name: assign-reviewer-review-capture
 # Note that pull_request_review runs the PR's own copy of this workflow, so a
 # fork PR can run a modified version of this file. That gains no privileges
 # (the token stays read-only), but it means the artifact contents are not
-# trusted: the apply workflow validates every field and binds the artifact to
-# the triggering PR's head SHA before acting on it.
+# trusted: the apply workflow validates every field, binds the artifact to the
+# triggering PR's head SHA, and confirms via the API that the claimed review
+# exists before acting on it.
 
 on:
   pull_request_review:

--- a/.github/workflows/assign_reviewer_review_capture.yaml
+++ b/.github/workflows/assign_reviewer_review_capture.yaml
@@ -8,10 +8,12 @@ name: assign-reviewer-review-capture
 # assign-reviewer-review-apply workflow (triggered via workflow_run) needs to
 # move the assignee with a write token.
 #
-# It never writes to the repository, never checks out or runs any PR code, and
-# only records the PR number, the review state, and the reviewer login, all of
-# which come from trusted event metadata (this file runs from the default
-# branch). The apply workflow still validates every field before use.
+# It never writes to the repository and never checks out or runs any PR code.
+# Note that pull_request_review runs the PR's own copy of this workflow, so a
+# fork PR can run a modified version of this file. That gains no privileges
+# (the token stays read-only), but it means the artifact contents are not
+# trusted: the apply workflow validates every field and binds the artifact to
+# the triggering PR's head SHA before acting on it.
 
 on:
   pull_request_review:

--- a/.github/workflows/assign_reviewer_review_capture.yaml
+++ b/.github/workflows/assign_reviewer_review_capture.yaml
@@ -1,0 +1,44 @@
+name: assign-reviewer-review-capture
+
+# Unprivileged half of the review ball-in-court update.
+#
+# The pull_request_review token is read-only for PRs from forks, so the
+# assignee write cannot happen here. This workflow only reads the review event
+# and writes a small artifact with the data the privileged
+# assign-reviewer-review-apply workflow (triggered via workflow_run) needs to
+# move the assignee with a write token.
+#
+# It never writes to the repository, never checks out or runs any PR code, and
+# only records the PR number, the review state, and the reviewer login, all of
+# which come from trusted event metadata (this file runs from the default
+# branch). The apply workflow still validates every field before use.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const review = context.payload.review;
+            const data = {
+              pr_number: context.payload.pull_request.number,
+              review_state: (review.state || '').toLowerCase(),
+              submitter: review.user.login,
+            };
+            fs.writeFileSync('review.json', JSON.stringify(data));
+            core.info(`Captured ${data.review_state} review by ${data.submitter} on PR #${data.pr_number}.`);
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: assign-reviewer-review
+          path: review.json
+          retention-days: 1
+          if-no-files-found: error # fail loudly rather than produce no artifact


### PR DESCRIPTION
The `assign-reviewer` workflow sets a rotated maintainer as the PR assignee ("ball in court") and flips the assignee to the author when changes are requested. The open-time assignment works on pull requests from forks because it runs on `pull_request_target`, which has a write-scoped token even for forks. The flip on a review submission, however, ran on `pull_request_review`, whose token is read-only for fork PRs, so the assignee write returned `403 Resource not accessible by integration` on every external contribution.

This moves the review-submission handling to the two-stage `workflow_run` pattern that GitHub's Security Lab recommends for acting on fork pull requests with a write token (https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/). An unprivileged `assign-reviewer-review-capture` workflow runs on `pull_request_review`, reads the event, and writes a small artifact with the PR number, review state, and reviewer. A privileged `assign-reviewer-review-apply` workflow then runs on `workflow_run`, which executes from the default branch with a write-scoped token even when the originating review was on a fork PR, downloads the artifact, and moves the assignee. The open, ready-for-review, and re-request paths stay on `pull_request_target` and are unchanged.

This also drops the `awaiting-author` label that previously marked the author's court. External contributors turn out to be assignable to their own pull request, so the author's court is now a plain assignee like everything else, which collapses the two court helpers into one.

The reviewer pool is defined in `.github/reviewer-pool.json`, a single source of truth that both workflows read at runtime from the default branch. Updating the roster is a one-file change, the two workflows cannot drift, and reading from the default branch keeps a fork PR from substituting its own pool.

Security:
- No workflow checks out or runs any code from the pull request.
- The capture artifact is treated as untrusted, because `pull_request_review` runs the pull request's own copy of the capture workflow, so a fork PR can run a modified capture (it stays read-only and gains no privileges, but it can write arbitrary artifact contents). Before acting, the apply validates that the PR number is a positive integer and the review state is one of the known values, binds the artifact to the triggering PR by requiring the re-fetched PR head to equal the run's head SHA, confirms via the API that the named reviewer actually submitted a review in that state, only assigns a login that is in the reviewer pool or is the PR author re-fetched from the API, skips bot-authored PRs, and never interpolates artifact data into a shell. Together the head-SHA binding and the review check mean a forged artifact can neither target a victim PR nor fabricate a review.
- Only GitHub-controlled values (`workflow_run.id`, `head_sha`) appear in workflow expressions, never PR-controlled text in a shell.
- Permissions are deny-by-default: `contents: read` to read the reviewer pool file, `issues: write` and `pull-requests: write` where assignees are managed (assignees are an Issues-API property even on a pull request), `actions: read` on the apply job for the cross-run artifact download, and the capture job stays read-only.

Known limitations, both rare and self-correcting: the apply job serializes per head commit SHA rather than per PR (the PR number is not available in the `workflow_run` context for fork PRs), so two distinct open PRs from the same fork on the same commit would share a concurrency group; and because the apply is asynchronous and runs in a separate concurrency domain from the re-request handler, a narrow interleaving window exists. The design is stateless and reconciles on the next event.
