### PR TITLE
spire-agent: try to enable SE_DEBUG_PRIVILEGE at startup on windows

### DIFF
--- a/cmd/spire-agent/cli/run/run_windows.go
+++ b/cmd/spire-agent/cli/run/run_windows.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"unsafe"
 
 	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
 	"github.com/spiffe/spire/pkg/agent"
@@ -79,5 +80,23 @@ func enableSeDebugPrivilege() error {
 		},
 	}
 
-	return windows.AdjustTokenPrivileges(token, false, &tp, 0, nil, nil)
+	// We can't use the AdjustTokenPrivileges function from x/sys/windows because
+	// it currently does not handle the ERROR_NOT_ALL_ASSIGNED error. Based on testing
+	// it seems to return a nil error even if fails to adjust the privileges.
+	procAdjustTokenPrivileges := windows.NewLazySystemDLL("advapi32.dll").NewProc("AdjustTokenPrivileges")
+	result, _, err := procAdjustTokenPrivileges.Call(
+		uintptr(token),
+		0,
+		uintptr(unsafe.Pointer(&tp)),
+		0,
+		0,
+		0,
+	)
+	if result == 0 {
+		return fmt.Errorf("AdjustTokenPrivileges failed: %w", err)
+	}
+	if errors.Is(err, windows.ERROR_NOT_ALL_ASSIGNED) {
+		return errors.New("SeDebugPrivilege is not held by this token")
+	}
+	return nil
 }

--- a/cmd/spire-agent/cli/run/run_windows.go
+++ b/cmd/spire-agent/cli/run/run_windows.go
@@ -15,6 +15,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+var (
+	// We can't use the AdjustTokenPrivileges function from x/sys/windows because
+	// it currently does not handle the ERROR_NOT_ALL_ASSIGNED error. Based on testing
+	// it seems to return a nil error even if fails to adjust the privileges.
+	procAdjustTokenPrivileges = windows.NewLazySystemDLL("advapi32.dll").NewProc("AdjustTokenPrivileges")
+)
+
 func (c *agentConfig) addOSFlags(flags *flag.FlagSet) {
 	flags.StringVar(&c.Experimental.NamedPipeName, "namedPipeName", "", "Pipe name to bind the SPIRE Agent API named pipe")
 }
@@ -80,10 +87,6 @@ func enableSeDebugPrivilege() error {
 		},
 	}
 
-	// We can't use the AdjustTokenPrivileges function from x/sys/windows because
-	// it currently does not handle the ERROR_NOT_ALL_ASSIGNED error. Based on testing
-	// it seems to return a nil error even if fails to adjust the privileges.
-	procAdjustTokenPrivileges := windows.NewLazySystemDLL("advapi32.dll").NewProc("AdjustTokenPrivileges")
 	result, _, err := procAdjustTokenPrivileges.Call(
 		uintptr(token),
 		0,

--- a/cmd/spire-agent/cli/run/run_windows.go
+++ b/cmd/spire-agent/cli/run/run_windows.go
@@ -5,11 +5,13 @@ package run
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"net"
 
 	"github.com/spiffe/spire/cmd/spire-agent/cli/common"
 	"github.com/spiffe/spire/pkg/agent"
 	"github.com/spiffe/spire/pkg/common/namedpipe"
+	"golang.org/x/sys/windows"
 )
 
 func (c *agentConfig) addOSFlags(flags *flag.FlagSet) {
@@ -43,7 +45,39 @@ func (c *agentConfig) validateOS() error {
 	return nil
 }
 
-func prepareEndpoints(*agent.Config) error {
-	// Nothing to do in this platform
+func prepareEndpoints(c *agent.Config) error {
+	if err := enableSeDebugPrivilege(); err != nil {
+		c.Log.WithError(err).Warn("Could not enable SeDebugPrivilege; workload attestation of processes running as more privileged users may fail")
+	} else {
+		c.Log.Info("Enabled SeDebugPrivilege")
+	}
 	return nil
+}
+
+func enableSeDebugPrivilege() error {
+	var token windows.Token
+	err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &token)
+	if err != nil {
+		return fmt.Errorf("failed to open process token: %w", err)
+	}
+	defer token.Close()
+
+	var luid windows.LUID
+	seDebug, err := windows.UTF16PtrFromString("SeDebugPrivilege")
+	if err != nil {
+		return fmt.Errorf("failed to encode privilege name: %w", err)
+	}
+	err = windows.LookupPrivilegeValue(nil, seDebug, &luid)
+	if err != nil {
+		return fmt.Errorf("failed to look up SeDebugPrivilege: %w", err)
+	}
+
+	tp := windows.Tokenprivileges{
+		PrivilegeCount: 1,
+		Privileges: [1]windows.LUIDAndAttributes{
+			{Luid: luid, Attributes: windows.SE_PRIVILEGE_ENABLED},
+		},
+	}
+
+	return windows.AdjustTokenPrivileges(token, false, &tp, 0, nil, nil)
 }

--- a/doc/plugin_agent_workloadattestor_windows.md
+++ b/doc/plugin_agent_workloadattestor_windows.md
@@ -41,6 +41,8 @@ Defenses against this are:
 
 ### Notes
 
+- The workload attestor opens the access token of the calling process using [OpenProcessToken](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken). When the workload runs under a more privileged account than the SPIRE agent, this requires the agent process to have the [SE_DEBUG_NAME](https://learn.microsoft.com/en-us/windows/win32/secauthz/privilege-constants) privilege. The SPIRE agent attempts to enable this privilege at startup and logs a warning if it cannot. Ensure the account running the SPIRE agent has been granted this privilege if attestation of higher-privileged workloads is needed.
+
 - An enabled group in a token is a group that has the [SE_GROUP_ENABLED](https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-attributes-in-an-access-token) attribute.
 
 - User and group account names are expressed using the [down-level logon name format](https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name).


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Windows workload attestor

**Description of change**
The [OpenProcessToken](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-openprocesstoken) API mentions that SE_DEBUG_NAME/SeDebugPrivilege (why two different names, windows???) privilege is required for opening the process token for a process running as a more privileged account (it does work from admin to admin users without this).

**Which issue this PR fixes**
fixes #7068
