### PR TITLE
Document the ball-in-court review process in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,19 @@ https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md
 
 2. Please remember to include a DCO on every commit (`git commit -s`)
 https://github.com/apps/dco
+
+3. How the review process works ("ball in court"):
+   - When you open this PR (or mark it ready for review), a maintainer is
+     automatically assigned to it. The assignee shows whose turn it is to act
+     next, so you can always see who currently holds the ball.
+   - Pushing new commits does not automatically reassign the PR to the
+     maintainer. Once you are done addressing comments, re-request a review
+     from the assigned maintainer (the "Reviewers" section of the PR has a
+     refresh icon next to their name). This puts the ball back in their court
+     so they know it is ready for another look.
+   - Please also look at any comments from Copilot and address them if needed.
+     Posting a short reply to each one helps reviewers see whether it has been
+     addressed or consciously considered, even when no code change is needed.
 -->
 
 **Pull Request check list**


### PR DESCRIPTION
The pull request template does not explain how the review process works, so contributors do not always know that a maintainer is assigned automatically, or what they need to do to hand the review back after addressing comments.

This PR adds a short note to the template describing the "ball in court" flow driven by the `assign-reviewer` workflow: a maintainer is assigned automatically when a PR is opened or marked ready for review, and the assignee signals whose turn it is to act. It also calls out that pushing new commits does not reassign the PR, so contributors need to re-request a review from the assigned maintainer once they are done addressing comments. Finally, it asks contributors to look at Copilot comments and reply to them, which makes it clear whether each one has been addressed or consciously considered.
