### PR TITLE
tpmdevid: reuse owner-hierarchy SRK across NewSession to reduce TPM2_CreatePrimary calls

### DIFF
--- a/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/devid_test.go
@@ -395,7 +395,7 @@ func TestAidAttestationFailures(t *testing.T) {
 	}{
 		{
 			name:         "AidAttestation fails if a new session cannot be started",
-			expErr:       `rpc error: code = Internal desc = nodeattestor(tpm_devid): unable to start a new TPM session: cannot load DevID key on TPM`,
+			expErr:       `rpc error: code = Internal desc = nodeattestor(tpm_devid): unable to start a new TPM session: cannot create owner SRK`,
 			openTPMFail:  true,
 			serverStream: streamBuilder.Build(),
 		},
@@ -461,7 +461,7 @@ func TestAidAttestationFailures(t *testing.T) {
 		},
 		{
 			name:                        "AidAttestation fails if a wrong owner hierarchy password is provided",
-			expErr:                      `rpc error: code = Internal desc = nodeattestor(tpm_devid): unable to start a new TPM session: cannot load DevID key on TPM`,
+			expErr:                      `rpc error: code = Internal desc = nodeattestor(tpm_devid): unable to start a new TPM session: cannot create owner SRK`,
 			wrongOwnerHierarchyPassword: true,
 			serverStream:                streamBuilder.Build(),
 		},

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session.go
@@ -141,10 +141,21 @@ func NewSession(scfg *SessionConfig) (*Session, error) {
 		return nil, fmt.Errorf("cannot generate random password for attesation key: %w", err)
 	}
 
-	// For ECC DevIDs the AK always uses SRKTemplateHighRSA, so a separate SRK
-	// is needed. For RSA DevIDs the same SRK serves all three operations.
+	// For ECC DevIDs the AK always uses SRKTemplateHighRSA, so a separate RSA
+	// SRK is needed. Flush the ECC devIDSRKHandle immediately after devID is
+	// loaded — it is no longer needed, and freeing the slot avoids hitting the
+	// TPM's transient object limit when the RSA akSRKHandle is created.
+	// For RSA DevIDs the same SRK serves all three operations.
+	//
+	// separateAKSRK tracks whether akSRKHandle is a distinct object from
+	// devIDSRKHandle. We cannot use handle-value comparison after flushing
+	// devIDSRKHandle because the TPM may reuse the same handle number for the
+	// newly created akSRKHandle.
+	separateAKSRK := false
 	akSRKHandle := devIDSRKHandle
 	if devIDPub.Type == tpm2.AlgECC {
+		tpm.flushContext(devIDSRKHandle)
+		separateAKSRK = true
 		akSRKHandle, _, _, _, _, _, err = tpm2.CreatePrimaryEx(
 			rwc, tpm2.HandleOwner,
 			tpm2.PCRSelection{},
@@ -153,15 +164,16 @@ func NewSession(scfg *SessionConfig) (*Session, error) {
 			SRKTemplateHighRSA(),
 		)
 		if err != nil {
-			tpm.flushContext(devIDSRKHandle)
 			return nil, fmt.Errorf("cannot create RSA SRK for attestation key: %w", err)
 		}
 	}
 
 	akPriv, akPub, err := tpm.createAttestationKeyWithSRK(akSRKHandle, srkPassword, akPassword)
 	if err != nil {
-		tpm.flushContext(devIDSRKHandle)
-		if akSRKHandle != devIDSRKHandle {
+		if !separateAKSRK {
+			tpm.flushContext(devIDSRKHandle)
+		}
+		if separateAKSRK {
 			tpm.flushContext(akSRKHandle)
 		}
 		return nil, fmt.Errorf("cannot create attestation key: %w", err)
@@ -179,8 +191,10 @@ func NewSession(scfg *SessionConfig) (*Session, error) {
 	// Flush SRK(s) before creating the EK. At this point devID and ak occupy two
 	// transient slots; some chips (e.g. Infineon SLB9672) enforce a three-slot
 	// limit, so the EK CreatePrimary needs the SRK slot freed first.
-	tpm.flushContext(devIDSRKHandle)
-	if akSRKHandle != devIDSRKHandle {
+	if !separateAKSRK {
+		tpm.flushContext(devIDSRKHandle)
+	}
+	if separateAKSRK {
 		tpm.flushContext(akSRKHandle)
 	}
 	if err != nil {

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session.go
@@ -90,33 +90,99 @@ func NewSession(scfg *SessionConfig) (*Session, error) {
 		return nil, fmt.Errorf("cannot generate random password for storage root key: %w", err)
 	}
 
+	// Determine which SRK template the DevID key requires.
+	// RSA DevID → SRKTemplateHighRSA; ECC DevID → SRKTemplateHighECC.
+	devIDPub, err := tpm2.DecodePublic(scfg.DevIDPub)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode DevID public key: %w", err)
+	}
+	var devIDSRKTemplate tpm2.Public
+	switch devIDPub.Type {
+	case tpm2.AlgRSA:
+		devIDSRKTemplate = SRKTemplateHighRSA()
+	case tpm2.AlgECC:
+		devIDSRKTemplate = SRKTemplateHighECC()
+	default:
+		return nil, fmt.Errorf("unsupported DevID key type: 0x%04x", devIDPub.Type)
+	}
+
+	// Create one owner-hierarchy SRK. For RSA DevIDs this handle is reused for
+	// DevID loading, AK creation, and AK loading — TPM2_CreatePrimary is called
+	// once instead of three times. For ECC DevIDs a second RSA SRK is needed for
+	// the AK (reducing from three calls to two).
+	devIDSRKHandle, _, _, _, _, _, err := tpm2.CreatePrimaryEx(
+		rwc, tpm2.HandleOwner,
+		tpm2.PCRSelection{},
+		scfg.Passwords.OwnerHierarchy,
+		srkPassword,
+		devIDSRKTemplate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create owner SRK: %w", err)
+	}
+
 	// Load DevID
-	tpm.devID, err = tpm.loadKey(
+	tpm.devID, err = tpm.loadKeyWithSRK(
 		scfg.DevIDPub,
 		scfg.DevIDPriv,
+		devIDSRKHandle,
 		srkPassword,
-		scfg.Passwords.DevIDKey)
+		scfg.Passwords.DevIDKey,
+	)
 	if err != nil {
+		tpm.flushContext(devIDSRKHandle)
 		return nil, fmt.Errorf("cannot load DevID key on TPM: %w", err)
 	}
 
 	// Create Attestation Key
 	akPassword, err := newRandomPassword()
 	if err != nil {
+		tpm.flushContext(devIDSRKHandle)
 		return nil, fmt.Errorf("cannot generate random password for attesation key: %w", err)
 	}
-	akPriv, akPub, err := tpm.createAttestationKey(srkPassword, akPassword)
+
+	// For ECC DevIDs the AK always uses SRKTemplateHighRSA, so a separate SRK
+	// is needed. For RSA DevIDs the same SRK serves all three operations.
+	akSRKHandle := devIDSRKHandle
+	if devIDPub.Type == tpm2.AlgECC {
+		akSRKHandle, _, _, _, _, _, err = tpm2.CreatePrimaryEx(
+			rwc, tpm2.HandleOwner,
+			tpm2.PCRSelection{},
+			scfg.Passwords.OwnerHierarchy,
+			srkPassword,
+			SRKTemplateHighRSA(),
+		)
+		if err != nil {
+			tpm.flushContext(devIDSRKHandle)
+			return nil, fmt.Errorf("cannot create RSA SRK for attestation key: %w", err)
+		}
+	}
+
+	akPriv, akPub, err := tpm.createAttestationKeyWithSRK(akSRKHandle, srkPassword, akPassword)
 	if err != nil {
+		tpm.flushContext(devIDSRKHandle)
+		if akSRKHandle != devIDSRKHandle {
+			tpm.flushContext(akSRKHandle)
+		}
 		return nil, fmt.Errorf("cannot create attestation key: %w", err)
 	}
 	tpm.akPub = akPub
 
 	// Load Attestation Key
-	tpm.ak, err = tpm.loadKey(
+	tpm.ak, err = tpm.loadKeyWithSRK(
 		akPub,
 		akPriv,
+		akSRKHandle,
 		srkPassword,
-		akPassword)
+		akPassword,
+	)
+	// Flush SRK(s) before creating the EK. At this point devID and ak occupy two
+	// transient slots; some chips (e.g. Infineon SLB9672) enforce a three-slot
+	// limit, so the EK CreatePrimary needs the SRK slot freed first.
+	tpm.flushContext(devIDSRKHandle)
+	if akSRKHandle != devIDSRKHandle {
+		tpm.flushContext(akSRKHandle)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot load attestation key: %w", err)
 	}
@@ -317,6 +383,53 @@ func (c *Session) loadKey(publicKey, privateKey []byte, parentKeyPassword, keyPa
 	}, nil
 }
 
+// loadKeyWithSRK loads a key pair into the TPM under an already-created SRK.
+// The caller is responsible for flushing srkHandle after all operations complete.
+func (c *Session) loadKeyWithSRK(publicKey, privateKey []byte, srkHandle tpmutil.Handle, srkPassword, keyPassword string) (*SigningKey, error) {
+	pub, err := tpm2.DecodePublic(publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("tpm2.DecodePublic failed: %w", err)
+	}
+
+	canSign := pub.Attributes&tpm2.FlagSign != 0
+	if !canSign {
+		return nil, errors.New("not a signing key")
+	}
+
+	var sigHashAlg tpm2.Algorithm
+	switch pub.Type {
+	case tpm2.AlgRSA:
+		rsaParams := pub.RSAParameters
+		if rsaParams != nil {
+			sigHashAlg = rsaParams.Sign.Hash
+		}
+	case tpm2.AlgECC:
+		eccParams := pub.ECCParameters
+		if eccParams != nil {
+			sigHashAlg = eccParams.Sign.Hash
+		}
+	default:
+		return nil, fmt.Errorf("bad key type: 0x%04x", pub.Type)
+	}
+
+	if sigHashAlg.IsNull() {
+		return nil, errors.New("signature hash algorithm is NULL")
+	}
+
+	keyHandle, _, err := tpm2.Load(c.rwc, srkHandle, srkPassword, publicKey, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("tpm2.Load failed: %w", err)
+	}
+
+	return &SigningKey{
+		Handle:     keyHandle,
+		sigHashAlg: sigHashAlg,
+		rw:         c.rwc,
+		log:        c.log,
+		password:   keyPassword,
+	}, nil
+}
+
 func (c *Session) createAttestationKey(parentKeyPassword, keyPassword string) ([]byte, []byte, error) {
 	srkHandle, _, _, _, _, _, err :=
 		tpm2.CreatePrimaryEx(c.rwc,
@@ -342,6 +455,23 @@ func (c *Session) createAttestationKey(parentKeyPassword, keyPassword string) ([
 		return nil, nil, fmt.Errorf("failed to create AK: %w", err)
 	}
 
+	return privBlob, pubBlob, nil
+}
+
+// createAttestationKeyWithSRK creates an RSA attestation key under an already-created SRK.
+// The caller is responsible for flushing srkHandle after all operations complete.
+func (c *Session) createAttestationKeyWithSRK(srkHandle tpmutil.Handle, srkPassword, keyPassword string) ([]byte, []byte, error) {
+	privBlob, pubBlob, _, _, _, err := tpm2.CreateKey(
+		c.rwc,
+		srkHandle,
+		tpm2.PCRSelection{},
+		srkPassword,
+		keyPassword,
+		client.AKTemplateRSA(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create AK: %w", err)
+	}
 	return privBlob, pubBlob, nil
 }
 

--- a/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
+++ b/pkg/agent/plugin/nodeattestor/tpmdevid/tpmutil/session_test.go
@@ -90,7 +90,7 @@ func TestNewSession(t *testing.T) {
 		},
 		{
 			name:   "NewSesion fails if DevID blobs cannot be loaded",
-			expErr: "cannot load DevID key on TPM: tpm2.DecodePublic failed: decoding TPMT_PUBLIC: unexpected EOF",
+			expErr: "cannot decode DevID public key: decoding TPMT_PUBLIC: unexpected EOF",
 			scfg: &tpmutil.SessionConfig{
 				DevicePath: "/dev/tpmrm0",
 				DevIDPriv:  []byte("not a private key blob"),
@@ -112,7 +112,7 @@ func TestNewSession(t *testing.T) {
 		},
 		{
 			name:   "NewSesion fails if owner hierarchy password is not correct",
-			expErr: "cannot load DevID key on TPM: tpm2.CreatePrimaryEx failed: session 1, error code 0x22 : authorization failure without DA implications",
+			expErr: "cannot create owner SRK: session 1, error code 0x22 : authorization failure without DA implications",
 			scfg: &tpmutil.SessionConfig{
 				DevicePath: "/dev/tpmrm0",
 				DevIDPriv:  devIDRSA.PrivateBlob,


### PR DESCRIPTION
### Problem

`NewSession()` calls `TPM2_CreatePrimary` three times on every node attestation — once inside `loadKey()` for the DevID key, once inside `createAttestationKey()` for the attestation key, and once inside `loadKey()` for the attestation key. All three use the owner hierarchy with the same SRK template and the same password.

`TPM2_CreatePrimary` performs a full on-chip RSA 2048-bit key derivation on every call and cannot use the TPM's background pre-generation pool. The Infineon SLB9672 datasheet is explicit: *"Pre-generation of Primary and Derived keys are not supported because their generation depends on caller-provided data."* On hardware where this operation is slow, three calls compound significantly.

### Evidence

Traced with bpftrace on `/dev/tpmrm0` on an Infineon SLB9672 (ipc9), watching `write()`/`read()` traffic from the `spire-agent` process. A `read()` returning 490 bytes is the TPM returning the public portion of a freshly created RSA 2048-bit SRK — the response size is characteristic of `TPM2_CreatePrimary` with `SRKTemplateHighRSA`. The three distinct 490-byte `read()` responses in the unpatched trace correspond to the three `CreatePrimaryEx` calls in `NewSession()`. The patched trace shows one.

**Interleaved attestation timing**, same node, same persistent TPM handles verified before and after every trial, 60-second cooldown between trials:

| Trial | Variant | Attestation time | CreatePrimary calls |
|-------|---------|-----------------|---------------------|
| 1 | unpatched | 77s | 3 |
| 2 | patched | 28s | 1 |
| 3 | unpatched | 76s | 3 |
| 4 | patched | 28s | 1 |

The per-CreatePrimary cost is approximately 24s on this chip. Everything else in the attestation — key loads, `ActivateCredential`, the SPIRE protocol round-trip — totals under 320ms.

### Fix

Per TPM 2.0 Part 1 §30, a child object loaded via `TPM2_Load` is independent of its parent handle after loading completes. The parent SRK can be flushed without affecting the child. There is no correctness reason to create a new SRK for each operation.

This PR lifts SRK creation out of `loadKey()` and `createAttestationKey()` into `NewSession()`, adding `loadKeyWithSRK` and `createAttestationKeyWithSRK` helpers that accept a caller-provided handle. The original `loadKey()` and `createAttestationKey()` are preserved unchanged.

For RSA DevIDs (the common case): 3 `CreatePrimary` calls → 1.
For ECC DevIDs: the AK always uses `SRKTemplateHighRSA`, so a second SRK is still needed; 3 calls → 2.

One implementation note: the SRK is flushed explicitly after the AK is loaded, before the EK `CreatePrimary`, rather than being deferred to function return. At that point devID and AK occupy two transient slots; on chips that enforce a three-slot limit (Infineon SLB9672, and the ms-tpm-20-ref simulator used in the test suite), a deferred flush causes `TPM_RC_OBJECT_MEMORY` on the EK `CreatePrimary`.

For ECC DevIDs specifically, the ECC SRK is flushed immediately after the DevID is loaded and before the RSA SRK for the AK is created. Because the TPM reuses handle numbers for newly allocated transient objects, the new RSA SRK handle may be numerically equal to the just-flushed ECC SRK handle even though they are distinct objects. A boolean `separateAKSRK` flag is used instead of handle comparison to track whether two SRKs were created.

### Test changes

Three existing test expectations are updated to reflect the new code paths in `NewSession()`.

Previously, `CreatePrimaryEx` for the SRK was called inside `loadKey()` and `createAttestationKey()`, so any failure there propagated up through those functions' error wrapping. With SRK creation now happening directly in `NewSession()` before those helpers are called, the same failure conditions produce errors at that level instead.

Concretely:

- Tests that exercise a wrong owner hierarchy password now follow a path where `CreatePrimaryEx` fails in `NewSession()` directly, producing `"cannot create owner SRK: ..."` rather than `"cannot load DevID key on TPM: tpm2.CreatePrimaryEx failed: ..."`.
- The test that exercises an invalid DevID public key blob now follows a path where `tpm2.DecodePublic` is called in `NewSession()` upfront (to determine the SRK template), producing `"cannot decode DevID public key: ..."` rather than `"cannot load DevID key on TPM: tpm2.DecodePublic failed: ..."`.

The test scenarios themselves are unchanged — same inputs, same failure conditions. The expected error strings are updated to match where in `NewSession()` those failures now surface.

### Testing

- Unit tests in `pkg/agent/plugin/nodeattestor/tpmdevid/...` pass against the ms-tpm-20-ref simulator, covering RSA and ECC DevID paths: `ok .../tpmdevid 3.648s`, `ok .../tpmutil 1.657s`.
- Verified on Infineon SLB9672 (discrete TPM) with RSA DevID keys via interleaved hardware trials (results above). Persistent TPM handles confirmed intact before and after each trial.