### PR TITLE
Simplify k8s workload attestor broker configuration

### DIFF
--- a/conf/agent/agent_full.conf
+++ b/conf/agent/agent_full.conf
@@ -547,9 +547,11 @@ plugins {
             # experimental.broker: Broker API-specific configuration used by AttestReference.
             # Broker API uses AttestReference, so this block is required for
             # all Broker API references handled by this plugin, including
-            # WorkloadPIDReference and KubernetesObjectReference. Each broker
-            # entry identifies a broker SPIFFE ID. IDs must be valid, unique,
-            # and non-empty. access_policy controls whether the plugin runs
+            # WorkloadPIDReference and KubernetesObjectReference. The brokers
+            # list is optional and holds per-broker overrides; a broker that is
+            # not listed uses the default configuration. Each broker entry
+            # identifies a broker SPIFFE ID. IDs must be valid, unique,
+            # and non-empty. access_policy is required and controls whether the plugin runs
             # SubjectAccessReview checks for resolved objects. It must be set
             # to "enforced" or "permissive". When set to "enforced",
             # the broker SPIFFE ID is used as the

--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -73,7 +73,7 @@ These are the current experimental configurations.
 | experimental               | Description                                                                                                                                           | Default |
 |:---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `api_server.cache.enabled` | If true, enables a controller-runtime Kubernetes API server cache for object-reference lookups.                                                       | false   |
-| `broker`                   | Broker API options for `AttestReference`. Optional; when omitted, brokers get the default (node-scoped) configuration. See [Broker API](#broker-api). |         |
+| `broker`                   | Broker API options for `AttestReference`. Required when this plugin handles Broker API references. See [Broker API](#broker-api).                     |         |
 
 ## Sigstore feature
 
@@ -144,6 +144,10 @@ When SPIRE Agent's [SPIFFE Broker API](spire_agent.md#spiffe-broker-api) is
 enabled, the k8s workload attestor handles Broker API `AttestReference`
 requests for `WorkloadPIDReference` and `KubernetesObjectReference`.
 
+`AttestReference` requires an `experimental.broker` block in the plugin
+configuration, with `access_policy` set. The `brokers` list inside it is
+optional.
+
 The `experimental.broker.brokers` list carries **per-broker overrides**,
 naming brokers that need a wider scope than the default and configuring each
 one. A broker with no entry uses the **default broker configuration**:
@@ -156,16 +160,15 @@ nodes. When listed, broker IDs must be valid, unique, and non-empty.
 Which brokers may reach the plugin at all is decided by the agent's own broker
 endpoint (`experimental.broker.brokers` in the agent configuration), so the
 plugin serves every authorized broker with the default configuration unless an
-entry overrides it. The list may be empty or omitted — as may the whole
-`experimental.broker` block — leaving every broker on the default.
+entry overrides it. The list may be empty or omitted, leaving every broker on
+the default.
 
-The block-level `access_policy` setting (required when the `broker` block is
-present) controls whether the plugin creates Kubernetes `SubjectAccessReview`
-requests for resolved objects. Use `access_policy = "enforced"` to authorize
-every resolved object with Kubernetes before selectors are returned (the
-review uses the broker SPIFFE ID as the SAR username, so this applies to
-default brokers too). Use `access_policy = "permissive"` to skip that
-authorization check. With no `broker` block, behavior is permissive.
+The block-level `access_policy` setting is required and has no default. It
+controls whether the plugin creates Kubernetes `SubjectAccessReview` requests
+for resolved objects. Use `access_policy = "enforced"` to authorize every
+resolved object with Kubernetes before selectors are returned (the review uses
+the broker SPIFFE ID as the SAR username, so this applies to default brokers
+too). Use `access_policy = "permissive"` to skip that authorization check.
 
 > [!IMPORTANT]
 > In `permissive` mode, any broker the agent's broker endpoint forwarded can

--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -70,10 +70,10 @@ since [hostprocess](https://kubernetes.io/docs/tasks/configure-pod-container/cre
 
 These are the current experimental configurations.
 
-| experimental               | Description                                                                                                                       | Default |
-|:---------------------------|-----------------------------------------------------------------------------------------------------------------------------------|---------|
-| `api_server.cache.enabled` | If true, enables a controller-runtime Kubernetes API server cache for object-reference lookups.                                   | false   |
-| `broker`                   | Broker API options for `AttestReference`. Required when this plugin handles Broker API references. See [Broker API](#broker-api). |         |
+| experimental               | Description                                                                                                                                           | Default |
+|:---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `api_server.cache.enabled` | If true, enables a controller-runtime Kubernetes API server cache for object-reference lookups.                                                       | false   |
+| `broker`                   | Broker API options for `AttestReference`. Optional; when omitted, brokers get the default (node-scoped) configuration. See [Broker API](#broker-api). |         |
 
 ## Sigstore feature
 
@@ -143,20 +143,64 @@ If `ignore_tlog` is set to `true`, the selectors based on the Rekor bundle (`-lo
 When SPIRE Agent's [SPIFFE Broker API](spire_agent.md#spiffe-broker-api) is
 enabled, the k8s workload attestor handles Broker API `AttestReference`
 requests for `WorkloadPIDReference` and `KubernetesObjectReference`.
-`AttestReference` requires an `experimental.broker` block in the plugin configuration. Each
-`experimental.broker.brokers` entry identifies one broker SPIFFE ID that may use this
-plugin. Broker IDs must be valid, unique, and non-empty. The required
-block-level `access_policy` setting controls whether the plugin creates
-Kubernetes `SubjectAccessReview` requests for resolved objects. Use
-`access_policy = "enforced"` to authorize every resolved object with
-Kubernetes before selectors are returned. Use `access_policy = "permissive"`
-to skip that authorization check. Each broker may set `pod_reference_scope` to
-`agent_node` (default) or `cluster`; this only affects pod
-`KubernetesObjectReference` resolution. Broker-only agents that set
-`disable_kubelet_client = true` must configure every broker with
-`pod_reference_scope = "cluster"`.
 
-Example:
+The `experimental.broker.brokers` list carries **per-broker overrides**,
+naming brokers that need a wider scope than the default and configuring each
+one. A broker with no entry uses the **default broker configuration**:
+`pod_reference_scope = "agent_node"`, which allows `WorkloadPIDReference` and
+node-local pod `KubernetesObjectReference`s. List a broker with
+`pod_reference_scope = "cluster"` to let it resolve resources beyond the
+agent's node — pods on other nodes and non-pod objects, which are cluster-wide.
+When listed, broker IDs must be valid, unique, and non-empty.
+
+Which brokers may reach the plugin at all is decided by the agent's own broker
+endpoint (`experimental.broker.brokers` in the agent configuration), so the
+plugin serves every authorized broker with the default configuration unless an
+entry overrides it. The list may be empty or omitted — as may the whole
+`experimental.broker` block — leaving every broker on the default.
+
+The block-level `access_policy` setting (required when the `broker` block is
+present) controls whether the plugin creates Kubernetes `SubjectAccessReview`
+requests for resolved objects. Use `access_policy = "enforced"` to authorize
+every resolved object with Kubernetes before selectors are returned (the
+review uses the broker SPIFFE ID as the SAR username, so this applies to
+default brokers too). Use `access_policy = "permissive"` to skip that
+authorization check. With no `broker` block, behavior is permissive.
+
+> [!IMPORTANT]
+> In `permissive` mode, any broker the agent's broker endpoint forwarded can
+> resolve node-scoped pods with no Kubernetes authorization check. Use
+> `access_policy = "enforced"` to require a `SubjectAccessReview` per resolved
+> object.
+
+`pod_reference_scope` bounds what a broker may resolve. `agent_node` (the
+default) limits it to node-local resources — pods on the agent's node, resolved
+through the local kubelet. `cluster` widens resolution to the Kubernetes API
+server: pods on any node, plus non-pod `KubernetesObjectReference`s, which are
+inherently cluster-wide. A node-scoped broker that sends a non-pod object
+reference is rejected with `PermissionDenied`. Broker-only agents that set
+`disable_kubelet_client = true` must configure every *listed* broker with
+`pod_reference_scope = "cluster"`; the default broker's scope automatically
+becomes `cluster` in that mode, since node scope is unavailable without the
+kubelet client.
+
+Minimal configuration — default (node-scoped) access for every authorized
+broker, with Kubernetes authorization enforced:
+
+```hcl
+WorkloadAttestor "k8s" {
+  plugin_data {
+    experimental {
+      broker {
+        access_policy = "enforced"
+      }
+    }
+  }
+}
+```
+
+Example with a per-broker override (cluster scope for one broker; all other
+brokers still get the node-scoped default):
 
 ```hcl
 WorkloadAttestor "k8s" {
@@ -194,8 +238,10 @@ kubelet client is available. With the default
 references are limited to information returned by the local kubelet. With
 `pod_reference_scope = "cluster"`, a disabled or unavailable kubelet client does
 not prevent resolution: the plugin falls back to the Kubernetes API server and
-can resolve pods on any node. Non-pod object references are resolved through
-the Kubernetes API server. When
+can resolve pods on any node. Non-pod object references are cluster-wide, so
+they require `pod_reference_scope = "cluster"` and are resolved through the
+Kubernetes API server; a node-scoped broker that sends one is rejected with
+`PermissionDenied`. When
 `experimental.broker.access_policy = "enforced"`, the plugin then creates the same
 `SubjectAccessReview` for the referenced object. The review uses the broker
 SPIFFE ID as the SAR username, no groups, the reference's resource group and

--- a/doc/plugin_agent_workloadattestor_k8s.md
+++ b/doc/plugin_agent_workloadattestor_k8s.md
@@ -147,11 +147,11 @@ requests for `WorkloadPIDReference` and `KubernetesObjectReference`.
 The `experimental.broker.brokers` list carries **per-broker overrides**,
 naming brokers that need a wider scope than the default and configuring each
 one. A broker with no entry uses the **default broker configuration**:
-`pod_reference_scope = "agent_node"`, which allows `WorkloadPIDReference` and
-node-local pod `KubernetesObjectReference`s. List a broker with
-`pod_reference_scope = "cluster"` to let it resolve resources beyond the
-agent's node — pods on other nodes and non-pod objects, which are cluster-wide.
-When listed, broker IDs must be valid, unique, and non-empty.
+`pod_reference_scope = "agent_node"`, which allows `WorkloadPIDReference`,
+node-local pod `KubernetesObjectReference`s, and non-pod
+`KubernetesObjectReference`s (always resolved cluster-wide). List a broker
+with `pod_reference_scope = "cluster"` to let it also resolve pods on other
+nodes. When listed, broker IDs must be valid, unique, and non-empty.
 
 Which brokers may reach the plugin at all is decided by the agent's own broker
 endpoint (`experimental.broker.brokers` in the agent configuration), so the
@@ -173,12 +173,13 @@ authorization check. With no `broker` block, behavior is permissive.
 > `access_policy = "enforced"` to require a `SubjectAccessReview` per resolved
 > object.
 
-`pod_reference_scope` bounds what a broker may resolve. `agent_node` (the
-default) limits it to node-local resources — pods on the agent's node, resolved
-through the local kubelet. `cluster` widens resolution to the Kubernetes API
-server: pods on any node, plus non-pod `KubernetesObjectReference`s, which are
-inherently cluster-wide. A node-scoped broker that sends a non-pod object
-reference is rejected with `PermissionDenied`. Broker-only agents that set
+`pod_reference_scope` bounds what a broker may resolve for pod references.
+`agent_node` (the default) limits pod resolution to node-local resources —
+pods on the agent's node, resolved through the local kubelet. `cluster` widens
+pod resolution to the Kubernetes API server: pods on any node. Non-pod
+`KubernetesObjectReference`s are inherently cluster-wide and are always
+resolved through the Kubernetes API server, regardless of the broker's
+`pod_reference_scope`. Broker-only agents that set
 `disable_kubelet_client = true` must configure every *listed* broker with
 `pod_reference_scope = "cluster"`; the default broker's scope automatically
 becomes `cluster` in that mode, since node scope is unavailable without the
@@ -238,10 +239,9 @@ kubelet client is available. With the default
 references are limited to information returned by the local kubelet. With
 `pod_reference_scope = "cluster"`, a disabled or unavailable kubelet client does
 not prevent resolution: the plugin falls back to the Kubernetes API server and
-can resolve pods on any node. Non-pod object references are cluster-wide, so
-they require `pod_reference_scope = "cluster"` and are resolved through the
-Kubernetes API server; a node-scoped broker that sends one is rejected with
-`PermissionDenied`. When
+can resolve pods on any node. Non-pod object references are cluster-wide and
+are always resolved through the Kubernetes API server, regardless of
+`pod_reference_scope`. When
 `experimental.broker.access_policy = "enforced"`, the plugin then creates the same
 `SubjectAccessReview` for the referenced object. The review uses the broker
 SPIFFE ID as the SAR username, no groups, the reference's resource group and

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -812,7 +812,7 @@ func (p *Plugin) checkBrokerImpersonationForReference(ctx context.Context, confi
 	if brokerEntry == nil {
 		return nil
 	}
-	if config.Broker == nil || config.Broker.AccessPolicy != brokerAccessPolicyEnforced {
+	if config.Broker.AccessPolicy != brokerAccessPolicyEnforced {
 		return nil
 	}
 	objRef := result.ObjectReference
@@ -854,15 +854,17 @@ func (p *Plugin) getBrokerEntryIfPresent(ctx context.Context, config *k8sConfig)
 		return nil, nil
 	}
 
+	if config.Broker == nil {
+		return nil, status.Error(codes.Internal, "broker configuration missing")
+	}
+
 	// The brokers map holds per-broker overrides only. A broker that is
-	// explicitly configured uses its entry; any other broker (including when
-	// no broker block is configured at all) falls back to the default entry
-	// below rather than being rejected. The agent's broker endpoint is the
-	// allowlist for which brokers may reach the plugin in the first place.
-	if config.Broker != nil {
-		if brokerEntry, ok := config.Broker.Brokers[callerID.String()]; ok {
-			return &brokerEntry, nil
-		}
+	// explicitly configured uses its entry; any other broker falls back to the
+	// default entry below rather than being rejected. The agent's broker
+	// endpoint is the allowlist for which brokers may reach the plugin in the
+	// first place.
+	if brokerEntry, ok := config.Broker.Brokers[callerID.String()]; ok {
+		return &brokerEntry, nil
 	}
 
 	// Synthesize the default entry: node scope, which limits the broker to

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -449,14 +449,10 @@ func buildBrokerConfig(path string, brokerConfig *k8sBrokerHCLConfig, status *pl
 
 	pluginconf.ReportUnusedKeys(status, brokerConfig.UnusedKeyPositions)
 	accessPolicy, _ := buildBrokerAccessPolicy(path, brokerConfig.AccessPolicy, status)
-	if len(brokerConfig.Brokers) == 0 {
-		status.ReportErrorf("%s.brokers: at least one broker is required", path)
-		return &k8sBrokerConfig{
-			AccessPolicy: accessPolicy,
-			Brokers:      map[string]k8sBrokerEntry{},
-		}
-	}
 
+	// The brokers list carries per-broker override configuration (e.g. pod_reference_scope).
+	// Any broker not listed here falls back to the default entry synthesized in getBrokerEntryIfPresent,
+	// so an empty (or omitted) list is valid.
 	brokers := make(map[string]k8sBrokerEntry, len(brokerConfig.Brokers))
 	seen := make(map[string]struct{}, len(brokerConfig.Brokers))
 	for i, b := range brokerConfig.Brokers {
@@ -808,6 +804,11 @@ func (p *Plugin) attestByKubernetesObjectReference(ctx context.Context, brokerEn
 	case objType.Plural == "pods" && objType.Group == "core":
 		return p.attestByPodReference(ctx, brokerEntry, objRef)
 	default:
+		// Non-pod objects are cluster-wide, so they require cluster scope;
+		// node-scoped brokers are limited to pods.
+		if brokerPodReferenceScope(brokerEntry) != podReferenceScopeCluster {
+			return nil, status.Error(codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
+		}
 		return p.attestByObjectReference(ctx, objRef)
 	}
 }
@@ -854,16 +855,32 @@ func (p *Plugin) getBrokerEntryIfPresent(ctx context.Context, config *k8sConfig)
 		return nil, status.Errorf(codes.Internal, "unable to determine broker caller identity: %v", err)
 	}
 	if !ok {
+		// Not a broker call; normal PID-based attestation applies.
 		return nil, nil
 	}
-	if config.Broker == nil {
-		return nil, status.Error(codes.Internal, "broker configuration missing")
+
+	// The brokers map holds per-broker overrides only. A broker that is
+	// explicitly configured uses its entry; any other broker (including when
+	// no broker block is configured at all) falls back to the default entry
+	// below rather than being rejected. The agent's broker endpoint is the
+	// allowlist for which brokers may reach the plugin in the first place.
+	if config.Broker != nil {
+		if brokerEntry, ok := config.Broker.Brokers[callerID.String()]; ok {
+			return &brokerEntry, nil
+		}
 	}
-	brokerEntry, ok := config.Broker.Brokers[callerID.String()]
-	if !ok {
-		return nil, status.Errorf(codes.PermissionDenied, "broker %q is not configured", callerID.String())
+
+	// Synthesize the default entry: node scope, which limits the broker to
+	// PID and pod references. Node scope needs the kubelet client, so fall
+	// back to cluster scope when it is disabled.
+	scope := podReferenceScopeAgentNode
+	if config.DisableKubeletClient {
+		scope = podReferenceScopeCluster
 	}
-	return &brokerEntry, nil
+	return &k8sBrokerEntry{
+		ID:                callerID,
+		PodReferenceScope: scope,
+	}, nil
 }
 
 // attestByPodReference handles the `pods/core` path: a Kubernetes object

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s.go
@@ -804,11 +804,6 @@ func (p *Plugin) attestByKubernetesObjectReference(ctx context.Context, brokerEn
 	case objType.Plural == "pods" && objType.Group == "core":
 		return p.attestByPodReference(ctx, brokerEntry, objRef)
 	default:
-		// Non-pod objects are cluster-wide, so they require cluster scope;
-		// node-scoped brokers are limited to pods.
-		if brokerPodReferenceScope(brokerEntry) != podReferenceScopeCluster {
-			return nil, status.Error(codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
-		}
 		return p.attestByObjectReference(ctx, objRef)
 	}
 }

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -2249,40 +2249,6 @@ func (s *Suite) TestAttestReferenceWithoutBrokerConfigUsesDefaultBroker() {
 	s.requireSelectorsEqual(testPodSelectors, selectors)
 }
 
-func (s *Suite) TestAttestReferenceDefaultBrokerRejectsNonPodObjectReference() {
-	s.startInsecureKubelet()
-	p := s.loadInsecurePlugin()
-
-	// The default broker is node-scoped, so it is limited to pods; non-pod
-	// (cluster-wide) objects require cluster scope.
-	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
-		Type: &broker.KubernetesObjectType{Plural: "deployments", Group: "apps"},
-		Key:  &broker.KubernetesObjectKey{Namespace: "default", Name: "blog"},
-	})
-	s.Require().NoError(err)
-
-	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
-	s.RequireGRPCStatusContains(err, codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
-	s.Require().Nil(selectors)
-}
-
-func (s *Suite) TestAttestReferenceNodeScopedBrokerRejectsNonPodObjectReference() {
-	s.startInsecureKubelet()
-	// An explicitly listed broker with the default (agent_node) scope is also
-	// limited to pods: non-pod object references require cluster scope.
-	p := s.loadInsecurePluginWithExtra(testBrokerConfig())
-
-	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
-		Type: &broker.KubernetesObjectType{Plural: "deployments", Group: "apps"},
-		Key:  &broker.KubernetesObjectKey{Namespace: "default", Name: "blog"},
-	})
-	s.Require().NoError(err)
-
-	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
-	s.RequireGRPCStatusContains(err, codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
-	s.Require().Nil(selectors)
-}
-
 func (s *Suite) TestAttestReferenceWithoutBrokerCallerDoesNotRequireBrokerConfig() {
 	s.startInsecureKubelet()
 	p := s.loadInsecurePlugin()

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -2036,10 +2036,17 @@ func (s *Suite) TestAttestReferenceWithPodName_FallsBackToAPIServerWhenKubeletCl
 func (s *Suite) TestAttestReferenceDefaultBrokerUsesClusterScopeWhenKubeletClientDisabled() {
 	liveClient := fakeKubeClientWithSubjectAccessReview(true, nil, testAPIServerBlogPod())
 	metadataClient := fakeKubeMetadataClient(testAPIServerBlogPodMetadata())
-	// No broker block: the default entry falls back to cluster scope because
-	// node scope is unavailable when the kubelet client is disabled, so the
-	// pod resolves via the API server.
-	wa := s.loadPluginWithKubeClients(`disable_kubelet_client = true`, liveClient, metadataClient)
+	// The broker is not listed, so it gets the default entry, which falls back
+	// to cluster scope because node scope is unavailable when the kubelet
+	// client is disabled, so the pod resolves via the API server.
+	wa := s.loadPluginWithKubeClients(`
+		disable_kubelet_client = true
+		experimental {
+			broker {
+				access_policy = "permissive"
+			}
+		}
+	`, liveClient, metadataClient)
 
 	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
 	s.Require().NoError(err)
@@ -2233,14 +2240,34 @@ func (s *Suite) TestAttestReferenceKubernetesObjectValidation() {
 	}
 }
 
-func (s *Suite) TestAttestReferenceWithoutBrokerConfigUsesDefaultBroker() {
+func (s *Suite) TestAttestReferenceRequiresBrokerConfig() {
 	s.startInsecureKubelet()
 	p := s.loadInsecurePlugin()
+
+	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
+	s.Require().NoError(err)
+
+	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
+	s.RequireGRPCStatusContains(err, codes.Internal, "broker configuration missing")
+	s.Require().Nil(selectors)
+}
+
+func (s *Suite) TestAttestReferenceUnlistedBrokerUsesDefaultEntry() {
+	s.startInsecureKubelet()
+	p := s.loadPluginWithKubeClient(fmt.Sprintf(`
+		kubelet_read_only_port = %d
+		max_poll_attempts = 5
+		poll_retry_interval = "1s"
+		experimental {
+			broker {
+				access_policy = "permissive"
+			}
+		}
+	`, s.kubeletPort()), fakeKubeClientWithSubjectAccessReview(true, nil))
 	s.addPodListResponse(podListFilePath)
 
-	// A broker caller resolves via the default (node-scoped) entry even when no
-	// broker block is configured; the plugin does not require brokers to be
-	// enumerated here.
+	// A broker caller with no entry in the brokers list resolves via the
+	// default (node-scoped) entry; brokers do not have to be enumerated.
 	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
 	s.Require().NoError(err)
 

--- a/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
+++ b/pkg/agent/plugin/workloadattestor/k8s/k8s_test.go
@@ -925,7 +925,7 @@ func (s *Suite) TestConfigureBroker() {
 			expectedErr: `experimental.broker.access_policy: unsupported value "disabled"; must be one of [permissive, enforced]`,
 		},
 		{
-			name: "empty brokers",
+			name: "empty brokers is allowed",
 			hcl: `
 				kubelet_read_only_port = 12345
 				experimental {
@@ -935,7 +935,28 @@ func (s *Suite) TestConfigureBroker() {
 					}
 				}
 			`,
-			expectedErr: "experimental.broker.brokers: at least one broker is required",
+		},
+		{
+			name: "omitted brokers is allowed",
+			hcl: `
+				kubelet_read_only_port = 12345
+				experimental {
+					broker {
+						access_policy = "permissive"
+					}
+				}
+			`,
+		},
+		{
+			name: "empty brokers with kubelet client disabled is allowed",
+			hcl: `
+				disable_kubelet_client = true
+				experimental {
+					broker {
+						access_policy = "permissive"
+					}
+				}
+			`,
 		},
 		{
 			name: "missing id",
@@ -2012,6 +2033,50 @@ func (s *Suite) TestAttestReferenceWithPodName_FallsBackToAPIServerWhenKubeletCl
 	s.requireSelectorsEqual(testPodSelectors, selectors)
 }
 
+func (s *Suite) TestAttestReferenceDefaultBrokerUsesClusterScopeWhenKubeletClientDisabled() {
+	liveClient := fakeKubeClientWithSubjectAccessReview(true, nil, testAPIServerBlogPod())
+	metadataClient := fakeKubeMetadataClient(testAPIServerBlogPodMetadata())
+	// No broker block: the default entry falls back to cluster scope because
+	// node scope is unavailable when the kubelet client is disabled, so the
+	// pod resolves via the API server.
+	wa := s.loadPluginWithKubeClients(`disable_kubelet_client = true`, liveClient, metadataClient)
+
+	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
+	s.Require().NoError(err)
+
+	selectors, err := wa.AttestReference(testBrokerContext(), anyRef)
+	s.Require().NoError(err)
+	s.requireSelectorsEqual(testPodSelectors, selectors)
+}
+
+func (s *Suite) TestAttestReferenceEnforcedDefaultBrokerRunsRBAC() {
+	s.startInsecureKubelet()
+	var reviews []authv1.SubjectAccessReview
+	cfg := fmt.Sprintf(`
+		kubelet_read_only_port = %d
+		max_poll_attempts = 5
+		poll_retry_interval = "1s"
+		experimental {
+			broker {
+				access_policy = "enforced"
+			}
+		}
+`, s.kubeletPort())
+	wa := s.loadPluginWithKubeClient(cfg, fakeKubeClientWithSubjectAccessReview(true, &reviews))
+	s.addPodListResponse(podListFilePath)
+
+	// A broker with no explicit entry still runs the SubjectAccessReview under
+	// enforced access policy, using the caller's SPIFFE ID as the SAR user.
+	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
+	s.Require().NoError(err)
+
+	selectors, err := wa.AttestReference(testBrokerContext(), anyRef)
+	s.Require().NoError(err)
+	s.requireSelectorsEqual(testPodSelectors, selectors)
+	s.Require().Len(reviews, 1)
+	assert.Equal(s.T(), testBrokerID, reviews[0].Spec.User)
+}
+
 func (s *Suite) TestAttestReferenceWithPID_FailsWhenKubeletClientDisabled() {
 	wa := s.loadPluginWithKubeClient(`disable_kubelet_client = true`, fakeKubeClientWithSubjectAccessReview(true, nil))
 
@@ -2168,15 +2233,53 @@ func (s *Suite) TestAttestReferenceKubernetesObjectValidation() {
 	}
 }
 
-func (s *Suite) TestAttestReferenceRequiresBrokerConfig() {
+func (s *Suite) TestAttestReferenceWithoutBrokerConfigUsesDefaultBroker() {
 	s.startInsecureKubelet()
 	p := s.loadInsecurePlugin()
+	s.addPodListResponse(podListFilePath)
 
+	// A broker caller resolves via the default (node-scoped) entry even when no
+	// broker block is configured; the plugin does not require brokers to be
+	// enumerated here.
 	anyRef, err := anypb.New(&broker.KubernetesObjectReference{Type: &broker.KubernetesObjectType{Plural: "pods", Group: "core"}, Uid: testPodUID})
 	s.Require().NoError(err)
 
 	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
-	s.RequireGRPCStatusContains(err, codes.Internal, "broker configuration missing")
+	s.Require().NoError(err)
+	s.requireSelectorsEqual(testPodSelectors, selectors)
+}
+
+func (s *Suite) TestAttestReferenceDefaultBrokerRejectsNonPodObjectReference() {
+	s.startInsecureKubelet()
+	p := s.loadInsecurePlugin()
+
+	// The default broker is node-scoped, so it is limited to pods; non-pod
+	// (cluster-wide) objects require cluster scope.
+	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
+		Type: &broker.KubernetesObjectType{Plural: "deployments", Group: "apps"},
+		Key:  &broker.KubernetesObjectKey{Namespace: "default", Name: "blog"},
+	})
+	s.Require().NoError(err)
+
+	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
+	s.RequireGRPCStatusContains(err, codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
+	s.Require().Nil(selectors)
+}
+
+func (s *Suite) TestAttestReferenceNodeScopedBrokerRejectsNonPodObjectReference() {
+	s.startInsecureKubelet()
+	// An explicitly listed broker with the default (agent_node) scope is also
+	// limited to pods: non-pod object references require cluster scope.
+	p := s.loadInsecurePluginWithExtra(testBrokerConfig())
+
+	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
+		Type: &broker.KubernetesObjectType{Plural: "deployments", Group: "apps"},
+		Key:  &broker.KubernetesObjectKey{Namespace: "default", Name: "blog"},
+	})
+	s.Require().NoError(err)
+
+	selectors, err := p.AttestReference(testBrokerContext(), anyRef)
+	s.RequireGRPCStatusContains(err, codes.PermissionDenied, `non-pod object references require pod_reference_scope "cluster"`)
 	s.Require().Nil(selectors)
 }
 
@@ -2289,7 +2392,7 @@ func (s *Suite) TestAttestReferenceGenericObject_NamespaceLabels() {
 		poll_retry_interval = "1s"
 		enable_namespace_labels = true
 		%s
-	`, s.kubeletPort(), testBrokerConfig()), kubeClient)
+	`, s.kubeletPort(), testBrokerConfigWithClusterPodReferenceScope()), kubeClient)
 
 	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
 		Type: &broker.KubernetesObjectType{
@@ -2342,7 +2445,14 @@ func (s *Suite) TestAttestReferenceBrokerRBACUsesResolvedGenericObject() {
 	obj.SetGroupVersionKind(gvk)
 
 	var reviews []authv1.SubjectAccessReview
-	p := s.loadInsecurePluginWithEnforcedAccessPolicyAndKubeClient(fakeKubeClientWithSubjectAccessReviewAndRESTMapper(true, &reviews, mapper, obj))
+	// Non-pod objects require cluster scope, so this broker is listed with it.
+	cfg := fmt.Sprintf(`
+		kubelet_read_only_port = %d
+		max_poll_attempts = 5
+		poll_retry_interval = "1s"
+		%s
+`, s.kubeletPort(), testBrokerConfigWithAccessPolicy(string(podReferenceScopeCluster), string(brokerAccessPolicyEnforced)))
+	p := s.loadPluginWithKubeClient(cfg, fakeKubeClientWithSubjectAccessReviewAndRESTMapper(true, &reviews, mapper, obj))
 
 	anyRef, err := anypb.New(&broker.KubernetesObjectReference{
 		Type: &broker.KubernetesObjectType{

--- a/test/integration/suites/broker-api-k8s/05-test-broker-by-flux-kustomization
+++ b/test/integration/suites/broker-api-k8s/05-test-broker-by-flux-kustomization
@@ -4,13 +4,16 @@ set -e
 
 source init-kubectl
 
-log-info "Test: broker fetches Flux Kustomization SVID via KubernetesObjectReference"
+log-info "Test: cluster-scoped broker fetches Flux Kustomization SVID via KubernetesObjectReference"
 
-./bin/kubectl -nspire exec -t broker -- /brokerclient \
+# Non-pod object references are cluster-wide, so they require a broker with
+# pod_reference_scope = "cluster"; the node-scoped default broker cannot
+# resolve them (see 04-test-broker-pod-reference-scopes / doc/plugin_agent_workloadattestor_k8s.md).
+./bin/kubectl -nspire exec -t cluster-broker -- /brokerclient \
     -ref-type object \
     -plural kustomizations -group kustomize.toolkit.fluxcd.io \
     -namespace spire -name target-kustomization \
     -expected-spiffe spiffe://example.org/target-kustomization \
-    || fail-now "broker failed to fetch SVID for Flux Kustomization"
+    || fail-now "cluster-scoped broker failed to fetch SVID for Flux Kustomization"
 
-log-success "broker fetched Flux Kustomization SVID via KubernetesObjectReference"
+log-success "cluster-scoped broker fetched Flux Kustomization SVID via KubernetesObjectReference"

--- a/test/integration/suites/broker-api-k8s/08-test-broker-by-tcp
+++ b/test/integration/suites/broker-api-k8s/08-test-broker-by-tcp
@@ -4,18 +4,21 @@ set -e
 
 source init-kubectl
 
-log-info "Test: broker fetches Flux Kustomization SVID via the TCP broker listener"
+log-info "Test: cluster-scoped broker fetches Flux Kustomization SVID via the TCP broker listener"
 
-# The broker pod normally dials the agent over the local UDS. For this
-# step we override -broker-addr to point at the spire-broker ClusterIP
+# The cluster-broker pod normally dials the agent over the local UDS. For
+# this step we override -broker-addr to point at the spire-broker ClusterIP
 # Service, which fronts the agent's TCP listener on port 8443. mTLS,
 # allowlist, and reference-type semantics are identical to the UDS path.
-./bin/kubectl -nspire exec -t broker -- /brokerclient \
+# Non-pod object references require pod_reference_scope = "cluster", which
+# is why this uses cluster-broker rather than the node-scoped default broker
+# (see 04-test-broker-pod-reference-scopes).
+./bin/kubectl -nspire exec -t cluster-broker -- /brokerclient \
     -broker-addr dns:///spire-broker:8443 \
     -ref-type object \
     -plural kustomizations -group kustomize.toolkit.fluxcd.io \
     -namespace spire -name target-kustomization \
     -expected-spiffe spiffe://example.org/target-kustomization \
-    || fail-now "broker failed to fetch SVID over TCP"
+    || fail-now "cluster-scoped broker failed to fetch SVID over TCP"
 
-log-success "broker fetched SVID over TCP via the spire-broker Service"
+log-success "cluster-scoped broker fetched SVID over TCP via the spire-broker Service"


### PR DESCRIPTION
We can apply some sensible defaults to the values here so that users do not have to specify brokers twice in a lot of cases.