### PR TITLE
Move JWTSVIDCache outside of the LRUCache

### DIFF
--- a/doc/telemetry/telemetry.md
+++ b/doc/telemetry/telemetry.md
@@ -96,6 +96,7 @@ The following metrics are emitted:
 | Counter      | `sds_api`, `connections`                                                 |                              | The SDS API has successfully established a connection.                                |
 | Gauge        | `sds_api`, `connections`                                                 |                              | The number of active connection that the SDS API has.                                 |
 | Gauge        | `lru_cache_svid_map_size`                                                |                              | The total number of SVIDs in the LRU cache SVID map.                                  |
+| Gauge        | `jwt_svid_cache_size`                                                    |                              | The total number of JWT-SVIDs in the JWT-SVID cache.                                  |
 | Counter      | `workload_api`, `bundles_update`, `jwt`                                  |                              | The Workload API has successfully updated a JWT bundle.                               |
 | Counter      | `workload_api`, `connection`                                             |                              | The Workload API has successfully established a new connection.                       |
 | Gauge        | `workload_api`, `connections`                                            |                              | The number of active connections that the Workload API has.                           |

--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -1131,7 +1131,7 @@ func (m *FakeManager) SubscribeToBundleChanges() *cache.BundleStream {
 
 func newTestCache() *cache.LRUCache {
 	log, _ := test.NewNullLogger()
-	return cache.NewLRUCache(log, trustDomain1, bundle1, telemetry.Blackhole{}, cache.DefaultSVIDCacheMaxSize, cache.DefaultSVIDCacheMaxSize, clock.New())
+	return cache.NewLRUCache(log, trustDomain1, bundle1, telemetry.Blackhole{}, cache.DefaultSVIDCacheMaxSize, clock.New())
 }
 
 func generateSubscribeToX509SVIDMetrics() []fakemetrics.MetricItem {

--- a/pkg/agent/manager/cache/jwt_cache.go
+++ b/pkg/agent/manager/cache/jwt_cache.go
@@ -39,8 +39,8 @@ type jwtSvidElement struct {
 }
 
 func (c *JWTSVIDCache) CountJWTSVIDs() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	return len(c.svids)
 }

--- a/pkg/agent/manager/cache/jwt_cache.go
+++ b/pkg/agent/manager/cache/jwt_cache.go
@@ -74,6 +74,8 @@ func (c *JWTSVIDCache) GetJWTSVID(spiffeID spiffeid.ID, audience []string) (*cli
 }
 
 func (c *JWTSVIDCache) SetJWTSVID(spiffeID spiffeid.ID, audience []string, svid *client.JWTSVID) {
+	defer func() { agent.SetJWTSVIDCacheSize(c.metrics, c.CountJWTSVIDs()) }()
+
 	key := jwtSVIDKey(spiffeID, audience)
 
 	c.mu.Lock()
@@ -103,6 +105,8 @@ func (c *JWTSVIDCache) SetJWTSVID(spiffeID spiffeid.ID, audience []string, svid 
 }
 
 func (c *JWTSVIDCache) TaintJWTSVIDs(ctx context.Context, taintedJWTAuthorities map[string]struct{}) {
+	defer func() { agent.SetJWTSVIDCacheSize(c.metrics, c.CountJWTSVIDs()) }()
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/pkg/agent/manager/cache/jwt_cache_test.go
+++ b/pkg/agent/manager/cache/jwt_cache_test.go
@@ -87,6 +87,11 @@ func TestJWTSVIDCache(t *testing.T) {
 					Val:    0,
 					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
 				},
+				{
+					Type: fakemetrics.SetGaugeType,
+					Key:  []string{telemetry.JWTSVIDCacheSize},
+					Val:  0,
+				},
 			},
 		},
 		{
@@ -123,6 +128,11 @@ func TestJWTSVIDCache(t *testing.T) {
 					Key:    []string{telemetry.CacheManager, agent.CacheTypeWorkload, telemetry.ProcessTaintedJWTSVIDs, telemetry.ElapsedTime},
 					Val:    0,
 					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
+				},
+				{
+					Type: fakemetrics.SetGaugeType,
+					Key:  []string{telemetry.JWTSVIDCacheSize},
+					Val:  0,
 				},
 			},
 		},
