### PR TITLE
Fix flaky fetch-jwt-svids integration test by waiting for the restarted server

### DIFF
--- a/test/integration/common
+++ b/test/integration/common
@@ -144,6 +144,37 @@ check-server-started() {
   fail-now "timed out waiting for server to start"
 }
 
+# Counts how many times the server has logged that it started its APIs. The
+# server emits the "Starting Server APIs" line twice per boot (TCP and UDS
+# listeners).
+count-server-api-starts() {
+  # grep -c exits non-zero when there are no matches, which would trip the
+  # step's errexit/pipefail, so swallow that into a zero count.
+  docker compose logs "$1" | grep -c "Starting Server APIs" || true
+}
+
+# Like check-server-started but safe to use after "docker compose restart".
+# A restart reuses the same container, so its log still contains the
+# "Starting Server APIs" markers from the pre-restart boot. Callers capture the
+# marker count before restarting and pass it here so we wait for the restarted
+# server to emit its own two markers rather than returning on the stale ones.
+wait-for-server-restarted() {
+  local container="$1"
+  local baseline="$2"
+  local want=$((baseline + 2))
+  MAXCHECKS=30
+  CHECKINTERVAL=1
+  for ((i=1;i<=MAXCHECKS;i++)); do
+      log-info "checking for restarted server APIs ($i of $MAXCHECKS max)..."
+      if [ "$(count-server-api-starts "$container")" -ge "$want" ]; then
+          return 0
+      fi
+      sleep "${CHECKINTERVAL}"
+  done
+
+  fail-now "timed out waiting for server to restart"
+}
+
 check-log-line() {
   # Check at most 30 times (with one second in between) that the agent has
   # successfully synced down the workload entry.

--- a/test/integration/common
+++ b/test/integration/common
@@ -148,9 +148,12 @@ check-server-started() {
 # server emits the "Starting Server APIs" line twice per boot (TCP and UDS
 # listeners).
 count-server-api-starts() {
-  # grep -c exits non-zero when there are no matches, which would trip the
-  # step's errexit/pipefail, so swallow that into a zero count.
-  docker compose logs "$1" | grep -c "Starting Server APIs" || true
+  # Capture the logs first so a "docker compose logs" failure still surfaces
+  # under errexit/pipefail. Only grep's no-match exit code is tolerated, since
+  # zero matches is a valid count.
+  local logs
+  logs=$(docker compose logs "$1")
+  echo "${logs}" | grep -c "Starting Server APIs" || true
 }
 
 # Like check-server-started but safe to use after "docker compose restart".
@@ -173,6 +176,26 @@ wait-for-server-restarted() {
   done
 
   fail-now "timed out waiting for server to restart"
+}
+
+# Restarts the given server containers and waits for each to be ready again.
+# Unlike a fresh start, "docker compose restart" reuses the container and keeps
+# the pre-restart "Starting Server APIs" markers in its log, so the marker count
+# is baselined before the restart and we wait for it to grow afterwards.
+docker-spire-server-restart() {
+  local -a baselines=()
+  local container
+  for container in "$@"; do
+      baselines+=("$(count-server-api-starts "${container}")")
+  done
+
+  docker compose restart "$@"
+
+  local i=0
+  for container in "$@"; do
+      wait-for-server-restarted "${container}" "${baselines[$i]}"
+      i=$((i + 1))
+  done
 }
 
 check-log-line() {

--- a/test/integration/suites/fetch-jwt-svids/08-test-disabled-jwt
+++ b/test/integration/suites/fetch-jwt-svids/08-test-disabled-jwt
@@ -5,13 +5,7 @@ log-info "testing disabled JWT functionality..."
 # Replace with disable_jwt_svids = true configuration
 sed -i.bak "s#disable_jwt_svids = false#disable_jwt_svids = true#g" conf/server/server.conf
 
-# The restart reuses the container, so its log keeps the "Starting Server APIs"
-# markers from the original boot. Capture that count first and wait for the
-# restarted server to emit its own markers, otherwise the readiness check would
-# return on the stale ones before the server is actually listening again.
-baseline=$(count-server-api-starts spire-server)
-docker compose restart spire-server
-wait-for-server-restarted spire-server "$baseline"
+docker-spire-server-restart spire-server
 
 test-jwt-disabled-command() {
     local test_name="$1"

--- a/test/integration/suites/fetch-jwt-svids/08-test-disabled-jwt
+++ b/test/integration/suites/fetch-jwt-svids/08-test-disabled-jwt
@@ -4,23 +4,40 @@ log-info "testing disabled JWT functionality..."
 
 # Replace with disable_jwt_svids = true configuration
 sed -i.bak "s#disable_jwt_svids = false#disable_jwt_svids = true#g" conf/server/server.conf
+
+# The restart reuses the container, so its log keeps the "Starting Server APIs"
+# markers from the original boot. Capture that count first and wait for the
+# restarted server to emit its own markers, otherwise the readiness check would
+# return on the stale ones before the server is actually listening again.
+baseline=$(count-server-api-starts spire-server)
 docker compose restart spire-server
-check-server-started spire-server
+wait-for-server-restarted spire-server "$baseline"
 
 test-jwt-disabled-command() {
     local test_name="$1"
     shift 1
     local command=("$@")
-    
-    if ! ERROR_OUTPUT=$("${command[@]}" 2>&1); then
+
+    # Retry to ride out the brief window right after the restart where the
+    # server (or the agent's connection to it) is not ready yet and the command
+    # fails with a transient transport error instead of the expected JWT
+    # disabled error. The agent JWT fetch reaches the server over its TCP API,
+    # so it is the check most prone to racing the restart.
+    local MAXCHECKS=15
+    local CHECKINTERVAL=1
+    for ((i=1;i<=MAXCHECKS;i++)); do
+        if ERROR_OUTPUT=$("${command[@]}" 2>&1); then
+            fail-now "$test_name should have failed when JWT is disabled"
+        fi
         if echo "$ERROR_OUTPUT" | grep -q "JWT functionality is disabled"; then
             log-info "✓ $test_name correctly failed with JWT disabled error"
-        else
-            fail-now "$test_name expected JWT disabled error, but got: $ERROR_OUTPUT"
+            return 0
         fi
-    else
-        fail-now "$test_name should have failed when JWT is disabled"
-    fi
+        log-info "$test_name not ready yet (attempt $i of $MAXCHECKS): $ERROR_OUTPUT"
+        sleep "${CHECKINTERVAL}"
+    done
+
+    fail-now "$test_name expected JWT disabled error, but got: $ERROR_OUTPUT"
 }
 
 test-jwt-disabled-command "JWT authority prepare" \


### PR DESCRIPTION
The `08-test-disabled-jwt` step of the `fetch-jwt-svids` integration suite restarts the SPIRE server with `disable_jwt_svids = true` and then checks that JWT operations fail with a "JWT functionality is disabled" error. It intermittently fails on the final check, where the agent fetches a JWT-SVID, with a transport error instead:

```
JWT fetch expected JWT disabled error, but got: rpc error: code = Unavailable desc = could not fetch JWT-SVID: failed to fetch JWT SVID: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 172.18.0.2:8081: connect: connection refused"
```

The root cause is that the readiness check after the restart is not restart-safe. `check-server-started` counts occurrences of the `Starting Server APIs` log line and returns once it sees at least two (the TCP and UDS listeners). A `docker compose restart` reuses the same container, so its log still contains the two markers from the original boot in step `01`. The count is already satisfied the instant the check runs, so it returns immediately without waiting for the restarted server to actually be listening again.

The six checks that run `spire-server` commands inside the server container reach the server over its local UDS admin socket, which comes up quickly, so they pass. The final check runs `spire-agent api fetch jwt`, which makes the agent reach the server over its TCP API on port `8081`. During the window where the restarted server (or the agent's connection to it) is not ready yet, that fetch gets a transient `connection refused` instead of the expected disabled error, and the step fails.

This PR makes the step wait for the server that was actually restarted and tolerate the brief post-restart window:

- Adds `count-server-api-starts` and `wait-for-server-restarted` helpers to `test/integration/common`. The step now records the marker count before the restart and waits for it to grow by two, so it waits for the restarted server's own listeners rather than returning on the stale markers.
- Wraps each JWT-disabled check in a retry loop that rides out transient transport errors. A command that succeeds still fails the step immediately (JWT must be disabled), a command that returns the expected disabled error passes, and any other error is retried until the server settles.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/28516261957/job/84530600505?pr=7105
