### PR TITLE
Fix flaky `gcp_kms` key manager tests caused by mock clock handling and shared fixture mutation

### DIFF
--- a/pkg/server/plugin/keymanager/gcpkms/client_fake.go
+++ b/pkg/server/plugin/keymanager/gcpkms/client_fake.go
@@ -586,8 +586,11 @@ func (k *fakeKMSClient) GetPublicKey(_ context.Context, req *kmspb.GetPublicKeyR
 	}
 
 	if k.pemCrc32C != nil {
-		// Override pemCrc32C
-		fakeCryptoKeyVersion.publicKey.PemCrc32C = k.pemCrc32C
+		// Override pemCrc32C on a clone so the shared fixture public key is
+		// not mutated, which would corrupt it for other tests and reruns.
+		publicKey := proto.Clone(fakeCryptoKeyVersion.publicKey).(*kmspb.PublicKey)
+		publicKey.PemCrc32C = k.pemCrc32C
+		return publicKey, nil
 	}
 
 	return fakeCryptoKeyVersion.publicKey, nil

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -401,13 +401,22 @@ func TestConfigure(t *testing.T) {
 				require.Nil(t, tt.config, "The test case must define a configuration or a configuration request, not both.")
 				configureRequest = tt.configureRequest
 			}
+			// The retry loop blocks on the mock clock's Sleep. Advance the
+			// clock from a background goroutine by exactly the slept duration
+			// each time a sleep begins, until the call under test completes.
+			done := make(chan struct{})
 			go func() {
-				for range tt.getPublicKeyErrCount - 1 {
-					ts.clockHook.WaitForSleep(testTimeout, "timed out waiting for backoff sleep")
-					ts.clockHook.Add(time.Second) // >= backoffMax, releases the pending sleep
+				for {
+					select {
+					case <-done:
+						return
+					case d := <-ts.clockHook.SleepCh():
+						ts.clockHook.Add(d)
+					}
 				}
 			}()
 			_, err := ts.plugin.Configure(ctx, configureRequest)
+			close(done)
 
 			spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMsg)
 			if tt.expectCode != codes.OK {
@@ -1006,13 +1015,22 @@ func TestGenerateKey(t *testing.T) {
 
 			ts.fakeKMSClient.setGetPublicKeySequentialErrs(tt.getPublicKeyErr, tt.getPublicKeyErrCount)
 
+			// The retry loop blocks on the mock clock's Sleep. Advance the
+			// clock from a background goroutine by exactly the slept duration
+			// each time a sleep begins, until the call under test completes.
+			done := make(chan struct{})
 			go func() {
-				for range tt.getPublicKeyErrCount - 1 {
-					ts.clockHook.WaitForSleep(testTimeout, "timed out waiting for backoff sleep")
-					ts.clockHook.Add(time.Second) // >= backoffMax, releases the pending sleep
+				for {
+					select {
+					case <-done:
+						return
+					case d := <-ts.clockHook.SleepCh():
+						ts.clockHook.Add(d)
+					}
 				}
 			}()
 			resp, err := ts.plugin.GenerateKey(ctx, tt.generateKeyReq)
+			close(done)
 			if tt.expectMsg != "" {
 				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMsg)
 				return

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -405,6 +405,7 @@ func TestConfigure(t *testing.T) {
 			// clock from a background goroutine by exactly the slept duration
 			// each time a sleep begins, until the call under test completes.
 			done := make(chan struct{})
+			defer close(done)
 			go func() {
 				for {
 					select {
@@ -416,7 +417,6 @@ func TestConfigure(t *testing.T) {
 				}
 			}()
 			_, err := ts.plugin.Configure(ctx, configureRequest)
-			close(done)
 
 			spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMsg)
 			if tt.expectCode != codes.OK {
@@ -1019,6 +1019,7 @@ func TestGenerateKey(t *testing.T) {
 			// clock from a background goroutine by exactly the slept duration
 			// each time a sleep begins, until the call under test completes.
 			done := make(chan struct{})
+			defer close(done)
 			go func() {
 				for {
 					select {
@@ -1030,7 +1031,6 @@ func TestGenerateKey(t *testing.T) {
 				}
 			}()
 			resp, err := ts.plugin.GenerateKey(ctx, tt.generateKeyReq)
-			close(done)
 			if tt.expectMsg != "" {
 				spiretest.RequireGRPCStatusContains(t, err, tt.expectCode, tt.expectMsg)
 				return

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -62,9 +62,13 @@ func (m *Mock) WaitForAfterCh() <-chan time.Duration {
 	return m.afterC
 }
 
-// SleepCh returns a channel that receives the duration of each Sleep as it
-// begins. Callers can use it to advance the clock by the slept duration,
-// driving a Sleep-based retry loop without coupling to the number of sleeps.
+// SleepCh returns the channel that Sleep notifies when a sleep begins,
+// carrying the sleep duration. The notification is a non-blocking send on a
+// buffered channel, so it can be dropped if a previous one has not been
+// drained. Drive a Sleep-based retry loop by receiving each notification and
+// advancing the clock by its duration before the next Sleep can begin: that
+// keeps at most one sleep outstanding (so nothing is dropped) and avoids
+// coupling to the number of sleeps.
 func (m *Mock) SleepCh() <-chan time.Duration {
 	return m.sleepC
 }

--- a/test/clock/clock.go
+++ b/test/clock/clock.go
@@ -62,6 +62,13 @@ func (m *Mock) WaitForAfterCh() <-chan time.Duration {
 	return m.afterC
 }
 
+// SleepCh returns a channel that receives the duration of each Sleep as it
+// begins. Callers can use it to advance the clock by the slept duration,
+// driving a Sleep-based retry loop without coupling to the number of sleeps.
+func (m *Mock) SleepCh() <-chan time.Duration {
+	return m.sleepC
+}
+
 // WaitForTimer waits up to the specified timeout for Timer to be called on the clock.
 func (m *Mock) WaitForTimer(timeout time.Duration, format string, args ...any) {
 	select {


### PR DESCRIPTION
PR #6924 added an exponential backoff with `clk.Sleep` to `getPublicKeyFromCryptoKeyVersion` in the `gcp_kms` KeyManager plugin, and drove the resulting sleeps in `TestConfigure` and `TestGenerateKey` by looping `WaitForSleep` plus `Add` a fixed number of times. That pump coupled the test to the exact retry count (`getPublicKeyErrCount - 1`) and advanced the mock clock by a blanket one second per sleep. Advancing by far more than the pending backoff lets a single `Add` coalesce several backoff timers at once, and the test clock's sleep channel drops surplus signals, so the pump and the retry loop can drift out of sync. `WaitForSleep` also calls `t.Fatalf` on timeout from the spawned goroutine, where a failure would not be reported correctly.

This PR replaces that pump with a count-free one: a background goroutine advances the mock clock by exactly the slept duration each time a sleep begins, until the call under test returns. The call under test stays on the main test goroutine, advancing by the exact duration keeps the handshake one-to-one with no coalescing or dropped signals, and there is no `WaitForSleep` timeout running off the test goroutine. A new `SleepCh` accessor on the test clock exposes the sleep-duration channel, mirroring the existing `WaitForAfterCh`.

While verifying this, I also found a pre-existing flake unrelated to the clock. The `gcp_kms` fake client's `GetPublicKey` overrode `PemCrc32C` directly on the shared fixture public key when a test set a custom checksum. The "integrity verification error" case in `TestGetPublicKey` sets a bad checksum, which permanently corrupted the shared `pubKey`, so a later test or a `-count` rerun that reused it failed the integrity check with "response corrupted in-transit". The fake now overrides the checksum on a clone, leaving the shared fixture intact.

The full `gcp_kms` package passes `go test -race -count=10` with both changes.
