### PR TITLE
Fix flaky TestDisposeStaleCryptoKeys caused by mock clock ticker handling

### DIFF
--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -512,7 +512,8 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 	// advances below deterministically fire it. Advancing before the ticker is
 	// created shifts the ticker's baseline, which makes the runs below depend
 	// on goroutine scheduling.
-	_ = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
+	err = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
+	require.NoError(t, err)
 
 	// Advance one ticker period to run disposeCryptoKeys. The CryptoKeys are
 	// already stale, so this run schedules their CryptoKeyVersions for
@@ -547,7 +548,8 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 	// CryptoKeys no longer have enabled CryptoKeyVersions, this run marks them
 	// inactive.
 	ts.clockHook.Add(disposeCryptoKeysFrequency)
-	_ = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
+	err = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
+	require.NoError(t, err)
 
 	// Since the CryptoKey doesn't have any enabled CryptoKeyVersions at
 	// this point, it should be set as inactive.

--- a/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
+++ b/pkg/server/plugin/keymanager/gcpkms/gcpkms_test.go
@@ -447,13 +447,18 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 	configureRequest := configureRequestWithDefaults(t)
 	ts := setupTest(t)
 	now := ts.clockHook.Now()
+	// The CryptoKeys carry a last-update timestamp older than maxStaleDuration,
+	// so they are already stale. Combined with the single-period clock advances
+	// below, this makes stale detection independent of the exact mock-clock
+	// value observed at each ticker tick.
+	staleLastUpdate := fmt.Sprintf("%d", now.Add(-maxStaleDuration-time.Hour).Unix())
 	fakeCryptoKeys := []*fakeCryptoKey{
 		{
 			CryptoKey: &kmspb.CryptoKey{
 				Name: cryptoKeyName1,
 				Labels: map[string]string{
 					labelNameActive:     "true",
-					labelNameLastUpdate: fmt.Sprintf("%d", now.Unix()),
+					labelNameLastUpdate: staleLastUpdate,
 				},
 				VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
 			},
@@ -473,7 +478,7 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 				Name: cryptoKeyName2,
 				Labels: map[string]string{
 					labelNameActive:     "true",
-					labelNameLastUpdate: fmt.Sprintf("%d", now.Unix()),
+					labelNameLastUpdate: staleLastUpdate,
 				},
 				VersionTemplate: &kmspb.CryptoKeyVersionTemplate{Algorithm: kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256},
 			},
@@ -501,15 +506,20 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 	_, err := ts.plugin.Configure(ctx, configureRequest)
 	require.NoError(t, err)
 
-	// Move the clock to start disposeCryptoKeysTask.
-	clkAdv := maxDuration(disposeCryptoKeysFrequency, maxStaleDuration)
-	ts.clockHook.Add(clkAdv)
-
-	// Wait for dispose disposeCryptoKeysTask to be initialized.
+	// Wait for disposeCryptoKeysTask to be initialized before advancing the
+	// clock. The task creates its ticker and only then emits this
+	// notification, so draining it here guarantees the ticker exists and the
+	// advances below deterministically fire it. Advancing before the ticker is
+	// created shifts the ticker's baseline, which makes the runs below depend
+	// on goroutine scheduling.
 	_ = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
 
-	// Move the clock to make sure that we have stale CryptoKeys.
-	ts.clockHook.Add(maxStaleDuration)
+	// Advance one ticker period to run disposeCryptoKeys. The CryptoKeys are
+	// already stale, so this run schedules their CryptoKeyVersions for
+	// destruction. Advancing exactly one period fires the ticker once with the
+	// clock at the advanced time, avoiding the intermediate clock values that a
+	// multi-period advance would expose to the running task.
+	ts.clockHook.Add(disposeCryptoKeysFrequency)
 
 	// Wait for destroy notification of all the CryptoKeyVersions.
 	storedFakeCryptoKeys := ts.fakeKMSClient.store.fetchFakeCryptoKeys()
@@ -531,10 +541,12 @@ func TestDisposeStaleCryptoKeys(t *testing.T) {
 		}
 	}
 
-	// Move the clock to start disposeCryptoKeysTask again.
+	// Advance another ticker period to run disposeCryptoKeys again. The task
+	// blocks on the unbuffered notification channel after each run, so drain
+	// the previous run's notification to let this run proceed. Since the
+	// CryptoKeys no longer have enabled CryptoKeyVersions, this run marks them
+	// inactive.
 	ts.clockHook.Add(disposeCryptoKeysFrequency)
-
-	// Wait for dispose disposeCryptoKeysTask to be initialized.
 	_ = waitForSignal(t, ts.plugin.hooks.disposeCryptoKeysSignal)
 
 	// Since the CryptoKey doesn't have any enabled CryptoKeyVersions at
@@ -1800,12 +1812,4 @@ func waitForSignal(t *testing.T, ch chan error) error {
 		t.Fail()
 	}
 	return nil
-}
-
-func maxDuration(d1, d2 time.Duration) time.Duration {
-	if d1 > d2 {
-		return d1
-	}
-
-	return d2
 }


### PR DESCRIPTION
`TestDisposeStaleCryptoKeys` drives `disposeCryptoKeysTask` through the mock clock, but its correctness depended on goroutine scheduling in two ways, so it would occasionally hang until the test timed out.

`disposeCryptoKeysTask` creates its ticker and only then emits an initialization notification, yet the test advanced the clock before draining that notification. When the task goroutine won the race and created its ticker at the starting time, the ticker's baseline was earlier than the test assumed. The first dispose run then executed while the CryptoKeys were not yet stale, and because the task blocks on the unbuffered notification channel after each run, that non-stale run's notification stalled the single task goroutine before it could reach the run that schedules destruction. The test then waited forever for a destroy notification that never arrived.

The test also advanced the clock by many ticker periods at once. `github.com/andres-erbsen/clock` advances its notion of "now" incrementally as it fires each intermediate tick and yields between them, so a multi-period advance fires the ticker while "now" is still at an intermediate value. The dispose run could observe a not-yet-stale clock even though the advance targeted a stale time.

This PR makes the handshake deterministic. The test drains the initialization notification before advancing the clock, so the ticker's baseline is fixed. The CryptoKeys start with a last-update timestamp older than `maxStaleDuration` so they are already stale, and the clock is advanced exactly one ticker period at a time, which fires the ticker once with the clock already at the advanced time. Stale detection no longer depends on which intermediate clock value the running task happens to observe.

This is a follow-up to #7081, which addressed the `Sleep`-based retry loops in other `gcp_kms` tests but not the ticker handshake in this one.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/28537752222/job/84603474025

```
panic: test timed out after 1m30s
	running tests:
		TestDisposeStaleCryptoKeys (1m30s)

goroutine 437 [select]:
...gcpkms.waitForSignal(...)
	.../gcpkms/gcpkms_test.go:1796
...gcpkms.TestDisposeStaleCryptoKeys(...)
	.../gcpkms/gcpkms_test.go:519
```
