### PR TITLE
Support runtime log level adjustment on spire-agent

### DIFF
--- a/cmd/spire-agent/cli/cli.go
+++ b/cmd/spire-agent/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mitchellh/cli"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/api"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/healthcheck"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/logger"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/run"
 	"github.com/spiffe/spire/cmd/spire-agent/cli/validate"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -42,6 +43,15 @@ func (cc *CLI) Run(ctx context.Context, args []string) int {
 		},
 		"healthcheck": func() (cli.Command, error) {
 			return healthcheck.NewHealthCheckCommand(), nil
+		},
+		"logger get": func() (cli.Command, error) {
+			return logger.NewGetCommand(), nil
+		},
+		"logger set": func() (cli.Command, error) {
+			return logger.NewSetCommand(), nil
+		},
+		"logger reset": func() (cli.Command, error) {
+			return logger.NewResetCommand(), nil
 		},
 		"validate": func() (cli.Command, error) {
 			return validate.NewValidateCommand(), nil

--- a/cmd/spire-agent/cli/logger/get.go
+++ b/cmd/spire-agent/cli/logger/get.go
@@ -1,0 +1,54 @@
+package logger
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/mitchellh/cli"
+	api "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	"github.com/spiffe/spire/cmd/spire-agent/util"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/cliprinter"
+)
+
+type getCommand struct {
+	env     *commoncli.Env
+	printer cliprinter.Printer
+}
+
+// Returns a cli.command that gets the logger information using
+// the default cli environment.
+func NewGetCommand() cli.Command {
+	return NewGetCommandWithEnv(commoncli.DefaultEnv)
+}
+
+// Returns a cli.command that gets the root logger information.
+func NewGetCommandWithEnv(env *commoncli.Env) cli.Command {
+	return util.AdaptCommand(env, &getCommand{env: env})
+}
+
+func (*getCommand) Name() string {
+	return "logger get"
+}
+
+func (*getCommand) Synopsis() string {
+	return "Gets the logger details"
+}
+
+func (c *getCommand) AppendFlags(fs *flag.FlagSet) {
+	cliprinter.AppendFlagWithCustomPretty(&c.printer, fs, c.env, c.prettyPrintLogger)
+}
+
+func (c *getCommand) Run(ctx context.Context, _ *commoncli.Env, agentClient util.AgentClient) error {
+	logger, err := agentClient.NewLoggerClient().GetLogger(ctx, &api.GetLoggerRequest{})
+	if err != nil {
+		return fmt.Errorf("error fetching logger: %w", err)
+	}
+
+	return c.printer.PrintProto(logger)
+}
+
+func (c *getCommand) prettyPrintLogger(env *commoncli.Env, results ...any) error {
+	return PrettyPrintLogger(env, results...)
+}

--- a/cmd/spire-agent/cli/logger/get_posix_test.go
+++ b/cmd/spire-agent/cli/logger/get_posix_test.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package logger_test
+
+var (
+	getUsage = `Usage of logger get:
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+  -socketPath string
+    	Path to the SPIRE Agent Admin API socket (default "/tmp/spire-agent/private/admin.sock")
+`
+)

