### PR TITLE
Fix Dependabot Milestone workflow by granting pull-requests: write

### DIFF
--- a/.github/workflows/dependabot_milestone.yml
+++ b/.github/workflows/dependabot_milestone.yml
@@ -6,15 +6,19 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  # A milestone is set on a Dependabot PR, and the write is checked against
+  # the pull-requests scope because the target object is a pull request, even
+  # though it goes through the issues REST endpoint. issues: write is not
+  # enough here.
+  pull-requests: write
 
 jobs:
   assign-milestone:
     name: assign-milestone
     runs-on: ubuntu-22.04
     # Only act on PRs opened by Dependabot. pull_request_target runs in
-    # the base branch context, so GITHUB_TOKEN can write to issues and
-    # pull requests, and the PR branch code never executes here.
+    # the base branch context, so GITHUB_TOKEN can write to pull requests,
+    # and the PR branch code never executes here.
     if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:


### PR DESCRIPTION
The Dependabot Milestone workflow has failed on every Dependabot pull request since it was introduced. The job runs to completion, resolves the target milestone, and then fails on the final step that sets the milestone with `gh: Resource not accessible by integration (HTTP 403)`.

The root cause is the workflow `permissions` block. It granted `contents: read` and `issues: write`, but declaring an explicit block sets every unlisted scope to `none`, including `pull-requests`. Setting a milestone on a Dependabot PR goes through the `PATCH /repos/{repo}/issues/{n}` REST endpoint, but because the target object is a pull request, GitHub checks the write against the pull-requests scope rather than issues, so `issues: write` alone is rejected.

This regressed in #7070, which dropped the old `dependabot_automerge.yml` workflow and moved the milestone logic into the standalone `dependabot_milestone.yml`. The milestone call is unchanged, but the old workflow granted `pull-requests: write` (alongside `contents: write` and `issues: write`), and the new workflow carried over `issues: write` while dropping the `pull-requests: write` scope that the call actually needs.

This is not the Dependabot read-only token restriction. The workflow uses `pull_request_target` with a base ref on `main`, so the run gets a write-capable token and secrets are available, which is why the read API calls earlier in the job succeed.

This PR replaces `issues: write` with `pull-requests: write`. The workflow only ever writes to a Dependabot pull request, so `issues: write` was never exercised and is dropped.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/28531397631
