### PR TITLE
doc/telemetry: drop empty targets from the two status piecharts

### DIFF
--- a/doc/telemetry/spire_grafana_dashboard.json
+++ b/doc/telemetry/spire_grafana_dashboard.json
@@ -555,18 +555,6 @@
               "interval": "",
               "legendFormat": "",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "B"
             }
           ],
           "title": "SPIRE Agent: GET JWT status",
@@ -645,18 +633,6 @@
               "interval": "",
               "legendFormat": "",
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
-              },
-              "exemplar": true,
-              "expr": "",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "",
-              "refId": "B"
             }
           ],
           "title": "SPIRE Agent: GET x509 status",


### PR DESCRIPTION
Fixes #6918.

`doc/telemetry/spire_grafana_dashboard.json` has two piechart panels, `SPIRE Agent: GET JWT status` and `SPIRE Agent: GET x509 status`, that each carry a second target with `"expr": ""` under `refId: B`. Grafana still issues that target, Prometheus rejects an empty query, and the panel renders a query error next to the series it did manage to fetch.

Nothing references `refId: B` in either panel: no transformation, no override, no legend entry. It looks like a leftover from editing the panels in the Grafana UI.

The other empty `expr` values in the file are on `row` panels, which do not query anything, so I left those alone. After the change the only remaining empty exprs in the dashboard are on rows.

Checked with a small script over the JSON before and after: two non-row panels with an empty target before, none after, and the file still parses.