### PR TITLE
Add azure_imds network interface unmarshal regression test

### DIFF
--- a/pkg/server/plugin/nodeattestor/azureimds/client.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/client.go
@@ -175,6 +175,12 @@ func (c *azureClient) getVMSSInfo(ctx context.Context, subscriptionIDs []*string
 }
 
 func (c *azureClient) getNetworkInterfaces(ctx context.Context, vmId string, subscriptionId *string) ([]*NetworkInterface, error) {
+	// Azure Resource Graph lowercases the resourceGroup segment of the id
+	// column on the resources table, but nested property values such as
+	// properties.virtualMachine.id keep their original casing. Compare with
+	// tolower on both sides so a standalone VM whose NIC records a
+	// differently-cased VM id still matches. See:
+	// https://learn.microsoft.com/en-us/azure/governance/resource-graph/concepts/explore-resources
 	query := fmt.Sprintf(`
 	Resources
 	| where type == "microsoft.network/networkinterfaces"

--- a/pkg/server/plugin/nodeattestor/azureimds/client_test.go
+++ b/pkg/server/plugin/nodeattestor/azureimds/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,4 +197,95 @@ func TestBuildVirtualMachineFromVMSSInstanceNoNetworkProfile(t *testing.T) {
 	require.Equal(t, vmID, vm.VMID)
 	require.Equal(t, "rg", vm.ResourceGroup)
 	require.Empty(t, vm.Interfaces)
+}
+
+// TestExtractArmResourceGraphItemsNetworkInterface locks in the shape the
+// standalone-VM NIC query must return. The Resource Graph response must carry
+// securityGroup as an object so it unmarshals into SecurityGroup; a string
+// value (the pre-fix behavior) fails to unmarshal and breaks attestation.
+func TestExtractArmResourceGraphItemsNetworkInterface(t *testing.T) {
+	tests := []struct {
+		name        string
+		totalRecord int64
+		data        any
+		expected    []*NetworkInterface
+		expectErr   string
+	}{
+		{
+			name:        "security group as object unmarshals",
+			totalRecord: 1,
+			data: []any{
+				map[string]any{
+					"name":          "nic-1",
+					"resourceGroup": "rg-1",
+					"securityGroup": map[string]any{
+						"resourceGroup": "nsg-rg",
+						"name":          "nsg-1",
+					},
+					"subnets": []any{
+						map[string]any{"vnet": "vnet-1", "name": "subnet-1"},
+					},
+				},
+			},
+			expected: []*NetworkInterface{
+				{
+					Name:          "nic-1",
+					SecurityGroup: SecurityGroup{ResourceGroup: "nsg-rg", Name: "nsg-1"},
+					Subnets:       []Subnet{{VNet: "vnet-1", SubnetName: "subnet-1"}},
+				},
+			},
+		},
+		{
+			name:        "empty security group object unmarshals",
+			totalRecord: 1,
+			data: []any{
+				map[string]any{
+					"name":          "nic-1",
+					"resourceGroup": "rg-1",
+					"securityGroup": map[string]any{"resourceGroup": "", "name": ""},
+				},
+			},
+			expected: []*NetworkInterface{
+				{Name: "nic-1", SecurityGroup: SecurityGroup{}},
+			},
+		},
+		{
+			name:        "security group as string fails to unmarshal",
+			totalRecord: 1,
+			data: []any{
+				map[string]any{
+					"name":          "nic-1",
+					"resourceGroup": "rg-1",
+					"securityGroup": `{"resourceGroup":"nsg-rg","name":"nsg-1"}`,
+				},
+			},
+			expectErr: "unable to unmarshal item",
+		},
+		{
+			name:        "no records returns not found",
+			totalRecord: 0,
+			data:        []any{},
+			expectErr:   "resource not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := armresourcegraph.ClientResourcesResponse{
+				QueryResponse: armresourcegraph.QueryResponse{
+					TotalRecords: &tc.totalRecord,
+					Data:         tc.data,
+				},
+			}
+
+			items, err := extractArmResourceGraphItems[NetworkInterface](resp)
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				require.Nil(t, items)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, items)
+		})
+	}
 }


### PR DESCRIPTION
Follow-up to #6807, which fixed azure_imds node attestation for standalone VMs. That change corrected the standalone-VM network interface query so securityGroup returns as an object rather than a string, but nothing in the suite exercised the Resource Graph response to struct unmarshal path where the bug lived, since the fake mocks at the apiClient interface and returns pre-built structs.

This adds a regression test over extractArmResourceGraphItems[NetworkInterface] that locks in the object shape the unmarshaler expects, including the empty security group case, and pins that a string value fails to unmarshal. It also adds a comment recording why the VM id match is case-insensitive, since Azure Resource Graph lowercases the resourceGroup segment of the id column on the resources table while nested property values such as properties.virtualMachine.id keep their original casing.

Fixes nothing on its own; it hardens coverage and documents the casing behavior discussed on #6807.