### PR TITLE
k8s suite: replace k8sbundle notifier with k8s_configmap BundlePublisher

### DIFF
--- a/test/integration/suites/k8s/README.md
+++ b/test/integration/suites/k8s/README.md
@@ -7,3 +7,6 @@ This suite sets up a Kubernetes cluster using [Kind](https://kind.sigs.k8s.io) a
 * SPIRE server attests SPIRE agents by verifying Kubernetes Projected Service
   Account Tokens (i.e. `k8s_psat`) via the Token Review API.
 * K8s Workload attestation is successful against a manually registered workload
+* The `k8s_configmap` BundlePublisher publishes the trust bundle to the
+  `spire:spire-bundle` ConfigMap that SPIRE agents mount to bootstrap trust
+  with the server.

--- a/test/integration/suites/k8s/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s/conf/server/spire-server.yaml
@@ -89,9 +89,9 @@ roleRef:
 ---
 
 # ConfigMap containing the latest trust bundle for the trust domain. It is
-# updated by SPIRE using the k8sbundle notifier plugin. SPIRE agents mount
-# this config map and use the certificate to bootstrap trust with the SPIRE
-# server during attestation.
+# updated by SPIRE using the k8s_configmap BundlePublisher plugin. SPIRE agents
+# mount this config map and use the certificate to bootstrap trust with the
+# SPIRE server during attestation.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -147,10 +147,19 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap, which SPIRE agents mount to bootstrap
+          # trust with the server during attestation.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Trust bundle distribution in the `k8s` integration test suite. No product code is touched, only the suite's server configuration and its README.

**Description of change**

The `k8s` suite configured the `k8sbundle` Notifier to keep the `spire:spire-bundle` ConfigMap up to date. Since that Notifier is being deprecated in favor of the `k8s_configmap` BundlePublisher, this replaces it so the suite exercises the plugin that is going to stay.

The BundlePublisher is pointed at the same ConfigMap and key the Notifier was writing:

```hcl
BundlePublisher "k8s_configmap" {
  plugin_data {
    clusters = {
      "example-cluster" = {
        configmap_name = "spire-bundle"
        configmap_key  = "bundle.crt"
        namespace      = "spire"
        format         = "pem"
      }
    }
  }
}
```

Because the target is unchanged, nothing else in the suite needs to move:

* Agents keep bootstrapping from the mounted `spire-bundle` ConfigMap via `trust_bundle_path = "/run/spire/bundle/bundle.crt"`, so the agent configuration is untouched.
* `pem` is used because that is what the agent reads at that path. Any other format would also require setting `trust_bundle_format` on the agent, which felt out of scope here.
* The server Role already grants `get` and `patch` on `resourceNames: ["spire-bundle"]`, which covers the Apply the plugin performs, so no RBAC change is needed.

A stale comment above the ConfigMap that still credited the Notifier has been updated, and the suite README now mentions the bundle publishing that the suite asserts.

On testing: the suite itself is the regression check. `02-check-for-workload-svid` only succeeds if an agent can read the trust bundle from that ConfigMap, so a bad publisher configuration fails the suite rather than passing silently. Verified locally on linux/arm64 against the unmodified suite first and then with this change, both passing, with the server logging:

```
msg="Bundle published to Kubernetes ConfigMap" cluster_id=example-cluster
configmap=spire-bundle key=bundle.crt namespace=spire format=pem
plugin_name=k8s_configmap plugin_type=BundlePublisher
```

One thing worth calling out for reviewers who have not seen the issue: this removes the Notifier from a suite while the plugin still ships. That is deliberate and was the direction asked for in #6127, where the preference was to replace it outright in all of these tests rather than run both side by side, given the deprecation. This is the first of the series, kept to the `k8s` suite so the approach can be checked before the same change is applied to `k8s-sigstore`, `broker-api-k8s`, `key-manager-vault` and `upstream-authority-vault`.

**Which issue this PR fixes**

Part of #6127
