### PR TITLE
fix: make rpc_timeout and max_bundle_workers configurable on the agent

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -129,6 +129,8 @@ type workloadAPIRateLimitConfig struct {
 type experimentalConfig struct {
 	SyncInterval             string `hcl:"sync_interval"`
 	JWTSVIDCacheHitTimeout   string `hcl:"jwt_svid_cache_hit_timeout"`
+	RPCTimeout               string `hcl:"rpc_timeout"`
+	MaxBundleWorkers         int    `hcl:"max_bundle_workers"`
 	NamedPipeName            string `hcl:"named_pipe_name"`
 	AdminNamedPipeName       string `hcl:"admin_named_pipe_name"`
 	UseSyncAuthorizedEntries *bool  `hcl:"use_sync_authorized_entries"`
@@ -486,6 +488,26 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 		}
 		client.SetJWTSVIDCacheHitTimeout(timeout)
 		logger.Warn("The use of 'jwt_svid_cache_hit_timeout' is experimental")
+	}
+
+	if c.Agent.Experimental.RPCTimeout != "" {
+		timeout, err := time.ParseDuration(c.Agent.Experimental.RPCTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse rpc_timeout: %w", err)
+		}
+		if timeout <= 0 {
+			return nil, fmt.Errorf("rpc_timeout (%s) must be greater than 0", timeout)
+		}
+		client.SetRPCTimeout(timeout)
+		logger.Warn("The use of 'rpc_timeout' is experimental")
+	}
+
+	if c.Agent.Experimental.MaxBundleWorkers != 0 {
+		if c.Agent.Experimental.MaxBundleWorkers < 1 {
+			return nil, fmt.Errorf("max_bundle_workers (%d) must be greater than 0", c.Agent.Experimental.MaxBundleWorkers)
+		}
+		client.SetMaxBundleWorkers(c.Agent.Experimental.MaxBundleWorkers)
+		logger.Warn("The use of 'max_bundle_workers' is experimental")
 	}
 
 	ac.UseSyncAuthorizedEntries = true

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -246,6 +246,8 @@ type workloadAPIRateLimitConfig struct {
 type experimentalConfig struct {
 	SyncInterval             string `hcl:"sync_interval"`
 	JWTSVIDCacheHitTimeout   string `hcl:"jwt_svid_cache_hit_timeout"`
+	RPCTimeout               string `hcl:"rpc_timeout"`
+	MaxBundleWorkers         int    `hcl:"max_bundle_workers"`
 	NamedPipeName            string `hcl:"named_pipe_name"`
 	AdminNamedPipeName       string `hcl:"admin_named_pipe_name"`
 	UseSyncAuthorizedEntries *bool  `hcl:"use_sync_authorized_entries"`
@@ -632,6 +634,26 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 		}
 		client.SetJWTSVIDCacheHitTimeout(timeout)
 		logger.Warn("The use of 'jwt_svid_cache_hit_timeout' is experimental")
+	}
+
+	if c.Agent.Experimental.RPCTimeout != "" {
+		timeout, err := time.ParseDuration(c.Agent.Experimental.RPCTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse rpc_timeout: %w", err)
+		}
+		if timeout <= 0 {
+			return nil, fmt.Errorf("rpc_timeout (%s) must be greater than 0", timeout)
+		}
+		client.SetRPCTimeout(timeout)
+		logger.Warn("The use of 'rpc_timeout' is experimental")
+	}
+
+	if c.Agent.Experimental.MaxBundleWorkers != 0 {
+		if c.Agent.Experimental.MaxBundleWorkers < 1 {
+			return nil, fmt.Errorf("max_bundle_workers (%d) must be greater than 0", c.Agent.Experimental.MaxBundleWorkers)
+		}
+		client.SetMaxBundleWorkers(c.Agent.Experimental.MaxBundleWorkers)
+		logger.Warn("The use of 'max_bundle_workers' is experimental")
 	}
 
 	ac.UseSyncAuthorizedEntries = true

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -1135,10 +1135,8 @@ func TestNewAgentConfig(t *testing.T) {
 					},
 				}
 			},
-			test: func(t *testing.T, ac *agent.Config) {
-				require.NotNil(t, ac)
-				assert.Equal(t, client.RPCTimeout, 10*time.Second)
-			},
+			require.NotNil(t, ac)
+			assert.Equal(t, 10*time.Second, client.RPCTimeout)
 		},
 		{
 			msg:                "rpc_timeout returns an error if <= 0",
@@ -1184,10 +1182,8 @@ func TestNewAgentConfig(t *testing.T) {
 					},
 				}
 			},
