### PR TITLE
fix: correct TTL logging in delegated identity X.509 SVID subscriber

### DIFF
--- a/pkg/agent/api/delegatedidentity/v1/service.go
+++ b/pkg/agent/api/delegatedidentity/v1/service.go
@@ -236,11 +236,11 @@ func sendX509SVIDResponse(update *cache.WorkloadUpdate, stream delegatedidentity
 	// log details on each SVID
 	// a response has already been sent so nothing is
 	// blocked on this logic
-	for i, svid := range resp.X509Svids {
+	for _, svid := range resp.X509Svids {
 		// Ideally ID Proto parsing should succeed, but if it fails,
 		// ignore the error and still log with empty spiffe_id.
 		id, _ := idutil.IDProtoString(svid.X509Svid.Id)
-		ttl := time.Until(update.Identities[i].SVID[0].NotAfter)
+		ttl := time.Until(time.Unix(svid.X509Svid.ExpiresAt, 0))
 		log.WithFields(logrus.Fields{
 			telemetry.SPIFFEID: id,
 			telemetry.TTL:      ttl.Seconds(),

--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -326,6 +326,51 @@ func TestSubscribeToX509SVIDs(t *testing.T) {
 			},
 			expectMetrics: generateSubscribeToX509SVIDMetrics(),
 		},
+		{
+			testName:     "admin and downstream identities excluded from X509 SVIDs response",
+			authSpiffeID: []string{"spiffe://example.org/one"},
+			identities: []cache.Identity{
+				identities[0],
+			},
+			updates: []*cache.WorkloadUpdate{
+				{
+					Identities: []cache.Identity{
+						{
+							Entry: &common.RegistrationEntry{
+								SpiffeId: id1.String(),
+								Admin:    true,
+							},
+							PrivateKey: x509SVID1.PrivateKey,
+							SVID:       x509SVID1.Certificates,
+						},
+						{
+							Entry: &common.RegistrationEntry{
+								SpiffeId:   id1.String(),
+								Downstream: true,
+							},
+							PrivateKey: x509SVID1.PrivateKey,
+							SVID:       x509SVID1.Certificates,
+						},
+						identities[1],
+					},
+					Bundle: bundle,
+				},
+			},
+			expectResp: &delegatedidentityv1.SubscribeToX509SVIDsResponse{
+				X509Svids: []*delegatedidentityv1.X509SVIDWithKey{
+					{
+						X509Svid: &types.X509SVID{
+							Id:        utilIDProtoFromString(t, x509SVID2.ID.String()),
+							CertChain: x509util.RawCertsFromCertificates(x509SVID2.Certificates),
+							ExpiresAt: x509SVID2.Certificates[0].NotAfter.Unix(),
+							Hint:      "external",
+						},
+						X509SvidKey: pkcs8FromSigner(t, x509SVID2.PrivateKey),
+					},
+				},
+			},
+			expectMetrics: generateSubscribeToX509SVIDMetrics(),
+		},
 	} {
 		t.Run(tt.testName, func(t *testing.T) {
 			metrics := fakemetrics.New()


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

Debug TTL logging in `SubscribeToX509SVIDs`.

**Description of change**

`composeX509SVIDBySelectors` skips admin/downstream identities, so `resp.X509Svids` is a filtered subset of `update.Identities`. The logging loop used `update.Identities[i]` where `i` is an index into the filtered slice - indices fall out of sync and the wrong TTL gets logged.

Fix: use `svid.X509Svid.ExpiresAt` directly (already set correctly by `composeX509SVIDBySelectors`). No behavior change to the actual response.

**How to reproduce**

Have a workload with an admin entry and a regular entry sharing the same selectors. With debug logging on, `SubscribeToX509SVIDs` logs the admin entry's TTL instead of the regular SVID's.

**Which issue this PR fixes**

N/A