### PR TITLE
Start agent telemetry sinks before node attestation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -96,6 +96,15 @@ func (a *Agent) Run(ctx context.Context) error {
 		defer mgrMu.Unlock()
 		return mgr
 	}
+	// Kept separate from newManager so the lock is only held for the assignment.
+	// newManager retries Initialize for up to bootstrapBackoffMaxElapsedTime, or
+	// rebootstrapBackoffMaxElapsedTime when rebootstrapping, and holding mgrMu
+	// across that would stall every scrape for the same period.
+	setManager := func(m manager.Manager) {
+		mgrMu.Lock()
+		defer mgrMu.Unlock()
+		mgr = m
+	}
 
 	metrics, err := telemetry.NewMetrics(&telemetry.MetricsConfig{
 		FileConfig:  a.c.Telemetry,
@@ -292,12 +301,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Publish under the lock; the telemetry callbacks may already be reading via
-	// getManager. Reads below are on this goroutine and need no locking, as
-	// nothing else writes mgr.
-	mgrMu.Lock()
-	mgr = newMgr
-	mgrMu.Unlock()
+	// Publish it; the telemetry callbacks may already be reading via getManager.
+	// Reads below are on this goroutine and need no locking, as nothing else
+	// writes mgr.
+	setManager(newMgr)
 
 	storeService := a.newSVIDStoreService(svidStoreCache, cat, metrics)
 	workloadAttestor := workload_attestor.New(&workload_attestor.Config{

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -82,7 +82,21 @@ func (a *Agent) Run(ctx context.Context) error {
 		defer stopProfiling()
 	}
 
-	var mgr manager.Manager
+	// mgr is assigned by newManager well after the telemetry sinks are started, so
+	// the callbacks below can run on exporter goroutines before that write lands.
+	// An interface value is two words, making an unsynchronized read a data race
+	// rather than just a torn nil check, so all reads from other goroutines go
+	// through getManager.
+	var (
+		mgrMu sync.Mutex
+		mgr   manager.Manager
+	)
+	getManager := func() manager.Manager {
+		mgrMu.Lock()
+		defer mgrMu.Unlock()
+		return mgr
+	}
+
 	metrics, err := telemetry.NewMetrics(&telemetry.MetricsConfig{
 		FileConfig:  a.c.Telemetry,
 		Logger:      a.c.Log.WithField(telemetry.SubsystemName, telemetry.Telemetry),
@@ -90,6 +104,7 @@ func (a *Agent) Run(ctx context.Context) error {
 		TrustDomain: a.c.TrustDomain.Name(),
 		TLSPolicy:   a.c.TLSPolicy,
 		GetX509SVID: func() (*x509svid.SVID, error) {
+			mgr := getManager()
 			if mgr == nil {
 				return nil, errors.New("agent manager is not initialized")
 			}
@@ -111,6 +126,7 @@ func (a *Agent) Run(ctx context.Context) error {
 			}, nil
 		},
 		GetX509BundleAuthorities: func(td spiffeid.TrustDomain) ([]*x509.Certificate, error) {
+			mgr := getManager()
 			if mgr == nil {
 				return nil, errors.New("agent manager is not initialized")
 			}
@@ -146,6 +162,16 @@ func (a *Agent) Run(ctx context.Context) error {
 	}
 
 	taskRunner := util.NewTaskRunner(ctx, cancel)
+
+	// Start the telemetry sinks before node attestation. Attestation can retry for
+	// bootstrapBackoffMaxElapsedTime, or rebootstrapBackoffMaxElapsedTime when
+	// rebootstrapping, and every return before StartTasks(tasks...) below would
+	// otherwise leave the exporter unbound - so an agent that never attests
+	// successfully exposes no metrics at all, including spire_agent_started,
+	// spire_agent_uptime and the bootstrap gauges. This also gates the InMem sink's
+	// signal handler, since MetricsImpl.ListenAndServe drives every sink runner.
+	taskRunner.StartTasks(metrics.ListenAndServe)
+
 	nodeAttestor := nodeattestor.JoinToken(a.c.Log, a.c.JoinToken)
 	if a.c.JoinToken == "" {
 		nodeAttestor = cat.GetNodeAttestor()
@@ -262,10 +288,16 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	svidStoreCache := a.newSVIDStoreCache(metrics)
 
-	mgr, err = a.newManager(ctx, sto, cat, metrics, as, svidStoreCache, nodeAttestor)
+	newMgr, err := a.newManager(ctx, sto, cat, metrics, as, svidStoreCache, nodeAttestor)
 	if err != nil {
 		return err
 	}
+	// Publish under the lock; the telemetry callbacks may already be reading via
+	// getManager. Reads below are on this goroutine and need no locking, as
+	// nothing else writes mgr.
+	mgrMu.Lock()
+	mgr = newMgr
+	mgrMu.Unlock()
 
 	storeService := a.newSVIDStoreService(svidStoreCache, cat, metrics)
 	workloadAttestor := workload_attestor.New(&workload_attestor.Config{
@@ -275,7 +307,6 @@ func (a *Agent) Run(ctx context.Context) error {
 	})
 
 	tasks := []func(context.Context) error{
-		metrics.ListenAndServe,
 		mgr.Run,
 		storeService.Run,
 		catalog.ReconfigureTask(a.c.Log.WithField(telemetry.SubsystemName, "reconfigurer"), cat),

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -178,36 +179,56 @@ func reserveFreePorts(t *testing.T, n int) []int {
 func requireScrapeContains(t *testing.T, port int, runErr <-chan error, want string) string {
 	t.Helper()
 	endpoint := fmt.Sprintf("http://127.0.0.1:%d/metrics", port)
-	deadline := time.Now().Add(30 * time.Second)
-	var lastErr error
+	// Bounded per-request timeout so a stalled response fails this attempt rather
+	// than hanging until the outer deadline.
+	client := &http.Client{Timeout: 2 * time.Second}
 
-	for time.Now().Before(deadline) {
+	// The condition runs on another goroutine, so these are mutex-guarded rather
+	// than relying on require.Eventually's internal ordering.
+	var (
+		mu      sync.Mutex
+		body    string
+		lastErr error
+		exitErr error
+		exited  bool
+	)
+
+	require.Eventually(t, func() bool {
 		select {
 		case err := <-runErr:
-			t.Fatalf("Run returned before %q was scrapeable: %v", want, err)
+			mu.Lock()
+			exitErr, exited = err, true
+			mu.Unlock()
+			return true
 		default:
 		}
 
-		body, err := scrapeOnce(endpoint)
+		got, err := scrapeOnce(client, endpoint)
+		mu.Lock()
+		defer mu.Unlock()
 		if err != nil {
 			lastErr = err
-			time.Sleep(100 * time.Millisecond)
-			continue
+			return false
 		}
-		if strings.Contains(body, want) {
-			return body
+		if strings.Contains(got, want) {
+			body = got
+			return true
 		}
-		time.Sleep(100 * time.Millisecond)
-	}
+		return false
+	}, 30*time.Second, 100*time.Millisecond,
+		"%q never became scrapeable on %s; "+
+			"is metrics.ListenAndServe still started before node attestation in Run?",
+		want, endpoint)
 
-	t.Fatalf("%q never became scrapeable on %s (last error: %v); "+
-		"is metrics.ListenAndServe still started before node attestation in Run?",
-		want, endpoint, lastErr)
-	return ""
+	mu.Lock()
+	defer mu.Unlock()
+	require.False(t, exited, "Run returned before %q was scrapeable: %v", want, exitErr)
+	require.NotEmpty(t, body, "no metrics body captured (last scrape error: %v)", lastErr)
+	return body
 }
 
-func scrapeOnce(endpoint string) (string, error) {
-	resp, err := http.Get(endpoint) //nolint: gosec // fixed loopback URL built in-test
+func scrapeOnce(client *http.Client, endpoint string) (string, error) {
+	resp, err := client.Get(endpoint) //nolint: gosec // fixed loopback URL built in-test
 	if err != nil {
 		return "", err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -7,13 +7,14 @@ import (
 	"net"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	"github.com/sirupsen/logrus/hooks/test"
+	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -125,7 +126,7 @@ func TestMetricsServedDuringAttestationRetry(t *testing.T) {
 		PluginConfigs: catalog.PluginConfigs{
 			{Type: "KeyManager", Name: "memory"},
 			{Type: "NodeAttestor", Name: "join_token"},
-			{Type: "WorkloadAttestor", Name: "unix"},
+			{Type: "WorkloadAttestor", Name: platformWorkloadAttestor()},
 		},
 		// Insecure bootstrap keeps the test free of certificates and bundle files:
 		// GetBundle returns no bundle, and attestation proceeds straight to the dial.
@@ -155,6 +156,16 @@ func TestMetricsServedDuringAttestationRetry(t *testing.T) {
 	case <-time.After(30 * time.Second):
 		t.Fatal("timeout waiting for Run to return after context cancellation")
 	}
+}
+
+// platformWorkloadAttestor names a WorkloadAttestor that loads on this platform.
+// catalog.Load requires at least one, and the unix and windows attestors are
+// mirror images that return Unimplemented on the other platform.
+func platformWorkloadAttestor() string {
+	if runtime.GOOS == "windows" {
+		return "windows"
+	}
+	return "unix"
 }
 
 // reserveFreePorts returns n distinct ports with nothing listening on them.
@@ -228,7 +239,7 @@ func requireScrapeContains(t *testing.T, port int, runErr <-chan error, want str
 }
 
 func scrapeOnce(client *http.Client, endpoint string) (string, error) {
-	resp, err := client.Get(endpoint) //nolint: gosec // fixed loopback URL built in-test
+	resp, err := client.Get(endpoint)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1,15 +1,27 @@
 package agent
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	workload_pb "github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/spiffe/spire/pkg/agent/trustbundlesources"
+	"github.com/spiffe/spire/pkg/common/catalog"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/test/spiretest"
 )
 
@@ -79,6 +91,135 @@ func TestCheckHealth(t *testing.T) {
 			}, state.LiveDetails)
 		})
 	}
+}
+
+// TestMetricsServedDuringAttestationRetry asserts that the telemetry listener is
+// already serving while node attestation is still retrying.
+//
+// Attestation retries for up to bootstrapBackoffMaxElapsedTime, or
+// rebootstrapBackoffMaxElapsedTime when rebootstrapping, and every early return
+// in that loop happens before the task batch at the end of Run. If
+// metrics.ListenAndServe is started from that batch rather than before
+// attestation, an agent that never attests successfully exposes no metrics at
+// all - it is indistinguishable from an agent that is not running, which is the
+// situation #6164 fixed. This test fails if that placement regresses.
+func TestMetricsServedDuringAttestationRetry(t *testing.T) {
+	log, _ := test.NewNullLogger()
+
+	// Two free ports: one for the exporter to bind, and one with nothing behind it
+	// so attestation fails with a retryable error and Run stays in its backoff
+	// loop rather than returning.
+	ports := reserveFreePorts(t, 2)
+	promPort, deadServerPort := ports[0], ports[1]
+
+	a := New(&Config{
+		DataDir:         filepath.Join(t.TempDir(), "data"),
+		Log:             log,
+		TrustDomain:     spiffeid.RequireTrustDomainFromString("example.org"),
+		ServerAddress:   fmt.Sprintf("127.0.0.1:%d", deadServerPort),
+		RebootstrapMode: RebootstrapNever,
+		// A join token keeps the node attestor out of the catalog; the failure being
+		// exercised is the dial, not the attestor.
+		JoinToken: "TOKEN",
+		PluginConfigs: catalog.PluginConfigs{
+			{Type: "KeyManager", Name: "memory"},
+			{Type: "NodeAttestor", Name: "join_token"},
+			{Type: "WorkloadAttestor", Name: "unix"},
+		},
+		// Insecure bootstrap keeps the test free of certificates and bundle files:
+		// GetBundle returns no bundle, and attestation proceeds straight to the dial.
+		TrustBundleSources: trustbundlesources.New(&trustbundlesources.Config{
+			InsecureBootstrap: true,
+			TrustDomain:       "example.org",
+		}, log),
+		Telemetry: telemetry.FileConfig{
+			Prometheus: &telemetry.PrometheusConfig{Host: "127.0.0.1", Port: promPort},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- a.Run(ctx) }()
+
+	body := requireScrapeContains(t, promPort, runErr, "spire_agent_started")
+	// Emitted from GetBundle on every attestation attempt, so its presence shows
+	// the retry loop is observable and not merely that the socket is open.
+	require.Contains(t, body, "spire_agent_bootstrap_attempts")
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout waiting for Run to return after context cancellation")
+	}
+}
+
+// reserveFreePorts returns n distinct ports with nothing listening on them.
+func reserveFreePorts(t *testing.T, n int) []int {
+	t.Helper()
+	listeners := make([]net.Listener, 0, n)
+	ports := make([]int, 0, n)
+	for range n {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		listeners = append(listeners, l)
+		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
+	}
+	for _, l := range listeners {
+		require.NoError(t, l.Close())
+	}
+	return ports
+}
+
+// requireScrapeContains polls /metrics until it serves a body containing want,
+// failing if the agent exits first or the deadline passes.
+func requireScrapeContains(t *testing.T, port int, runErr <-chan error, want string) string {
+	t.Helper()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d/metrics", port)
+	deadline := time.Now().Add(30 * time.Second)
+	var lastErr error
+
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-runErr:
+			t.Fatalf("Run returned before %q was scrapeable: %v", want, err)
+		default:
+		}
+
+		body, err := scrapeOnce(endpoint)
+		if err != nil {
+			lastErr = err
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		if strings.Contains(body, want) {
+			return body
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	t.Fatalf("%q never became scrapeable on %s (last error: %v); "+
+		"is metrics.ListenAndServe still started before node attestation in Run?",
+		want, endpoint, lastErr)
+	return ""
+}
+
+func scrapeOnce(endpoint string) (string, error) {
+	resp, err := http.Get(endpoint) //nolint: gosec // fixed loopback URL built in-test
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	return string(body), nil
 }
 
 type unavailableWorkloadAPI struct {


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated? — no user-facing config or behaviour change, so nothing to document.

**Affected functionality**

Agent telemetry startup. The Prometheus exporter and the `InMem` sink's signal handler are no longer started before node attestation, so an agent that fails or retries attestation serves no metrics at all.

**Description of change**

Restores the placement from #6164, which #6812 reverted while adding the Prometheus TLS identity feature. Only the metrics half was undone — #6164's health-check half survived via `startHealthChecks`, which is why an agent stuck bootstrapping still serves health checks but not its exporter.

```
$ git log --oneline -S 'taskRunner.StartTasks(metrics.ListenAndServe)' -- pkg/agent/agent.go
9b83deff1 Add SPIRE-backed Prometheus TLS identity and SPIFFE allowlist (#6812)
1328bd896 Fix metrics/health checks when retry_bootstrap=true (#6164)
```

#6164's stated rationale still applies verbatim:

> When retry_bootstrap is true, during the startup/retrying, health checks / metrics are not started. This time is currently is capped at 5 minutes, requiring fairly long health check delays on Kubernetes, and no ability to collect metrics on what its doing.

With `metrics.ListenAndServe` in the post-`newManager` task batch, every return before `StartTasks(tasks...)` leaves the exporter unbound. That covers the whole attestation retry loop, which backs off for up to `bootstrapBackoffMaxElapsedTime`, or `rebootstrapBackoffMaxElapsedTime` when rebootstrapping. Unscrapeable on those paths:

| Metric | Emitted at |
| --- | --- |
| `spire_agent_started{version,trust_domain_id}` | `agent.go`, before the catalog loads |
| `spire_agent_uptime` | same, then every 10s |
| `spire_agent_bootstrapped` | `trustbundlesources/bundle.go` |
| `spire_agent_bootstrap_seconds{mode}` | `trustbundlesources/bundle.go` |
| `spire_agent_bootstrap_attempts{mode}` | `trustbundlesources/bundle.go`, per attempt |

The bootstrap gauges come from #5892, so the observability #6164 restored for that feature is gone again. `MetricsImpl.ListenAndServe` drives *every* sink runner's `run()`, and `inmemRunner.run` is what installs the `NewInmemSignal` handler — so the `SIGUSR1` dump is gated too, and both telemetry escape hatches are unavailable in the same window.

Net effect: an agent that never attests successfully is indistinguishable from one that is not running.

**Why `mgr` also needs synchronizing**

Simply restoring #6164's placement is not sufficient on its own, which is the one part of this change that goes beyond a revert.

`GetX509SVID` and `GetX509BundleAuthorities` close over `mgr`, assigned much later by `newManager`. Starting the sinks early makes the exporter's handler goroutines live before that write, and an interface value is two words, so an unsynchronized read is a data race rather than merely a torn nil check — `go test -race` would flag it for TLS-enabled exporters.

This is not a pre-existing condition #6164 accepted. Before #6812 nothing captured the manager (it was a fresh `manager, err := a.newManager(...)`, and `NewMetrics` took no callbacks), so the early start carried no race. The two changes only conflict in combination, which is part of why the revert was easy to miss.

`mgr` is therefore guarded by a mutex, with both callbacks reading through `getManager()`. Reads after the assignment stay unlocked, being on the same goroutine as the write, and nothing else ever writes it. Happy to reshape this if you would prefer a different form — e.g. handing the callbacks a dedicated holder rather than closing over a local.

**Tests**

`TestMetricsServedDuringAttestationRetry` in `pkg/agent/agent_test.go` asserts the exporter is serving while attestation is still retrying. There was no test covering this ordering, which is why the revert went unnoticed.

It points the agent at a closed port so attestation fails with a retryable error and `Run` stays in its backoff loop, then scrapes `/metrics` and requires `spire_agent_started` and `spire_agent_bootstrap_attempts`. Insecure bootstrap keeps it free of certificates and bundle files, and a join token keeps the node attestor out of the catalog, so the only failure exercised is the dial.

Verified in both directions on this branch:

```
with the fix     --- PASS (0.11s)
without the fix  --- FAIL (30.08s)
    "spire_agent_started" never became scrapeable on http://127.0.0.1:58992/metrics
    (last error: dial tcp 127.0.0.1:58992: connect: connection refused);
    is metrics.ListenAndServe still started before node attestation in Run?
```

The failing case confirms the agent stays alive and retrying throughout while nothing is listening, rather than exiting early.

Full run, race enabled:

```
go build ./...                                                  ok
go vet ./pkg/agent/...                                          ok
go test -race ./pkg/agent/... ./pkg/common/telemetry/...         51 ok, 0 failures, 0 races
```

**Which issue this PR fixes**

fixes #7164