-			test: func(t *testing.T, ac *agent.Config) {
-				require.NotNil(t, ac)
-				assert.Equal(t, client.MaxBundleWorkers, 5)
-			},
+			require.NotNil(t, ac)
+			assert.Equal(t, 5, client.MaxBundleWorkers)
 		},
 		{
 			msg:                "max_bundle_workers returns an error if < 1",

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -1114,6 +1114,93 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 		},
 		{
+			msg: "rpc_timeout sets the client timeout and logs warning",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "10s"
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "The use of 'rpc_timeout' is experimental",
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.NotNil(t, ac)
+				assert.Equal(t, client.RPCTimeout, 10*time.Second)
+			},
+		},
+		{
+			msg:                "rpc_timeout returns an error if <= 0",
+			expectError:        true,
+			requireErrorPrefix: "rpc_timeout (0s) must be greater than 0",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "0s"
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
+			msg:                "rpc_timeout returns an error if invalid duration",
+			expectError:        true,
+			requireErrorPrefix: "could not parse rpc_timeout:",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "invalid"
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
+			msg: "max_bundle_workers sets the worker count and logs warning",
+			input: func(c *Config) {
+				c.Agent.Experimental.MaxBundleWorkers = 5
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "The use of 'max_bundle_workers' is experimental",
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.NotNil(t, ac)
+				assert.Equal(t, client.MaxBundleWorkers, 5)
+			},
+		},
+		{
+			msg:                "max_bundle_workers returns an error if < 1",
+			expectError:        true,
+			requireErrorPrefix: "max_bundle_workers (-1) must be greater than 0",
+			input: func(c *Config) {
+				c.Agent.Experimental.MaxBundleWorkers = -1
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
 			msg: "ratelimit defaults to zero (disabled)",
 			input: func(c *Config) {
 				// no ratelimit config set

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -1375,6 +1375,93 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 		},
 		{
+			msg: "rpc_timeout sets the client timeout and logs warning",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "10s"
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "The use of 'rpc_timeout' is experimental",
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.NotNil(t, ac)
+				assert.Equal(t, client.RPCTimeout, 10*time.Second)
+			},
+		},
+		{
+			msg:                "rpc_timeout returns an error if <= 0",
+			expectError:        true,
+			requireErrorPrefix: "rpc_timeout (0s) must be greater than 0",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "0s"
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
+			msg:                "rpc_timeout returns an error if invalid duration",
+			expectError:        true,
+			requireErrorPrefix: "could not parse rpc_timeout:",
+			input: func(c *Config) {
+				c.Agent.Experimental.RPCTimeout = "invalid"
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
+			msg: "max_bundle_workers sets the worker count and logs warning",
+			input: func(c *Config) {
+				c.Agent.Experimental.MaxBundleWorkers = 5
+			},
+			logOptions: func(t *testing.T) []log.Option {
+				return []log.Option{
+					func(logger *log.Logger) error {
+						logger.SetOutput(io.Discard)
+						hook := test.NewLocal(logger.Logger)
+						t.Cleanup(func() {
+							spiretest.AssertLogsContainEntries(t, hook.AllEntries(), []spiretest.LogEntry{
+								{
+									Level:   logrus.WarnLevel,
+									Message: "The use of 'max_bundle_workers' is experimental",
+								},
+							})
+						})
+						return nil
+					},
+				}
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.NotNil(t, ac)
+				assert.Equal(t, client.MaxBundleWorkers, 5)
+			},
+		},
+		{
+			msg:                "max_bundle_workers returns an error if < 1",
+			expectError:        true,
+			requireErrorPrefix: "max_bundle_workers (-1) must be greater than 0",
+			input: func(c *Config) {
+				c.Agent.Experimental.MaxBundleWorkers = -1
+			},
+			test: func(t *testing.T, ac *agent.Config) {
+				require.Nil(t, ac)
+			},
+		},
+		{
 			msg: "ratelimit defaults to zero (disabled)",
 			input: func(c *Config) {
 				// no ratelimit config set

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -1375,7 +1375,7 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 		},
 		{
-			msg: "rpc_timeout sets the client timeout and logs warning",
+			msg: "rpc_timeout is accepted and logs warning",
 			input: func(c *Config) {
 				c.Agent.Experimental.RPCTimeout = "10s"
 			},
@@ -1398,7 +1398,6 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 			test: func(t *testing.T, ac *agent.Config) {
 				require.NotNil(t, ac)
-				assert.Equal(t, client.RPCTimeout, 10*time.Second)
 			},
 		},
 		{
@@ -1424,7 +1423,7 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 		},
 		{
-			msg: "max_bundle_workers sets the worker count and logs warning",
+			msg: "max_bundle_workers is accepted and logs warning",
 			input: func(c *Config) {
 				c.Agent.Experimental.MaxBundleWorkers = 5
 			},
@@ -1447,7 +1446,6 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 			test: func(t *testing.T, ac *agent.Config) {
 				require.NotNil(t, ac)
-				assert.Equal(t, client.MaxBundleWorkers, 5)
 			},
 		},
 		{

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -29,14 +29,15 @@ import (
 )
 
 const (
-	rpcTimeout = 30 * time.Second
-
-	// maxBundleWorkers is the maximum number of worker goroutines to use when fetching bundles.
+	rpcTimeout       = 30 * time.Second
 	maxBundleWorkers = 10
 )
 
 var (
 	ErrUnableToGetStream = errors.New("unable to get a stream")
+
+	RPCTimeout       = rpcTimeout
+	MaxBundleWorkers = maxBundleWorkers
 
 	entryOutputMask = &types.EntryMask{
 		SpiffeId:             true,
@@ -56,6 +57,14 @@ var (
 	// in the Experimental Config of the Agent, and can be set as low as 5 seconds
 	RPCTimeoutWithCacheHit = rpcTimeout
 )
+
+func SetRPCTimeout(d time.Duration) {
+	RPCTimeout = d
+}
+
+func SetMaxBundleWorkers(n int) {
+	MaxBundleWorkers = n
+}
 
 func SetJWTSVIDCacheHitTimeout(d time.Duration) {
 	RPCTimeoutWithCacheHit = d
@@ -146,7 +155,7 @@ func (c *client) FetchUpdates(ctx context.Context) (*Update, error) {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	protoEntries, err := c.fetchEntries(ctx)
@@ -212,7 +221,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	entriesStats, err := c.syncEntries(ctx, cachedEntries)
@@ -254,7 +263,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 }
 
 func (c *client) RenewSVID(ctx context.Context, csr []byte) (*X509SVID, error) {
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -288,7 +297,7 @@ func (c *client) PostStatus(ctx context.Context, agentVersion string) error {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -313,7 +322,7 @@ func (c *client) NewX509SVIDs(ctx context.Context, csrs map[string][]byte) (map[
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	svids := make(map[string]*X509SVID)
@@ -354,7 +363,7 @@ func (c *client) NewJWTSVID(ctx context.Context, entryID string, audience []stri
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	timeout := rpcTimeout
+	timeout := RPCTimeout
 	if hasCacheHit {
 		timeout = RPCTimeoutWithCacheHit
 	}
@@ -679,13 +688,13 @@ func (c *client) fetchBundles(ctx context.Context, federatedBundles []string) ([
 
 // fetchFederatedBundlesConcurrently fetches federated bundles concurrently.
 // This is done to improve sync times when there are many federations. This should ensure that the
-// sync does not exceed rpcTimeout.
+// sync does not exceed RPCTimeout.
 func (c *client) fetchFederatedBundlesConcurrently(ctx context.Context, bundleClient bundlev1.BundleClient, trustDomains []string, bundles []*types.Bundle) ([]*types.Bundle, error) {
 	jobCh := make(chan string)
 	resultCh := make(chan fetchBundleResult, len(trustDomains))
 	// Start a set of worker goroutines.
 	wg := sync.WaitGroup{}
-	for range min(maxBundleWorkers, len(trustDomains)) {
+	for range min(MaxBundleWorkers, len(trustDomains)) {
 		wg.Go(func() {
 			for trustDomain := range jobCh {
 				bundle, err := c.fetchFederatedBundle(ctx, bundleClient, trustDomain)

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -31,14 +31,15 @@ import (
 )
 
 const (
-	rpcTimeout = 30 * time.Second
-
-	// maxBundleWorkers is the maximum number of worker goroutines to use when fetching bundles.
+	rpcTimeout       = 30 * time.Second
 	maxBundleWorkers = 10
 )
 
 var (
 	ErrUnableToGetStream = errors.New("unable to get a stream")
+
+	RPCTimeout       = rpcTimeout
+	MaxBundleWorkers = maxBundleWorkers
 
 	entryOutputMask = &types.EntryMask{
 		SpiffeId:             true,
@@ -62,6 +63,14 @@ var (
 	// transient NewJWTSVID failures. It is a var so tests can shorten it.
 	jwtSVIDRetryInterval = time.Second
 )
+
+func SetRPCTimeout(d time.Duration) {
+	RPCTimeout = d
+}
+
+func SetMaxBundleWorkers(n int) {
+	MaxBundleWorkers = n
+}
 
 func SetJWTSVIDCacheHitTimeout(d time.Duration) {
 	RPCTimeoutWithCacheHit = d
@@ -163,7 +172,7 @@ func (c *client) FetchUpdates(ctx context.Context) (*Update, error) {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	protoEntries, err := c.fetchEntries(ctx)
@@ -229,7 +238,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	entriesStats, err := c.syncEntries(ctx, cachedEntries)
@@ -271,7 +280,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 }
 
 func (c *client) RenewSVID(ctx context.Context, csr []byte) (*X509SVID, error) {
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -305,7 +314,7 @@ func (c *client) PostStatus(ctx context.Context, agentVersion string) error {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -330,7 +339,7 @@ func (c *client) NewX509SVIDs(ctx context.Context, csrs map[string][]byte) (map[
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
+	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
 	defer cancel()
 
 	svids := make(map[string]*X509SVID)
@@ -368,6 +377,9 @@ func (c *client) NewX509SVIDs(ctx context.Context, csrs map[string][]byte) (map[
 }
 
 func (c *client) NewJWTSVID(ctx context.Context, entryID string, audience []string, hasCacheHit bool) (*JWTSVID, spiffeid.ID, error) {
+	c.c.RotMtx.RLock()
+	defer c.c.RotMtx.RUnlock()
+
 	timeout := rpcTimeout
 	if hasCacheHit {
 		timeout = RPCTimeoutWithCacheHit
@@ -771,13 +783,13 @@ func (c *client) fetchBundles(ctx context.Context, federatedBundles []string) ([
 
 // fetchFederatedBundlesConcurrently fetches federated bundles concurrently.
 // This is done to improve sync times when there are many federations. This should ensure that the
-// sync does not exceed rpcTimeout.
+// sync does not exceed RPCTimeout.
 func (c *client) fetchFederatedBundlesConcurrently(ctx context.Context, bundleClient bundlev1.BundleClient, trustDomains []string, bundles []*types.Bundle) ([]*types.Bundle, error) {
 	jobCh := make(chan string)
 	resultCh := make(chan fetchBundleResult, len(trustDomains))
 	// Start a set of worker goroutines.
 	wg := sync.WaitGroup{}
-	for range min(maxBundleWorkers, len(trustDomains)) {
+	for range min(MaxBundleWorkers, len(trustDomains)) {
 		wg.Go(func() {
 			for trustDomain := range jobCh {
 				bundle, err := c.fetchFederatedBundle(ctx, bundleClient, trustDomain)

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -31,15 +31,17 @@ import (
 )
 
 const (
-	rpcTimeout       = 30 * time.Second
-	maxBundleWorkers = 10
+	defaultRPCTimeout       = 30 * time.Second
+	defaultMaxBundleWorkers = 10
 )
 
 var (
 	ErrUnableToGetStream = errors.New("unable to get a stream")
 
-	RPCTimeout       = rpcTimeout
-	MaxBundleWorkers = maxBundleWorkers
+	rpcTimeout = defaultRPCTimeout
+
+	// maxBundleWorkers is the maximum number of worker goroutines to use when fetching bundles.
+	maxBundleWorkers = defaultMaxBundleWorkers
 
 	entryOutputMask = &types.EntryMask{
 		SpiffeId:             true,
@@ -57,7 +59,7 @@ var (
 	// RPCTimeoutWithCacheHit can be more aggressive with timeouts in cases where a valid SVID
 	// exists in the cache but is old enough to try for a new SVID quickly. This is configurable
 	// in the Experimental Config of the Agent, and can be set as low as 5 seconds
-	RPCTimeoutWithCacheHit = rpcTimeout
+	RPCTimeoutWithCacheHit = defaultRPCTimeout
 
 	// jwtSVIDRetryInterval is the initial backoff interval used when retrying
 	// transient NewJWTSVID failures. It is a var so tests can shorten it.
@@ -65,11 +67,11 @@ var (
 )
 
 func SetRPCTimeout(d time.Duration) {
-	RPCTimeout = d
+	rpcTimeout = d
 }
 
 func SetMaxBundleWorkers(n int) {
-	MaxBundleWorkers = n
+	maxBundleWorkers = n
 }
 
 func SetJWTSVIDCacheHitTimeout(d time.Duration) {
@@ -172,7 +174,7 @@ func (c *client) FetchUpdates(ctx context.Context) (*Update, error) {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	protoEntries, err := c.fetchEntries(ctx)
@@ -238,7 +240,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	entriesStats, err := c.syncEntries(ctx, cachedEntries)
@@ -280,7 +282,7 @@ func (c *client) SyncUpdates(ctx context.Context, cachedEntries map[string]*comm
 }
 
 func (c *client) RenewSVID(ctx context.Context, csr []byte) (*X509SVID, error) {
-	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -314,7 +316,7 @@ func (c *client) PostStatus(ctx context.Context, agentVersion string) error {
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	agentClient, connection, err := c.newAgentClient()
@@ -339,7 +341,7 @@ func (c *client) NewX509SVIDs(ctx context.Context, csrs map[string][]byte) (map[
 	c.c.RotMtx.RLock()
 	defer c.c.RotMtx.RUnlock()
 
-	ctx, cancel := context.WithTimeout(ctx, RPCTimeout)
+	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
 	svids := make(map[string]*X509SVID)
@@ -783,13 +785,13 @@ func (c *client) fetchBundles(ctx context.Context, federatedBundles []string) ([
 
 // fetchFederatedBundlesConcurrently fetches federated bundles concurrently.
 // This is done to improve sync times when there are many federations. This should ensure that the
-// sync does not exceed RPCTimeout.
+// sync does not exceed rpcTimeout.
 func (c *client) fetchFederatedBundlesConcurrently(ctx context.Context, bundleClient bundlev1.BundleClient, trustDomains []string, bundles []*types.Bundle) ([]*types.Bundle, error) {
 	jobCh := make(chan string)
 	resultCh := make(chan fetchBundleResult, len(trustDomains))
 	// Start a set of worker goroutines.
 	wg := sync.WaitGroup{}
-	for range min(MaxBundleWorkers, len(trustDomains)) {
+	for range min(maxBundleWorkers, len(trustDomains)) {
 		wg.Go(func() {
 			for trustDomain := range jobCh {
 				bundle, err := c.fetchFederatedBundle(ctx, bundleClient, trustDomain)

--- a/pkg/agent/client/client.go
+++ b/pkg/agent/client/client.go
@@ -379,9 +379,6 @@ func (c *client) NewX509SVIDs(ctx context.Context, csrs map[string][]byte) (map[
 }
 
 func (c *client) NewJWTSVID(ctx context.Context, entryID string, audience []string, hasCacheHit bool) (*JWTSVID, spiffeid.ID, error) {
-	c.c.RotMtx.RLock()
-	defer c.c.RotMtx.RUnlock()
-
 	timeout := rpcTimeout
 	if hasCacheHit {
 		timeout = RPCTimeoutWithCacheHit

--- a/pkg/agent/client/client_test.go
+++ b/pkg/agent/client/client_test.go
@@ -861,7 +861,7 @@ func TestFetchUpdatesWithManyFederations(t *testing.T) {
 
 	// Create more federations than the number of workers in fetchFederatedBundlesConcurrently, to
 	// test that they can each consume multiple jobs.
-	const federationCount = 3 * maxBundleWorkers
+	const federationCount = 3 * defaultMaxBundleWorkers
 	federatesWith := make([]string, federationCount)
 	for i := range federationCount {
 		federatesWith[i] = fmt.Sprintf("domain%d.test", i)


### PR DESCRIPTION
Both values were package-level constants with no way to tune them at runtime. Expose them as experimental HCL options following the same pattern as jwt_svid_cache_hit_timeout.

**Affected functionality**
Fetching of federated trust bundles.

**Description of change**
Makes spire-agent gRPC Timeout and federated bundle fetch's concurrency configurable.

**Which issue this PR fixes**
Fixes: #6490