--- a/cmd/spire-agent/cli/logger/get_test.go
+++ b/cmd/spire-agent/cli/logger/get_test.go
@@ -1,0 +1,178 @@
+package logger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/logger"
+)
+
+func TestGetHelp(t *testing.T) {
+	test := setupCliTest(t, &mockLoggerService{}, logger.NewGetCommandWithEnv)
+	test.client.Help()
+	require.Equal(t, "", test.stdout.String())
+	require.Equal(t, getUsage, test.stderr.String())
+}
+
+func TestGetSynopsis(t *testing.T) {
+	cmd := logger.NewGetCommand()
+	require.Equal(t, "Gets the logger details", cmd.Synopsis())
+}
+
+func TestGet(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		// server state
+		server *mockLoggerService
+		// input
+		args []string
+		// expected items
+		expectReturnCode int
+		expectStdout     string
+		expectStderr     string
+	}{
+		{
+			name: "configured to info, set to info, using pretty output",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : info
+Launch Level : info
+
+`,
+		},
+		{
+			name: "configured to debug, set to warn, using pretty output",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_WARN,
+					LaunchLevel:  types.LogLevel_DEBUG,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : warning
+Launch Level : debug
+
+`,
+		},
+		{
+			name: "configured to error, set to trace, using pretty output",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_TRACE,
+					LaunchLevel:  types.LogLevel_ERROR,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : trace
+Launch Level : error
+
+`,
+		},
+		{
+			name: "configured to panic, set to fatal, using pretty output",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_FATAL,
+					LaunchLevel:  types.LogLevel_PANIC,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : fatal
+Launch Level : panic
+
+`,
+		},
+		{
+			name: "configured to info, set to info, using json output",
+			args: []string{"-output", "json"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `{"current_level":"INFO","launch_level":"INFO"}
+`,
+		},
+		{
+			name: "configured to debug, set to warn, using json output",
+			args: []string{"-output", "json"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_WARN,
+					LaunchLevel:  types.LogLevel_DEBUG,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `{"current_level":"WARN","launch_level":"DEBUG"}
+`,
+		},
+		{
+			name: "configured to error, set to trace, using json output",
+			args: []string{"-output", "json"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_TRACE,
+					LaunchLevel:  types.LogLevel_ERROR,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `{"current_level":"TRACE","launch_level":"ERROR"}
+`,
+		},
+		{
+			name: "configured to panic, set to fatal, using json output",
+			args: []string{"-output", "json"},
+			server: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_FATAL,
+					LaunchLevel:  types.LogLevel_PANIC,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `{"current_level":"FATAL","launch_level":"PANIC"}
+`,
+		},
+		{
+			name: "configured to info, set to info, server will error",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnErr: errors.New("server is unavailable"),
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: error fetching logger: rpc error: code = Unknown desc = server is unavailable
+`,
+		},
+		{
+			name: "bizzarro world, returns neither logger nor error",
+			args: []string{"-output", "pretty"},
+			server: &mockLoggerService{
+				returnLogger: nil,
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: internal error: returned current log level is undefined; please report this as a bug
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupCliTest(t, tt.server, logger.NewGetCommandWithEnv)
+			returnCode := test.client.Run(append(test.args, tt.args...))
+			require.Equal(t, tt.expectStdout, test.stdout.String())
+			require.Equal(t, tt.expectStderr, test.stderr.String())
+			require.Equal(t, tt.expectReturnCode, returnCode)
+		})
+	}
+}

--- a/cmd/spire-agent/cli/logger/get_windows_test.go
+++ b/cmd/spire-agent/cli/logger/get_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package logger_test
+
+var (
+	getUsage = `Usage of logger get:
+  -namedPipeName string
+    	Pipe name of the SPIRE Agent Admin API named pipe (default "\\spire-agent\\private\\admin")
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+`
+)

--- a/cmd/spire-agent/cli/logger/mocks_test.go
+++ b/cmd/spire-agent/cli/logger/mocks_test.go
@@ -1,0 +1,104 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/spiffe/spire/test/clitest"
+	"github.com/spiffe/spire/test/spiretest"
+
+	"github.com/mitchellh/cli"
+	loggerv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+	"google.golang.org/grpc"
+)
+
+type loggerTest struct {
+	stdin  *bytes.Buffer
+	stdout *bytes.Buffer
+	stderr *bytes.Buffer
+	args   []string
+	server *mockLoggerService
+	client cli.Command
+}
+
+func (l *loggerTest) afterTest(t *testing.T) {
+	t.Logf("TEST:%s", t.Name())
+	t.Logf("STDOUT:\n%s", l.stdout.String())
+	t.Logf("STDIN:\n%s", l.stdin.String())
+	t.Logf("STDERR:\n%s", l.stderr.String())
+}
+
+func setupCliTest(t *testing.T, server *mockLoggerService, newClient func(*commoncli.Env) cli.Command) *loggerTest {
+	addr := spiretest.StartGRPCServer(t, func(s *grpc.Server) {
+		loggerv1.RegisterLoggerServer(s, server)
+	})
+
+	stdin := new(bytes.Buffer)
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	client := newClient(&commoncli.Env{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	})
+
+	test := &loggerTest{
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+		args:   []string{clitest.AddrArg, clitest.GetAddr(addr)},
+		server: server,
+		client: client,
+	}
+
+	t.Cleanup(func() {
+		test.afterTest(t)
+	})
+
+	return test
+}
+
+type mockLoggerService struct {
+	loggerv1.UnimplementedLoggerServer
+
+	receivedSetValue *types.LogLevel
+	returnLogger     *types.Logger
+	returnErr        error
+}
+
+func (s *mockLoggerService) GetLogger(context.Context, *loggerv1.GetLoggerRequest) (*types.Logger, error) {
+	return s.returnLogger, s.returnErr
+}
+
+func (s *mockLoggerService) SetLogLevel(_ context.Context, req *loggerv1.SetLogLevelRequest) (*types.Logger, error) {
+	s.receivedSetValue = &req.NewLevel
+	return s.returnLogger, s.returnErr
+}
+
+func (s *mockLoggerService) ResetLogLevel(context.Context, *loggerv1.ResetLogLevelRequest) (*types.Logger, error) {
+	s.receivedSetValue = nil
+	return s.returnLogger, s.returnErr
+}
+
+var _ io.Writer = &errorWriter{}
+
+type errorWriter struct {
+	ReturnError error
+	Buffer      bytes.Buffer
+}
+
+func (e *errorWriter) Write(p []byte) (n int, err error) {
+	if e.ReturnError != nil {
+		return 0, e.ReturnError
+	}
+	return e.Buffer.Write(p)
+}
+
+func (e *errorWriter) String() string {
+	return e.Buffer.String()
+}

--- a/cmd/spire-agent/cli/logger/printers.go
+++ b/cmd/spire-agent/cli/logger/printers.go
@@ -1,0 +1,38 @@
+package logger
+
+import (
+	"errors"
+	"fmt"
+
+	apitype "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+
+	agentlogger "github.com/spiffe/spire/pkg/agent/api/logger/v1"
+)
+
+func PrettyPrintLogger(env *commoncli.Env, results ...any) error {
+	apiLogger, ok := results[0].(*apitype.Logger)
+	if !ok {
+		return fmt.Errorf("internal error: unexpected type %T returned; please report this as a bug", results[0])
+	}
+
+	logrusCurrent, found := agentlogger.LogrusLevel[apiLogger.CurrentLevel]
+	if !found {
+		return errors.New("internal error: returned current log level is undefined; please report this as a bug")
+	}
+	currentText, err := logrusCurrent.MarshalText()
+	if err != nil {
+		return fmt.Errorf("internal error: logrus log level %d has no name; please report this as a bug", logrusCurrent)
+	}
+
+	logrusLaunch, found := agentlogger.LogrusLevel[apiLogger.LaunchLevel]
+	if !found {
+		return errors.New("internal error: returned launch log level is undefined; please report this as a bug")
+	}
+	launchText, err := logrusLaunch.MarshalText()
+	if err != nil {
+		return fmt.Errorf("internal error: logrus log level %d has no name; please report this as a bug", logrusLaunch)
+	}
+
+	return env.Printf("Logger Level : %s\nLaunch Level : %s\n\n", currentText, launchText)
+}

--- a/cmd/spire-agent/cli/logger/printers_test.go
+++ b/cmd/spire-agent/cli/logger/printers_test.go
@@ -1,0 +1,66 @@
+package logger_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/logger"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+)
+
+func TestPrettyPrintLogger(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		logger         any
+		outWriter      errorWriter
+		errWriter      errorWriter
+		env            *commoncli.Env
+		expectedStdout string
+		expectedStderr string
+		expectedError  error
+	}{
+		{
+			name: "test",
+			logger: &types.Logger{
+				CurrentLevel: types.LogLevel_DEBUG,
+				LaunchLevel:  types.LogLevel_INFO,
+			},
+			expectedStdout: `Logger Level : debug
+Launch Level : info
+
+`,
+		},
+		{
+			name: "test env returning an error",
+			outWriter: errorWriter{
+				ReturnError: errors.New("cannot write"),
+			},
+			logger: &types.Logger{
+				CurrentLevel: types.LogLevel_DEBUG,
+				LaunchLevel:  types.LogLevel_INFO,
+			},
+			expectedError: errors.New("cannot write"),
+		},
+		{
+			name: "test nil logger",
+			outWriter: errorWriter{
+				ReturnError: errors.New("cannot write"),
+			},
+			logger:        &types.Entry{},
+			expectedError: errors.New("internal error: unexpected type *types.Entry returned; please report this as a bug"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.env = &commoncli.Env{
+				Stdout: &tt.outWriter,
+				Stderr: &tt.errWriter,
+			}
+			require.Equal(t, logger.PrettyPrintLogger(tt.env, tt.logger), tt.expectedError)
+			require.Equal(t, tt.outWriter.String(), tt.expectedStdout)
+			require.Equal(t, tt.errWriter.String(), tt.expectedStderr)
+		})
+	}
+}

--- a/cmd/spire-agent/cli/logger/reset.go
+++ b/cmd/spire-agent/cli/logger/reset.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/mitchellh/cli"
+	api "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	"github.com/spiffe/spire/cmd/spire-agent/util"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/cliprinter"
+)
+
+type resetCommand struct {
+	env     *commoncli.Env
+	printer cliprinter.Printer
+}
+
+// Returns a cli.command that resets the log level using the default
+// cli environment.
+func NewResetCommand() cli.Command {
+	return NewResetCommandWithEnv(commoncli.DefaultEnv)
+}
+
+// Returns a cli.command that resets the log level.
+func NewResetCommandWithEnv(env *commoncli.Env) cli.Command {
+	return util.AdaptCommand(env, &resetCommand{env: env})
+}
+
+func (*resetCommand) Name() string {
+	return "logger reset"
+}
+
+func (*resetCommand) Synopsis() string {
+	return "Reset the logger details to launch level"
+}
+
+func (c *resetCommand) AppendFlags(fs *flag.FlagSet) {
+	cliprinter.AppendFlagWithCustomPretty(&c.printer, fs, c.env, c.prettyPrintLogger)
+}
+
+func (c *resetCommand) Run(ctx context.Context, _ *commoncli.Env, agentClient util.AgentClient) error {
+	logger, err := agentClient.NewLoggerClient().ResetLogLevel(ctx, &api.ResetLogLevelRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to reset logger: %w", err)
+	}
+	return c.printer.PrintProto(logger)
+}
+
+func (c *resetCommand) prettyPrintLogger(env *commoncli.Env, results ...any) error {
+	return PrettyPrintLogger(env, results...)
+}

--- a/cmd/spire-agent/cli/logger/reset_posix_test.go
+++ b/cmd/spire-agent/cli/logger/reset_posix_test.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package logger_test
+
+var (
+	resetUsage = `Usage of logger reset:
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+  -socketPath string
+    	Path to the SPIRE Agent Admin API socket (default "/tmp/spire-agent/private/admin.sock")
+`
+)

--- a/cmd/spire-agent/cli/logger/reset_test.go
+++ b/cmd/spire-agent/cli/logger/reset_test.go
@@ -1,0 +1,69 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/logger"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestResetHelp(t *testing.T) {
+	test := setupCliTest(t, &mockLoggerService{}, logger.NewResetCommandWithEnv)
+	test.client.Help()
+	require.Equal(t, "", test.stdout.String())
+	require.Equal(t, resetUsage, test.stderr.String())
+}
+
+func TestResetSynopsis(t *testing.T) {
+	cmd := logger.NewResetCommand()
+	require.Equal(t, "Reset the logger details to launch level", cmd.Synopsis())
+}
+
+func TestReset(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		args    []string
+		service *mockLoggerService
+
+		expectReturnCode int
+		expectStdout     string
+		expectStderr     string
+	}{
+		{
+			name: "reset successfully",
+			args: []string{"-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : info
+Launch Level : info
+
+`,
+		},
+		{
+			name: "service failed",
+			args: []string{"-output", "pretty"},
+			service: &mockLoggerService{
+				returnErr: status.Error(codes.Internal, "oh no"),
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: failed to reset logger: rpc error: code = Internal desc = oh no
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupCliTest(t, tt.service, logger.NewResetCommandWithEnv)
+			returnCode := test.client.Run(append(test.args, tt.args...))
+			require.Equal(t, tt.expectReturnCode, returnCode)
+			require.Equal(t, tt.expectStderr, test.stderr.String())
+			require.Equal(t, tt.expectStdout, test.stdout.String())
+		})
+	}
+}

--- a/cmd/spire-agent/cli/logger/reset_windows_test.go
+++ b/cmd/spire-agent/cli/logger/reset_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package logger_test
+
+var (
+	resetUsage = `Usage of logger reset:
+  -namedPipeName string
+    	Pipe name of the SPIRE Agent Admin API named pipe (default "\\spire-agent\\private\\admin")
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+`
+)

--- a/cmd/spire-agent/cli/logger/set.go
+++ b/cmd/spire-agent/cli/logger/set.go
@@ -1,0 +1,77 @@
+package logger
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/sirupsen/logrus"
+	api "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	"github.com/spiffe/spire/cmd/spire-agent/util"
+	commoncli "github.com/spiffe/spire/pkg/common/cli"
+	"github.com/spiffe/spire/pkg/common/cliprinter"
+
+	agentlogger "github.com/spiffe/spire/pkg/agent/api/logger/v1"
+)
+
+type setCommand struct {
+	env      *commoncli.Env
+	newLevel string
+	printer  cliprinter.Printer
+}
+
+// Returns a cli.command that sets the log level using the default
+// cli environment.
+func NewSetCommand() cli.Command {
+	return NewSetCommandWithEnv(commoncli.DefaultEnv)
+}
+
+// Returns a cli.command that sets the log level.
+func NewSetCommandWithEnv(env *commoncli.Env) cli.Command {
+	return util.AdaptCommand(env, &setCommand{env: env})
+}
+
+func (*setCommand) Name() string {
+	return "logger set"
+}
+
+func (*setCommand) Synopsis() string {
+	return "Sets the logger details"
+}
+
+func (c *setCommand) AppendFlags(fs *flag.FlagSet) {
+	fs.StringVar(&c.newLevel, "level", "", "The new log level, one of (panic, fatal, error, warn, info, debug, trace)")
+	cliprinter.AppendFlagWithCustomPretty(&c.printer, fs, c.env, c.prettyPrintLogger)
+}
+
+func (c *setCommand) Run(ctx context.Context, _ *commoncli.Env, agentClient util.AgentClient) error {
+	if c.newLevel == "" {
+		return errors.New("a value (-level) must be set")
+	}
+
+	level := strings.ToLower(c.newLevel)
+	logrusLevel, err := logrus.ParseLevel(level)
+	if err != nil {
+		return fmt.Errorf("the value %q is not a valid setting", c.newLevel)
+	}
+
+	apiLevel, found := agentlogger.APILevel[logrusLevel]
+	if !found {
+		return fmt.Errorf("the logrus level %q could not be transformed into an api log level", level)
+	}
+	logger, err := agentClient.NewLoggerClient().SetLogLevel(ctx, &api.SetLogLevelRequest{
+		NewLevel: apiLevel,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to set log level: %w", err)
+	}
+
+	return c.printer.PrintProto(logger)
+}
+
+func (c *setCommand) prettyPrintLogger(env *commoncli.Env, results ...any) error {
+	return PrettyPrintLogger(env, results...)
+}

--- a/cmd/spire-agent/cli/logger/set_posix_test.go
+++ b/cmd/spire-agent/cli/logger/set_posix_test.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package logger_test
+
+var (
+	setUsage = `Usage of logger set:
+  -level string
+    	The new log level, one of (panic, fatal, error, warn, info, debug, trace)
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+  -socketPath string
+    	Path to the SPIRE Agent Admin API socket (default "/tmp/spire-agent/private/admin.sock")
+`
+)

--- a/cmd/spire-agent/cli/logger/set_test.go
+++ b/cmd/spire-agent/cli/logger/set_test.go
@@ -1,0 +1,148 @@
+package logger_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/logger"
+)
+
+func TestSetHelp(t *testing.T) {
+	test := setupCliTest(t, &mockLoggerService{}, logger.NewSetCommandWithEnv)
+	test.client.Help()
+	require.Equal(t, "", test.stdout.String())
+	require.Equal(t, setUsage, test.stderr.String())
+}
+
+func TestSetSynopsis(t *testing.T) {
+	cmd := logger.NewSetCommand()
+	require.Equal(t, "Sets the logger details", cmd.Synopsis())
+}
+
+func TestSet(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		// service state
+		service *mockLoggerService
+		// input
+		args []string
+		// expected items
+		expectedSetValue types.LogLevel
+		expectReturnCode int
+		expectStdout     string
+		expectStderr     string
+	}{
+		{
+			name: "set to debug, configured to info, using pretty output",
+			args: []string{"-level", "debug", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_DEBUG,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectedSetValue: types.LogLevel_DEBUG,
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : debug
+Launch Level : info
+
+`,
+		},
+		{
+			name: "set to warn, configured to debug, using pretty output",
+			args: []string{"-level", "warn", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_WARN,
+					LaunchLevel:  types.LogLevel_DEBUG,
+				},
+			},
+			expectedSetValue: types.LogLevel_WARN,
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : warning
+Launch Level : debug
+
+`,
+		},
+		{
+			name: "set to panic, configured to fatal, using pretty output",
+			args: []string{"-level", "panic", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_PANIC,
+					LaunchLevel:  types.LogLevel_FATAL,
+				},
+			},
+			expectedSetValue: types.LogLevel_PANIC,
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : panic
+Launch Level : fatal
+
+`,
+		},
+		{
+			name: "set with invalid setting of never, logger unadjusted from (info,info)",
+			args: []string{"-level", "never", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: the value "never" is not a valid setting
+`,
+		},
+		{
+			name: "No attribute set, cli returns error",
+			args: []string{"-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: a value (-level) must be set
+`,
+		},
+		{
+			name: "bizzarro world, set to trace, logger unadjusted from (info,info)",
+			args: []string{"-level", "trace", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnLogger: &types.Logger{
+					CurrentLevel: types.LogLevel_INFO,
+					LaunchLevel:  types.LogLevel_INFO,
+				},
+			},
+			expectedSetValue: types.LogLevel_TRACE,
+			expectReturnCode: 0,
+			expectStdout: `Logger Level : info
+Launch Level : info
+
+`,
+		},
+		{
+			name: "service failed to set",
+			args: []string{"-level", "trace", "-output", "pretty"},
+			service: &mockLoggerService{
+				returnErr: status.Error(codes.Internal, "oh no"),
+			},
+			expectReturnCode: 1,
+			expectStderr: `Error: failed to set log level: rpc error: code = Internal desc = oh no
+`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupCliTest(t, tt.service, logger.NewSetCommandWithEnv)
+			returnCode := test.client.Run(append(test.args, tt.args...))
+			require.Equal(t, tt.expectReturnCode, returnCode)
+			require.Equal(t, tt.expectStderr, test.stderr.String())
+			require.Equal(t, tt.expectStdout, test.stdout.String())
+		})
+	}
+}

--- a/cmd/spire-agent/cli/logger/set_windows_test.go
+++ b/cmd/spire-agent/cli/logger/set_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package logger_test
+
+var (
+	setUsage = `Usage of logger set:
+  -level string
+    	The new log level, one of (panic, fatal, error, warn, info, debug, trace)
+  -namedPipeName string
+    	Pipe name of the SPIRE Agent Admin API named pipe (default "\\spire-agent\\private\\admin")
+  -output value
+    	Desired output format (pretty, json); default: pretty.
+`
+)

--- a/cmd/spire-agent/util/util.go
+++ b/cmd/spire-agent/util/util.go
@@ -1,0 +1,110 @@
+package util
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	loggerv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	common_cli "github.com/spiffe/spire/pkg/common/cli"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func NewGRPCClient(addr string) (*grpc.ClientConn, error) {
+	return grpc.NewClient(
+		addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+	)
+}
+
+type AgentClient interface {
+	Release()
+	NewLoggerClient() loggerv1.LoggerClient
+}
+
+func NewAgentClient(addr string) (AgentClient, error) {
+	conn, err := NewGRPCClient(addr)
+	if err != nil {
+		return nil, err
+	}
+	return &agentClient{conn: conn}, nil
+}
+
+type agentClient struct {
+	conn *grpc.ClientConn
+}
+
+func (c *agentClient) Release() {
+	c.conn.Close()
+}
+
+func (c *agentClient) NewLoggerClient() loggerv1.LoggerClient {
+	return loggerv1.NewLoggerClient(c.conn)
+}
+
+// Command is a common interface for commands in this package. The adapter
+// can adapt this interface to the Command interface from github.com/mitchellh/cli.
+type Command interface {
+	Name() string
+	Synopsis() string
+	AppendFlags(*flag.FlagSet)
+	Run(context.Context, *common_cli.Env, AgentClient) error
+}
+
+type Adapter struct {
+	env *common_cli.Env
+	cmd Command
+
+	flags *flag.FlagSet
+
+	adapterOS // OS specific
+}
+
+// AdaptCommand converts a command into one conforming to the Command interface from github.com/mitchellh/cli
+func AdaptCommand(env *common_cli.Env, cmd Command) *Adapter {
+	a := &Adapter{
+		cmd: cmd,
+		env: env,
+	}
+
+	f := flag.NewFlagSet(cmd.Name(), flag.ContinueOnError)
+	f.SetOutput(env.Stderr)
+	a.addOSFlags(f)
+	a.cmd.AppendFlags(f)
+	a.flags = f
+
+	return a
+}
+
+func (a *Adapter) Run(args []string) int {
+	ctx := context.Background()
+
+	if err := a.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	addr := a.getGRPCAddr()
+	client, err := NewAgentClient(addr)
+	if err != nil {
+		fmt.Fprintln(a.env.Stderr, "Error: "+err.Error())
+		return 1
+	}
+	defer client.Release()
+
+	if err := a.cmd.Run(ctx, a.env, client); err != nil {
+		fmt.Fprintln(a.env.Stderr, "Error: "+err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+func (a *Adapter) Help() string {
+	return a.flags.Parse([]string{"-h"}).Error()
+}
+
+func (a *Adapter) Synopsis() string {
+	return a.cmd.Synopsis()
+}

--- a/cmd/spire-agent/util/util_posix.go
+++ b/cmd/spire-agent/util/util_posix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package util
+
+import (
+	"context"
+	"flag"
+	"net"
+	"strings"
+
+	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
+)
+
+type adapterOS struct {
+	adminSocketPath string
+}
+
+func (a *Adapter) addOSFlags(flags *flag.FlagSet) {
+	flags.StringVar(&a.adminSocketPath, "socketPath", common.DefaultAdminSocketPath, "Path to the SPIRE Agent Admin API socket")
+}
+
+func (a *Adapter) getGRPCAddr() string {
+	if a.adminSocketPath == "" {
+		a.adminSocketPath = common.DefaultAdminSocketPath
+	}
+
+	return "unix:" + a.adminSocketPath
+}
+
+func dialer(ctx context.Context, addr string) (net.Conn, error) {
+	socketPathAddr := strings.TrimPrefix(addr, "unix:")
+	return (&net.Dialer{}).DialContext(ctx, "unix", socketPathAddr)
+}

--- a/cmd/spire-agent/util/util_windows.go
+++ b/cmd/spire-agent/util/util_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package util
+
+import (
+	"context"
+	"flag"
+	"net"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
+	"github.com/spiffe/spire/pkg/common/namedpipe"
+)
+
+type adapterOS struct {
+	adminNamedPipeName string
+}
+
+func (a *Adapter) addOSFlags(flags *flag.FlagSet) {
+	flags.StringVar(&a.adminNamedPipeName, "namedPipeName", common.DefaultAdminNamedPipeName, "Pipe name of the SPIRE Agent Admin API named pipe")
+}
+
+func dialer(ctx context.Context, addr string) (net.Conn, error) {
+	npipeAddr := strings.TrimPrefix(addr, "passthrough:")
+	return winio.DialPipeContext(ctx, npipeAddr)
+}
+
+func (a *Adapter) getGRPCAddr() string {
+	if a.adminNamedPipeName == "" {
+		a.adminNamedPipeName = common.DefaultAdminNamedPipeName
+	}
+
+	return "passthrough:" + namedpipe.AddrFromName(a.adminNamedPipeName).String()
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 	admin_api "github.com/spiffe/spire/pkg/agent/api"
+	agentlogger "github.com/spiffe/spire/pkg/agent/api/logger/v1"
 	node_attestor "github.com/spiffe/spire/pkg/agent/attestor/node"
 	workload_attestor "github.com/spiffe/spire/pkg/agent/attestor/workload"
 	"github.com/spiffe/spire/pkg/agent/catalog"
@@ -288,7 +289,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	if a.c.AdminBindAddress != nil {
-		adminEndpoints := a.newAdminEndpoints(metrics, mgr, workloadAttestor, a.c.AuthorizedDelegates)
+		adminEndpoints, err := a.newAdminEndpoints(metrics, mgr, workloadAttestor, a.c.AuthorizedDelegates)
+		if err != nil {
+			return err
+		}
 		tasks = append(tasks, adminEndpoints.ListenAndServe)
 	}
 
@@ -502,11 +506,17 @@ func (a *Agent) newEndpoints(metrics telemetry.Metrics, mgr manager.Manager, att
 	})
 }
 
-func (a *Agent) newAdminEndpoints(metrics telemetry.Metrics, mgr manager.Manager, attestor workload_attestor.Attestor, authorizedDelegates []string) admin_api.Server {
+func (a *Agent) newAdminEndpoints(metrics telemetry.Metrics, mgr manager.Manager, attestor workload_attestor.Attestor, authorizedDelegates []string) (admin_api.Server, error) {
+	rootLog, ok := a.c.Log.(agentlogger.Logger)
+	if !ok {
+		return nil, fmt.Errorf("logger type %T does not support runtime level adjustment (need agentlogger.Logger interface)", a.c.Log)
+	}
+
 	config := &admin_api.Config{
 		BindAddr:            a.c.AdminBindAddress,
 		Manager:             mgr,
 		Log:                 a.c.Log,
+		RootLog:             rootLog,
 		Metrics:             metrics,
 		TrustDomain:         a.c.TrustDomain,
 		Uptime:              uptime.Uptime,
@@ -514,7 +524,7 @@ func (a *Agent) newAdminEndpoints(metrics telemetry.Metrics, mgr manager.Manager
 		AuthorizedDelegates: authorizedDelegates,
 	}
 
-	return admin_api.New(config)
+	return admin_api.New(config), nil
 }
 
 // CheckHealth is used as a top-level health check for the agent.

--- a/pkg/agent/api/config.go
+++ b/pkg/agent/api/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	loggerv1 "github.com/spiffe/spire/pkg/agent/api/logger/v1"
 	attestor "github.com/spiffe/spire/pkg/agent/attestor/workload"
 	"github.com/spiffe/spire/pkg/agent/manager"
 	"github.com/spiffe/spire/pkg/common/peertracker"
@@ -18,6 +19,10 @@ type Config struct {
 	Manager manager.Manager
 
 	Log logrus.FieldLogger
+
+	// RootLog is the root logger for the entire process, used by the
+	// Logger service to get/set/reset log levels at runtime.
+	RootLog loggerv1.Logger
 
 	Metrics telemetry.Metrics
 

--- a/pkg/agent/api/endpoints.go
+++ b/pkg/agent/api/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	debugv1 "github.com/spiffe/spire/pkg/agent/api/debug/v1"
 	delegatedidentityv1 "github.com/spiffe/spire/pkg/agent/api/delegatedidentity/v1"
+	loggerv1 "github.com/spiffe/spire/pkg/agent/api/logger/v1"
 	"github.com/spiffe/spire/pkg/agent/endpoints"
 	"github.com/spiffe/spire/pkg/common/api/middleware"
 	"github.com/spiffe/spire/pkg/common/peertracker"
@@ -37,6 +38,7 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 
 	e.registerDebugAPI(server)
 	e.registerDelegatedIdentityAPI(server)
+	e.registerLoggerAPI(server)
 
 	l, err := e.createListener()
 	if err != nil {
@@ -87,4 +89,12 @@ func (e *Endpoints) registerDelegatedIdentityAPI(server *grpc.Server) {
 	})
 
 	delegatedidentityv1.RegisterService(server, service)
+}
+
+func (e *Endpoints) registerLoggerAPI(server *grpc.Server) {
+	service := loggerv1.New(loggerv1.Config{
+		Log: e.c.RootLog,
+	})
+
+	loggerv1.RegisterService(server, service)
 }

--- a/pkg/agent/api/logger/v1/levels.go
+++ b/pkg/agent/api/logger/v1/levels.go
@@ -1,0 +1,26 @@
+package logger
+
+import (
+	"github.com/sirupsen/logrus"
+	apitype "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+)
+
+var APILevel = map[logrus.Level]apitype.LogLevel{
+	logrus.PanicLevel: apitype.LogLevel_PANIC,
+	logrus.FatalLevel: apitype.LogLevel_FATAL,
+	logrus.ErrorLevel: apitype.LogLevel_ERROR,
+	logrus.WarnLevel:  apitype.LogLevel_WARN,
+	logrus.InfoLevel:  apitype.LogLevel_INFO,
+	logrus.DebugLevel: apitype.LogLevel_DEBUG,
+	logrus.TraceLevel: apitype.LogLevel_TRACE,
+}
+
+var LogrusLevel = map[apitype.LogLevel]logrus.Level{
+	apitype.LogLevel_PANIC: logrus.PanicLevel,
+	apitype.LogLevel_FATAL: logrus.FatalLevel,
+	apitype.LogLevel_ERROR: logrus.ErrorLevel,
+	apitype.LogLevel_WARN:  logrus.WarnLevel,
+	apitype.LogLevel_INFO:  logrus.InfoLevel,
+	apitype.LogLevel_DEBUG: logrus.DebugLevel,
+	apitype.LogLevel_TRACE: logrus.TraceLevel,
+}

--- a/pkg/agent/api/logger/v1/service.go
+++ b/pkg/agent/api/logger/v1/service.go
@@ -1,0 +1,93 @@
+package logger
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	loggerv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	apitype "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/agent/api/rpccontext"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type Logger interface {
+	logrus.FieldLogger
+
+	GetLevel() logrus.Level
+	SetLevel(level logrus.Level)
+}
+
+func RegisterService(s grpc.ServiceRegistrar, service *Service) {
+	loggerv1.RegisterLoggerServer(s, service)
+}
+
+type Config struct {
+	Log Logger
+}
+
+type Service struct {
+	loggerv1.UnsafeLoggerServer
+
+	log         Logger
+	launchLevel logrus.Level
+}
+
+func New(c Config) *Service {
+	launchLogLevel := c.Log.GetLevel()
+	c.Log.WithFields(logrus.Fields{
+		telemetry.LaunchLogLevel: launchLogLevel,
+	}).Info("Logger service configured")
+
+	return &Service{
+		log:         c.Log,
+		launchLevel: launchLogLevel,
+	}
+}
+
+func (s *Service) GetLogger(ctx context.Context, _ *loggerv1.GetLoggerRequest) (*apitype.Logger, error) {
+	log := rpccontext.Logger(ctx)
+	log.Info("GetLogger Called")
+
+	return s.createAPILogger(), nil
+}
+
+func (s *Service) SetLogLevel(ctx context.Context, req *loggerv1.SetLogLevelRequest) (*apitype.Logger, error) {
+	log := rpccontext.Logger(ctx)
+
+	if req.NewLevel == apitype.LogLevel_UNSPECIFIED {
+		log.Error("Invalid argument: newLevel value cannot be LogLevel_UNSPECIFIED")
+		return nil, status.Error(codes.InvalidArgument, "newLevel value cannot be LogLevel_UNSPECIFIED")
+	}
+
+	newLogLevel, ok := LogrusLevel[req.NewLevel]
+	if !ok {
+		log.Error("Invalid argument: unsupported log level")
+		return nil, status.Error(codes.InvalidArgument, "unsupported log level")
+	}
+
+	log.WithFields(logrus.Fields{
+		telemetry.NewLogLevel: newLogLevel.String(),
+	}).Info("SetLogLevel Called")
+	s.log.SetLevel(newLogLevel)
+
+	return s.createAPILogger(), nil
+}
+
+func (s *Service) ResetLogLevel(ctx context.Context, _ *loggerv1.ResetLogLevelRequest) (*apitype.Logger, error) {
+	log := rpccontext.Logger(ctx)
+	log.WithField(telemetry.LaunchLogLevel, s.launchLevel).Info("ResetLogLevel Called")
+
+	s.log.SetLevel(s.launchLevel)
+
+	return s.createAPILogger(), nil
+}
+
+func (s *Service) createAPILogger() *apitype.Logger {
+	return &apitype.Logger{
+		CurrentLevel: APILevel[s.log.GetLevel()],
+		LaunchLevel:  APILevel[s.launchLevel],
+	}
+}

--- a/pkg/agent/api/logger/v1/service_test.go
+++ b/pkg/agent/api/logger/v1/service_test.go
@@ -1,0 +1,603 @@
+package logger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	loggerv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
+	apitype "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/pkg/agent/api/logger/v1"
+	"github.com/spiffe/spire/pkg/agent/api/rpccontext"
+	"github.com/spiffe/spire/pkg/common/telemetry"
+	"github.com/spiffe/spire/test/grpctest"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func TestGetLogger(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		launchLevel logrus.Level
+
+		expectedResponse *apitype.Logger
+		expectedLogs     []spiretest.LogEntry
+	}{
+		{
+			name:        "test GetLogger on initialized to PANIC",
+			launchLevel: logrus.PanicLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+			expectedLogs: nil,
+		},
+		{
+			name:        "test GetLogger on initialized to FATAL",
+			launchLevel: logrus.FatalLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_FATAL,
+				LaunchLevel:  apitype.LogLevel_FATAL,
+			},
+			expectedLogs: nil,
+		},
+		{
+			name:        "test GetLogger on initialized to ERROR",
+			launchLevel: logrus.ErrorLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_ERROR,
+				LaunchLevel:  apitype.LogLevel_ERROR,
+			},
+			expectedLogs: nil,
+		},
+		{
+			name:        "test GetLogger on initialized to WARN",
+			launchLevel: logrus.WarnLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_WARN,
+				LaunchLevel:  apitype.LogLevel_WARN,
+			},
+			expectedLogs: nil,
+		},
+		{
+			name:        "test GetLogger on initialized to INFO",
+			launchLevel: logrus.InfoLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "GetLogger Called",
+				},
+			},
+		},
+		{
+			name:        "test GetLogger on initialized to DEBUG",
+			launchLevel: logrus.DebugLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_DEBUG,
+				LaunchLevel:  apitype.LogLevel_DEBUG,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "GetLogger Called",
+				},
+			},
+		},
+		{
+			name:        "test GetLogger on initialized to TRACE",
+			launchLevel: logrus.TraceLevel,
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_TRACE,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "GetLogger Called",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupServiceTest(t, tt.launchLevel)
+			defer test.Cleanup()
+
+			resp, err := test.client.GetLogger(context.Background(), &loggerv1.GetLoggerRequest{})
+			require.NoError(t, err)
+			spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectedLogs)
+			spiretest.RequireProtoEqual(t, resp, tt.expectedResponse)
+		})
+	}
+}
+
+func TestSetLoggerThenGetLogger(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		launchLevel        logrus.Level
+		setLogLevelRequest *loggerv1.SetLogLevelRequest
+
+		expectedResponse *apitype.Logger
+		expectedLogs     []spiretest.LogEntry
+	}{
+		{
+			name:        "test SetLogger to FATAL on initialized to PANIC",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_FATAL,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_FATAL,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+		},
+		{
+			name:        "test SetLogger to INFO on initialized to PANIC",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+		},
+		{
+			name:        "test SetLogger to DEBUG on initialized to PANIC",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_DEBUG,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+		},
+		{
+			name:        "test SetLogger to PANIC on initialized to INFO",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_PANIC,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "panic",
+					},
+				},
+			},
+		},
+		{
+			name:        "test SetLogger to INFO on initialized to INFO",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "info",
+					},
+				},
+			},
+		},
+		{
+			name:        "test SetLogger to DEBUG on initialized to INFO",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_DEBUG,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "debug",
+					},
+				},
+			},
+		},
+		{
+			name:        "test SetLogger to PANIC on initialized to TRACE",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_PANIC,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "panic",
+					},
+				},
+			},
+		},
+		{
+			name:        "test SetLogger to INFO on initialized to TRACE",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "info",
+					},
+				},
+			},
+		},
+		{
+			name:        "test SetLogger to DEBUG on initialized to TRACE",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_DEBUG,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "SetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.NewLogLevel: "debug",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupServiceTest(t, tt.launchLevel)
+			defer test.Cleanup()
+
+			resp, err := test.client.SetLogLevel(context.Background(), tt.setLogLevelRequest)
+			require.NoError(t, err)
+			spiretest.RequireProtoEqual(t, resp, tt.expectedResponse)
+			spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectedLogs)
+
+			getResp, err := test.client.GetLogger(context.Background(), &loggerv1.GetLoggerRequest{})
+			require.NoError(t, err)
+			spiretest.RequireProtoEqual(t, getResp, tt.expectedResponse)
+		})
+	}
+}
+
+func TestResetLogger(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		launchLevel        logrus.Level
+		setLogLevelRequest *loggerv1.SetLogLevelRequest
+
+		expectedResponse *apitype.Logger
+		expectedLogs     []spiretest.LogEntry
+	}{
+		{
+			name:        "test PANIC Logger set to FATAL then RESET",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_FATAL,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+		},
+		{
+			name:        "test PANIC Logger set to INFO then RESET",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "panic",
+					},
+				},
+			},
+		},
+		{
+			name:        "test PANIC Logger set to DEBUG then RESET",
+			launchLevel: logrus.PanicLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_PANIC,
+				LaunchLevel:  apitype.LogLevel_PANIC,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "panic",
+					},
+				},
+			},
+		},
+		{
+			name:        "test INFO Logger set to PANIC and then RESET",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_PANIC,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+		},
+		{
+			name:        "test INFO Logger set to INFO and then RESET",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "info",
+					},
+				},
+			},
+		},
+		{
+			name:        "test INFO Logger set to DEBUG and then RESET",
+			launchLevel: logrus.InfoLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_INFO,
+				LaunchLevel:  apitype.LogLevel_INFO,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "info",
+					},
+				},
+			},
+		},
+		{
+			name:        "test TRACE Logger set to PANIC and then RESET",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_PANIC,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_TRACE,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+		},
+		{
+			name:        "test TRACE Logger set to INFO and then RESET",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_INFO,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_TRACE,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "trace",
+					},
+				},
+			},
+		},
+		{
+			name:        "test TRACE Logger set to DEBUG and then RESET",
+			launchLevel: logrus.TraceLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_DEBUG,
+			},
+
+			expectedResponse: &apitype.Logger{
+				CurrentLevel: apitype.LogLevel_TRACE,
+				LaunchLevel:  apitype.LogLevel_TRACE,
+			},
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.InfoLevel,
+					Message: "ResetLogLevel Called",
+					Data: logrus.Fields{
+						telemetry.LaunchLogLevel: "trace",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupServiceTest(t, tt.launchLevel)
+			defer test.Cleanup()
+
+			_, err := test.client.SetLogLevel(context.Background(), tt.setLogLevelRequest)
+			require.NoError(t, err)
+			test.logHook.Reset()
+
+			resp, err := test.client.ResetLogLevel(context.Background(), &loggerv1.ResetLogLevelRequest{})
+			require.NoError(t, err)
+
+			spiretest.RequireProtoEqual(t, resp, tt.expectedResponse)
+			spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectedLogs)
+
+			getResp, err := test.client.GetLogger(context.Background(), &loggerv1.GetLoggerRequest{})
+			require.NoError(t, err)
+			spiretest.AssertProtoEqual(t, tt.expectedResponse, getResp)
+		})
+	}
+}
+
+func TestUnsetSetLogLevelRequest(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		launchLevel        logrus.Level
+		setLogLevelRequest *loggerv1.SetLogLevelRequest
+
+		code             codes.Code
+		expectedErr      string
+		expectedResponse *apitype.Logger
+		expectedLogs     []spiretest.LogEntry
+	}{
+		{
+			name:               "logger no set without a log level",
+			launchLevel:        logrus.DebugLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{},
+
+			code:             codes.InvalidArgument,
+			expectedErr:      "newLevel value cannot be LogLevel_UNSPECIFIED",
+			expectedResponse: nil,
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid argument: newLevel value cannot be LogLevel_UNSPECIFIED",
+				},
+			},
+		},
+		{
+			name:        "logger no set to UNSPECIFIED",
+			launchLevel: logrus.DebugLevel,
+			setLogLevelRequest: &loggerv1.SetLogLevelRequest{
+				NewLevel: apitype.LogLevel_UNSPECIFIED,
+			},
+
+			code:             codes.InvalidArgument,
+			expectedErr:      "newLevel value cannot be LogLevel_UNSPECIFIED",
+			expectedResponse: nil,
+			expectedLogs: []spiretest.LogEntry{
+				{
+					Level:   logrus.ErrorLevel,
+					Message: "Invalid argument: newLevel value cannot be LogLevel_UNSPECIFIED",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			test := setupServiceTest(t, tt.launchLevel)
+			defer test.Cleanup()
+
+			resp, err := test.client.SetLogLevel(context.Background(), tt.setLogLevelRequest)
+			spiretest.RequireGRPCStatusContains(t, err, tt.code, tt.expectedErr)
+			require.Nil(t, resp)
+
+			spiretest.RequireProtoEqual(t, resp, tt.expectedResponse)
+			spiretest.AssertLogs(t, test.logHook.AllEntries(), tt.expectedLogs)
+		})
+	}
+}
+
+type serviceTest struct {
+	client loggerv1.LoggerClient
+	done   func()
+
+	logHook *test.Hook
+}
+
+func (s *serviceTest) Cleanup() {
+	s.done()
+}
+
+func setupServiceTest(t *testing.T, launchLevel logrus.Level) *serviceTest {
+	log, logHook := test.NewNullLogger()
+	log.SetLevel(launchLevel)
+	service := logger.New(logger.Config{
+		Log: log,
+	})
+
+	registerFn := func(s grpc.ServiceRegistrar) {
+		logger.RegisterService(s, service)
+	}
+	overrideContext := func(ctx context.Context) context.Context {
+		ctx = rpccontext.WithLogger(ctx, log)
+		return ctx
+	}
+	server := grpctest.StartServer(t, registerFn,
+		grpctest.OverrideContext(overrideContext))
+	conn := server.NewGRPCClient(t)
+	logHook.Reset()
+
+	test := &serviceTest{
+		done:    server.Stop,
+		logHook: logHook,
+		client:  loggerv1.NewLoggerClient(conn),
+	}
+
+	return test
+}

--- a/pkg/agent/endpoints/metrics.go
+++ b/pkg/agent/endpoints/metrics.go
@@ -24,6 +24,7 @@ type connectionMetrics struct {
 	sdsAPIConns               int32
 	debugAPIConns             int32
 	delegatedIdentityAPIConns int32
+	loggerAPIConns            int32
 }
 
 func (m *connectionMetrics) Preprocess(ctx context.Context, _ string, _ any) (context.Context, error) {
@@ -41,6 +42,9 @@ func (m *connectionMetrics) Preprocess(ctx context.Context, _ string, _ any) (co
 		case middleware.DebugServiceName:
 			adminapi.IncrDebugAPIConnectionCounter(m.metrics)
 			adminapi.SetDebugAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.debugAPIConns, 1))
+		case middleware.AgentLoggerServiceName:
+			adminapi.IncrLoggerAPIConnectionCounter(m.metrics)
+			adminapi.SetLoggerAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.loggerAPIConns, 1))
 		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
 			// Intentionally not emitting metrics for health and reflection services
 		default:
@@ -61,6 +65,8 @@ func (m *connectionMetrics) Postprocess(ctx context.Context, _ string, _ bool, _
 			adminapi.SetDelegatedIdentityAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.delegatedIdentityAPIConns, -1))
 		case middleware.DebugServiceName:
 			adminapi.SetDebugAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.debugAPIConns, -1))
+		case middleware.AgentLoggerServiceName:
+			adminapi.SetLoggerAPIConnectionGauge(m.metrics, atomic.AddInt32(&m.loggerAPIConns, -1))
 		case middleware.HealthServiceName, middleware.ServerReflectionServiceName, middleware.ServerReflectionV1AlphaServiceName:
 			// Intentionally not emitting metrics for health and reflection services
 		default:

--- a/pkg/agent/endpoints/metrics_test.go
+++ b/pkg/agent/endpoints/metrics_test.go
@@ -12,6 +12,7 @@ import (
 	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	debugv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/debug/v1"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	loggerv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/logger/v1"
 	"github.com/spiffe/spire/pkg/common/peertracker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,52 @@ func TestDebugServiceConnectionMetrics(t *testing.T) {
 	assert.True(t, foundGaugeDown, "Expected debug_api connections gauge to decrement")
 }
 
+// TestLoggerServiceConnectionMetrics verifies that Logger API calls going through
+// the agent middleware emit the correct connection metrics.
+func TestLoggerServiceConnectionMetrics(t *testing.T) {
+	log, hook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+	metrics := fakemetrics.New()
+
+	server := grpctest.StartServer(t,
+		func(s grpc.ServiceRegistrar) {
+			loggerv1.RegisterLoggerServer(s, &fakeLoggerServer{})
+		},
+		grpctest.Middleware(Middleware(log, metrics)),
+	)
+
+	conn := server.NewGRPCClient(t)
+	client := loggerv1.NewLoggerClient(conn)
+
+	_, _ = client.GetLogger(context.Background(), &loggerv1.GetLoggerRequest{})
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel {
+			assert.NotContains(t, entry.Message, "unrecognized service for connection metrics",
+				"Logger service should be recognized by connection metrics middleware")
+		}
+	}
+
+	allMetrics := metrics.AllMetrics()
+	require.NotEmpty(t, allMetrics)
+
+	var foundConnectionCounter, foundGaugeUp, foundGaugeDown bool
+	for _, m := range allMetrics {
+		if m.Type == fakemetrics.IncrCounterType && assert.ObjectsAreEqual([]string{"logger_api", "connection"}, m.Key) {
+			foundConnectionCounter = true
+		}
+		if m.Type == fakemetrics.SetGaugeType && assert.ObjectsAreEqual([]string{"logger_api", "connections"}, m.Key) && m.Val == 1 {
+			foundGaugeUp = true
+		}
+		if m.Type == fakemetrics.SetGaugeType && assert.ObjectsAreEqual([]string{"logger_api", "connections"}, m.Key) && m.Val == 0 {
+			foundGaugeDown = true
+		}
+	}
+	assert.True(t, foundConnectionCounter, "Expected logger_api connection counter metric")
+	assert.True(t, foundGaugeUp, "Expected logger_api connections gauge to increment")
+	assert.True(t, foundGaugeDown, "Expected logger_api connections gauge to decrement")
+}
+
 // TestAllAgentServicesHandledByConnectionMetrics registers every gRPC service
 // that the agent exposes (across both the Workload API and Admin API servers),
 // makes a call to each one through the middleware, and asserts that none
@@ -92,6 +139,7 @@ func TestAllAgentServicesHandledByConnectionMetrics(t *testing.T) {
 			grpc_health_v1.RegisterHealthServer(s, &grpc_health_v1.UnimplementedHealthServer{})
 			debugv1.RegisterDebugServer(s, &fakeDebugServer{})
 			delegatedidentityv1.RegisterDelegatedIdentityServer(s, &fakeDelegatedIdentityServer{})
+			loggerv1.RegisterLoggerServer(s, &fakeLoggerServer{})
 		},
 		grpctest.Middleware(Middleware(log, metrics)),
 	)
@@ -133,6 +181,13 @@ func TestAllAgentServicesHandledByConnectionMetrics(t *testing.T) {
 		hook.Reset()
 		client := delegatedidentityv1.NewDelegatedIdentityClient(conn)
 		_, _ = client.FetchJWTSVIDs(ctx, &delegatedidentityv1.FetchJWTSVIDsRequest{})
+		assertNoMisconfigurationLog(t, hook)
+	})
+
+	t.Run("Logger", func(t *testing.T) {
+		hook.Reset()
+		client := loggerv1.NewLoggerClient(conn)
+		_, _ = client.GetLogger(ctx, &loggerv1.GetLoggerRequest{})
 		assertNoMisconfigurationLog(t, hook)
 	})
 }
@@ -253,3 +308,7 @@ type fakeWatcherWithPID int
 func (w fakeWatcherWithPID) Close()         {}
 func (w fakeWatcherWithPID) IsAlive() error { return nil }
 func (w fakeWatcherWithPID) PID() int32     { return int32(w) }
+
+type fakeLoggerServer struct {
+	loggerv1.UnimplementedLoggerServer
+}

--- a/pkg/common/api/middleware/names.go
+++ b/pkg/common/api/middleware/names.go
@@ -21,6 +21,7 @@ const (
 	HealthServiceShortName             = "Health"
 	LoggerServiceName                  = "logger.v1.Logger"
 	LoggerServiceShortName             = "Logger"
+	AgentLoggerServiceName             = "spire.api.agent.logger.v1.Logger"
 	DebugServiceName                   = "spire.agent.debug.v1.Debug"
 	DebugServiceShortName              = "Debug"
 	DelegatedIdentityServiceName       = "spire.api.agent.delegatedidentity.v1.DelegatedIdentity"
@@ -37,6 +38,7 @@ var (
 		WorkloadAPIServiceName, WorkloadAPIServiceShortName,
 		EnvoySDSv3ServiceName, EnvoySDSv3ServiceShortName,
 		HealthServiceName, HealthServiceShortName,
+		AgentLoggerServiceName, LoggerServiceShortName,
 		LoggerServiceName, LoggerServiceShortName,
 		DebugServiceName, DebugServiceShortName,
 		DelegatedIdentityServiceName, DelegatedIdentityServiceShortName,

--- a/pkg/common/telemetry/agent/adminapi/loggerapi.go
+++ b/pkg/common/telemetry/agent/adminapi/loggerapi.go
@@ -1,0 +1,16 @@
+package adminapi
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// IncrLoggerAPIConnectionCounter indicate Logger
+// API connection (some connection is made, running total count)
+func IncrLoggerAPIConnectionCounter(m telemetry.Metrics) {
+	m.IncrCounter([]string{telemetry.LoggerAPI, telemetry.Connection}, 1)
+}
+
+// SetLoggerAPIConnectionGauge sets the number of active Logger API connections
+func SetLoggerAPIConnectionGauge(m telemetry.Metrics, connections int32) {
+	m.SetGauge([]string{telemetry.LoggerAPI, telemetry.Connections}, float32(connections))
+}

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -864,6 +864,9 @@ const (
 	// DelegatedIdentityAPI functionality related to delegated identity endpoints
 	DelegatedIdentityAPI = "delegated_identity_api"
 
+	// LoggerAPI functionality related to logger endpoints
+	LoggerAPI = "logger_api"
+
 	// DeleteFederatedBundle functionality related to deleting a federated bundle
 	DeleteFederatedBundle = "delete_federated_bundle"
 


### PR DESCRIPTION
Closes #4986
Implements the Logger API (GetLogger, SetLogLevel, ResetLogLevel) on the agent's admin UDS, bringing the agent to parity with the server. The API already existed in spire-api-sdk (`proto/spire/api/agent/logger/v1`), this PR adds the service implementation, CLI commands, telemetry, and tests.

