### PR TITLE
oidc-discovery-provider: soften allow_insecure_scheme warning wording

### DIFF
--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -66,13 +66,13 @@ The configuration file is **required** by the provider. It contains
 
 [1]: One of `acme`, `serving_cert_file` or `listen_socket_path` must be defined.
 
-[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_socket_path`.
+[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, when TLS is terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_socket_path`.
 
 #### Considerations for Windows platforms
 
 [1]: One of `acme`, `serving_cert_file` or `listen_named_pipe_name` must be defined.
 
-[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
+[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, when TLS is terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
 
 #### Considerations for all platforms
 

--- a/support/oidc-discovery-provider/README.md
+++ b/support/oidc-discovery-provider/README.md
@@ -66,13 +66,13 @@ The configuration file is **required** by the provider. It contains
 
 [1]: One of `acme`, `serving_cert_file` or `listen_socket_path` must be defined.
 
-[3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_socket_path`.
+[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_socket_path`.
 
 #### Considerations for Windows platforms
 
 [1]: One of `acme`, `serving_cert_file` or `listen_named_pipe_name` must be defined.
 
-[3]: The `allow_insecure_scheme` should only be used in a local development environment for testing purposes. It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
+[3]: The `allow_insecure_scheme` should only be enabled when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network). It only works in conjunction with `insecure_addr` or `listen_named_pipe_name`.
 
 #### Considerations for all platforms
 

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -64,7 +64,7 @@ func run(configPath string, expandEnv bool) error {
 	defer log.Close()
 
 	if config.AllowInsecureScheme {
-		log.Warn("allow_insecure_scheme is enabled. JWKS keys will be served over HTTP. Only enable this when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network).")
+		log.Warn("allow_insecure_scheme is enabled. JWKS keys will be served over HTTP. Only enable this when the network path to the provider is trusted end-to-end (for example, when TLS is terminated at a trusted reverse proxy or load balancer on a private network)")
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/support/oidc-discovery-provider/main.go
+++ b/support/oidc-discovery-provider/main.go
@@ -64,7 +64,7 @@ func run(configPath string, expandEnv bool) error {
 	defer log.Close()
 
 	if config.AllowInsecureScheme {
-		log.Warn("allow_insecure_scheme is enabled. JWKS keys will be served over HTTP. This setting must only be used in development environments.")
+		log.Warn("allow_insecure_scheme is enabled. JWKS keys will be served over HTTP. Only enable this when the network path to the provider is trusted end-to-end (for example, TLS terminated at a trusted reverse proxy or load balancer on a private network).")
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)


### PR DESCRIPTION
Motivation:
allow_insecure_scheme logs a WARN on every startup stating the setting
"must only be used in development environments." This is inaccurate:
terminating TLS at a load balancer or reverse proxy and forwarding
plaintext to the provider over a private network is a legitimate
production topology, not just a dev-only pattern. The wording gave
operators no way to reconcile a correct, trusted-network production
deployment with a message that implies they're doing something wrong.

Approach:
Reword the WARN log message (and the matching README footnotes for
allow_insecure_scheme) to describe the actual safety condition instead
of asserting an environment: only enable this when the network path to
the provider is trusted end-to-end (e.g. TLS terminated at a trusted
reverse proxy or load balancer on a private network). This matches the
wording a SPIRE maintainer (sorindumitru) explicitly agreed to on the
issue. The log stays at WARN level and still fires on every startup
when the setting is enabled; only the message text changes. This is a
wording/documentation clarity fix, not a behavior change.

Validation:
- go build ./support/oidc-discovery-provider/...
- go test ./support/oidc-discovery-provider/... -> ok

Fixes #7155

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>