### PR TITLE
Add force-push guidance to the PR template and reference it from CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,11 @@ https://github.com/apps/dco
      from the assigned maintainer (the "Reviewers" section of the PR has a
      refresh icon next to their name). This puts the ball back in their court
      so they know it is ready for another look.
+   - When addressing review comments, please add new commits rather than
+     force-pushing. Individual commits that address comments are easier to
+     review than a single commit containing all the changes again. Pull
+     requests are squashed at merge time, so there is no need to squash and
+     force-push in the PR.
    - Please also look at any comments from Copilot and address them if needed.
      Posting a short reply to each one helps reviewers see whether it has been
      addressed or consciously considered, even when no code change is needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,15 @@ In addition to the conventions covered in the SPIFFE project's
 [CONTRIBUTING](https://github.com/spiffe/spiffe/blob/main/CONTRIBUTING.md), the following
 conventions apply to the SPIRE repository:
 
+### Pull request review process
+
+When you open a pull request, the description is pre-filled from our
+[pull request template](.github/PULL_REQUEST_TEMPLATE.md?plain=1), which
+explains how our review process works: the rotating "ball in court" assignee,
+re-requesting a review after you address comments, preferring new commits over
+force-pushing, and handling Copilot comments. Please follow the guidance shown
+there when you open and iterate on your PR.
+
 ### SQL Plugin Changes
 
 Datastore changes must be present in at least one full minor release cycle prior to introducing code changes that depend on them.


### PR DESCRIPTION
When addressing review comments, force-pushing over existing commits erases the delta that reviewers rely on to see what changed. This PR adds a note to the pull request template asking contributors to add new commits rather than force-pushing, since individual commits that address comments are easier to review than a single commit containing all the changes again, and pull requests are squashed at merge time anyway.

It also adds a short "Pull request review process" section to CONTRIBUTING.md. The template already explains how the `assign-reviewer` "ball in court" flow works, but that guidance lives in an HTML comment shown when opening a PR and was not referenced from CONTRIBUTING.md, where contributors are most likely to look for process documentation. The new section points to the template so the guidance is discoverable without duplicating it. The link uses `?plain=1` because the guidance is in an HTML comment and would otherwise be hidden in the rendered template file.
