### PR TITLE
workload attestor windows: support windows service

### DIFF
--- a/doc/plugin_agent_workloadattestor_windows.md
+++ b/doc/plugin_agent_workloadattestor_windows.md
@@ -19,6 +19,7 @@ It does so by opening an access token associated with the workload process. The 
 | `windows:group_sid:se_group_enabled:false`  | The security identifier (SID) that identifies a not enabled group associated with the access token from the workload process (e.g. `windows:group_sid:se_group_enabled:false:S-1-5-32-544`)                             |
 | `windows:group_name:se_group_enabled:true`  | The group name of an enabled group associated with the access token from the workload process (e.g. `windows:group_name:se_group_enabled:true:computer-or-domain\mygroup`)                                              |
 | `windows:group_name:se_group_enabled:false` | The group name of a not enabled group associated with the access token from the workload process (e.g. `windows:group_name:se_group_enabled:false:computer-or-domain\mygroup`)                                          |
+| `windows:service_name`                      | The name of the service associated with the workload if it is running as a service (e.g. `windows:service_name:MyService`)                                                                                              |
 
 Workload path enabled selectors (available when configured with `discover_workload_path = true`):
 
@@ -49,6 +50,8 @@ Defenses against this are:
 - User and group account names are expressed using the [down-level logon name format](https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats#down-level-logon-name).
 
 - Enabling `disable_group_name_selectors` will cause existing workload registration entries that use `group_name` selectors to stop matching. Operators should audit those entries and switch them to `group_sid` selectors before enabling this flag.
+
+- The `service_name` selector requires a one-time admin action on the service to opt-in with an unrestricted SID Type. In order to do this for a custom service run `sc.exe sidtype <ServiceName> unrestricted` as admin. Read more about [SERVICE_SID_INFO](https://learn.microsoft.com/en-us/windows/win32/api/winsvc/ns-winsvc-service_sid_info).
 
 ## Configuration
 

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows.go
@@ -5,6 +5,7 @@ package windows
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -67,6 +68,9 @@ type processInfo struct {
 	path       string
 	groups     []string
 	groupsSIDs []string
+	// Services are a slice type, as windows allows shared services (e.g., svchost.exe)
+	serviceNames        []string
+	serviceDisplayNames []string
 }
 
 func (p *Plugin) SetLogger(log hclog.Logger) {
@@ -91,6 +95,10 @@ func (p *Plugin) Attest(_ context.Context, req *workloadattestorv1.AttestRequest
 	}
 	for _, group := range process.groups {
 		selectorValues = addSelectorValueIfNotEmpty(selectorValues, "group_name", group)
+	}
+
+	for _, serviceName := range process.serviceNames {
+		selectorValues = addSelectorValueIfNotEmpty(selectorValues, "service_name", serviceName)
 	}
 
 	// obtaining the workload process path and digest are behind a config flag
@@ -169,6 +177,9 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames boo
 	}
 	groups := p.q.AllGroups(tokenGroups)
 
+	const AllServicesSid = "S-1-5-80-0"
+	const ServiceSidPrefix = "S-1-5-80-"
+
 	start := time.Now()
 	for _, group := range groups {
 		// Each group has a set of attributes that control how
@@ -177,14 +188,31 @@ func (p *Plugin) newProcessInfo(pid int32, queryPath bool, disableGroupNames boo
 		// https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-attributes-in-an-access-token
 		enabledSelector := getGroupEnabledSelector(group.Attributes)
 		processInfo.groupsSIDs = append(processInfo.groupsSIDs, enabledSelector+":"+group.Sid.String())
+		var groupAccount, groupDomain string
 		if !disableGroupNames {
-			groupAccount, groupDomain, err := p.q.LookupAccount(group.Sid)
+			groupAccount, groupDomain, err = p.q.LookupAccount(group.Sid)
 			if err != nil {
 				p.log.Warn("failed to lookup account from group SID", "sid", group.Sid, "error", err)
 				continue
 			}
 			// If the LookupAccount call succeeded, we know that groupAccount is not empty
 			processInfo.groups = append(processInfo.groups, enabledSelector+":"+parseAccount(groupAccount, groupDomain))
+		}
+		// Is this a service?
+		if strings.HasPrefix(group.Sid.String(), ServiceSidPrefix) && group.Sid.String() != AllServicesSid {
+			// if disableGroupNames is set, we have to do a LookupAccount call anyway to get the service name,
+			// this lookup is local only, we will not force queries on an AD so this should be fine.
+			if groupAccount == "" {
+				groupAccount, groupDomain, err = p.q.LookupAccount(group.Sid)
+				if err != nil {
+					p.log.Warn("failed to lookup account from group SID", "sid", group.Sid, "error", err)
+					continue
+				}
+			}
+
+			var serviceName = groupAccount
+
+			processInfo.serviceNames = append(processInfo.serviceNames, serviceName)
 		}
 	}
 	if !disableGroupNames {

--- a/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
+++ b/pkg/agent/plugin/workloadattestor/windows/windows_windows_test.go
@@ -30,6 +30,9 @@ var (
 	sidGroup1, _     = windows.StringToSid("S-1-5-21-759542327-988462579-1707944338-1004")
 	sidGroup2, _     = windows.StringToSid("S-1-5-21-759542327-988462579-1707944338-1005")
 	sidGroup3, _     = windows.StringToSid("S-1-2-0")
+	sidSvcUser, _    = windows.StringToSid("S-1-5-80-1234567890-1234567890-1234567890-12")
+	sidSvcGroup, _   = windows.StringToSid("S-1-5-80-1234567890-1234567890-1234567890-13")
+	sidAllSvc, _     = windows.StringToSid("S-1-5-80-0")
 	sidAndAttrGroup1 = windows.SIDAndAttributes{
 		Sid:        sidGroup1,
 		Attributes: windows.SE_GROUP_ENABLED,
@@ -41,6 +44,22 @@ var (
 	sidAndAttrGroup3 = windows.SIDAndAttributes{
 		Sid:        sidGroup3,
 		Attributes: windows.SE_GROUP_ENABLED,
+	}
+	sidAndAttrGroup4 = windows.SIDAndAttributes{
+		Sid:        sidSvcGroup,
+		Attributes: windows.SE_GROUP_ENABLED,
+	}
+	sidAndAttrGroup5 = windows.SIDAndAttributes{
+		Sid:        sidSvcGroup,
+		Attributes: windows.SE_GROUP_USE_FOR_DENY_ONLY,
+	}
+	sidAndAttrGroup6 = windows.SIDAndAttributes{
+		Sid:        sidAllSvc,
+		Attributes: windows.SE_GROUP_ENABLED,
+	}
+	sidAndAttrGroup7 = windows.SIDAndAttributes{
+		Sid:        sidAllSvc,
+		Attributes: windows.SE_GROUP_USE_FOR_DENY_ONLY,
 	}
 )
 
@@ -355,6 +374,86 @@ func TestAttest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "successful for service with groups enabled",
+			trustDomain: "example.org",
+			pq: &fakeProcessQuery{
+				handle:             windows.InvalidHandle,
+				tokenUser:          &windows.Tokenuser{User: windows.SIDAndAttributes{Sid: sidSvcUser}},
+				tokenGroups:        &windows.Tokengroups{Groups: [1]windows.SIDAndAttributes{sidAndAttrGroup4}},
+				account:            "NetworkService",
+				domain:             "NT AUTHORITY",
+				sidAndAttributes:   []windows.SIDAndAttributes{sidAndAttrGroup4},
+				serviceDisplayName: "My Fancy Service Name",
+			},
+			expectSelectors: []string{
+				"windows:user_name:NT AUTHORITY\\NetworkService",
+				"windows:user_sid:" + sidSvcUser.String(),
+				"windows:group_sid:se_group_enabled:true:" + sidSvcGroup.String(),
+				"windows:group_name:se_group_enabled:true:My Service",
+				"windows:service_name:My Service",
+			},
+			expectCode: codes.OK,
+		},
+		{
+			name:        "successful for service with groups disabled",
+			trustDomain: "example.org",
+			pq: &fakeProcessQuery{
+				handle:             windows.InvalidHandle,
+				tokenUser:          &windows.Tokenuser{User: windows.SIDAndAttributes{Sid: sidSvcUser}},
+				tokenGroups:        &windows.Tokengroups{Groups: [1]windows.SIDAndAttributes{sidAndAttrGroup5}},
+				account:            "NetworkService",
+				domain:             "NT AUTHORITY",
+				sidAndAttributes:   []windows.SIDAndAttributes{sidAndAttrGroup5},
+				serviceDisplayName: "My Fancy Service Name",
+			},
+			expectSelectors: []string{
+				"windows:user_name:NT AUTHORITY\\NetworkService",
+				"windows:user_sid:" + sidSvcUser.String(),
+				"windows:group_sid:se_group_enabled:false:" + sidSvcGroup.String(),
+				"windows:group_name:se_group_enabled:false:My Service",
+				"windows:service_name:My Service",
+			},
+			expectCode: codes.OK,
+		},
+		{
+			name:        "successful for all service group",
+			trustDomain: "example.org",
+			pq: &fakeProcessQuery{
+				handle:           windows.InvalidHandle,
+				tokenUser:        &windows.Tokenuser{User: windows.SIDAndAttributes{Sid: sidAllSvc}},
+				tokenGroups:      &windows.Tokengroups{Groups: [1]windows.SIDAndAttributes{sidAndAttrGroup6}},
+				account:          "SYSTEM",
+				domain:           "NT AUTHORITY",
+				sidAndAttributes: []windows.SIDAndAttributes{sidAndAttrGroup6},
+			},
+			expectSelectors: []string{
+				"windows:user_name:NT AUTHORITY\\SYSTEM",
+				"windows:user_sid:" + sidAllSvc.String(),
+				"windows:group_sid:se_group_enabled:true:" + sidAllSvc.String(),
+				"windows:group_name:se_group_enabled:true:NT AUTHORITY\\SYSTEM",
+			},
+			expectCode: codes.OK,
+		},
+		{
+			name:        "successful for all service with groups disabled",
+			trustDomain: "example.org",
+			pq: &fakeProcessQuery{
+				handle:           windows.InvalidHandle,
+				tokenUser:        &windows.Tokenuser{User: windows.SIDAndAttributes{Sid: sidAllSvc}},
+				tokenGroups:      &windows.Tokengroups{Groups: [1]windows.SIDAndAttributes{sidAndAttrGroup7}},
+				account:          "SYSTEM",
+				domain:           "NT AUTHORITY",
+				sidAndAttributes: []windows.SIDAndAttributes{sidAndAttrGroup7},
+			},
+			expectSelectors: []string{
+				"windows:user_name:NT AUTHORITY\\SYSTEM",
+				"windows:user_sid:" + sidAllSvc.String(),
+				"windows:group_sid:se_group_enabled:false:" + sidAllSvc.String(),
+				"windows:group_name:se_group_enabled:false:NT AUTHORITY\\SYSTEM",
+			},
+			expectCode: codes.OK,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -416,21 +515,23 @@ func (w *windowsTest) loadPlugin(t *testing.T, q *fakeProcessQuery, trustDomain 
 }
 
 type fakeProcessQuery struct {
-	handle           windows.Handle
-	tokenUser        *windows.Tokenuser
-	tokenGroups      *windows.Tokengroups
-	account, domain  string
-	sidAndAttributes []windows.SIDAndAttributes
-	exe              string
+	handle             windows.Handle
+	tokenUser          *windows.Tokenuser
+	tokenGroups        *windows.Tokengroups
+	account, domain    string
+	sidAndAttributes   []windows.SIDAndAttributes
+	exe                string
+	serviceDisplayName string
 
-	openProcessErr       error
-	openProcessTokenErr  error
-	lookupAccountErr     error
-	getTokenUserErr      error
-	getTokenGroupsErr    error
-	closeHandleErr       error
-	closeProcessTokenErr error
-	getProcessExeErr     error
+	openProcessErr           error
+	openProcessTokenErr      error
+	lookupAccountErr         error
+	getTokenUserErr          error
+	getTokenGroupsErr        error
+	closeHandleErr           error
+	closeProcessTokenErr     error
+	getProcessExeErr         error
+	getServiceDisplayNameErr error
 }
 
 func (q *fakeProcessQuery) OpenProcess(int32) (handle windows.Handle, err error) {
@@ -455,6 +556,12 @@ func (q *fakeProcessQuery) LookupAccount(sid *windows.SID) (account, domain stri
 		return "group2", "domain2", nil
 	case sidGroup3:
 		return "LOCAL", "", nil
+	case sidSvcUser:
+		return "NetworkService", "NT AUTHORITY", nil
+	case sidSvcGroup:
+		return "My Service", "", nil
+	case sidAllSvc:
+		return "SYSTEM", "NT AUTHORITY", nil
 	}
 
 	return "", "", fmt.Errorf("sid not expected: %s", sid.String())


### PR DESCRIPTION
<!--
1. If this is your first PR, please read our contributor guidelines
https://github.com/spiffe/spiffe/blob/master/CONTRIBUTING.md
https://github.com/spiffe/spire/blob/main/CONTRIBUTING.md

2. Please remember to include a DCO on every commit (`git commit -s`)
https://github.com/apps/dco

3. How the review process works ("ball in court"):
   - When you open this PR (or mark it ready for review), a maintainer is
     automatically assigned to it. The assignee shows whose turn it is to act
     next, so you can always see who currently holds the ball.
   - Pushing new commits does not automatically reassign the PR to the
     maintainer. Once you are done addressing comments, re-request a review
     from the assigned maintainer (the "Reviewers" section of the PR has a
     refresh icon next to their name). This puts the ball back in their court
     so they know it is ready for another look.
   - When addressing review comments, please add new commits rather than
     force-pushing. Individual commits that address comments are easier to
     review than a single commit containing all the changes again. Pull
     requests are squashed at merge time, so there is no need to squash and
     force-push in the PR.
   - Please also look at any comments from Copilot and address them if needed.
     Posting a short reply to each one helps reviewers see whether it has been
     addressed or consciously considered, even when no code change is needed.
-->

**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
<!-- Please provide a description of the affected functionality -->
Created new plugin for attesting windows services. 
Similar to the systemd plugin.


**Description of change**
<!-- Please provide a description of the change -->
I created a new plugin that uses the SCM api for attesting a workload running as service under windows.
This plugin returns 2 selectors: name and display_name of the service.


**Which issue this PR fixes**
<!-- optional. `fixes #<issue number>` format will close an issue when this PR is merged -->

