### PR TITLE
Fix data races in built-in BundlePublisher plugins on dynamic reconfiguration

### DIFF
--- a/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere.go
+++ b/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere.go
@@ -98,12 +98,10 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client: %v", err)
 	}
-	p.rolesAnywhereClient = rolesAnywhere
-
-	p.configMtx.Lock()
-	defer p.configMtx.Unlock()
-	p.config = newConfig
-
+	// Store the config and client together under one lock so that
+	// PublishBundle always observes a matching pair, even when Configure
+	// runs concurrently as a result of a dynamic reconfiguration.
+	p.setConfig(newConfig, rolesAnywhere)
 	p.setBundle(nil)
 	return &configv1.ConfigureResponse{}, nil
 }
@@ -120,7 +118,7 @@ func (p *Plugin) Validate(ctx context.Context, req *configv1.ValidateRequest) (*
 // PublishBundle puts the bundle in the Roles Anywhere trust anchor, with
 // the configured id.
 func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.PublishBundleRequest) (*bundlepublisherv1.PublishBundleResponse, error) {
-	config, err := p.getConfig()
+	config, rolesAnywhereClient, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +156,7 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 			},
 		},
 	}
-	updateTrustAnchorOutput, err := p.rolesAnywhereClient.UpdateTrustAnchor(ctx, &updateTrustAnchorInput)
+	updateTrustAnchorOutput, err := rolesAnywhereClient.UpdateTrustAnchor(ctx, &updateTrustAnchorInput)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update trust anchor: %v", err)
 	}
@@ -172,21 +170,33 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 
 // getBundle gets the latest bundle that the plugin has.
 func (p *Plugin) getBundle() *types.Bundle {
-	p.configMtx.RLock()
-	defer p.configMtx.RUnlock()
+	p.bundleMtx.RLock()
+	defer p.bundleMtx.RUnlock()
 
 	return p.bundle
 }
 
-// getConfig gets the configuration of the plugin.
-func (p *Plugin) getConfig() (*Config, error) {
+// getConfig gets the configuration of the plugin along with the client
+// created for it. Both are returned together so callers always observe a
+// matching pair.
+func (p *Plugin) getConfig() (*Config, rolesAnywhere, error) {
 	p.configMtx.RLock()
 	defer p.configMtx.RUnlock()
 
 	if p.config == nil {
-		return nil, status.Error(codes.FailedPrecondition, "not configured")
+		return nil, nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
-	return p.config, nil
+	return p.config, p.rolesAnywhereClient, nil
+}
+
+// setConfig sets the configuration for the plugin along with the client
+// created for it, updating both atomically under one lock.
+func (p *Plugin) setConfig(config *Config, client rolesAnywhere) {
+	p.configMtx.Lock()
+	defer p.configMtx.Unlock()
+
+	p.config = config
+	p.rolesAnywhereClient = client
 }
 
 // setBundle updates the current bundle in the plugin with the provided bundle.

--- a/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere_test.go
+++ b/pkg/server/plugin/bundlepublisher/awsrolesanywhere/awsrolesanywhere_test.go
@@ -3,7 +3,9 @@ package awsrolesanywhere
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,6 +21,7 @@ import (
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestConfigure(t *testing.T) {
@@ -312,6 +315,82 @@ func TestPublishMultiple(t *testing.T) {
 	})
 	require.Nil(t, resp)
 	require.Error(t, err)
+}
+
+// TestConcurrentConfigureAndPublish exercises Configure running concurrently
+// with PublishBundle, as happens with dynamic reconfiguration. It is meant to
+// be run with the race detector to catch unsynchronized access to the client.
+func TestConcurrentConfigureAndPublish(t *testing.T) {
+	config := &Config{
+		AccessKeyID:     "access-key-id",
+		SecretAccessKey: "secret-access-key",
+		Region:          "region",
+		TrustAnchorID:   "trust-anchor-id",
+	}
+
+	newClient := func(awsConfig aws.Config) (rolesAnywhere, error) {
+		return &fakeClient{
+			t:                   t,
+			expectTrustAnchorID: aws.String(config.TrustAnchorID),
+		}, nil
+	}
+	p := newPlugin(newClient)
+
+	var err error
+	plugintest.Load(t, builtin(p), nil,
+		plugintest.CaptureConfigureError(&err),
+		plugintest.CoreConfig(catalog.CoreConfig{
+			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
+		}),
+		plugintest.ConfigureJSON(config),
+	)
+	require.NoError(t, err)
+
+	hclConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+	configureReq := &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  string(hclConfig),
+	}
+
+	bundle := getTestBundle(t)
+
+	const iterations = 100
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if _, cerr := p.Configure(context.Background(), configureReq); cerr != nil {
+				errCh <- cerr
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			// Vary the bundle so the dedup check does not short-circuit and
+			// PublishBundle reaches the client.
+			b := proto.Clone(bundle).(*types.Bundle)
+			b.SequenceNumber = uint64(i + 1)
+			if _, perr := p.PublishBundle(context.Background(), &bundlepublisherv1.PublishBundleRequest{
+				Bundle: b,
+			}); perr != nil {
+				errCh <- perr
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		require.NoError(t, e)
+	}
 }
 
 type fakeClient struct {

--- a/pkg/server/plugin/bundlepublisher/awss3/awss3.go
+++ b/pkg/server/plugin/bundlepublisher/awss3/awss3.go
@@ -141,7 +141,6 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		p.log.Warn(note)
 	}
 
-	// seems wrong to change plugin s3Client before config change
 	awsCfg, err := newAWSConfig(ctx, newConfig)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client configuration: %v", err)
@@ -150,9 +149,11 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client: %v", err)
 	}
-	p.s3Client = s3Client
 
-	p.setConfig(newConfig)
+	// Store the config and client together under one lock so that
+	// PublishBundle always observes a matching pair, even when Configure
+	// runs concurrently as a result of a dynamic reconfiguration.
+	p.setConfig(newConfig, s3Client)
 	p.setBundle(nil)
 	return &configv1.ConfigureResponse{}, nil
 }
