### PR TITLE
Make AWS default CA test less dependant on real zones

### DIFF
--- a/pkg/server/plugin/nodeattestor/awsiid/awsca_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/awsca_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/spiffe/spire/pkg/common/pemutil"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid/awsrsa1024"
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor/awsiid/awsrsa2048"
 )
@@ -34,9 +35,13 @@ func TestGetAWSCACertificate(t *testing.T) {
 
 	// RSA-1024 falls back to a default cert for regions not in its map
 	t.Run("RSA1024/default_fallback", func(t *testing.T) {
-		cert, err := getAWSCACertificate("us-east-1", RSA1024)
+		defaultCA, err := pemutil.ParseCertificate([]byte(awsrsa1024.AWSCACert))
+		require.NoError(t, err)
+
+		cert, err := getAWSCACertificate("us-east-0", RSA1024)
 		require.NoError(t, err)
 		assert.NotNil(t, cert)
+		assert.Equal(t, cert, defaultCA)
 	})
 
 	// RSA-2048 has no fallback — unknown regions must error

--- a/pkg/server/plugin/nodeattestor/awsiid/awsca_test.go
+++ b/pkg/server/plugin/nodeattestor/awsiid/awsca_test.go
@@ -38,10 +38,10 @@ func TestGetAWSCACertificate(t *testing.T) {
 		defaultCA, err := pemutil.ParseCertificate([]byte(awsrsa1024.AWSCACert))
 		require.NoError(t, err)
 
-		cert, err := getAWSCACertificate("us-east-0", RSA1024)
+		cert, err := getAWSCACertificate("xx-fake-0", RSA1024)
 		require.NoError(t, err)
-		assert.NotNil(t, cert)
-		assert.Equal(t, cert, defaultCA)
+		require.NotNil(t, cert)
+		assert.Equal(t, defaultCA, cert)
 	})
 
 	// RSA-2048 has no fallback — unknown regions must error


### PR DESCRIPTION
If we add a certificate of us-east-1 this test will fail to test what it is intended to test, so use a fake zone.