@@ -170,6 +180,11 @@ func TestJWTSVIDCache(t *testing.T) {
 					Val:    0,
 					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
 				},
+				{
+					Type: fakemetrics.SetGaugeType,
+					Key:  []string{telemetry.JWTSVIDCacheSize},
+					Val:  0,
+				},
 			},
 		},
 		{
@@ -198,6 +213,11 @@ func TestJWTSVIDCache(t *testing.T) {
 					Val:    0,
 					Labels: []metrics.Label{{Name: "status", Value: "OK"}},
 				},
+				{
+					Type: fakemetrics.SetGaugeType,
+					Key:  []string{telemetry.JWTSVIDCacheSize},
+					Val:  3,
+				},
 			},
 		},
 	} {
@@ -206,6 +226,10 @@ func TestJWTSVIDCache(t *testing.T) {
 			if tt.setJWTSVIDsCached != nil {
 				tt.setJWTSVIDsCached(cache)
 			}
+
+			// Reset after populating the cache so the assertions below only
+			// cover the metrics emitted while tainting.
+			resetLogsAndMetrics(logHook, fakeMetrics)
 
 			// Remove tainted authority, should not be cached anymore
 			cache.TaintJWTSVIDs(ctx, tt.taintedKeyIDs)

--- a/pkg/agent/manager/cache/jwt_cache_test.go
+++ b/pkg/agent/manager/cache/jwt_cache_test.go
@@ -286,6 +286,47 @@ func TestJWTSVIDCacheSize(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestCountJWTSVIDs(t *testing.T) {
+	now := time.Now()
+	// Tokens signed with distinct key IDs (keyID1/keyID2) so they can be tainted.
+	tok1 := "eyJhbGciOiJFUzI1NiIsImtpZCI6ImRaRGZZaXcxdUd6TXdkTVlITDdGRVl5SzhIT0tLd0xYIiwidHlwIjoiSldUIn0.eyJhdWQiOlsidGVzdC1hdWRpZW5jZSJdLCJleHAiOjE3MjQzNjU3MzEsImlhdCI6MTcyNDI3OTQwNywic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvYWdlbnQvZGJ1c2VyIn0.dFr-oWhm5tK0bBuVXt-sGESM5l7hhoY-Gtt5DkuFoJL5Y9d4ZfmicCvUCjL4CqDB3BO_cPqmFfrO7H7pxQbGLg"
+	tok2 := "eyJhbGciOiJFUzI1NiIsImtpZCI6ImNKMXI5TVY4OTZTWXBMY0RMUjN3Q29QRHprTXpkN25tIiwidHlwIjoiSldUIn0.eyJhdWQiOlsidGVzdC1hdWRpZW5jZSJdLCJleHAiOjE3Mjg1NzEwMjUsImlhdCI6MTcyODU3MDcyNSwic3ViIjoic3BpZmZlOi8vZXhhbXBsZS5vcmcvYWdlbnQvZGJ1c2VyIn0.1YnDj7nknwIHEuNKEN0cNypXKS4SUeILXlNOsOs2XElHzfKhhDcl0sYKYtQc1Itf6cygz9C16VOQ_Yjoos2Qfg"
+	keyID1 := "dZDfYiw1uGzMwdMYHL7FEYyK8HOKKwLX"
+	svid1 := &client.JWTSVID{Token: tok1, IssuedAt: now, ExpiresAt: now.Add(time.Minute)}
+	svid2 := &client.JWTSVID{Token: tok2, IssuedAt: now, ExpiresAt: now.Add(time.Minute)}
+
+	fakeMetrics := fakemetrics.New()
+	log, _ := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+	cache := NewJWTSVIDCache(log, fakeMetrics, 2)
+
+	spiffeID := spiffeid.RequireFromString("spiffe://example.org/blog")
+
+	// An empty cache holds no SVIDs.
+	assert.Equal(t, 0, cache.CountJWTSVIDs())
+
+	// Caching an SVID increases the count.
+	cache.SetJWTSVID(spiffeID, []string{"audience-1"}, svid1)
+	assert.Equal(t, 1, cache.CountJWTSVIDs())
+
+	// A distinct key (different audience) increases the count.
+	cache.SetJWTSVID(spiffeID, []string{"audience-2"}, svid2)
+	assert.Equal(t, 2, cache.CountJWTSVIDs())
+
+	// Overwriting an existing key does not change the count.
+	cache.SetJWTSVID(spiffeID, []string{"audience-1"}, svid2)
+	assert.Equal(t, 2, cache.CountJWTSVIDs())
+
+	// The count never exceeds the configured max size; inserting past the
+	// limit evicts the least recently used entry.
+	cache.SetJWTSVID(spiffeID, []string{"audience-3"}, svid1)
+	assert.Equal(t, 2, cache.CountJWTSVIDs())
+
+	// Tainting removes matching SVIDs and lowers the count.
+	cache.TaintJWTSVIDs(context.Background(), map[string]struct{}{keyID1: {}})
+	assert.Equal(t, 1, cache.CountJWTSVIDs())
+}
+
 func TestJWTSVIDCacheKeyHashing(t *testing.T) {
 	spiffeID := spiffeid.RequireFromString("spiffe://example.org/blog")
 	now := time.Now()

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -115,7 +115,6 @@ type StaleEntry struct {
 // consumers MUST NOT mutate the data.
 type LRUCache struct {
 	*BundleCache
-	*JWTSVIDCache
 
 	log         logrus.FieldLogger
 	trustDomain spiffeid.TrustDomain
@@ -150,15 +149,13 @@ type LRUCache struct {
 	taintedBatchProcessedCh chan struct{}
 }
 
-func NewLRUCache(log logrus.FieldLogger, trustDomain spiffeid.TrustDomain, bundle *Bundle, metrics telemetry.Metrics, x509SvidCacheMaxSize int, jwtSvidCacheMaxSize int, clk clock.Clock) *LRUCache {
+func NewLRUCache(log logrus.FieldLogger, trustDomain spiffeid.TrustDomain, bundle *Bundle, metrics telemetry.Metrics, x509SvidCacheMaxSize int, clk clock.Clock) *LRUCache {
 	if x509SvidCacheMaxSize <= 0 {
 		x509SvidCacheMaxSize = DefaultSVIDCacheMaxSize
 	}
 
 	return &LRUCache{
 		BundleCache:  NewBundleCache(trustDomain, bundle),
-		JWTSVIDCache: NewJWTSVIDCache(log, metrics, jwtSvidCacheMaxSize),
-
 		log:          log,
 		metrics:      metrics,
 		trustDomain:  trustDomain,
@@ -215,10 +212,6 @@ func (c *LRUCache) CountX509SVIDs() int {
 	defer c.mu.RUnlock()
 
 	return len(c.svids)
-}
-
-func (c *LRUCache) CountJWTSVIDs() int {
-	return c.JWTSVIDCache.CountJWTSVIDs()
 }
 
 func (c *LRUCache) CountRecords() int {

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -1255,16 +1255,16 @@ func TestNewLRUCache(t *testing.T) {
 	// Negative for value for svidCacheMaxSize should set default value in
 	// cache.svidCacheMaxSize
 	cache := newTestLRUCacheWithConfig(-5, clock.NewMock(t))
-	require.Equal(t, DefaultSVIDCacheMaxSize, cache.svidCacheMaxSize)
+	require.Equal(t, DefaultSVIDCacheMaxSize, cache.x509SvidCacheMaxSize)
 
 	// Zero for value for svidCacheMaxSize should set default value in
 	// cache.svidCacheMaxSize
 	cache = newTestLRUCacheWithConfig(0, clock.NewMock(t))
-	require.Equal(t, DefaultSVIDCacheMaxSize, cache.svidCacheMaxSize)
+	require.Equal(t, DefaultSVIDCacheMaxSize, cache.x509SvidCacheMaxSize)
 
 	// Custom value for svidCacheMaxSize should propagate properly
 	cache = newTestLRUCacheWithConfig(55, clock.NewMock(t))
-	require.Equal(t, 55, cache.svidCacheMaxSize)
+	require.Equal(t, 55, cache.x509SvidCacheMaxSize)
 }
 
 func BenchmarkLRUCacheGlobalNotification(b *testing.B) {
@@ -1315,12 +1315,12 @@ func BenchmarkLRUCacheGlobalNotification(b *testing.B) {
 func newTestLRUCache(t testing.TB) *LRUCache {
 	log, _ := test.NewNullLogger()
 	return NewLRUCache(log, spiffeid.RequireTrustDomainFromString("domain.test"), bundleV1,
-		telemetry.Blackhole{}, 0, 0, clock.NewMock(t))
+		telemetry.Blackhole{}, 0, clock.NewMock(t))
 }
 
 func newTestLRUCacheWithConfig(svidCacheMaxSize int, clk clock.Clock) *LRUCache {
 	log, _ := test.NewNullLogger()
-	return NewLRUCache(log, trustDomain1, bundleV1, telemetry.Blackhole{}, svidCacheMaxSize, svidCacheMaxSize, clk)
+	return NewLRUCache(log, trustDomain1, bundleV1, telemetry.Blackhole{}, svidCacheMaxSize, clk)
 }
 
 // numEntries should not be more than 12 digits

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -72,8 +72,11 @@ func newManager(c *Config) *manager {
 		c.Clk = clock.New()
 	}
 
-	cache := managerCache.NewLRUCache(c.Log.WithField(telemetry.SubsystemName, telemetry.CacheManager), c.TrustDomain, c.Bundle,
-		c.Metrics, c.X509SVIDCacheMaxSize, c.JWTSVIDCacheMaxSize, c.Clk)
+	logger := c.Log.WithField(telemetry.SubsystemName, telemetry.CacheManager)
+	cache := managerCache.NewLRUCache(logger, c.TrustDomain, c.Bundle,
+		c.Metrics, c.X509SVIDCacheMaxSize, c.Clk)
+
+	jwtCache := managerCache.NewJWTSVIDCache(logger, c.Metrics, c.JWTSVIDCacheMaxSize)
 
 	rotCfg := &svid.RotatorConfig{
 		SVIDKeyManager:   keymanager.ForSVID(c.Catalog.GetKeyManager()),
@@ -95,6 +98,7 @@ func newManager(c *Config) *manager {
 
 	m := &manager{
 		cache:          cache,
+		jwtCache:       jwtCache,
 		c:              c,
 		mtx:            new(sync.RWMutex),
 		svid:           svidRotator,

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -129,17 +129,8 @@ type Cache interface {
 	// CountX509SVIDs in cache stored
 	CountX509SVIDs() int
 
-	// CountJWTSVIDs in cache stored
-	CountJWTSVIDs() int
-
 	// FetchWorkloadUpdate for given selectors
 	FetchWorkloadUpdate(selectors []*common.Selector) *cache.WorkloadUpdate
-
-	// GetJWTSVID provides JWT-SVID
-	GetJWTSVID(id spiffeid.ID, audience []string) (*client.JWTSVID, bool)
-
-	// SetJWTSVID adds JWT-SVID to cache
-	SetJWTSVID(id spiffeid.ID, audience []string, svid *client.JWTSVID)
 
 	// Entries get all registration entries
 	Entries() []*common.RegistrationEntry
@@ -150,6 +141,22 @@ type Cache interface {
 	X509Bundle() x509bundle.Source
 }
 
+type JWTCache interface {
+	// CountJWTSVIDs in cache stored
+	CountJWTSVIDs() int
+
+	// GetJWTSVID provides JWT-SVID
+	GetJWTSVID(id spiffeid.ID, audience []string) (*client.JWTSVID, bool)
+
+	// SetJWTSVID adds JWT-SVID to cache
+	SetJWTSVID(id spiffeid.ID, audience []string, svid *client.JWTSVID)
+
+	// TaintJWTSVIDs removes JWT-SVIDs with tainted authorities from the cache,
+	// forcing the server to issue a new JWT-SVID when one with a tainted
+	// authority is requested.
+	TaintJWTSVIDs(ctx context.Context, taintedJWTAuthorities map[string]struct{})
+}
+
 type manager struct {
 	c *Config
 
@@ -158,8 +165,9 @@ type manager struct {
 	// Protects multiple goroutines from requesting SVID signings at the same time
 	updateSVIDMu sync.RWMutex
 
-	cache Cache
-	svid  svid.Rotator
+	cache    Cache
+	jwtCache JWTCache
+	svid     svid.Rotator
 
 	storage storage.Storage
 
@@ -294,7 +302,7 @@ func (m *manager) CountX509SVIDs() int {
 }
 
 func (m *manager) CountJWTSVIDs() int {
-	return m.cache.CountJWTSVIDs()
+	return m.jwtCache.CountJWTSVIDs()
 }
 
 func (m *manager) CountSVIDStoreX509SVIDs() int {
@@ -320,7 +328,7 @@ func (m *manager) FetchJWTSVID(ctx context.Context, entry *common.RegistrationEn
 	var cachedSVID *client.JWTSVID
 	var ok bool
 	if !bypassCache {
-		cachedSVID, ok = m.cache.GetJWTSVID(spiffeID, audience)
+		cachedSVID, ok = m.jwtCache.GetJWTSVID(spiffeID, audience)
 		if ok && !m.c.RotationStrategy.JWTSVIDExpiresSoon(cachedSVID, now) {
 			return cachedSVID, nil
 		}
@@ -344,7 +352,7 @@ func (m *manager) FetchJWTSVID(ctx context.Context, entry *common.RegistrationEn
 	}
 
 	if !bypassCache {
-		m.cache.SetJWTSVID(svidSPIFFEID, audience, newSVID)
+		m.jwtCache.SetJWTSVID(svidSPIFFEID, audience, newSVID)
 	}
 	return newSVID, nil
 }

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -41,11 +41,6 @@ type SVIDCache interface {
 	// TaintX509SVIDs marks all SVIDs signed by a tainted X.509 authority as tainted
 	// to force their rotation.
 	TaintX509SVIDs(ctx context.Context, taintedX509Authorities []*x509.Certificate)
-
-	// TaintJWTSVIDs removes JWT-SVIDs with tainted authorities from the cache,
-	// forcing the server to issue a new JWT-SVID when one with a tainted
-	// authority is requested.
-	TaintJWTSVIDs(ctx context.Context, taintedJWTAuthorities map[string]struct{})
 }
 
 func (m *manager) syncSVIDs(ctx context.Context) (err error) {
@@ -87,7 +82,7 @@ func (m *manager) processTaintedAuthorities(ctx context.Context, bundle *spiffeb
 			Debug("New tainted JWT authorities found")
 
 		// Taint JWT-SVIDs in the cache
-		m.cache.TaintJWTSVIDs(ctx, jwtAuthorities)
+		m.jwtCache.TaintJWTSVIDs(ctx, jwtAuthorities)
 
 		for _, subjectKeyID := range newTaintedJWTAuthorities {
 			m.processedTaintedJWTAuthorities[subjectKeyID] = struct{}{}

--- a/pkg/common/telemetry/agent/lru.go
+++ b/pkg/common/telemetry/agent/lru.go
@@ -21,3 +21,7 @@ func SetEntriesMapSize(m telemetry.Metrics, recordMapSize int) {
 func SetSVIDMapSize(m telemetry.Metrics, svidMapSize int) {
 	m.SetGauge([]string{telemetry.SVIDMapSize}, float32(svidMapSize))
 }
+
+func SetJWTSVIDCacheSize(m telemetry.Metrics, cacheSize int) {
+	m.SetGauge([]string{telemetry.JWTSVIDCacheSize}, float32(cacheSize))
+}

--- a/pkg/common/telemetry/names.go
+++ b/pkg/common/telemetry/names.go
@@ -66,6 +66,9 @@ const (
 	// (server)
 	GetPublicKeys = "get_public_keys"
 
+	// JWTSVIDCacheSize is the gauge that holds the number of cached JWT-SVIDs
+	JWTSVIDCacheSize = "jwt_svid_cache_size"
+
 	// Keys related to keys used on HCL
 	Keys = "keys"
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
There should be no functionality change here. Just extracting this cache out of the LRU cache to make room for caching the new WIT-SVID.

**Description of change**

There's no particular reason to keep these together and it makes it a bit weirder if we want to use the LRU cache for different SVID types (i.e. X509 and WIT)

