### PR TITLE
datastore: UNION ALL for mysql list entries query

### DIFF
--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -2931,7 +2931,7 @@ FROM
 	registered_entries
 WHERE id IN (SELECT id FROM listing)
 
-UNION
+UNION ALL
 
 SELECT
 	F.registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, B.trust_domain, NULL, NULL, NULL, NULL, NULL
@@ -2944,7 +2944,7 @@ ON
 WHERE
 	F.registered_entry_id IN (SELECT id FROM listing)
 
-UNION
+UNION ALL
 
 SELECT
 	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, value, NULL, NULL, NULL
@@ -2952,7 +2952,7 @@ FROM
 	dns_names
 WHERE registered_entry_id IN (SELECT id FROM listing)
 
-UNION
+UNION ALL
 
 SELECT
 	registered_entry_id, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, id, type, value, NULL, NULL, NULL, NULL, NULL, NULL


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
Improve performance for list registration queries in mysql 8+.

**Description of change**
We have seen high CPU on mysql DB. Optimizing this frequent query should help. This brings the mysql 8 and above that supports WITH clause on par with postgresql. Essentially port
https://github.com/spiffe/spire/pull/4111 to
buildFetchRegistrationEntriesQueryMySQLCTE.