### PR TITLE
integration: replace k8sbundle notifier with k8s_configmap BundlePublisher

### DIFF
--- a/test/integration/suites/broker-api-k8s/conf/server/spire-server.yaml
+++ b/test/integration/suites/broker-api-k8s/conf/server/spire-server.yaml
@@ -89,9 +89,9 @@ roleRef:
 ---
 
 # ConfigMap containing the latest trust bundle for the trust domain. It is
-# updated by SPIRE using the k8sbundle notifier plugin. SPIRE agents mount
-# this config map and use the certificate to bootstrap trust with the SPIRE
-# server during attestation.
+# updated by SPIRE using the k8s_configmap BundlePublisher plugin. SPIRE agents
+# mount this config map and use the certificate to bootstrap trust with the
+# SPIRE server during attestation.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -147,10 +147,19 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap, which SPIRE agents mount to bootstrap
+          # trust with the server during attestation.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/k8s-sigstore/conf/server/spire-server.yaml
+++ b/test/integration/suites/k8s-sigstore/conf/server/spire-server.yaml
@@ -80,9 +80,9 @@ roleRef:
 ---
 
 # ConfigMap containing the latest trust bundle for the trust domain. It is
-# updated by SPIRE using the k8sbundle notifier plugin. SPIRE agents mount
-# this config map and use the certificate to bootstrap trust with the SPIRE
-# server during attestation.
+# updated by SPIRE using the k8s_configmap BundlePublisher plugin. SPIRE agents
+# mount this config map and use the certificate to bootstrap trust with the
+# SPIRE server during attestation.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -131,10 +131,19 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap, which SPIRE agents mount to bootstrap
+          # trust with the server during attestation.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/key-manager-vault/conf/server/approle-auth/spire-server.yaml
+++ b/test/integration/suites/key-manager-vault/conf/server/approle-auth/spire-server.yaml
@@ -47,10 +47,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/key-manager-vault/conf/server/base/spire-server.yaml
+++ b/test/integration/suites/key-manager-vault/conf/server/base/spire-server.yaml
@@ -84,9 +84,7 @@ roleRef:
 ---
 
 # ConfigMap containing the latest trust bundle for the trust domain. It is
-# updated by SPIRE using the k8sbundle notifier plugin. SPIRE agents mount
-# this config map and use the certificate to bootstrap trust with the SPIRE
-# server during attestation.
+# updated by SPIRE using the k8s_configmap BundlePublisher plugin.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -149,10 +147,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/key-manager-vault/conf/server/cert-auth/spire-server.yaml
+++ b/test/integration/suites/key-manager-vault/conf/server/cert-auth/spire-server.yaml
@@ -50,10 +50,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/key-manager-vault/conf/server/k8s-auth/spire-server.yaml
+++ b/test/integration/suites/key-manager-vault/conf/server/k8s-auth/spire-server.yaml
@@ -50,10 +50,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/key-manager-vault/conf/server/token-auth/spire-server.yaml
+++ b/test/integration/suites/key-manager-vault/conf/server/token-auth/spire-server.yaml
@@ -47,10 +47,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/upstream-authority-vault/conf/server/approle-auth/spire-server-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/approle-auth/spire-server-configmap.yaml
@@ -53,10 +53,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/upstream-authority-vault/conf/server/base/spire-server-bundle-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/base/spire-server-bundle-configmap.yaml
@@ -1,7 +1,5 @@
 # ConfigMap containing the latest trust bundle for the trust domain. It is
-# updated by SPIRE using the k8sbundle notifier plugin. SPIRE agents mount
-# this config map and use the certificate to bootstrap trust with the SPIRE
-# server during attestation.
+# updated by SPIRE using the k8s_configmap BundlePublisher plugin.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/test/integration/suites/upstream-authority-vault/conf/server/base/spire-server-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/base/spire-server-configmap.yaml
@@ -52,10 +52,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/upstream-authority-vault/conf/server/cert-auth/spire-server-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/cert-auth/spire-server-configmap.yaml
@@ -56,10 +56,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/upstream-authority-vault/conf/server/k8s-auth/spire-server-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/k8s-auth/spire-server-configmap.yaml
@@ -56,10 +56,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }

