### PR TITLE
Fix data race in spiretest log assertion helper

### DIFF
--- a/test/spiretest/logs.go
+++ b/test/spiretest/logs.go
@@ -61,8 +61,13 @@ func normalizeData(data logrus.Fields) logrus.Fields {
 	if len(data) == 0 {
 		return nil
 	}
+	// Build a new map rather than mutating the caller's. The entries come
+	// from a logrus hook that shares each entry's Data map with logrus
+	// itself, so a background goroutine may still be formatting (reading)
+	// the same map while we normalize it. Mutating in place would race.
+	out := make(logrus.Fields, len(data))
 	for key, field := range data {
-		data[key] = fmt.Sprint(field)
+		out[key] = fmt.Sprint(field)
 	}
-	return data
+	return out
 }


### PR DESCRIPTION
The `normalizeData` helper in `test/spiretest/logs.go` mutated each `logrus.Entry.Data` map in place while normalizing field values for comparison. The entries it normalizes come from a `logrus` test hook, and `Hook.AllEntries()` copies the entry slice and the `Entry` structs but not their `Data` maps, so every returned entry still shares its `Data` map with `logrus`. When a test asserts on captured logs while a background goroutine is still emitting logs, `logrus` reads an entry's `Data` map in its formatter at the same time that `normalizeData` writes to it, which is a data race. I saw this recently in a CI run of the GCP KMS `KeyManager` tests, where the key destruction goroutine keeps logging while `TestGenerateKey` asserts on the captured entries.

This PR makes `normalizeData` build and return a new map instead of mutating the caller's, so both the assertion path and the `logrus` formatter only ever read the shared map. Concurrent reads of a map are safe, so this removes the race at its root in the shared helper, which covers every package that uses the `spiretest.AssertLogs*` helpers rather than fixing it one test at a time.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/28253622343/job/83711146520?pr=7006

```
WARNING: DATA RACE
Write at 0x00c0000fc0f0 by goroutine 1303:
      test/spiretest/logs.go:65
      test/spiretest/logs.go:54
      test/spiretest/logs.go:43
      pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go:1058

Previous read at 0x00c0000fc0f0 by goroutine 1332:
      github.com/sirupsen/logrus/text_formatter.go:135
      github.com/sirupsen/logrus/entry.go:292
      pkg/common/log/hclog_adapter.go:46
      pkg/server/plugin/keymanager/gcpkms/gcpkms.go:937
```
