### PR TITLE
Move bundle cache out of lru cache

### DIFF
--- a/pkg/agent/api/delegatedidentity/v1/service_test.go
+++ b/pkg/agent/api/delegatedidentity/v1/service_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
@@ -1123,15 +1122,10 @@ func utilIDProtoFromString(t *testing.T, id string) *types.SPIFFEID {
 }
 
 func (m *FakeManager) SubscribeToBundleChanges() *cache.BundleStream {
-	myCache := newTestCache()
-	myCache.BundleCache.Update(m.cacheUpdate)
+	bundleCache := cache.NewBundleCache(trustDomain1, bundle1)
+	bundleCache.Update(m.cacheUpdate)
 
-	return myCache.BundleCache.SubscribeToBundleChanges()
-}
-
-func newTestCache() *cache.LRUCache {
-	log, _ := test.NewNullLogger()
-	return cache.NewLRUCache(log, trustDomain1, bundle1, telemetry.Blackhole{}, cache.DefaultSVIDCacheMaxSize, clock.New())
+	return bundleCache.SubscribeToBundleChanges()
 }
 
 func generateSubscribeToX509SVIDMetrics() []fakemetrics.MetricItem {

--- a/pkg/agent/manager/cache/bundle_cache.go
+++ b/pkg/agent/manager/cache/bundle_cache.go
@@ -30,9 +30,41 @@ func NewBundleCache(trustDomain spiffeid.TrustDomain, bundle *Bundle) *BundleCac
 }
 
 func (c *BundleCache) Update(bundles map[spiffeid.TrustDomain]*Bundle) {
-	// the bundle map must be copied so that the source can be mutated
-	// afterward.
-	c.bundles.Update(copyBundleMap(bundles))
+	current := c.Bundles()
+
+	// Copy so we never mutate the caller's map (it is shared with the LRU
+	// cache and must not be modified).
+	next := copyBundleMap(bundles)
+
+	// The bundle for the agent's own trust domain must never be dropped even if
+	// it is absent from the update (which should only happen if there is a bug
+	// on the server), since it is required to authenticate the server.
+	if _, ok := next[c.trustDomain]; !ok {
+		if existing, ok := current[c.trustDomain]; ok {
+			if next == nil {
+				next = make(map[spiffeid.TrustDomain]*Bundle, 1)
+			}
+			next[c.trustDomain] = existing
+		}
+	}
+
+	if bundleMapsEqual(current, next) {
+		return
+	}
+	c.bundles.Update(next)
+}
+
+func bundleMapsEqual(a, b map[spiffeid.TrustDomain]*Bundle) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for td, bundleA := range a {
+		bundleB, ok := b[td]
+		if !ok || !bundleA.Equal(bundleB) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *BundleCache) Bundle() *Bundle {

--- a/pkg/agent/manager/cache/bundle_cache_test.go
+++ b/pkg/agent/manager/cache/bundle_cache_test.go
@@ -1,0 +1,104 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBundleCacheChanges(t *testing.T) {
+	bundleCache := NewBundleCache(trustDomain1, bundleV1)
+
+	bundleStream := bundleCache.SubscribeToBundleChanges()
+	assert.Equal(t, makeBundles(bundleV1), bundleStream.Value())
+
+	bundleCache.Update(makeBundles(bundleV1, otherBundleV1))
+	if assert.True(t, bundleStream.HasNext(), "has new bundle value after adding bundle") {
+		bundleStream.Next()
+		assert.Equal(t, makeBundles(bundleV1, otherBundleV1), bundleStream.Value())
+	}
+
+	bundleCache.Update(makeBundles(bundleV1))
+	if assert.True(t, bundleStream.HasNext(), "has new bundle value after removing bundle") {
+		bundleStream.Next()
+		assert.Equal(t, makeBundles(bundleV1), bundleStream.Value())
+	}
+}
+
+func TestBundleCacheUpdate(t *testing.T) {
+	cache := NewBundleCache(trustDomain1, bundleV1)
+	stream := cache.SubscribeToBundleChanges()
+	assert.Equal(t, makeBundles(bundleV1), stream.Value())
+
+	// Adding a federated bundle is a real change and fires the stream.
+	cache.Update(makeBundles(bundleV1, otherBundleV1))
+	if assert.True(t, stream.HasNext(), "expected a notification after adding a bundle") {
+		stream.Next()
+		assert.Equal(t, makeBundles(bundleV1, otherBundleV1), stream.Value())
+	}
+
+	// Re-applying the same bundles is a no-op and must NOT fire the stream.
+	cache.Update(makeBundles(bundleV1, otherBundleV1))
+	assert.False(t, stream.HasNext(), "expected no notification when nothing changed")
+
+	// Removing the federated bundle is a real change and fires the stream.
+	cache.Update(makeBundles(bundleV1))
+	if assert.True(t, stream.HasNext(), "expected a notification after removing a bundle") {
+		stream.Next()
+		assert.Equal(t, makeBundles(bundleV1), stream.Value())
+	}
+}
+
+// TestBundleCacheUpdateOwnTrustDomain asserts that a change to the agent's own
+// trust domain bundle is applied and fires the stream.
+func TestBundleCacheUpdateOwnTrustDomain(t *testing.T) {
+	cache := NewBundleCache(trustDomain1, bundleV1)
+	stream := cache.SubscribeToBundleChanges()
+	assert.Equal(t, bundleV1, cache.Bundle())
+
+	// Rotating the agent's own trust domain bundle is a real change.
+	cache.Update(makeBundles(bundleV2))
+	if assert.True(t, stream.HasNext(), "expected a notification after the own bundle changed") {
+		stream.Next()
+	}
+	assert.Equal(t, bundleV2, cache.Bundle())
+	assert.Equal(t, makeBundles(bundleV2), cache.Bundles())
+
+	// Re-applying the same bundle is a no-op and must NOT fire the stream.
+	cache.Update(makeBundles(bundleV2))
+	assert.False(t, stream.HasNext(), "expected no notification when the own bundle is unchanged")
+	assert.Equal(t, bundleV2, cache.Bundle())
+}
+
+// TestBundleCacheUpdatePreservesOwnTrustDomain asserts that the agent's own
+// trust domain bundle is never dropped, even if the server omits it from an
+// update, since it is required to authenticate the server.
+func TestBundleCacheUpdatePreservesOwnTrustDomain(t *testing.T) {
+	cache := NewBundleCache(trustDomain1, bundleV1)
+	stream := cache.SubscribeToBundleChanges()
+
+	// Seed with a federated bundle alongside the agent's own bundle.
+	cache.Update(makeBundles(bundleV1, otherBundleV1))
+	if assert.True(t, stream.HasNext()) {
+		stream.Next()
+	}
+
+	// An update that omits the agent's own trust domain bundle must retain it.
+	// Here only the federated bundle is present in the update.
+	cache.Update(makeBundles(otherBundleV1))
+
+	// The own trust domain bundle is still available...
+	assert.Equal(t, bundleV1, cache.Bundle())
+	// ...and the full set is unchanged, so no notification should fire.
+	assert.Equal(t, makeBundles(bundleV1, otherBundleV1), cache.Bundles())
+	assert.False(t, stream.HasNext(), "expected no notification when the effective bundle set is unchanged")
+
+	// A genuine change to a federated bundle still fires while retaining the
+	// preserved own trust domain bundle.
+	cache.Update(makeBundles(otherBundleV2))
+	if assert.True(t, stream.HasNext(), "expected a notification when a federated bundle changed") {
+		stream.Next()
+	}
+	assert.Equal(t, bundleV1, cache.Bundle())
+	assert.Equal(t, makeBundles(bundleV1, otherBundleV2), cache.Bundles())
+}

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/andres-erbsen/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
-	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/backoff"
 	"github.com/spiffe/spire/pkg/common/telemetry"
@@ -114,8 +113,6 @@ type StaleEntry struct {
 // presumed to own ALL data passing in and out of the cache. Producers and
 // consumers MUST NOT mutate the data.
 type LRUCache struct {
-	*BundleCache
-
 	log         logrus.FieldLogger
 	trustDomain spiffeid.TrustDomain
 	clk         clock.Clock
@@ -155,7 +152,6 @@ func NewLRUCache(log logrus.FieldLogger, trustDomain spiffeid.TrustDomain, bundl
 	}
 
 	return &LRUCache{
-		BundleCache:  NewBundleCache(trustDomain, bundle),
 		log:          log,
 		metrics:      metrics,
 		trustDomain:  trustDomain,
@@ -268,11 +264,8 @@ func (c *LRUCache) UpdateEntries(update *UpdateEntries, checkSVID func(*common.R
 	// domain should NOT be removed even if not present (which should only be
 	// the case if there is a bug on the server) since it is necessary to
 	// authenticate the server.
-	bundleRemoved := false
 	for id := range c.bundles {
 		if _, ok := update.Bundles[id]; !ok && id != c.trustDomain {
-			bundleRemoved = true
-			// bundle no longer exists.
 			c.log.WithField(telemetry.TrustDomainID, id).Debug("Bundle removed")
 			delete(c.bundles, id)
 		}
@@ -469,10 +462,6 @@ func (c *LRUCache) UpdateEntries(update *UpdateEntries, checkSVID func(*common.R
 		c.log.WithField(telemetry.OutdatedSVIDs, len(outdatedEntries)).
 			Debug("Updating SVIDs with outdated attributes in cache")
 	}
-	if bundleRemoved || len(bundleChanged) > 0 {
-		c.BundleCache.Update(c.bundles)
-	}
-
 	if trustDomainBundleChanged {
 		c.notifyAll()
 	} else {
@@ -577,13 +566,6 @@ func (c *LRUCache) SyncSVIDsWithSubscribers() {
 	defer c.mu.Unlock()
 
 	c.syncSVIDsWithSubscribers()
-}
-
-func (c *LRUCache) X509Bundle() x509bundle.Source {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.BundleCache
 }
 
 // scheduleRotation processes SVID entries in batches, removing those tainted by X.509 authorities.

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -132,30 +132,6 @@ func TestLRUCacheCountRecords(t *testing.T) {
 	require.Equal(t, 2, cache.CountRecords())
 }
 
-func TestLRUCacheBundleChanges(t *testing.T) {
-	cache := newTestLRUCache(t)
-
-	bundleStream := cache.SubscribeToBundleChanges()
-	assert.Equal(t, makeBundles(bundleV1), bundleStream.Value())
-
-	cache.UpdateEntries(&UpdateEntries{
-		Bundles: makeBundles(bundleV1, otherBundleV1),
-	}, nil)
-	if assert.True(t, bundleStream.HasNext(), "has new bundle value after adding bundle") {
-		bundleStream.Next()
-		assert.Equal(t, makeBundles(bundleV1, otherBundleV1), bundleStream.Value())
-	}
-
-	cache.UpdateEntries(&UpdateEntries{
-		Bundles: makeBundles(bundleV1),
-	}, nil)
-
-	if assert.True(t, bundleStream.HasNext(), "has new bundle value after removing bundle") {
-		bundleStream.Next()
-		assert.Equal(t, makeBundles(bundleV1), bundleStream.Value())
-	}
-}
-
 func TestLRUCacheAllSubscribersNotifiedOnBundleChange(t *testing.T) {
 	cache := newTestLRUCache(t)
 

--- a/pkg/agent/manager/config.go
+++ b/pkg/agent/manager/config.go
@@ -78,13 +78,15 @@ func newManager(c *Config) *manager {
 
 	jwtCache := managerCache.NewJWTSVIDCache(logger, c.Metrics, c.JWTSVIDCacheMaxSize)
 
+	bundleCache := managerCache.NewBundleCache(c.TrustDomain, c.Bundle)
+
 	rotCfg := &svid.RotatorConfig{
 		SVIDKeyManager:   keymanager.ForSVID(c.Catalog.GetKeyManager()),
 		Log:              c.Log,
 		Metrics:          c.Metrics,
 		SVID:             c.SVID,
 		SVIDKey:          c.SVIDKey,
-		BundleStream:     cache.SubscribeToBundleChanges(),
+		BundleStream:     bundleCache.SubscribeToBundleChanges(),
 		ServerAddr:       c.ServerAddr,
 		TrustDomain:      c.TrustDomain,
 		Interval:         c.RotationInterval,
@@ -97,6 +99,7 @@ func newManager(c *Config) *manager {
 	svidRotator, client := svid.NewRotator(rotCfg)
 
 	m := &manager{
+		bundleCache:    bundleCache,
 		cache:          cache,
 		jwtCache:       jwtCache,
 		c:              c,

--- a/pkg/agent/manager/manager.go
+++ b/pkg/agent/manager/manager.go
@@ -108,20 +108,11 @@ type Manager interface {
 type Cache interface {
 	SVIDCache
 
-	// Bundle gets latest cached bundle
-	Bundle() *spiffebundle.Bundle
-
-	// Bundles gets the latest cached bundles for all trust domains.
-	Bundles() map[spiffeid.TrustDomain]*spiffebundle.Bundle
-
 	// SyncSVIDsWithSubscribers syncs SVID cache
 	SyncSVIDsWithSubscribers()
 
 	// SubscribeToWorkloadUpdates creates a subscriber for given selector set.
 	SubscribeToWorkloadUpdates(ctx context.Context, selectors cache.Selectors) (cache.Subscriber, error)
-
-	// SubscribeToBundleChanges creates a stream for providing bundle changes
-	SubscribeToBundleChanges() *cache.BundleStream
 
 	// MatchingRegistrationEntries with given selectors
 	MatchingRegistrationEntries(selectors []*common.Selector) []*common.RegistrationEntry
@@ -137,8 +128,6 @@ type Cache interface {
 
 	// Identities get all identities in cache
 	Identities() []cache.Identity
-
-	X509Bundle() x509bundle.Source
 }
 
 type JWTCache interface {
@@ -165,9 +154,10 @@ type manager struct {
 	// Protects multiple goroutines from requesting SVID signings at the same time
 	updateSVIDMu sync.RWMutex
 
-	cache    Cache
-	jwtCache JWTCache
-	svid     svid.Rotator
+	bundleCache *cache.BundleCache
+	cache       Cache
+	jwtCache    JWTCache
+	svid        svid.Rotator
 
 	storage storage.Storage
 
@@ -206,7 +196,7 @@ type manager struct {
 
 func (m *manager) Initialize(ctx context.Context) error {
 	m.storeSVID(m.svid.State().SVID, m.svid.State().Reattestable)
-	m.storeBundle(m.cache.Bundle())
+	m.storeBundle(m.bundleCache.Bundle())
 
 	// upper limit of backoff is 8 mins
 	synchronizeBackoffMaxInterval := min(synchronizeMaxInterval, synchronizeMaxIntervalMultiple*m.c.SyncInterval)
@@ -278,7 +268,7 @@ func (m *manager) SubscribeToSVIDChanges() observer.Stream {
 }
 
 func (m *manager) SubscribeToBundleChanges() *cache.BundleStream {
-	return m.cache.SubscribeToBundleChanges()
+	return m.bundleCache.SubscribeToBundleChanges()
 }
 
 func (m *manager) GetRotationMtx() *sync.RWMutex {
@@ -454,24 +444,15 @@ func (m *manager) GetLastSync() time.Time {
 }
 
 func (m *manager) GetBundle() *cache.Bundle {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	return m.cache.Bundle()
+	return m.bundleCache.Bundle()
 }
 
 func (m *manager) GetBundles() map[spiffeid.TrustDomain]*cache.Bundle {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	return m.cache.Bundles()
+	return m.bundleCache.Bundles()
 }
 
 func (m *manager) GetX509Bundle() x509bundle.Source {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-
-	return m.cache.X509Bundle()
+	return m.bundleCache
 }
 
 func (m *manager) runSVIDObserver(ctx context.Context) error {

--- a/pkg/agent/manager/sync.go
+++ b/pkg/agent/manager/sync.go
@@ -100,6 +100,13 @@ func (m *manager) synchronize(ctx context.Context) (err error) {
 		return err
 	}
 
+	// Update the shared bundle cache as soon as the latest bundles are
+	// available. This keeps bundle consumers (rotator, broker, bundle
+	// observer) in sync even if a later step (e.g. SVID fetching) fails, and
+	// avoids a stale bundle view relative to the workload cache, which is
+	// updated by updateCache below.
+	m.bundleCache.Update(cacheUpdate.Bundles)
+
 	// Process all tainted authorities. The bundle is shared between both caches using regular cache data.
 	if err := m.processTaintedAuthorities(ctx, cacheUpdate.Bundles[m.c.TrustDomain], cacheUpdate.TaintedX509Authorities, cacheUpdate.TaintedJWTAuthorities); err != nil {
 		return err


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
There should be no functionality change

**Description of change**
Similar to how we moved the JWT-SVIDs out of the cache, it makes a lot more sense to keep this outside of the LRU cache.
