### PR TITLE
Fix unrecognized parameters warnings

### DIFF
--- a/pkg/server/common/vault/client.go
+++ b/pkg/server/common/vault/client.go
@@ -512,9 +512,9 @@ func (c *Client) SignData(ctx context.Context, keyName string, data []byte, hash
 	encodedData := base64.StdEncoding.EncodeToString(data)
 
 	body := map[string]any{
-		"input":                 encodedData,
-		"marshalling_algorithm": "asn1",
-		"prehashed":             true,
+		"input":                encodedData,
+		"marshaling_algorithm": "asn1",
+		"prehashed":            true,
 	}
 	if signatureAlgo != TransitSignatureAlgorithmNone {
 		body["signature_algorithm"] = signatureAlgo

--- a/pkg/server/common/vault/client_test.go
+++ b/pkg/server/common/vault/client_test.go
@@ -1086,7 +1086,7 @@ func TestSignData(t *testing.T) {
 
 			require.NotNil(t, capturedBody, "sign request body not captured")
 			require.Equal(t, true, capturedBody["prehashed"], "prehashed must be boolean true")
-			require.Equal(t, "asn1", capturedBody["marshalling_algorithm"])
+			require.Equal(t, "asn1", capturedBody["marshaling_algorithm"])
 
 			_, hasSigAlgo := capturedBody["signature_algorithm"]
 			require.Equal(t, tt.wantSigAlgoInBody, hasSigAlgo,


### PR DESCRIPTION
**Affected functionality**
Currently, when using the hashicorp_vault KeyManager plugin with Vault or OpenBao, there are warnings in the audit log - "warnings":["Endpoint ignored these unrecognized parameters: [marshalling_algorithm]".

The correct parameter is "marshaling_algorithm". Note, this doesn't cause any issues as asn1 is the default anyway and the plugin works well. This fix just removes the warnings.

- https://developer.hashicorp.com/vault/api-docs/secret/transit#marshaling_algorithm
- https://openbao.org/api-docs/secret/transit/#parameters-20

**Description of change**
Get rid of unnecessary warning messages.