### PR TITLE
Don't log agent/server crashed on context canceled

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -343,7 +343,7 @@ func (cmd *Command) Run(args []string) int {
 	defer stop()
 
 	err = a.Run(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		c.Log.WithError(err).Error("Agent crashed")
 		return 1
 	}

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -287,7 +287,7 @@ func (cmd *Command) Run(args []string) int {
 	defer stop()
 
 	err = s.Run(ctx)
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		c.Log.WithError(err).Error("Server crashed")
 		return 1
 	}


### PR DESCRIPTION
If you stop the agent/server while starting up you will get a log line 'Agent/Server crashed' even though the error is just context canceled.

There are still a bunch of other errors, but this one can be somewhat misleading and might be nice to clean up. It also means an exit status of 0 instead 1, which is more representative of what happened.