### PR TITLE
fixes ordering of cache events

### DIFF
--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -1807,11 +1807,11 @@ func listAttestedNodeEvents(db *sqlDB, req *datastore.ListAttestedNodeEventsRequ
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 
-		if err := db.Find(&events, query.String(), id).Order("id asc").Error; err != nil {
+		if err := db.Order("id asc").Find(&events, query.String(), id).Error; err != nil {
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 	} else {
-		if err := db.Find(&events).Order("id asc").Error; err != nil {
+		if err := db.Order("id asc").Find(&events).Error; err != nil {
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 	}
@@ -4316,11 +4316,11 @@ func listRegistrationEntryEvents(db *sqlDB, req *datastore.ListRegistrationEntry
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 
-		if err := db.Find(&events, query.String(), id).Order("id asc").Error; err != nil {
+		if err := db.Order("id asc").Find(&events, query.String(), id).Error; err != nil {
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 	} else {
-		if err := db.Find(&events).Order("id asc").Error; err != nil {
+		if err := db.Order("id asc").Find(&events).Error; err != nil {
 			return nil, sqlcommon.NewWrappedSQLError(err)
 		}
 	}


### PR DESCRIPTION
## Summary
Addresses a root cause of the false skipped-event growth seen in #7181.
The events-based cache assumes `List*Events` returns rows ordered by ID and tracks every gap as a potentially late event.
With GORM v1, `Find()` executes immediately, so the existing trailing `Order("id asc")` had no effect.
An unordered startup scan can therefore classify a large portion of the event table as missing.
This causes unnecessary event lookups and can delay normal cache-update processing.
Apply `Order("id asc")` before `Find()` for attested-node and registration-entry event queries.

<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco

3. How the review process works ("ball in court"):
   - When you open this PR (or mark it ready for review), a maintainer is
     automatically assigned to it. The assignee shows whose turn it is to act
     next, so you can always see who currently holds the ball.
   - Pushing new commits does not automatically reassign the PR to the
     maintainer. Once you are done addressing comments, re-request a review
     from the assigned maintainer (the "Reviewers" section of the PR has a
     refresh icon next to their name). This puts the ball back in their court
     so they know it is ready for another look.
   - When addressing review comments, please add new commits rather than
     force-pushing. Individual commits that address comments are easier to
     review than a single commit containing all the changes again. Pull
     requests are squashed at merge time, so there is no need to squash and
     force-push in the PR.
   - Please also look at any comments from Copilot and address them if needed.
     Posting a short reply to each one helps reviewers see whether it has been
     addressed or consciously considered, even when no code change is needed.
-->

**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->

**Description of change**
<!-- Please provide a description of the change -->

**Which issue this PR fixes**
fixes #7181 

