### PR TITLE
Make the vault and broker-api-k8s integration suites runnable on macOS

### DIFF
--- a/test/integration/suites/broker-api-k8s/02-create-entries
+++ b/test/integration/suites/broker-api-k8s/02-create-entries
@@ -4,7 +4,10 @@ set -e
 
 source init-kubectl
 
-readarray -t NODEUIDS < <(./bin/kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}')
+NODEUIDS=()
+while IFS= read -r nodeUID; do
+    NODEUIDS+=("${nodeUID}")
+done < <(./bin/kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}')
 PARENTS=()
 for nodeUID in "${NODEUIDS[@]}"; do
     if [ -n "${nodeUID}" ]; then

--- a/test/integration/suites/key-manager-vault/01-setup-vault
+++ b/test/integration/suites/key-manager-vault/01-setup-vault
@@ -67,7 +67,16 @@ log-info "installing hashicorp vault..."
 ./bin/kubectl create -f csr.yaml
 ./bin/kubectl certificate -n vault approve vault.svc
 log-debug "waiting for certificate to be issued by k8s..."
-timeout 30s bash -c 'while [[ -z $(./bin/kubectl get csr -n vault vault.svc -o jsonpath="{.status.certificate}" 2>/dev/null) ]]; do sleep 1; done'
+MAXCERTCHECKS=30
+for ((i=1; i<=MAXCERTCHECKS; i++)); do
+    if [[ -n $(./bin/kubectl get csr -n vault vault.svc -o jsonpath="{.status.certificate}" 2>/dev/null) ]]; then
+        break
+    fi
+    if [[ $i -eq $MAXCERTCHECKS ]]; then
+        fail-now "certificate was not issued by k8s after ${MAXCERTCHECKS} checks"
+    fi
+    sleep 1
+done
 ./bin/kubectl get csr -n vault vault.svc -o jsonpath='{.status.certificate}' | openssl base64 -d -A -out vault.pem
 ./bin/kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' \
               | base64 -d > vault_ca.pem

--- a/test/integration/suites/key-manager-vault/04-verify-token-renewal.sh
+++ b/test/integration/suites/key-manager-vault/04-verify-token-renewal.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 log-debug "verifying token renewal..."
 
-timeout=$(date -ud "1 minute 30 second" +%s)
+timeout=$(( $(date -u +%s) + 90 ))
 count=0
 
 while [ $(date -u +%s) -lt $timeout ]; do

--- a/test/integration/suites/upstream-authority-vault/01-setup-vault
+++ b/test/integration/suites/upstream-authority-vault/01-setup-vault
@@ -67,7 +67,16 @@ log-info "installing hashicorp vault..."
 ./bin/kubectl create -f csr.yaml
 ./bin/kubectl certificate -n vault approve vault.svc
 log-debug "waiting for certificate to be issued by k8s..."
-timeout 30s bash -c 'while [[ -z $(./bin/kubectl get csr -n vault vault.svc -o jsonpath="{.status.certificate}" 2>/dev/null) ]]; do sleep 1; done'
+MAXCERTCHECKS=30
+for ((i=1; i<=MAXCERTCHECKS; i++)); do
+    if [[ -n $(./bin/kubectl get csr -n vault vault.svc -o jsonpath="{.status.certificate}" 2>/dev/null) ]]; then
+        break
+    fi
+    if [[ $i -eq $MAXCERTCHECKS ]]; then
+        fail-now "certificate was not issued by k8s after ${MAXCERTCHECKS} checks"
+    fi
+    sleep 1
+done
 ./bin/kubectl get csr -n vault vault.svc -o jsonpath='{.status.certificate}' | openssl base64 -d -A -out vault.pem
 ./bin/kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' \
               | base64 -d > vault_ca.pem

--- a/test/integration/suites/upstream-authority-vault/04-verify-token-renewal.sh
+++ b/test/integration/suites/upstream-authority-vault/04-verify-token-renewal.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 log-debug "verifying token renewal..."
 
-timeout=$(date -ud "1 minute 30 second" +%s)
+timeout=$(( $(date -u +%s) + 90 ))
 count=0
 
 while [ $(date -u +%s) -lt $timeout ]; do


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included? (the changed files are the integration suites themselves; all three were run end to end, below)
- [ ] Documentation updated? (not needed)

**Affected functionality**

The `key-manager-vault`, `upstream-authority-vault` and `broker-api-k8s` integration suites. No production code is touched and there is no behaviour change on Linux.

**Description of change**

These suites cannot run on a macOS host without installing GNU replacements first. CI only runs them on `ubuntu-22.04`, so the gap is invisible there.

- `timeout 30s bash -c '...'` in both vault suites becomes the bounded polling idiom `wait-for-rollout` already uses in `k8s/01-apply-config`, since macOS does not ship `timeout`. One deliberate difference: the budget is a check count now rather than wall-clock time, matching that suite, and it calls `fail-now` with a reason instead of dying at bare exit 124 under `set -e`.
- `date -ud "1 minute 30 second" +%s` becomes `$(( $(date -u +%s) + 90 ))`, since BSD `date` has no `-d`. Line 10 of the same script already compares against `date -u +%s`, so both sides agree.
- `readarray` becomes a `while IFS= read -r` loop, since it is a bash 4+ builtin and macOS ships bash 3.2 as `/bin/bash`. Kept as a separate commit: unlike the other two it has a workaround needing no repo change, so it is easy to drop if you would rather leave `broker-api-k8s` alone.

**Verification**

Run on Darwin 25.6.0 arm64 with `PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin`, which carries no GNU tools. Gated before running: `bash` is 3.2.57, `timeout` is absent, `date -d` is rejected, `readarray` is unavailable.

On unmodified main (`6215e5995`) the reported failure reproduces, after the kind cluster comes up healthy:

```
01-setup-vault: line 70: timeout: command not found
```

On this branch, same host and same PATH:

| Suite | Result |
| --- | --- |
| `upstream-authority-vault` | passed |
| `key-manager-vault` | passed |
| `broker-api-k8s` | passed |

The changed paths are exercised rather than skipped. The poll loop obtains a real certificate from k8s, `04-verify-token-renewal.sh` runs a real deadline loop and reports `token renewal is verified`, and `broker-api-k8s` comes up as a three node cluster so the read loop parses three distinct node UIDs.

**Which issue this PR fixes**

fixes #7174