--- a/test/integration/suites/upstream-authority-vault/conf/server/token-auth/spire-server-configmap.yaml
+++ b/test/integration/suites/upstream-authority-vault/conf/server/token-auth/spire-server-configmap.yaml
@@ -53,10 +53,18 @@ data:
         }
       }
 
-      Notifier "k8sbundle" {
+      BundlePublisher "k8s_configmap" {
         plugin_data {
-          # This plugin updates the bundle.crt value in the spire:spire-bundle
-          # ConfigMap by default, so no additional configuration is necessary.
+          # Publishes the trust bundle to the bundle.crt key of the
+          # spire:spire-bundle ConfigMap.
+          clusters = {
+            "example-cluster" = {
+              configmap_name = "spire-bundle"
+              configmap_key  = "bundle.crt"
+              namespace      = "spire"
+              format         = "pem"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Trust bundle distribution in the `k8s-sigstore`, `broker-api-k8s`, `key-manager-vault` and `upstream-authority-vault` integration suites. No product code is touched, only suite configuration.

**Description of change**

Follow up to #7172, which did the same thing for the `k8s` suite. This replaces the `k8sbundle` Notifier with the `k8s_configmap` BundlePublisher in the four remaining suites that were still configuring it, so that nothing under `test/` exercises the Notifier that is going to be deprecated.

The publisher is pointed at the same ConfigMap and key the Notifier was writing:

```hcl
BundlePublisher "k8s_configmap" {
  plugin_data {
    clusters = {
      "example-cluster" = {
        configmap_name = "spire-bundle"
        configmap_key  = "bundle.crt"
        namespace      = "spire"
        format         = "pem"
      }
    }
  }
}
```

Because the target is unchanged, nothing else has to move:

* Suites that deploy an agent keep bootstrapping from the mounted `spire-bundle` ConfigMap via `trust_bundle_path`, so agent configuration is untouched.
* `pem` is used because that is what those agents read at that path. Another format would also mean setting `trust_bundle_format` on the agent, and one format seemed enough per the discussion on #6127.
* Each suite's Role already grants `get` and `patch` on `resourceNames: ["spire-bundle"]`, which covers the Apply the plugin performs, so no RBAC change is needed.
* `"example-cluster"` matches the cluster ID each suite's `k8s_psat` NodeAttestor already uses.

`k8sbundle` no longer appears anywhere under `test/`. It is untouched in `pkg/`, `doc/` and `conf/`, since the plugin itself still ships.

**On testing**

The suites are the regression check, but they are not all equal here, so it is worth being precise:

* `k8s-sigstore` and `broker-api-k8s` deploy an agent that bootstraps from the ConfigMap, so a bad publisher configuration fails the suite rather than passing quietly. Both pass, and `broker-api-k8s` logs `Bundle published to Kubernetes ConfigMap ... configmap=spire-bundle key=bundle.crt format=pem`.
* `key-manager-vault` and `upstream-authority-vault` are server only, with no agent consuming the bundle, so a passing run alone would not prove the publisher worked. Both were additionally checked by reading `spire-bundle` back out of the cluster during a run and confirming `bundle.crt` contained PEM (756 and 1171 bytes respectively). That check was a local probe and is not part of this change.

All four suites were run locally on linux/arm64 and pass.

**Two things worth flagging for reviewers**

1. The comment above the `spire-bundle` ConfigMap in `key-manager-vault` and `upstream-authority-vault` claimed that "SPIRE agents mount this config map", which was not true in those suites even before this change, since neither deploys an agent. Since the change already rewrote the plugin name on that line, the inaccurate sentence was dropped rather than carried forward. The equivalent comment in `broker-api-k8s`, which does deploy an agent, is unchanged in meaning.
2. The diff touches 13 files but is the same replacement 11 times, so it should read quickly.

**Which issue this PR fixes**

Fixes #6127