@@ -169,7 +170,7 @@ func (p *Plugin) Validate(ctx context.Context, req *configv1.ValidateRequest) (*
 // PublishBundle puts the bundle in the configured S3 bucket name and
 // object key.
 func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.PublishBundleRequest) (*bundlepublisherv1.PublishBundleResponse, error) {
-	config, err := p.getConfig()
+	config, s3Client, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +196,7 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 		return nil, status.Errorf(codes.Internal, "could not format bundle: %v", err.Error())
 	}
 
-	_, err = p.s3Client.PutObject(ctx, &s3.PutObjectInput{
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(config.Bucket),
 		Body:   bytes.NewReader(bundleBytes),
 		Key:    aws.String(config.ObjectKey),
@@ -212,21 +213,23 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 
 // getBundle gets the latest bundle that the plugin has.
 func (p *Plugin) getBundle() *types.Bundle {
-	p.configMtx.RLock()
-	defer p.configMtx.RUnlock()
+	p.bundleMtx.RLock()
+	defer p.bundleMtx.RUnlock()
 
 	return p.bundle
 }
 
-// getConfig gets the configuration of the plugin.
-func (p *Plugin) getConfig() (*Config, error) {
+// getConfig gets the configuration of the plugin along with the client
+// created for it. Both are returned together so callers always observe a
+// matching pair.
+func (p *Plugin) getConfig() (*Config, simpleStorageService, error) {
 	p.configMtx.RLock()
 	defer p.configMtx.RUnlock()
 
 	if p.config == nil {
-		return nil, status.Error(codes.FailedPrecondition, "not configured")
+		return nil, nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
-	return p.config, nil
+	return p.config, p.s3Client, nil
 }
 
 // setBundle updates the current bundle in the plugin with the provided bundle.
@@ -237,12 +240,14 @@ func (p *Plugin) setBundle(bundle *types.Bundle) {
 	p.bundle = bundle
 }
 
-// setConfig sets the configuration for the plugin.
-func (p *Plugin) setConfig(config *Config) {
+// setConfig sets the configuration for the plugin along with the client
+// created for it, updating both atomically under one lock.
+func (p *Plugin) setConfig(config *Config, client simpleStorageService) {
 	p.configMtx.Lock()
 	defer p.configMtx.Unlock()
 
 	p.config = config
+	p.s3Client = client
 }
 
 // builtin creates a new BundlePublisher built-in plugin.

--- a/pkg/server/plugin/bundlepublisher/awss3/awss3_test.go
+++ b/pkg/server/plugin/bundlepublisher/awss3/awss3_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/spiffe/spire/test/util"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestConfigure(t *testing.T) {
@@ -523,6 +526,85 @@ func TestBundleWithRefreshHintPublishedOnce(t *testing.T) {
 	require.NotNil(t, resp)
 
 	require.Equal(t, 1, client.putObjectCount)
+}
+
+// TestConcurrentConfigureAndPublish exercises Configure running concurrently
+// with PublishBundle, as happens with dynamic reconfiguration. It is meant to
+// be run with the race detector to catch unsynchronized access to the client.
+func TestConcurrentConfigureAndPublish(t *testing.T) {
+	config := &Config{
+		AccessKeyID:     "access-key-id",
+		SecretAccessKey: "secret-access-key",
+		Region:          "region",
+		Bucket:          "bucket",
+		ObjectKey:       "object-key",
+		Format:          "spiffe",
+	}
+
+	newClient := func(awsConfig aws.Config) (simpleStorageService, error) {
+		return &fakeClient{
+			t:            t,
+			expectBucket: aws.String(config.Bucket),
+			expectKey:    aws.String(config.ObjectKey),
+		}, nil
+	}
+	p := newPlugin(newClient)
+
+	var err error
+	plugintest.Load(t, builtin(p), nil,
+		plugintest.CaptureConfigureError(&err),
+		plugintest.CoreConfig(catalog.CoreConfig{
+			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
+		}),
+		plugintest.ConfigureJSON(config),
+	)
+	require.NoError(t, err)
+
+	hclConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+	configureReq := &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  string(hclConfig),
+	}
+
+	bundle := getTestBundle(t)
+
+	const iterations = 100
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if _, cerr := p.Configure(context.Background(), configureReq); cerr != nil {
+				errCh <- cerr
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			// Vary the bundle so the dedup check does not short-circuit and
+			// PublishBundle reaches the client.
+			b := proto.Clone(bundle).(*types.Bundle)
+			b.SequenceNumber = uint64(i + 1)
+			if _, perr := p.PublishBundle(context.Background(), &bundlepublisherv1.PublishBundleRequest{
+				Bundle: b,
+			}); perr != nil {
+				errCh <- perr
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		require.NoError(t, e)
+	}
 }
 
 type fakeClient struct {

--- a/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage.go
+++ b/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage.go
@@ -141,9 +141,10 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client: %v", err)
 	}
-	p.gcsClient = gcsClient
-
-	p.setConfig(newConfig)
+	// Store the config and client together under one lock so that
+	// PublishBundle always observes a matching pair, even when Configure
+	// runs concurrently as a result of a dynamic reconfiguration.
+	p.setConfig(newConfig, gcsClient)
 
 	p.setBundle(nil)
 
@@ -161,7 +162,7 @@ func (p *Plugin) Validate(ctx context.Context, req *configv1.ValidateRequest) (*
 
 // PublishBundle puts the bundle in the configured GCS bucket and object name.
 func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.PublishBundleRequest) (*bundlepublisherv1.PublishBundleResponse, error) {
-	config, err := p.getConfig()
+	config, gcsClient, err := p.getConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +188,7 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 		return nil, status.Errorf(codes.Internal, "could not format bundle: %v", err.Error())
 	}
 
-	bucketHandle := p.gcsClient.Bucket(config.BucketName)
+	bucketHandle := gcsClient.Bucket(config.BucketName)
 	if bucketHandle == nil { // Purely defensive, the Bucket function implemented in GCS always returns a BucketHandle.
 		return nil, status.Error(codes.Internal, "could not get bucket handle")
 	}
@@ -233,30 +234,36 @@ func (p *Plugin) PublishBundle(ctx context.Context, req *bundlepublisherv1.Publi
 
 // Close is called when the plugin is unloaded. Closes the client.
 func (p *Plugin) Close() error {
-	if p.gcsClient == nil {
+	p.configMtx.RLock()
+	gcsClient := p.gcsClient
+	p.configMtx.RUnlock()
+
+	if gcsClient == nil {
 		return nil
 	}
 	p.log.Debug("Closing the connection to the Cloud Storage API service")
-	return p.gcsClient.Close()
+	return gcsClient.Close()
 }
 
 // getBundle gets the latest bundle that the plugin has.
 func (p *Plugin) getBundle() *types.Bundle {
-	p.configMtx.RLock()
-	defer p.configMtx.RUnlock()
+	p.bundleMtx.RLock()
+	defer p.bundleMtx.RUnlock()
 
 	return p.bundle
 }
 
-// getConfig gets the configuration of the plugin.
-func (p *Plugin) getConfig() (*Config, error) {
+// getConfig gets the configuration of the plugin along with the client
+// created for it. Both are returned together so callers always observe a
+// matching pair.
+func (p *Plugin) getConfig() (*Config, gcsService, error) {
 	p.configMtx.RLock()
 	defer p.configMtx.RUnlock()
 
 	if p.config == nil {
-		return nil, status.Error(codes.FailedPrecondition, "not configured")
+		return nil, nil, status.Error(codes.FailedPrecondition, "not configured")
 	}
-	return p.config, nil
+	return p.config, p.gcsClient, nil
 }
 
 // setBundle updates the current bundle in the plugin with the provided bundle.
@@ -267,12 +274,14 @@ func (p *Plugin) setBundle(bundle *types.Bundle) {
 	p.bundle = bundle
 }
 
-// setConfig sets the configuration for the plugin.
-func (p *Plugin) setConfig(config *Config) {
+// setConfig sets the configuration for the plugin along with the client
+// created for it, updating both atomically under one lock.
+func (p *Plugin) setConfig(config *Config, client gcsService) {
 	p.configMtx.Lock()
 	defer p.configMtx.Unlock()
 
 	p.config = config
+	p.gcsClient = client
 }
 
 // builtin creates a new BundlePublisher built-in plugin.

--- a/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage_test.go
+++ b/pkg/server/plugin/bundlepublisher/gcpcloudstorage/gcpcloudstorage_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestConfigure(t *testing.T) {
@@ -473,6 +476,81 @@ func TestBundleWithRefreshHintPublishedOnce(t *testing.T) {
 	require.NotNil(t, resp)
 
 	require.Equal(t, 1, testWriteObjectCount)
+}
+
+// TestConcurrentConfigureAndPublish exercises Configure running concurrently
+// with PublishBundle, as happens with dynamic reconfiguration. It is meant to
+// be run with the race detector to catch unsynchronized access to the client.
+func TestConcurrentConfigureAndPublish(t *testing.T) {
+	config := &Config{
+		BucketName: "bucket-name",
+		ObjectName: "object-name",
+		Format:     "spiffe",
+	}
+
+	newClient := func(ctx context.Context, opts ...option.ClientOption) (gcsService, error) {
+		return &fakeClient{}, nil
+	}
+	newStorageWriter := func(ctx context.Context, o *storage.ObjectHandle) io.WriteCloser {
+		return &fakeStorageWriter{}
+	}
+	p := newPlugin(newClient, newStorageWriter)
+
+	var err error
+	plugintest.Load(t, builtin(p), nil,
+		plugintest.CaptureConfigureError(&err),
+		plugintest.CoreConfig(catalog.CoreConfig{
+			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
+		}),
+		plugintest.ConfigureJSON(config),
+	)
+	require.NoError(t, err)
+
+	hclConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+	configureReq := &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "example.org"},
+		HclConfiguration:  string(hclConfig),
+	}
+
+	bundle := getTestBundle(t)
+
+	const iterations = 100
+	errCh := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if _, cerr := p.Configure(context.Background(), configureReq); cerr != nil {
+				errCh <- cerr
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := range iterations {
+			// Vary the bundle so the dedup check does not short-circuit and
+			// PublishBundle reaches the client.
+			b := proto.Clone(bundle).(*types.Bundle)
+			b.SequenceNumber = uint64(i + 1)
+			if _, perr := p.PublishBundle(context.Background(), &bundlepublisherv1.PublishBundleRequest{
+				Bundle: b,
+			}); perr != nil {
+				errCh <- perr
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		require.NoError(t, e)
+	}
 }
 
 type fakeClient struct {


### PR DESCRIPTION
The built-in BundlePublisher plugins assign their storage client in `Configure` and read it in `PublishBundle` without any synchronization. Several of them also read the cached bundle in `getBundle` while holding `configMtx`, even though `setBundle` writes it under a separate `bundleMtx`, so the two never exclude each other.

These were harmless while `Configure` only ran once during plugin initialization, but dynamic reconfiguration now calls `Configure` again at runtime, so it can run concurrently with `PublishBundle`. That produces data races on both the client field and the cached bundle, and a concurrent reconfiguration could also leave `PublishBundle` using a client that no longer matches the active configuration.

This PR fixes the `aws_s3`, `gcp_cloudstorage`, and `aws_rolesanywhere_trustanchor` plugins by storing the configuration and its client together and updating them atomically under `configMtx`, with `getConfig` returning both so that `PublishBundle` always observes a matching pair. It also corrects `getBundle` in those plugins to read under `bundleMtx`, matching `setBundle`. The `k8s_configmap` plugin already stores its clients inside the configuration and reads the bundle under the correct lock, so it needs no change. The `azure_blob` plugin under review in #7030 has the same structure and adopts this pattern there.

Changes:
- Store the config and storage client as a pair under `configMtx` in the `aws_s3`, `gcp_cloudstorage`, and `aws_rolesanywhere_trustanchor` plugins, returned together from `getConfig`.
- Read the cached bundle under `bundleMtx` in `getBundle` to match `setBundle` in those plugins.
- Guard the client read in the `gcp_cloudstorage` `Close` method.
- Add a `TestConcurrentConfigureAndPublish` regression test to each fixed plugin that runs `Configure` and `PublishBundle` concurrently and fails under `-race` without the fix.
