### PR TITLE
Move the testing functionality out of the main DataStore interface

### DIFF
--- a/pkg/common/telemetry/server/datastore/ca_journal.go
+++ b/pkg/common/telemetry/server/datastore/ca_journal.go
@@ -21,9 +21,3 @@ func StartFetchCAJournal(m telemetry.Metrics) *telemetry.CallCounter {
 func StartPruneCAJournalsCall(m telemetry.Metrics) *telemetry.CallCounter {
 	return telemetry.StartCall(m, telemetry.Datastore, telemetry.CAJournal, telemetry.Prune)
 }
-
-// StartListCAJournalsForTesting return metric
-// for server's datastore, on listing CA journals for testing.
-func StartListCAJournalsForTesting(m telemetry.Metrics) *telemetry.CallCounter {
-	return telemetry.StartCall(m, telemetry.Datastore, telemetry.CAJournal, telemetry.List)
-}

--- a/pkg/common/telemetry/server/datastore/event.go
+++ b/pkg/common/telemetry/server/datastore/event.go
@@ -16,18 +16,6 @@ func StartPruneRegistrationEntryEventsCall(m telemetry.Metrics) *telemetry.CallC
 	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntryEvent, telemetry.Prune)
 }
 
-// StartCreateRegistrationEntryEventForTestingCall return metric
-// for server's datastore, on creating a registration entry event.
-func StartCreateRegistrationEntryEventForTestingCall(m telemetry.Metrics) *telemetry.CallCounter {
-	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntryEvent, telemetry.Create)
-}
-
-// StartDeleteRegistrationEntryEventForTestingCall return metric
-// for server's datastore, on deleting a registration entry event.
-func StartDeleteRegistrationEntryEventForTestingCall(m telemetry.Metrics) *telemetry.CallCounter {
-	return telemetry.StartCall(m, telemetry.Datastore, telemetry.RegistrationEntryEvent, telemetry.Delete)
-}
-
 // StartFetchRegistrationEntryEventCall return metric
 // for server's datastore, on fetching a registration entry event.
 func StartFetchRegistrationEntryEventCall(m telemetry.Metrics) *telemetry.CallCounter {
@@ -44,18 +32,6 @@ func StartListAttestedNodeEventsCall(m telemetry.Metrics) *telemetry.CallCounter
 // for server's datastore, on pruning attested node events.
 func StartPruneAttestedNodeEventsCall(m telemetry.Metrics) *telemetry.CallCounter {
 	return telemetry.StartCall(m, telemetry.Datastore, telemetry.NodeEvent, telemetry.Prune)
-}
-
-// StartCreateAttestedNodeEventForTestingCall return metric
-// for server's datastore, on creating an attested node event.
-func StartCreateAttestedNodeEventForTestingCall(m telemetry.Metrics) *telemetry.CallCounter {
-	return telemetry.StartCall(m, telemetry.Datastore, telemetry.NodeEvent, telemetry.Create)
-}
-
-// StartDeleteAttestedNodeEventForTestingCall return metric
-// for server's datastore, on deleting an attested node event.
-func StartDeleteAttestedNodeEventForTestingCall(m telemetry.Metrics) *telemetry.CallCounter {
-	return telemetry.StartCall(m, telemetry.Datastore, telemetry.NodeEvent, telemetry.Delete)
 }
 
 // StartFetchAttestedNodeEventCall return metric

--- a/pkg/common/telemetry/server/datastore/wrapper.go
+++ b/pkg/common/telemetry/server/datastore/wrapper.go
@@ -35,12 +35,6 @@ func (w metricsWrapper) CreateAttestedNode(ctx context.Context, node *common.Att
 	return w.ds.CreateAttestedNode(ctx, node)
 }
 
-func (w metricsWrapper) CreateAttestedNodeEventForTesting(ctx context.Context, event *datastore.AttestedNodeEvent) (err error) {
-	callCounter := StartCreateAttestedNodeEventForTestingCall(w.m)
-	defer callCounter.Done(&err)
-	return w.ds.CreateAttestedNodeEventForTesting(ctx, event)
-}
-
 func (w metricsWrapper) CreateBundle(ctx context.Context, bundle *common.Bundle) (_ *common.Bundle, err error) {
 	callCounter := StartCreateBundleCall(w.m)
 	defer callCounter.Done(&err)
@@ -65,12 +59,6 @@ func (w metricsWrapper) CreateOrReturnRegistrationEntry(ctx context.Context, ent
 	return w.ds.CreateOrReturnRegistrationEntry(ctx, entry)
 }
 
-func (w metricsWrapper) CreateRegistrationEntryEventForTesting(ctx context.Context, event *datastore.RegistrationEntryEvent) (err error) {
-	callCounter := StartCreateRegistrationEntryEventForTestingCall(w.m)
-	defer callCounter.Done(&err)
-	return w.ds.CreateRegistrationEntryEventForTesting(ctx, event)
-}
-
 func (w metricsWrapper) CreateFederationRelationship(ctx context.Context, fr *datastore.FederationRelationship) (_ *datastore.FederationRelationship, err error) {
 	callCounter := StartCreateFederationRelationshipCall(w.m)
 	defer callCounter.Done(&err)
@@ -87,12 +75,6 @@ func (w metricsWrapper) DeleteAttestedNode(ctx context.Context, spiffeID string)
 	callCounter := StartDeleteNodeCall(w.m)
 	defer callCounter.Done(&err)
 	return w.ds.DeleteAttestedNode(ctx, spiffeID)
-}
-
-func (w metricsWrapper) DeleteAttestedNodeEventForTesting(ctx context.Context, eventID uint) (err error) {
-	callCounter := StartDeleteAttestedNodeEventForTestingCall(w.m)
-	defer callCounter.Done(&err)
-	return w.ds.DeleteAttestedNodeEventForTesting(ctx, eventID)
 }
 
 func (w metricsWrapper) DeleteBundle(ctx context.Context, trustDomain string, mode datastore.DeleteMode) (err error) {
@@ -117,12 +99,6 @@ func (w metricsWrapper) DeleteRegistrationEntry(ctx context.Context, entryID str
 	callCounter := StartDeleteRegistrationCall(w.m)
 	defer callCounter.Done(&err)
 	return w.ds.DeleteRegistrationEntry(ctx, entryID)
-}
-
-func (w metricsWrapper) DeleteRegistrationEntryEventForTesting(ctx context.Context, eventID uint) (err error) {
-	callCounter := StartDeleteRegistrationEntryEventForTestingCall(w.m)
-	defer callCounter.Done(&err)
-	return w.ds.DeleteRegistrationEntryEventForTesting(ctx, eventID)
 }
 
 func (w metricsWrapper) FetchAttestedNode(ctx context.Context, spiffeID string) (_ *common.AttestedNode, err error) {
@@ -345,12 +321,6 @@ func (w metricsWrapper) FetchCAJournal(ctx context.Context, activeX509AuthorityI
 	callCounter := StartFetchCAJournal(w.m)
 	defer callCounter.Done(&err)
 	return w.ds.FetchCAJournal(ctx, activeX509AuthorityID)
-}
-
-func (w metricsWrapper) ListCAJournalsForTesting(ctx context.Context) (_ []*datastore.CAJournal, err error) {
-	callCounter := StartListCAJournalsForTesting(w.m)
-	defer callCounter.Done(&err)
-	return w.ds.ListCAJournalsForTesting(ctx)
 }
 
 func (w metricsWrapper) PruneCAJournals(ctx context.Context, allCAsExpireBefore int64) (err error) {

--- a/pkg/common/telemetry/server/datastore/wrapper_test.go
+++ b/pkg/common/telemetry/server/datastore/wrapper_test.go
@@ -58,10 +58,6 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "CreateAttestedNode",
 		},
 		{
-			key:        "datastore.node_event.create",
-			methodName: "CreateAttestedNodeEventForTesting",
-		},
-		{
 			key:        "datastore.bundle.create",
 			methodName: "CreateBundle",
 		},
@@ -82,16 +78,8 @@ func TestWithMetrics(t *testing.T) {
 			methodName: "CreateOrReturnRegistrationEntry",
 		},
 		{
-			key:        "datastore.registration_entry_event.create",
-			methodName: "CreateRegistrationEntryEventForTesting",
-		},
-		{
 			key:        "datastore.node.delete",
 			methodName: "DeleteAttestedNode",
-		},
-		{
-			key:        "datastore.node_event.delete",
-			methodName: "DeleteAttestedNodeEventForTesting",
 		},
 		{
 			key:        "datastore.bundle.delete",
@@ -108,10 +96,6 @@ func TestWithMetrics(t *testing.T) {
 		{
 			key:        "datastore.registration_entry.delete",
 			methodName: "DeleteRegistrationEntry",
-		},
-		{
-			key:        "datastore.registration_entry_event.delete",
-			methodName: "DeleteRegistrationEntryEventForTesting",
 		},
 		{
 			key:        "datastore.node.fetch",
@@ -257,10 +241,6 @@ func TestWithMetrics(t *testing.T) {
 			key:        "datastore.ca_journal.prune",
 			methodName: "PruneCAJournals",
 		},
-		{
-			key:        "datastore.ca_journal.list",
-			methodName: "ListCAJournalsForTesting",
-		},
 	} {
 		methodType, ok := wt.MethodByName(tt.methodName)
 		require.True(t, ok, "method %q does not exist on DataStore interface", tt.methodName)
@@ -360,10 +340,6 @@ func (ds *fakeDataStore) CreateAttestedNode(context.Context, *common.AttestedNod
 	return &common.AttestedNode{}, ds.err
 }
 
-func (ds *fakeDataStore) CreateAttestedNodeEventForTesting(context.Context, *datastore.AttestedNodeEvent) error {
-	return ds.err
-}
-
 func (ds *fakeDataStore) CreateBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
 	return &common.Bundle{}, ds.err
 }
@@ -388,19 +364,11 @@ func (ds *fakeDataStore) CreateOrReturnRegistrationEntry(context.Context, *commo
 	return &common.RegistrationEntry{}, true, ds.err
 }
 
-func (ds *fakeDataStore) CreateRegistrationEntryEventForTesting(context.Context, *datastore.RegistrationEntryEvent) error {
-	return ds.err
-}
-
 func (ds *fakeDataStore) DeleteAttestedNode(context.Context, string) (*common.AttestedNode, error) {
 	return &common.AttestedNode{}, ds.err
 }
 
 func (ds *fakeDataStore) PruneAttestedExpiredNodes(context.Context, time.Time, bool, int) error {
-	return ds.err
-}
-
-func (ds *fakeDataStore) DeleteAttestedNodeEventForTesting(context.Context, uint) error {
 	return ds.err
 }
 
@@ -418,10 +386,6 @@ func (ds *fakeDataStore) DeleteJoinToken(context.Context, string) error {
 
 func (ds *fakeDataStore) DeleteRegistrationEntry(context.Context, string) (*common.RegistrationEntry, error) {
 	return &common.RegistrationEntry{}, ds.err
-}
-
-func (ds *fakeDataStore) DeleteRegistrationEntryEventForTesting(context.Context, uint) error {
-	return ds.err
 }
 
 func (ds *fakeDataStore) FetchAttestedNode(context.Context, string) (*common.AttestedNode, error) {
@@ -554,10 +518,6 @@ func (ds *fakeDataStore) SetCAJournal(context.Context, *datastore.CAJournal) (*d
 
 func (ds *fakeDataStore) FetchCAJournal(context.Context, string) (*datastore.CAJournal, error) {
 	return &datastore.CAJournal{}, ds.err
-}
-
-func (ds *fakeDataStore) ListCAJournalsForTesting(context.Context) ([]*datastore.CAJournal, error) {
-	return []*datastore.CAJournal{}, ds.err
 }
 
 func (ds *fakeDataStore) PruneCAJournals(context.Context, int64) error {

--- a/pkg/server/datastore/datastore.go
+++ b/pkg/server/datastore/datastore.go
@@ -44,8 +44,6 @@ type DataStore interface {
 	ListRegistrationEntryEvents(ctx context.Context, req *ListRegistrationEntryEventsRequest) (*ListRegistrationEntryEventsResponse, error)
 	PruneRegistrationEntryEvents(ctx context.Context, olderThan time.Duration) error
 	FetchRegistrationEntryEvent(ctx context.Context, eventID uint) (*RegistrationEntryEvent, error)
-	CreateRegistrationEntryEventForTesting(ctx context.Context, event *RegistrationEntryEvent) error
-	DeleteRegistrationEntryEventForTesting(ctx context.Context, eventID uint) error
 
 	// Nodes
 	CountAttestedNodes(context.Context, *CountAttestedNodesRequest) (int32, error)
@@ -63,8 +61,6 @@ type DataStore interface {
 	ListAttestedNodeEvents(ctx context.Context, req *ListAttestedNodeEventsRequest) (*ListAttestedNodeEventsResponse, error)
 	PruneAttestedNodeEvents(ctx context.Context, olderThan time.Duration) error
 	FetchAttestedNodeEvent(ctx context.Context, eventID uint) (*AttestedNodeEvent, error)
-	CreateAttestedNodeEventForTesting(ctx context.Context, event *AttestedNodeEvent) error
-	DeleteAttestedNodeEventForTesting(ctx context.Context, eventID uint) error
 
 	// Node selectors
 	GetNodeSelectors(ctx context.Context, spiffeID string, dataConsistency DataConsistency) ([]*common.Selector, error)
@@ -88,6 +84,19 @@ type DataStore interface {
 	SetCAJournal(ctx context.Context, caJournal *CAJournal) (*CAJournal, error)
 	FetchCAJournal(ctx context.Context, activeX509AuthorityID string) (*CAJournal, error)
 	PruneCAJournals(ctx context.Context, allCAsExpireBefore int64) error
+}
+
+// TestableDataStore extends DataStore with helper methods that are only meant
+// to be used from tests. Implementations that back tests (the SQL plugin and
+// the fake datastore) satisfy this interface; production code should depend on
+// DataStore instead.
+type TestableDataStore interface {
+	DataStore
+
+	CreateRegistrationEntryEventForTesting(ctx context.Context, event *RegistrationEntryEvent) error
+	DeleteRegistrationEntryEventForTesting(ctx context.Context, eventID uint) error
+	CreateAttestedNodeEventForTesting(ctx context.Context, event *AttestedNodeEvent) error
+	DeleteAttestedNodeEventForTesting(ctx context.Context, eventID uint) error
 	ListCAJournalsForTesting(ctx context.Context) ([]*CAJournal, error)
 }
 

--- a/test/fakes/fakedatastore/fakedatastore.go
+++ b/test/fakes/fakedatastore/fakedatastore.go
@@ -25,11 +25,11 @@ var (
 )
 
 type DataStore struct {
-	ds   datastore.DataStore
+	ds   datastore.TestableDataStore
 	errs []error
 }
 
-var _ datastore.DataStore = (*DataStore)(nil)
+var _ datastore.TestableDataStore = (*DataStore)(nil)
 
 func New(tb testing.TB) *DataStore {
 	log, _ := test.NewNullLogger()


### PR DESCRIPTION
This simplifies the interface a bit and makes it impossible to use these functions in core code.