### PR TITLE
feat(node-attestor/gcp_iit): allow alternative service account email whitelist

### DIFF
--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -4,7 +4,7 @@
 
 The `gcp_iit` plugin automatically attests instances using the [GCP Instance Identity Token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity). It also allows an operator to use GCP Instance IDs when defining SPIFFE ID attestation policies.
 Agents attested by the gcp_iit attestor will be issued a SPIFFE ID like `spiffe://TRUST_DOMAIN/spire/agent/gcp_iit/PROJECT_ID/INSTANCE_ID`
-This plugin requires an allow list of ProjectIDs from which nodes can be attested. Nodes may optionally be further restricted to a `service_account_email_allow_list` (see Security Considerations).
+This plugin requires either an allow list of Project IDs (the ID in which the instance runs, not the service account) from which nodes can be attested or an allow list for service account emails (see Security Considerations).
 
 ## Configuration
 

--- a/doc/plugin_server_nodeattestor_gcp_iit.md
+++ b/doc/plugin_server_nodeattestor_gcp_iit.md
@@ -4,19 +4,20 @@
 
 The `gcp_iit` plugin automatically attests instances using the [GCP Instance Identity Token](https://cloud.google.com/compute/docs/instances/verifying-instance-identity). It also allows an operator to use GCP Instance IDs when defining SPIFFE ID attestation policies.
 Agents attested by the gcp_iit attestor will be issued a SPIFFE ID like `spiffe://TRUST_DOMAIN/spire/agent/gcp_iit/PROJECT_ID/INSTANCE_ID`
-This plugin requires an allow list of ProjectID from which nodes can be attested. This also means that you shouldn't run multiple trust domains from the same GCP project.
+This plugin requires an allow list of ProjectIDs from which nodes can be attested. Nodes may optionally be further restricted to a `service_account_email_allow_list` (see Security Considerations).
 
 ## Configuration
 
-| Configuration             | Description                                                                                                                             | Default                                                   |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
-| `projectid_allow_list`    | List of ProjectIDs from which nodes can be attested.                                                                                    |                                                           |
-| `use_instance_metadata`   | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false                                                     |
-| `service_account_file`    | Path to the service account file used to authenticate with the Google Compute Engine API                                                |                                                           |
-| `allowed_label_keys`      | Instance label keys considered for selectors                                                                                            |                                                           |
-| `allowed_metadata_keys`   | Instance metadata keys considered for selectors                                                                                         |                                                           |
-| `max_metadata_value_size` | Sets the maximum metadata value size considered by the plugin for selectors                                                             | 128                                                       |
-| `agent_path_template`     | A URL path portion format of Agent's SPIFFE ID. Describe in text/template format.                                                       | `"/{{ .PluginName }}/{{ .ProjectID }}/{{ .InstanceID }}"` |
+| Configuration                      | Description                                                                                                                             | Default                                                   |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `projectid_allow_list`             | List of ProjectIDs from which nodes can be attested.                                                                                    |                                                           |
+| `service_account_email_allow_list` | List of service account emails from which nodes can be attested. If unset, nodes may attest using any service account.                  |                                                           |
+| `use_instance_metadata`            | If true, instance metadata is fetched from the Google Compute Engine API and used to augment the node selectors produced by the plugin. | false                                                     |
+| `service_account_file`             | Path to the service account file used to authenticate with the Google Compute Engine API                                                |                                                           |
+| `allowed_label_keys`               | Instance label keys considered for selectors                                                                                            |                                                           |
+| `allowed_metadata_keys`            | Instance metadata keys considered for selectors                                                                                         |                                                           |
+| `max_metadata_value_size`          | Sets the maximum metadata value size considered by the plugin for selectors                                                             | 128                                                       |
+| `agent_path_template`              | A URL path portion format of Agent's SPIFFE ID. Describe in text/template format.                                                       | `"/{{ .PluginName }}/{{ .ProjectID }}/{{ .InstanceID }}"` |
 
 A sample configuration:
 
@@ -33,7 +34,7 @@ A sample configuration:
 This plugin generates the following selectors based on information contained in the Instance Identity Token:
 
 | Selector                | Example                                                      | Description                               |
-|-------------------------|--------------------------------------------------------------|------------------------------------------ |
+|-------------------------|--------------------------------------------------------------|-------------------------------------------|
 | `gcp_iit:project-id`    | `gcp_iit:project-id:big-kahuna-123456`                       | ID of the project containing the instance |
 | `gcp_iit:zone`          | `gcp_iit:zone:us-west1-b`                                    | Zone containing the instance              |
 | `gcp_iit:instance-name` | `gcp_iit:instance-name:blog-server`                          | Name of the instance                      |
@@ -92,6 +93,6 @@ Some useful values are:
 
 The Instance Identity Token, which this attestor leverages to prove node identity, is available to any process running on the node by default. As a result, it is possible for non-agent code running on a node to attest to the SPIRE Server, allowing it to obtain any workload identity that the node is authorized to run.
 
-While many operators choose to configure their systems to block access to the Instance Identity Token, the SPIRE project cannot guarantee this posture. To mitigate the associated risk, the `gcp_iit` node attestor implements Trust On First Use (or TOFU) semantics. For any given node, attestation may occur only once. Subsequent attestation attempts will be rejected.
+While many operators choose to configure their systems to block access to the Instance Identity Token, the SPIRE project cannot guarantee this posture. To mitigate the associated risk, the `gcp_iit` node attestor implements Trust On First Use (or TOFU) semantics by default: for any given node, attestation may occur only once, and subsequent attestation attempts will be rejected. Configuring `service_account_email_allow_list` disables this protection, instead allowing repeat attestation from any node presenting a service account in the allow list. Only allow list service accounts that are exclusively used by trusted agents and consider changing the agent template to `"/{{ .PluginName }}/{{ .ServiceAccount }}"`.
 
 It is still possible for non-agent code to complete node attestation before SPIRE Agent can, however this condition is easily and quickly detectable as SPIRE Agent will fail to start, and both SPIRE Agent and SPIRE Server will log the occurrence. Such cases should be investigated as possible security incidents.

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit.go
@@ -77,13 +77,14 @@ type IITAttestorConfig struct {
 	allowedLabelKeys    map[string]bool
 	allowedMetadataKeys map[string]bool
 
-	ProjectIDAllowList   []string `hcl:"projectid_allow_list"`
-	AgentPathTemplate    string   `hcl:"agent_path_template"`
-	UseInstanceMetadata  bool     `hcl:"use_instance_metadata"`
-	AllowedLabelKeys     []string `hcl:"allowed_label_keys"`
-	AllowedMetadataKeys  []string `hcl:"allowed_metadata_keys"`
-	MaxMetadataValueSize int      `hcl:"max_metadata_value_size"`
-	ServiceAccountFile   string   `hcl:"service_account_file"`
+	ProjectIDAllowList           []string `hcl:"projectid_allow_list"`
+	ServiceAccountEmailAllowList []string `hcl:"service_account_email_allow_list"`
+	AgentPathTemplate            string   `hcl:"agent_path_template"`
+	UseInstanceMetadata          bool     `hcl:"use_instance_metadata"`
+	AllowedLabelKeys             []string `hcl:"allowed_label_keys"`
+	AllowedMetadataKeys          []string `hcl:"allowed_metadata_keys"`
+	MaxMetadataValueSize         int      `hcl:"max_metadata_value_size"`
+	ServiceAccountFile           string   `hcl:"service_account_file"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *IITAttestorConfig {
@@ -93,8 +94,8 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		return nil
 	}
 
-	if len(newConfig.ProjectIDAllowList) == 0 {
-		status.ReportError("projectid_allow_list is required")
+	if len(newConfig.ProjectIDAllowList) == 0 && len(newConfig.ServiceAccountEmailAllowList) == 0 {
+		status.ReportError("projectid_allow_list or service_account_email_allow_list is required")
 	}
 
 	tmpl := gcp.DefaultAgentPathTemplate
@@ -166,13 +167,19 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 		return status.Errorf(codes.PermissionDenied, "identity token project ID %q is not in the allow list", computeEngineMetadata.ProjectID)
 	}
 
+	if len(c.ServiceAccountEmailAllowList) > 0 && !slices.Contains(c.ServiceAccountEmailAllowList, identityMetadata.Email) {
+		return status.Errorf(codes.PermissionDenied, "identity token service account email %q is not in the allow list", identityMetadata.Email)
+	}
+
 	id, err := gcp.MakeAgentID(c.trustDomain, c.idPathTemplate, identityMetadata)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to create agent ID: %v", err)
 	}
 
-	if err := p.AssessTOFU(stream.Context(), id.String(), p.log); err != nil {
-		return err
+	if len(c.ServiceAccountEmailAllowList) == 0 {
+		if err := p.AssessTOFU(stream.Context(), id.String(), p.log); err != nil {
+			return err
+		}
 	}
 
 	var instance *compute.Instance

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit.go
@@ -162,13 +162,17 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 	}
 
 	computeEngineMetadata := identityMetadata.Google.ComputeEngine
+	requireTofu := true
 
-	if !slices.Contains(c.ProjectIDAllowList, computeEngineMetadata.ProjectID) {
+	if len(c.ProjectIDAllowList) > 0 && !slices.Contains(c.ProjectIDAllowList, computeEngineMetadata.ProjectID) {
 		return status.Errorf(codes.PermissionDenied, "identity token project ID %q is not in the allow list", computeEngineMetadata.ProjectID)
 	}
 
-	if len(c.ServiceAccountEmailAllowList) > 0 && !slices.Contains(c.ServiceAccountEmailAllowList, identityMetadata.Email) {
-		return status.Errorf(codes.PermissionDenied, "identity token service account email %q is not in the allow list", identityMetadata.Email)
+	if len(c.ServiceAccountEmailAllowList) > 0 {
+		requireTofu = false
+		if !slices.Contains(c.ServiceAccountEmailAllowList, identityMetadata.Email) {
+			return status.Errorf(codes.PermissionDenied, "identity token service account email %q is not in the allow list", identityMetadata.Email)
+		}
 	}
 
 	id, err := gcp.MakeAgentID(c.trustDomain, c.idPathTemplate, identityMetadata)
@@ -176,7 +180,7 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 		return status.Errorf(codes.Internal, "failed to create agent ID: %v", err)
 	}
 
-	if len(c.ServiceAccountEmailAllowList) == 0 {
+	if requireTofu {
 		if err := p.AssessTOFU(stream.Context(), id.String(), p.log); err != nil {
 			return err
 		}
@@ -209,7 +213,7 @@ func (p *IITAttestorPlugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServ
 			AgentAttributes: &nodeattestorv1.AgentAttributes{
 				SpiffeId:       id.String(),
 				SelectorValues: selectorValues,
-				CanReattest:    false,
+				CanReattest:    !requireTofu,
 			},
 		},
 	})

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
@@ -174,6 +174,20 @@ service_account_email_allow_list = ["` + testServiceAccount + `"]
 	s.Require().Equal(testAgentID, result.AgentID)
 }
 
+func (s *IITAttestorSuite) TestAttestSuccessWithOnlyServiceAccountEmailAllowListSkipsTOFU() {
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
+		AgentId: testAgentID,
+	})
+
+	s.attestor = s.loadPluginWithConfig(`
+service_account_email_allow_list = ["` + testServiceAccount + `"]
+`)
+
+	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
+	s.Require().NoError(err)
+	s.Require().Equal(testAgentID, result.AgentID)
+}
+
 func (s *IITAttestorSuite) TestAttestSuccess() {
 	payload := s.signDefaultToken()
 

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
@@ -157,6 +157,7 @@ service_account_email_allow_list = ["other@developer.gserviceaccount.com", "` + 
 	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
 	s.Require().NoError(err)
 	s.Require().Equal(testAgentID, result.AgentID)
+	s.Require().True(result.CanReattest)
 }
 
 func (s *IITAttestorSuite) TestAttestSuccessWithServiceAccountEmailAllowListSkipsTOFU() {
@@ -172,6 +173,7 @@ service_account_email_allow_list = ["` + testServiceAccount + `"]
 	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
 	s.Require().NoError(err)
 	s.Require().Equal(testAgentID, result.AgentID)
+	s.Require().True(result.CanReattest)
 }
 
 func (s *IITAttestorSuite) TestAttestSuccessWithOnlyServiceAccountEmailAllowListSkipsTOFU() {
@@ -186,6 +188,7 @@ service_account_email_allow_list = ["` + testServiceAccount + `"]
 	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
 	s.Require().NoError(err)
 	s.Require().Equal(testAgentID, result.AgentID)
+	s.Require().True(result.CanReattest)
 }
 
 func (s *IITAttestorSuite) TestAttestSuccess() {
@@ -195,6 +198,7 @@ func (s *IITAttestorSuite) TestAttestSuccess() {
 	s.Require().NoError(err)
 
 	s.Require().Equal(testAgentID, result.AgentID)
+	s.Require().False(result.CanReattest)
 	s.RequireProtoListEqual([]*common.Selector{
 		{Type: "gcp_iit", Value: "project-id:" + testProject},
 		{Type: "gcp_iit", Value: "zone:" + testZone},

--- a/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
+++ b/pkg/server/plugin/nodeattestor/gcpiit/iit_test.go
@@ -139,6 +139,41 @@ service_account_file = "error_sa.json"
 	s.requireAttestError(s.T(), s.signDefaultToken(), codes.Internal, `nodeattestor(gcp_iit): failed to fetch instance metadata: expected sa file "test_sa.json", got "error_sa.json"`)
 }
 
+func (s *IITAttestorSuite) TestErrorOnServiceAccountEmailMismatch() {
+	s.attestor = s.loadPluginWithConfig(`
+projectid_allow_list = ["test-project"]
+service_account_email_allow_list = ["other@developer.gserviceaccount.com"]
+`)
+
+	s.requireAttestError(s.T(), s.signDefaultToken(), codes.PermissionDenied, `nodeattestor(gcp_iit): identity token service account email "123456789-compute@developer.gserviceaccount.com" is not in the allow list`)
+}
+
+func (s *IITAttestorSuite) TestAttestSuccessWithServiceAccountEmailAllowList() {
+	s.attestor = s.loadPluginWithConfig(`
+projectid_allow_list = ["test-project"]
+service_account_email_allow_list = ["other@developer.gserviceaccount.com", "` + testServiceAccount + `"]
+`)
+
+	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
+	s.Require().NoError(err)
+	s.Require().Equal(testAgentID, result.AgentID)
+}
+
+func (s *IITAttestorSuite) TestAttestSuccessWithServiceAccountEmailAllowListSkipsTOFU() {
+	s.agentStore.SetAgentInfo(&agentstorev1.AgentInfo{
+		AgentId: testAgentID,
+	})
+
+	s.attestor = s.loadPluginWithConfig(`
+projectid_allow_list = ["test-project"]
+service_account_email_allow_list = ["` + testServiceAccount + `"]
+`)
+
+	result, err := s.attestor.Attest(context.Background(), s.signDefaultToken(), expectNoChallenge)
+	s.Require().NoError(err)
+	s.Require().Equal(testAgentID, result.AgentID)
+}
+
 func (s *IITAttestorSuite) TestAttestSuccess() {
 	payload := s.signDefaultToken()
 
@@ -284,9 +319,23 @@ projectid_allow_list = ["bar"]
 		spiretest.AssertGRPCStatusContains(t, err, codes.InvalidArgument, "server core configuration must contain trust_domain")
 	})
 
-	s.T().Run("missing projectID allow list", func(t *testing.T) {
+	s.T().Run("missing allow list", func(t *testing.T) {
 		err := doConfig(t, coreConfig, "")
-		spiretest.AssertGRPCStatusContains(t, err, codes.InvalidArgument, "projectid_allow_list is required")
+		spiretest.AssertGRPCStatusContains(t, err, codes.InvalidArgument, "projectid_allow_list or service_account_email_allow_list is required")
+	})
+
+	s.T().Run("only projectid_allow_list", func(t *testing.T) {
+		err := doConfig(t, coreConfig, `
+projectid_allow_list = ["bar"]
+		`)
+		require.NoError(t, err)
+	})
+
+	s.T().Run("only service_account_email_allow_list", func(t *testing.T) {
+		err := doConfig(t, coreConfig, `
+service_account_email_allow_list = ["test@developer.gserviceaccount.com"]
+		`)
+		require.NoError(t, err)
 	})
 
 	s.T().Run("bad SVID template", func(t *testing.T) {


### PR DESCRIPTION
With https://github.com/spiffe/spire/pull/6869, this attestor always has access to the email address, which allows a cheap whitelist check for it too.

So now, either project ID or service account email have to be whitelisted. Service accounts are already a granular subject whitelist, so no TOFU check is needed for that path.