### PR TITLE
ci: fix nightly AWS CA certs push and limit to main repo

### DIFF
--- a/.github/workflows/nightly_build.yaml
+++ b/.github/workflows/nightly_build.yaml
@@ -40,6 +40,7 @@ jobs:
         run: ./.github/workflows/scripts/push-images.sh nightly
 
   update-aws-ca-certs:
+    if: github.repository == 'spiffe/spire'
     runs-on: ubuntu-22.04
 
     permissions:
@@ -49,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - name: Setup go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:


### PR DESCRIPTION
## Summary

Fixes the nightly `update-aws-ca-certs` job that has been failing with `git push --force-with-lease` rejected as `stale info`.

1. **`fetch-depth: 0`** on the job checkout so the remote tracking ref for `bot/update-aws-ca-certs` exists and `--force-with-lease` can compare against it (default single-branch checkout only has `main`).
2. **`if: github.repository == 'spiffe/spire'`** so the job does not run on forks.

As discussed on #7184.

## Test plan

- [x] Diff limited to `.github/workflows/nightly_build.yaml`
- [ ] After merge: nightly (or `workflow_dispatch`) succeeds at the push step when certs drift
- [ ] On a fork, `update-aws-ca-certs` is skipped

Fixes #7184