### PR TITLE
feat: aws_iid support sourcing verify_organization account list from a file

### DIFF
--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -450,6 +450,11 @@ plugins {
     #             # It's an optional parameter. If specified, it should be greater than or equal to the duration of 1m (minute).
     #             # Default: 3m.
     #             # org_account_map_ttl = ""
+    #
+    #             # account_list_file: Source the org account list from a file instead of the AWS Organizations API.
+    #             # Mutually exclusive with management_account_id and assume_org_role.
+    #             # Optional parameter.
+    #             # account_list_file = ""
     #         }
              
     #         # validate_eks_cluster_membership: Validate if the attesting node is part of an EKS cluster.

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -53,10 +53,10 @@ For configuring AWS Node attestation method with organization validation followi
 
 | Field Name                | Description                                                                                   | Constraints                                  |
 |---------------------------|-----------------------------------------------------------------------------------------------|----------------------------------------------|
-| management_account_id     | Account id of the organization                                                                 | required (unless `account_list_file` is set) |
+| management_account_id     | Account id of the organization                                                                | required (unless `account_list_file` is set) |
 | management_account_region | Region of management account id                                                               | optional                                     |
-| assume_org_role           | IAM Role name, with capabilities to list accounts                                              | required (unless `account_list_file` is set) |
-| org_account_map_ttl       | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minutes. | optional                                     |
+| assume_org_role           | IAM Role name, with capabilities to list accounts                                             | required (unless `account_list_file` is set) |
+| org_account_map_ttl       | Cache the list of accounts for particular time. Should be >= 1 minute. Defaults to 3 minutes. | optional                                     |
 | account_list_file         | Source the org account list from a file instead of the AWS Organizations API                  | optional                                     |
 
 Using the block `verify_organization` the org validation node attestation method will be enabled. With above configuration spire server will form and try to assume the role as: `arn:aws:iam::management_account_id:role/assume_org_role`. When not used, block ex. `verify_organization = {}` should not be empty, it should be completely removed as its optional or should have all required parameters namely `management_account_id`, `assume_org_role`.

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -51,13 +51,13 @@ assuming AWS IID document sent from the spire agent contains `accountId : 123456
 
 For configuring AWS Node attestation method with organization validation following configuration can be used:
 
-| Field Name                 | Description                                                                                   | Constraints                                |
-|----------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------|
-| management_account_id      | Account id of the organzation                                                                 | required (unless `account_list_file` is set) |
-| management_account_region  | Region of management account id                                                               | optional                                   |
-| assume_org_role            | IAM Role name, with capablities to list accounts                                              | required (unless `account_list_file` is set) |
-| org_account_map_ttl        | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minute. | optional                                   |
-| account_list_file          | Path to a JSON file containing the org account list, used instead of the AWS Organizations API. Mutually exclusive with `management_account_id` / `assume_org_role`. | optional |
+| Field Name                | Description                                                                                   | Constraints                                  |
+|---------------------------|-----------------------------------------------------------------------------------------------|----------------------------------------------|
+| management_account_id     | Account id of the organzation                                                                 | required (unless `account_list_file` is set) |
+| management_account_region | Region of management account id                                                               | optional                                     |
+| assume_org_role           | IAM Role name, with capablities to list accounts                                              | required (unless `account_list_file` is set) |
+| org_account_map_ttl       | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minute. | optional                                     |
+| account_list_file         | Source the org account list from a file instead of the AWS Organizations API                  | optional                                     |
 
 Using the block `verify_organization` the org validation node attestation method will be enabled. With above configuration spire server will form and try to assume the role as: `arn:aws:iam::management_account_id:role/assume_org_role`. When not used, block ex. `verify_organization = {}` should not be empty, it should be completely removed as its optional or should have all required parameters namely `management_account_id`, `assume_org_role`.
 

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -92,7 +92,11 @@ NodeAttestor "aws_iid" {
 
 A common deployment pattern is to run a single org-wide enumerator (for example, a Kubernetes CronJob that calls `ListAccounts` and writes the result to a ConfigMap mounted into the `spire-server` pods). This gives all replicas a shared account list sourced from one AWS caller, without SPIRE needing to know anything about the refresh mechanism. The same approach works with a sidecar, an init container, or a file on a VM.
 
-The role under: `assume_role` must be created in the management account: `management_account_id`, and it should have a trust relationship with the role assumed by spire server. Below is a sample policy depicting the permissions required along with the trust relationship that needs to be created in management account.
+### AWS IAM Permissions for Organization Validation (API mode)
+
+When using the API-based configuration (with `management_account_id` and `assume_org_role`), the following IAM permissions are required.
+
+The role `assume_org_role` must be created in the management account (`management_account_id`) and should have a trust relationship with the role assumed by the SPIRE server. Below is a sample policy depicting the permissions required along with the trust relationship that needs to be created in the management account.
 
 Policy :
 
@@ -130,6 +134,8 @@ Trust Relationship
     ]
 }
 ```
+
+**Note:** No `organizations:ListAccounts` IAM permission is required when using `account_list_file` mode.
 
 ## Enabling AWS Node Attestation EKS Cluster Validation
 

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -53,12 +53,42 @@ For configuring AWS Node attestation method with organization validation followi
 
 | Field Name                 | Description                                                                                   | Constraints                                |
 |----------------------------|-----------------------------------------------------------------------------------------------|--------------------------------------------|
-| management_account_id      | Account id of the organzation                                                                 | required                                   |
+| management_account_id      | Account id of the organzation                                                                 | required (unless `account_list_file` is set) |
 | management_account_region  | Region of management account id                                                               | optional                                   |
-| assume_org_role            | IAM Role name, with capablities to list accounts                                              | required                                   |
+| assume_org_role            | IAM Role name, with capablities to list accounts                                              | required (unless `account_list_file` is set) |
 | org_account_map_ttl        | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minute. | optional                                   |
+| account_list_file          | Path to a JSON file containing the org account list, used instead of the AWS Organizations API. Mutually exclusive with `management_account_id` / `assume_org_role`. | optional |
 
 Using the block `verify_organization` the org validation node attestation method will be enabled. With above configuration spire server will form and try to assume the role as: `arn:aws:iam::management_account_id:role/assume_org_role`. When not used, block ex. `verify_organization = {}` should not be empty, it should be completely removed as its optional or should have all required parameters namely `management_account_id`, `assume_org_role`.
+
+### Sourcing the account list from a file
+
+For large organizations, calling `organizations:ListAccounts` can be expensive: the API returns at most 20 accounts per page, the list is cached per `spire-server` process, and the cache TTL timer is per replica. With many replicas and a large org this multiplies load on the management account's shared `ListAccounts` throttle pool and can lead to `TooManyRequestsException` errors for SPIRE and other callers.
+
+To avoid this, set `account_list_file` to the path of a JSON file containing the organization's account IDs. When set, the plugin reads the account list from this file instead of calling AWS, and **no `organizations:ListAccounts` IAM permission is required**. `account_list_file` is mutually exclusive with `management_account_id` and `assume_org_role`.
+
+The file is read and validated at configuration time (the plugin fails to start if the file is missing or malformed) and re-read on the `org_account_map_ttl` interval, so updates are picked up without restarting the server.
+
+The file format is a JSON array of 12-digit AWS account IDs. The operator is responsible for populating it with only eligible (e.g. ACTIVE) accounts:
+
+```json
+["111111111111", "222222222222", "333333333333"]
+```
+
+Sample configuration:
+
+```hcl
+NodeAttestor "aws_iid" {
+    plugin_data {
+        verify_organization = {
+            account_list_file   = "/etc/spire/org-accounts.json"
+            org_account_map_ttl = "15m"
+        }
+    }
+}
+```
+
+A common deployment pattern is to run a single org-wide enumerator (for example, a Kubernetes CronJob that calls `ListAccounts` and writes the result to a ConfigMap mounted into the `spire-server` pods). This gives all replicas a shared account list sourced from one AWS caller, without SPIRE needing to know anything about the refresh mechanism. The same approach works with a sidecar, an init container, or a file on a VM.
 
 The role under: `assume_role` must be created in the management account: `management_account_id`, and it should have a trust relationship with the role assumed by spire server. Below is a sample policy depicting the permissions required along with the trust relationship that needs to be created in management account.
 
@@ -180,7 +210,7 @@ The following is an example for a IAM policy needed to get instance's info from 
 
 **Note:** Additional permissions are required when using optional validation features:
 
-- For organization validation (`verify_organization`): `organizations:ListAccounts`
+- For organization validation (`verify_organization`): `organizations:ListAccounts` (not required when `account_list_file` is configured)
 - For EKS cluster validation (`validate_eks_cluster_membership`): `eks:ListNodegroups`, `eks:DescribeNodegroup`, `autoscaling:DescribeAutoScalingGroups`
 
 For more information on security credentials, see <https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html>.

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -67,7 +67,9 @@ For large organizations, calling `organizations:ListAccounts` can be expensive: 
 
 To avoid this, set `account_list_file` to the path of a JSON file containing the organization's account IDs. When set, the plugin reads the account list from this file instead of calling AWS, and **no `organizations:ListAccounts` IAM permission is required**. `account_list_file` is mutually exclusive with `management_account_id` and `assume_org_role`.
 
-The file is read and validated at configuration time (the plugin fails to start if the file is missing or malformed) and re-read on the `org_account_map_ttl` interval, so updates are picked up without restarting the server.
+The file is read and validated at configuration time (the plugin fails to start if the file is missing or malformed). It is then re-read when the cached list is older than `org_account_map_ttl`; the refresh happens lazily on the next attestation after the TTL has elapsed (there is no background timer), so updates are picked up without restarting the server.
+
+The list is fail-closed: if the file is empty, unreadable, or malformed at runtime, accounts validated against it will fail attestation rather than be allowed. Keep the file current, and note that an empty list (`[]`) rejects every account.
 
 The file format is a JSON array of 12-digit AWS account IDs. The operator is responsible for populating it with only eligible (e.g. ACTIVE) accounts:
 

--- a/doc/plugin_server_nodeattestor_aws_iid.md
+++ b/doc/plugin_server_nodeattestor_aws_iid.md
@@ -53,10 +53,10 @@ For configuring AWS Node attestation method with organization validation followi
 
 | Field Name                | Description                                                                                   | Constraints                                  |
 |---------------------------|-----------------------------------------------------------------------------------------------|----------------------------------------------|
-| management_account_id     | Account id of the organzation                                                                 | required (unless `account_list_file` is set) |
+| management_account_id     | Account id of the organization                                                                 | required (unless `account_list_file` is set) |
 | management_account_region | Region of management account id                                                               | optional                                     |
-| assume_org_role           | IAM Role name, with capablities to list accounts                                              | required (unless `account_list_file` is set) |
-| org_account_map_ttl       | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minute. | optional                                     |
+| assume_org_role           | IAM Role name, with capabilities to list accounts                                              | required (unless `account_list_file` is set) |
+| org_account_map_ttl       | Cache the list of accounts for particular time. Should be  >= 1 minute. Defaults to 3 minutes. | optional                                     |
 | account_list_file         | Source the org account list from a file instead of the AWS Organizations API                  | optional                                     |
 
 Using the block `verify_organization` the org validation node attestation method will be enabled. With above configuration spire server will form and try to assume the role as: `arn:aws:iam::management_account_id:role/assume_org_role`. When not used, block ex. `verify_organization = {}` should not be empty, it should be completely removed as its optional or should have all required parameters namely `management_account_id`, `assume_org_role`.

--- a/pkg/server/plugin/nodeattestor/awsiid/iid.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid.go
@@ -28,6 +28,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/fullsailor/pkcs7"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/hcl"
@@ -217,9 +218,15 @@ func (p *IIDAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 	if c.ValidateOrgAccountID != nil {
 		ctxValidateOrg, cancel := context.WithTimeout(stream.Context(), awsTimeout)
 		defer cancel()
-		orgClient, err := p.clients.getClient(ctxValidateOrg, c.ValidateOrgAccountID.AccountRegion, c.ValidateOrgAccountID.AccountID)
-		if err != nil {
-			return status.Errorf(codes.Internal, "failed to get org client: %v", err)
+
+		// In file mode the account list is sourced from disk, so no AWS
+		// Organizations client is required.
+		var orgClient organizations.ListAccountsAPIClient
+		if !c.ValidateOrgAccountID.useAccountListFile() {
+			orgClient, err = p.clients.getClient(ctxValidateOrg, c.ValidateOrgAccountID.AccountRegion, c.ValidateOrgAccountID.AccountID)
+			if err != nil {
+				return status.Errorf(codes.Internal, "failed to get org client: %v", err)
+			}
 		}
 
 		valid, err := p.orgValidation.IsMemberAccount(ctxValidateOrg, orgClient, attestationData.AccountID)
@@ -651,21 +658,32 @@ func isValidAWSPartition(partition string) bool {
 }
 
 func validateOrganizationConfig(config *IIDAttestorConfig) error {
-	checkAccID := config.ValidateOrgAccountID.AccountID
-	checkAccRole := config.ValidateOrgAccountID.AccountRole
-	checkAccRegion := config.ValidateOrgAccountID.AccountRegion
+	cfg := config.ValidateOrgAccountID
 
-	if checkAccID == "" || checkAccRole == "" {
-		return status.Errorf(codes.InvalidArgument, "please ensure that %q & %q are present inside block or remove the block: %q for feature node attestation using account id verification", orgAccountID, orgAccountRole, "verify_organization")
-	}
+	if cfg.useAccountListFile() {
+		// File mode: the account list is sourced from disk, so the AWS
+		// Organizations API fields are not used and must not be set.
+		if cfg.AccountID != "" || cfg.AccountRole != "" {
+			return status.Errorf(codes.InvalidArgument, "%q is mutually exclusive with %q and %q in the block: %q", orgAccountListFile, orgAccountID, orgAccountRole, "verify_organization")
+		}
 
-	if checkAccRegion == "" {
-		config.ValidateOrgAccountID.AccountRegion = orgDefaultAccRegion
+		// Fail at configure time if the file is missing or malformed.
+		if _, err := parseAccountListFile(cfg.AccountListFile); err != nil {
+			return status.Errorf(codes.InvalidArgument, "invalid %q in the block: %q: %v", orgAccountListFile, "verify_organization", err)
+		}
+	} else {
+		if cfg.AccountID == "" || cfg.AccountRole == "" {
+			return status.Errorf(codes.InvalidArgument, "please ensure that %q & %q are present inside block or remove the block: %q for feature node attestation using account id verification", orgAccountID, orgAccountRole, "verify_organization")
+		}
+
+		if cfg.AccountRegion == "" {
+			cfg.AccountRegion = orgDefaultAccRegion
+		}
 	}
 
 	// check TTL if specified
 	ttl := orgAccountDefaultListDuration
-	checkTTL := config.ValidateOrgAccountID.AccountListTTL
+	checkTTL := cfg.AccountListTTL
 	if checkTTL != "" {
 		t, err := time.ParseDuration(checkTTL)
 		if err != nil {
@@ -680,7 +698,7 @@ func validateOrganizationConfig(config *IIDAttestorConfig) error {
 	}
 
 	// Assign default ttl if ttl doesnt exist.
-	config.ValidateOrgAccountID.AccountListTTL = ttl.String()
+	cfg.AccountListTTL = ttl.String()
 
 	return nil
 }

--- a/pkg/server/plugin/nodeattestor/awsiid/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid_test.go
@@ -517,10 +517,13 @@ func TestAttest(t *testing.T) {
 			},
 		},
 		{
-			name:            "fail when account id is not present in account_list_file",
-			config:          fmt.Sprintf(`verify_organization = { account_list_file = %q }`, orgAccountListFilePath),
+			name:   "fail when account id is not present in account_list_file",
+			config: fmt.Sprintf(`verify_organization = { account_list_file = %q }`, orgAccountListFilePath),
+			overrideAttestationData: func(caws.IIDAttestationData) caws.IIDAttestationData {
+				return orgTestAttestationData
+			},
 			expectCode:      codes.Internal,
-			expectMsgPrefix: fmt.Sprintf("nodeattestor(aws_iid): failed aws ec2 attestation, nodes account id: %v is not part of configured organization or doesn't have ACTIVE status", testAccount),
+			expectMsgPrefix: fmt.Sprintf("nodeattestor(aws_iid): failed aws ec2 attestation, nodes account id: %v is not part of configured organization or doesn't have ACTIVE status", testAccountID),
 		},
 		{
 			name:     "success when EKS cluster validation feature is turned on",
@@ -863,6 +866,29 @@ func TestConfigure(t *testing.T) {
 		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q }`, filepath.ToSlash(accountListFile)))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "account_list_file")
+	})
+
+	t.Run("fail, account_list_file mutually exclusive even with a single AWS role field", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`["111111111111"]`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q management_account_id = "dummy_account" }`, filepath.ToSlash(accountListFile)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("success, account_list_file with management_account_region (region ignored)", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`["111111111111"]`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q management_account_region = "us-east-1" }`, filepath.ToSlash(accountListFile)))
+		require.NoError(t, err)
+	})
+
+	t.Run("fail, account_list_file with org_account_map_ttl below minimum", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`["111111111111"]`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q org_account_map_ttl = "10s" }`, filepath.ToSlash(accountListFile)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), orgAccountListTTL)
 	})
 
 	t.Run("success, validate_eks_cluster_membership block without eks_cluster_names property set", func(t *testing.T) {

--- a/pkg/server/plugin/nodeattestor/awsiid/iid_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/iid_test.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -81,6 +83,19 @@ func TestAttest(t *testing.T) {
 		AvailabilityZone: testAvailabilityZone,
 		ImageID:          testImageID,
 	})
+	orgFileTestAttestationData := buildAttestationDataRSA2048SignatureWithDoc(t, imds.InstanceIdentityDocument{
+		AccountID:        "111111111111",
+		InstanceID:       testInstance,
+		Region:           testRegion,
+		AvailabilityZone: testAvailabilityZone,
+		ImageID:          testImageID,
+	})
+	// Account list file containing "111111111111" but NOT testAccountID (the
+	// account the fake ListAccounts API returns), so a successful attestation
+	// with that account proves the list was sourced from the file rather than
+	// from the AWS Organizations API.
+	orgAccountListFilePath := filepath.ToSlash(filepath.Join(t.TempDir(), "org-accounts.json"))
+	require.NoError(t, os.WriteFile(orgAccountListFilePath, []byte(`["111111111111", "222222222222"]`), 0o600))
 
 	for _, tt := range []struct {
 		name                                  string
@@ -487,6 +502,27 @@ func TestAttest(t *testing.T) {
 			},
 		},
 		{
+			name:   "success when organization validation is sourced from account_list_file",
+			config: fmt.Sprintf(`verify_organization = { account_list_file = %q }`, orgAccountListFilePath),
+			overrideAttestationData: func(caws.IIDAttestationData) caws.IIDAttestationData {
+				return orgFileTestAttestationData
+			},
+			expectID: "spiffe://example.org/spire/agent/aws_iid/111111111111/test-region/test-instance",
+			expectSelectors: []*common.Selector{
+				{Type: caws.PluginName, Value: "account_id:111111111111"},
+				{Type: caws.PluginName, Value: "az:test-az"},
+				{Type: caws.PluginName, Value: "image:id:test-image-id"},
+				{Type: caws.PluginName, Value: "instance:id:test-instance"},
+				{Type: caws.PluginName, Value: "region:test-region"},
+			},
+		},
+		{
+			name:            "fail when account id is not present in account_list_file",
+			config:          fmt.Sprintf(`verify_organization = { account_list_file = %q }`, orgAccountListFilePath),
+			expectCode:      codes.Internal,
+			expectMsgPrefix: fmt.Sprintf("nodeattestor(aws_iid): failed aws ec2 attestation, nodes account id: %v is not part of configured organization or doesn't have ACTIVE status", testAccount),
+		},
+		{
 			name:     "success when EKS cluster validation feature is turned on",
 			config:   `validate_eks_cluster_membership = { eks_cluster_names = ["test-cluster"] }`,
 			expectID: "spiffe://example.org/spire/agent/aws_iid/test-account/test-region/test-instance",
@@ -797,6 +833,36 @@ func TestConfigure(t *testing.T) {
 	t.Run("success, verify_organization featured enabled with all params", func(t *testing.T) {
 		err := doConfig(t, coreConfig, `verify_organization = { management_account_id = "dummy_account" assume_org_role = "dummy_role" org_account_map_ttl = "1m30s" }`)
 		require.NoError(t, err)
+	})
+
+	t.Run("success, verify_organization with account_list_file", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`["111111111111", "222222222222"]`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q }`, filepath.ToSlash(accountListFile)))
+		require.NoError(t, err)
+	})
+
+	t.Run("fail, verify_organization account_list_file is mutually exclusive with management_account_id/assume_org_role", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`["111111111111"]`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q management_account_id = "dummy_account" assume_org_role = "dummy_role" }`, filepath.ToSlash(accountListFile)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("fail, verify_organization account_list_file does not exist", func(t *testing.T) {
+		missing := filepath.ToSlash(filepath.Join(t.TempDir(), "does-not-exist.json"))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q }`, missing))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "account_list_file")
+	})
+
+	t.Run("fail, verify_organization account_list_file is malformed", func(t *testing.T) {
+		accountListFile := filepath.Join(t.TempDir(), "org-accounts.json")
+		require.NoError(t, os.WriteFile(accountListFile, []byte(`not json`), 0o600))
+		err := doConfig(t, coreConfig, fmt.Sprintf(`verify_organization = { account_list_file = %q }`, filepath.ToSlash(accountListFile)))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "account_list_file")
 	})
 
 	t.Run("success, validate_eks_cluster_membership block without eks_cluster_names property set", func(t *testing.T) {

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -221,24 +221,15 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 		return o.orgAccountList, nil
 	}
 
-	// Build new org accounts list, either from a configured file or from the
-	// AWS Organizations API.
 	var orgAccountsMap map[string]any
+	var err error
 	if o.orgConfig.useAccountListFile() {
-		var err error
-		orgAccountsMap, err = parseAccountListFile(o.orgConfig.AccountListFile)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load org account list: %w", err)
-		}
-		if len(orgAccountsMap) == 0 {
-			o.log.Warn("org account list file is empty; all accounts will fail organization validation", "account_list_file", o.orgConfig.AccountListFile)
-		}
+		orgAccountsMap, err = o.reloadAccountListFromFile()
 	} else {
-		var err error
-		orgAccountsMap, err = listAccountsFromAPI(ctx, orgClient)
-		if err != nil {
-			return nil, err
-		}
+		orgAccountsMap, err = o.reloadAccountListFromAPI(ctx, orgClient)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	// Update timestamp, if it was not invoked as part of cache miss.
@@ -252,6 +243,21 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 	o.orgAccountList = orgAccountsMap
 
 	return o.orgAccountList, nil
+}
+
+func (o *orgValidator) reloadAccountListFromFile() (map[string]any, error) {
+	orgAccountsMap, err := parseAccountListFile(o.orgConfig.AccountListFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load org account list: %w", err)
+	}
+	if len(orgAccountsMap) == 0 {
+		o.log.Warn("org account list file is empty; all accounts will fail organization validation", "account_list_file", o.orgConfig.AccountListFile)
+	}
+	return orgAccountsMap, nil
+}
+
+func (o *orgValidator) reloadAccountListFromAPI(ctx context.Context, orgClient organizations.ListAccountsAPIClient) (map[string]any, error) {
+	return listAccountsFromAPI(ctx, orgClient)
 }
 
 // checkIFTTLIsExpire check if the creation time is pass defined ttl

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -72,6 +72,9 @@ func newOrganizationValidationBase(config *orgValidationConfig) *orgValidator {
 		orgConfig:      config,
 		retries:        orgAccountRetries,
 		clk:            clock.New(),
+		// Default to a no-op logger so direct callers (e.g. tests) never
+		// nil-deref; SetLogger replaces this in the plugin lifecycle.
+		log: hclog.NewNullLogger(),
 	}
 
 	return client
@@ -162,7 +165,7 @@ func (o *orgValidator) lookupCache(ctx context.Context, orgClient organizations.
 	if !accountIsmemberOfOrg && !reValidatedCache {
 		orgAccountList, err := o.refreshCache(ctx, orgClient)
 		if err != nil {
-			o.log.Error("Failed to refresh cache, while validating account id: %v", accountIDOfNode, "error", err.Error())
+			o.log.Error("failed to refresh org account list cache while validating account id", "account_id", accountIDOfNode, "error", err)
 			return false, err
 		}
 		_, accountIsmemberOfOrg = orgAccountList[accountIDOfNode]
@@ -226,6 +229,9 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 		orgAccountsMap, err = parseAccountListFile(o.orgConfig.AccountListFile)
 		if err != nil {
 			return nil, fmt.Errorf("issue while reading org account list file: %w", err)
+		}
+		if len(orgAccountsMap) == 0 {
+			o.log.Warn("org account list file is empty; all accounts will fail organization validation", "account_list_file", o.orgConfig.AccountListFile)
 		}
 	} else {
 		var err error

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -104,6 +104,7 @@ func (o *orgValidator) configure(config *orgValidationConfig) error {
 
 	// While doing configuration invalidate the map so we don't keep using old one.
 	o.orgAccountList = make(map[string]any)
+	o.orgAccountListValidDuration = time.Time{}
 	o.retries = orgAccountRetries
 
 	t, err := time.ParseDuration(config.AccountListTTL)
@@ -198,8 +199,8 @@ func (o *orgValidator) checkIfOrgAccountListIsStale() bool {
 	o.mutex.RLock()
 	defer o.mutex.RUnlock()
 
-	// Map is empty that means this is first time plugin is being initialised
-	if len(o.orgAccountList) == 0 {
+	// First init: account list not loaded yet.
+	if o.orgAccountListValidDuration.IsZero() {
 		return true
 	}
 
@@ -212,7 +213,7 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 	defer o.mutex.Unlock()
 
 	// Make sure: we are not doing cache burst and account map is not updated recently from different go routine.
-	if !catchBurst && len(o.orgAccountList) != 0 && !o.checkIfTTLIsExpired(o.orgAccountListValidDuration) {
+	if !catchBurst && !o.orgAccountListValidDuration.IsZero() && !o.checkIfTTLIsExpired(o.orgAccountListValidDuration) {
 		return o.orgAccountList, nil
 	}
 

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -2,7 +2,10 @@ package awsiid
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
 	"sync"
 	"time"
 
@@ -20,11 +23,15 @@ const (
 	orgAccRegion             = "management_account_region" // required for cache key
 	orgAccountStatus         = "ACTIVE"                    // Only allow node account id's with status ACTIVE
 	orgAccountListTTL        = "org_account_map_ttl"       // Cache the list of account for specific time, if not sent default will be used.
+	orgAccountListFile       = "account_list_file"         // Source the org account list from a file instead of the AWS Organizations API.
 	orgAccountDefaultListTTL = "3m"                        // pull account list after 3 minutes
 	orgAccountMinListTTL     = "1m"                        // Minimum TTL configuration to pull the org account list
 	orgAccountRetries        = 5
 	orgDefaultAccRegion      = "us-west-2"
 )
+
+// awsAccountIDPattern matches a 12-digit AWS account ID.
+var awsAccountIDPattern = regexp.MustCompile(`^[0-9]{12}$`)
 
 var (
 	orgAccountDefaultListDuration, _ = time.ParseDuration(orgAccountDefaultListTTL)
@@ -32,10 +39,17 @@ var (
 )
 
 type orgValidationConfig struct {
-	AccountID      string `hcl:"management_account_id"`
-	AccountRole    string `hcl:"assume_org_role"`
-	AccountRegion  string `hcl:"management_account_region"`
-	AccountListTTL string `hcl:"org_account_map_ttl"`
+	AccountID       string `hcl:"management_account_id"`
+	AccountRole     string `hcl:"assume_org_role"`
+	AccountRegion   string `hcl:"management_account_region"`
+	AccountListTTL  string `hcl:"org_account_map_ttl"`
+	AccountListFile string `hcl:"account_list_file"`
+}
+
+// useAccountListFile reports whether the org account list should be sourced from
+// a file rather than from the AWS Organizations API.
+func (c *orgValidationConfig) useAccountListFile() bool {
+	return c.AccountListFile != ""
 }
 
 type orgValidator struct {
@@ -204,13 +218,50 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 		return o.orgAccountList, nil
 	}
 
-	// Get the list of accounts
+	// Build new org accounts list, either from a configured file or from the
+	// AWS Organizations API.
+	var orgAccountsMap map[string]any
+	if o.orgConfig.useAccountListFile() {
+		var err error
+		orgAccountsMap, err = parseAccountListFile(o.orgConfig.AccountListFile)
+		if err != nil {
+			return nil, fmt.Errorf("issue while reading org account list file: %w", err)
+		}
+	} else {
+		var err error
+		orgAccountsMap, err = listAccountsFromAPI(ctx, orgClient)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Update timestamp, if it was not invoked as part of cache miss.
+	if !catchBurst {
+		o.orgAccountListValidDuration = o.clk.Now().UTC().Add(o.orgAccountListCacheTTL)
+		// Also reset the retries
+		o.retries = orgAccountRetries
+	}
+
+	// Overwrite the cache/list
+	o.orgAccountList = orgAccountsMap
+
+	return o.orgAccountList, nil
+}
+
+// checkIFTTLIsExpire check if the creation time is pass defined ttl
+func (o *orgValidator) checkIfTTLIsExpired(ttl time.Time) bool {
+	currTimeStamp := o.clk.Now().UTC()
+	return currTimeStamp.After(ttl)
+}
+
+// listAccountsFromAPI pulls the list of ACTIVE accounts belonging to the
+// organization from the AWS Organizations API, handling pagination.
+func listAccountsFromAPI(ctx context.Context, orgClient organizations.ListAccountsAPIClient) (map[string]any, error) {
 	listAccountsOp, err := orgClient.ListAccounts(ctx, &organizations.ListAccountsInput{})
 	if err != nil {
 		return nil, fmt.Errorf("issue while getting list of accounts: %w", err)
 	}
 
-	// Build new org accounts list
 	orgAccountsMap := make(map[string]any)
 
 	// Update the org account list cache with ACTIVE accounts & handle pagination
@@ -234,21 +285,31 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 		}
 	}
 
-	// Update timestamp, if it was not invoked as part of cache miss.
-	if !catchBurst {
-		o.orgAccountListValidDuration = o.clk.Now().UTC().Add(o.orgAccountListCacheTTL)
-		// Also reset the retries
-		o.retries = orgAccountRetries
-	}
-
-	// Overwrite the cache/list
-	o.orgAccountList = orgAccountsMap
-
-	return o.orgAccountList, nil
+	return orgAccountsMap, nil
 }
 
-// checkIFTTLIsExpire check if the creation time is pass defined ttl
-func (o *orgValidator) checkIfTTLIsExpired(ttl time.Time) bool {
-	currTimeStamp := o.clk.Now().UTC()
-	return currTimeStamp.After(ttl)
+// parseAccountListFile reads a JSON array of 12-digit AWS account IDs from the
+// given path and returns them as a lookup map matching the shape produced by the
+// AWS Organizations API path. The operator is responsible for populating the
+// file with only eligible (e.g. ACTIVE) accounts.
+func parseAccountListFile(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read account list file: %w", err)
+	}
+
+	var accountIDs []string
+	if err := json.Unmarshal(data, &accountIDs); err != nil {
+		return nil, fmt.Errorf("unable to parse account list file, expected a JSON array of account IDs: %w", err)
+	}
+
+	orgAccountsMap := make(map[string]any, len(accountIDs))
+	for _, accID := range accountIDs {
+		if !awsAccountIDPattern.MatchString(accID) {
+			return nil, fmt.Errorf("invalid account id %q in account list file, expected a 12-digit AWS account id", accID)
+		}
+		orgAccountsMap[accID] = struct{}{}
+	}
+
+	return orgAccountsMap, nil
 }

--- a/pkg/server/plugin/nodeattestor/awsiid/organization.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization.go
@@ -228,7 +228,7 @@ func (o *orgValidator) reloadAccountList(ctx context.Context, orgClient organiza
 		var err error
 		orgAccountsMap, err = parseAccountListFile(o.orgConfig.AccountListFile)
 		if err != nil {
-			return nil, fmt.Errorf("issue while reading org account list file: %w", err)
+			return nil, fmt.Errorf("failed to load org account list: %w", err)
 		}
 		if len(orgAccountsMap) == 0 {
 			o.log.Warn("org account list file is empty; all accounts will fail organization validation", "account_list_file", o.orgConfig.AccountListFile)
@@ -306,13 +306,13 @@ func parseAccountListFile(path string) (map[string]any, error) {
 
 	var accountIDs []string
 	if err := json.Unmarshal(data, &accountIDs); err != nil {
-		return nil, fmt.Errorf("unable to parse account list file, expected a JSON array of account IDs: %w", err)
+		return nil, fmt.Errorf("unable to parse account list file %q, expected a JSON array of account IDs: %w", path, err)
 	}
 
 	orgAccountsMap := make(map[string]any, len(accountIDs))
 	for _, accID := range accountIDs {
 		if !awsAccountIDPattern.MatchString(accID) {
-			return nil, fmt.Errorf("invalid account id %q in account list file, expected a 12-digit AWS account id", accID)
+			return nil, fmt.Errorf("invalid account id %q in account list file %q, expected a 12-digit AWS account id", accID, path)
 		}
 		orgAccountsMap[accID] = struct{}{}
 	}

--- a/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
@@ -222,7 +222,7 @@ func TestReloadAccountListFromFile(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte(`not json`), 0o600))
 	testOrgValidator.clk = buildNewMockClock(2*time.Minute, testClockMutAfter)
 	_, err = testOrgValidator.reloadAccountList(context.Background(), nil, false)
-	require.ErrorContains(t, err, "issue while reading org account list file")
+	require.ErrorContains(t, err, "failed to load org account list")
 }
 
 func TestIsMemberAccountFromFile(t *testing.T) {

--- a/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
@@ -2,6 +2,8 @@ package awsiid
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +17,9 @@ const (
 	testAccountListTTL = "1m"
 	testClockMutAfter  = "after"
 	testClockMutBefore = "before"
+
+	testFileAccountID      = "111111111111"
+	testFileAccountIDOther = "222222222222"
 )
 
 func TestIsMemberAccount(t *testing.T) {
@@ -125,6 +130,112 @@ func buildOrgValidationClient() *orgValidator {
 	testOrgValidator := newOrganizationValidationBase(testOrgValidationConfig)
 	_ = testOrgValidator.configure(testOrgValidationConfig)
 	return testOrgValidator
+}
+
+func buildOrgValidationClientFromFile(path string) *orgValidator {
+	testOrgValidationConfig := &orgValidationConfig{
+		AccountListFile: path,
+		AccountListTTL:  testAccountListTTL,
+	}
+	testOrgValidator := newOrganizationValidationBase(testOrgValidationConfig)
+	_ = testOrgValidator.configure(testOrgValidationConfig)
+	return testOrgValidator
+}
+
+// writeAccountListFile writes content to a temp file and returns its path.
+func writeAccountListFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "org-accounts.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestParseAccountListFile(t *testing.T) {
+	// valid file
+	path := writeAccountListFile(t, `["111111111111", "222222222222"]`)
+	accounts, err := parseAccountListFile(path)
+	require.NoError(t, err)
+	require.Len(t, accounts, 2)
+	require.Contains(t, accounts, testFileAccountID)
+	require.Contains(t, accounts, testFileAccountIDOther)
+
+	// missing file
+	_, err = parseAccountListFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.ErrorContains(t, err, "unable to read account list file")
+
+	// malformed JSON
+	path = writeAccountListFile(t, `{"not": "an array"}`)
+	_, err = parseAccountListFile(path)
+	require.ErrorContains(t, err, "unable to parse account list file")
+
+	// invalid account id (not 12 digits)
+	path = writeAccountListFile(t, `["123"]`)
+	_, err = parseAccountListFile(path)
+	require.ErrorContains(t, err, "invalid account id")
+
+	// invalid account id (non-numeric)
+	path = writeAccountListFile(t, `["abcdefghijkl"]`)
+	_, err = parseAccountListFile(path)
+	require.ErrorContains(t, err, "invalid account id")
+
+	// empty array is valid
+	path = writeAccountListFile(t, `[]`)
+	accounts, err = parseAccountListFile(path)
+	require.NoError(t, err)
+	require.Empty(t, accounts)
+}
+
+func TestReloadAccountListFromFile(t *testing.T) {
+	path := writeAccountListFile(t, `["111111111111", "222222222222"]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	// account list is sourced from the file; no AWS client is needed (nil)
+	_, err := testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Len(t, testOrgValidator.orgAccountList, 2)
+	require.Greater(t, testOrgValidator.orgAccountListValidDuration, time.Now())
+	require.Equal(t, testOrgValidator.retries, orgAccountRetries)
+
+	// a malformed file surfaces an error on reload once the cache is stale
+	require.NoError(t, os.WriteFile(path, []byte(`not json`), 0o600))
+	testOrgValidator.clk = buildNewMockClock(2*time.Minute, testClockMutAfter)
+	_, err = testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.ErrorContains(t, err, "issue while reading org account list file")
+}
+
+func TestIsMemberAccountFromFile(t *testing.T) {
+	path := writeAccountListFile(t, `["111111111111", "222222222222"]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	// member account passes
+	ok, err := testOrgValidator.IsMemberAccount(context.Background(), nil, testFileAccountID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// non-member account fails
+	ok, err = testOrgValidator.IsMemberAccount(context.Background(), nil, "999999999999")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestReloadAccountListFromFileTTL(t *testing.T) {
+	path := writeAccountListFile(t, `["111111111111"]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	_, err := testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Len(t, testOrgValidator.orgAccountList, 1)
+	require.Contains(t, testOrgValidator.orgAccountList, testFileAccountID)
+
+	// rewrite the file with a new account, then advance the clock past the TTL
+	require.NoError(t, os.WriteFile(path, []byte(`["222222222222"]`), 0o600))
+	testOrgValidator.clk = buildNewMockClock(10*time.Minute, testClockMutAfter)
+
+	_, err = testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Len(t, testOrgValidator.orgAccountList, 1)
+	require.Contains(t, testOrgValidator.orgAccountList, testFileAccountIDOther)
+	require.NotContains(t, testOrgValidator.orgAccountList, testFileAccountID)
 }
 
 func buildNewMockClock(t time.Duration, mut string) *clock.Mock {

--- a/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
@@ -298,6 +298,32 @@ func TestReloadAccountListFromEmptyFile(t *testing.T) {
 	require.False(t, ok)
 }
 
+// TestEmptyFileCachesProperly verifies that an empty account list file is
+// cached for the full TTL and not re-read on every attestation.
+func TestEmptyFileCachesProperly(t *testing.T) {
+	path := writeAccountListFile(t, `[]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	// First load seeds the cache.
+	_, err := testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Empty(t, testOrgValidator.orgAccountList)
+	require.False(t, testOrgValidator.orgAccountListValidDuration.IsZero())
+
+	// Rewrite the file with a different account. Within TTL direct reload
+	// calls with !catchBurst should short-circuit and NOT re-read.
+	require.NoError(t, os.WriteFile(path, []byte(`["111111111111"]`), 0o600))
+	_, err = testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Empty(t, testOrgValidator.orgAccountList, "empty list should be cached, not re-read within TTL")
+
+	// Advance past TTL: should re-read and pick up the new account.
+	testOrgValidator.clk = buildNewMockClock(2*time.Minute, testClockMutAfter)
+	accounts, err := testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Contains(t, accounts, testFileAccountID)
+}
+
 func buildNewMockClock(t time.Duration, mut string) *clock.Mock {
 	testClock := clock.NewMock()
 	switch mut := mut; mut {

--- a/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/organization_test.go
@@ -183,6 +183,28 @@ func TestParseAccountListFile(t *testing.T) {
 	accounts, err = parseAccountListFile(path)
 	require.NoError(t, err)
 	require.Empty(t, accounts)
+
+	// JSON null unmarshals to a nil slice and is treated as an empty list
+	path = writeAccountListFile(t, `null`)
+	accounts, err = parseAccountListFile(path)
+	require.NoError(t, err)
+	require.Empty(t, accounts)
+
+	// duplicate ids collapse to a single map entry
+	path = writeAccountListFile(t, `["111111111111", "111111111111"]`)
+	accounts, err = parseAccountListFile(path)
+	require.NoError(t, err)
+	require.Len(t, accounts, 1)
+
+	// whitespace-padded id is rejected (the pattern is anchored, no trimming)
+	path = writeAccountListFile(t, `[" 111111111111"]`)
+	_, err = parseAccountListFile(path)
+	require.ErrorContains(t, err, "invalid account id")
+
+	// overlong id (13 digits) is rejected (anchored on both ends)
+	path = writeAccountListFile(t, `["1111111111111"]`)
+	_, err = parseAccountListFile(path)
+	require.ErrorContains(t, err, "invalid account id")
 }
 
 func TestReloadAccountListFromFile(t *testing.T) {
@@ -194,7 +216,7 @@ func TestReloadAccountListFromFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, testOrgValidator.orgAccountList, 2)
 	require.Greater(t, testOrgValidator.orgAccountListValidDuration, time.Now())
-	require.Equal(t, testOrgValidator.retries, orgAccountRetries)
+	require.Equal(t, orgAccountRetries, testOrgValidator.retries)
 
 	// a malformed file surfaces an error on reload once the cache is stale
 	require.NoError(t, os.WriteFile(path, []byte(`not json`), 0o600))
@@ -236,6 +258,44 @@ func TestReloadAccountListFromFileTTL(t *testing.T) {
 	require.Len(t, testOrgValidator.orgAccountList, 1)
 	require.Contains(t, testOrgValidator.orgAccountList, testFileAccountIDOther)
 	require.NotContains(t, testOrgValidator.orgAccountList, testFileAccountID)
+}
+
+// TestIsMemberAccountFromFileFailsClosedOnBadReload exercises the path Attest
+// actually uses (IsMemberAccount -> validateCache), proving that a file that
+// becomes malformed after a good load causes a hard error rather than a silent
+// "not a member" result.
+func TestIsMemberAccountFromFileFailsClosedOnBadReload(t *testing.T) {
+	path := writeAccountListFile(t, `["111111111111"]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	// seed a good cache through the same entrypoint Attest uses
+	ok, err := testOrgValidator.IsMemberAccount(context.Background(), nil, testFileAccountID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// the file goes bad after startup; advance past the TTL so the cache is stale
+	require.NoError(t, os.WriteFile(path, []byte(`not json`), 0o600))
+	testOrgValidator.clk = buildNewMockClock(2*time.Minute, testClockMutAfter)
+
+	// must fail closed with an error, not silently return (false, nil)
+	ok, err = testOrgValidator.IsMemberAccount(context.Background(), nil, testFileAccountID)
+	require.Error(t, err)
+	require.False(t, ok)
+}
+
+// TestReloadAccountListFromEmptyFile confirms an empty list is accepted (the
+// warn path does not panic) and yields no members.
+func TestReloadAccountListFromEmptyFile(t *testing.T) {
+	path := writeAccountListFile(t, `[]`)
+	testOrgValidator := buildOrgValidationClientFromFile(path)
+
+	_, err := testOrgValidator.reloadAccountList(context.Background(), nil, false)
+	require.NoError(t, err)
+	require.Empty(t, testOrgValidator.orgAccountList)
+
+	ok, err := testOrgValidator.IsMemberAccount(context.Background(), nil, testFileAccountID)
+	require.NoError(t, err)
+	require.False(t, ok)
 }
 
 func buildNewMockClock(t time.Duration, mut string) *clock.Mock {


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

The `aws_iid` server node attestor's `verify_organization` feature, specifically how it sources the organization account list.

**Description of change**

Adds an optional `account_list_file` to the `verify_organization` block. When set, the plugin reads the organization's account allow-list from a local JSON file (an array of 12-digit account IDs) instead of calling the AWS Organizations `ListAccounts` API. This avoids `ListAccounts` throttling for large organizations and multi-replica deployments, where each replica otherwise polls the shared management-account API.

Behavior:

- `account_list_file` is mutually exclusive with `management_account_id` and `assume_org_role`; existing API-based configuration is unchanged.
- The file is validated at configuration time (the server fails to start if it is missing or malformed) and re-read when the cached list is older than `org_account_map_ttl`.
- Validation is fail-closed: an empty, unreadable, or malformed file causes affected accounts to fail attestation rather than be allowed.
- No `organizations:ListAccounts` IAM permission is required in this mode.

**Which issue this PR fixes**

fixes #7079
