### PR TITLE
Skip redundant federation queries on entry writes

### DIFF
--- a/pkg/server/datastore/sqlstore/sqlstore.go
+++ b/pkg/server/datastore/sqlstore/sqlstore.go
@@ -2692,7 +2692,9 @@ func createRegistrationEntry(tx *gorm.DB, entry *common.RegistrationEntry) (*com
 		}
 	}
 
-	registrationEntry, err := modelToEntry(tx, newRegisteredEntry)
+	// The federation associations were just written from federatesWith, so the
+	// trust domains are already known and do not need to be read back.
+	registrationEntry, err := modelToEntryWithFederatesWith(tx, newRegisteredEntry, bundlesToTrustDomains(federatesWith))
 	if err != nil {
 		return nil, err
 	}
@@ -4193,15 +4195,15 @@ func updateRegistrationEntry(tx *gorm.DB, e *common.RegistrationEntry, mask *com
 		if err := tx.Model(&entry).Association("FederatesWith").Replace(federatesWith).Error; err != nil {
 			return nil, err
 		}
-		// The FederatesWith field in entry is filled in by the call to modelToEntry below
+
+		// The associations were just replaced with federatesWith, so the trust
+		// domains are already known and do not need to be read back.
+		return modelToEntryWithFederatesWith(tx, entry, bundlesToTrustDomains(federatesWith))
 	}
 
-	returnEntry, err := modelToEntry(tx, entry)
-	if err != nil {
-		return nil, err
-	}
-
-	return returnEntry, nil
+	// FederatesWith was not part of this update, so the existing associations are
+	// unchanged and have to be read to build the response.
+	return modelToEntry(tx, entry)
 }
 
 func deleteRegistrationEntry(tx *gorm.DB, entryID string) (*common.RegistrationEntry, error) {
@@ -4746,6 +4748,18 @@ func bundleToModel(pb *common.Bundle) (*Bundle, error) {
 }
 
 func modelToEntry(tx *gorm.DB, model RegisteredEntry) (*common.RegistrationEntry, error) {
+	var fetchedBundles []*Bundle
+	if err := tx.Model(&model).Association("FederatesWith").Find(&fetchedBundles).Error; err != nil {
+		return nil, sqlcommon.NewWrappedSQLError(err)
+	}
+
+	return modelToEntryWithFederatesWith(tx, model, bundlesToTrustDomains(fetchedBundles))
+}
+
+// modelToEntryWithFederatesWith builds the API representation of an entry for
+// callers that already know which trust domains the entry federates with. It
+// avoids reading the FederatesWith association back from the database.
+func modelToEntryWithFederatesWith(tx *gorm.DB, model RegisteredEntry, federatesWith []string) (*common.RegistrationEntry, error) {
 	var fetchedSelectors []*Selector
 	if err := tx.Model(&model).Related(&fetchedSelectors).Error; err != nil {
 		return nil, sqlcommon.NewWrappedSQLError(err)
@@ -4770,16 +4784,6 @@ func modelToEntry(tx *gorm.DB, model RegisteredEntry) (*common.RegistrationEntry
 		for _, fetchedDNS := range fetchedDNSs {
 			dnsList = append(dnsList, fetchedDNS.Value)
 		}
-	}
-
-	var fetchedBundles []*Bundle
-	if err := tx.Model(&model).Association("FederatesWith").Find(&fetchedBundles).Error; err != nil {
-		return nil, sqlcommon.NewWrappedSQLError(err)
-	}
-
-	var federatesWith []string
-	for _, bundle := range fetchedBundles {
-		federatesWith = append(federatesWith, bundle.TrustDomain)
 	}
 
 	AdditionalAttributes := &common.RegistrationEntry_AdditionalAttributes{}
@@ -4856,6 +4860,12 @@ func modelToCAJournal(model CAJournal) *datastore.CAJournal {
 }
 
 func makeFederatesWith(tx *gorm.DB, ids []string) ([]*Bundle, error) {
+	if len(ids) == 0 {
+		// The query below cannot match a row when there are no ids to look for,
+		// and the verification loop below has nothing to check, so skip both.
+		return nil, nil
+	}
+
 	var bundles []*Bundle
 	if err := tx.Where("trust_domain in (?)", ids).Find(&bundles).Error; err != nil {
 		return nil, err
@@ -4874,6 +4884,22 @@ func makeFederatesWith(tx *gorm.DB, ids []string) ([]*Bundle, error) {
 	}
 
 	return bundles, nil
+}
+
+// bundlesToTrustDomains returns the trust domains of the given bundles. The
+// bundle rows are unique per trust domain, so the result contains no duplicates
+// even when the same trust domain was requested more than once.
+func bundlesToTrustDomains(bundles []*Bundle) []string {
+	if len(bundles) == 0 {
+		return nil
+	}
+
+	trustDomains := make([]string, 0, len(bundles))
+	for _, bundle := range bundles {
+		trustDomains = append(trustDomains, bundle.TrustDomain)
+	}
+
+	return trustDomains
 }
 
 func bindVars(db *gorm.DB, query string) string {

--- a/pkg/server/datastore/sqltest/datastore_suite.go
+++ b/pkg/server/datastore/sqltest/datastore_suite.go
@@ -4574,6 +4574,65 @@ func (s *Suite) TestRegistrationEntriesFederatesWithSuccess() {
 	s.RequireProtoEqual(expected, actual)
 }
 
+func (s *Suite) TestRegistrationEntriesFederatesWithMultipleBundles() {
+	// create three bundles but only federate with two, so that the entry is
+	// associated with the exact bundles referenced and no others
+	s.createBundle("spiffe://otherdomain.org")
+	s.createBundle("spiffe://otherdomain2.org")
+	s.createBundle("spiffe://otherdomain3.org")
+
+	entry := makeFederatedRegistrationEntry()
+	entry.FederatesWith = []string{"spiffe://otherdomain.org", "spiffe://otherdomain2.org"}
+
+	// no ordering is defined for the federated trust domains, so compare them as
+	// sets rather than asserting an order the queries do not guarantee
+	created := s.createRegistrationEntry(entry)
+	expected := []string{"spiffe://otherdomain.org", "spiffe://otherdomain2.org"}
+	s.Require().ElementsMatch(expected, created.FederatesWith)
+	s.Require().ElementsMatch(expected, s.fetchRegistrationEntry(created.EntryId).FederatesWith)
+
+	// updating the federated bundles is reflected in the returned entry
+	created.FederatesWith = []string{"spiffe://otherdomain3.org"}
+	updated, err := s.ds.UpdateRegistrationEntry(ctx, created, nil)
+	s.Require().NoError(err)
+	s.Require().Equal([]string{"spiffe://otherdomain3.org"}, updated.FederatesWith)
+	s.RequireProtoEqual(updated, s.fetchRegistrationEntry(updated.EntryId))
+}
+
+func (s *Suite) TestRegistrationEntriesFederatesWithDuplicateTrustDomain() {
+	s.createBundle("spiffe://otherdomain.org")
+
+	entry := makeFederatedRegistrationEntry()
+	entry.FederatesWith = []string{"spiffe://otherdomain.org", "spiffe://otherdomain.org"}
+
+	// a trust domain named more than once is associated with the entry once
+	created := s.createRegistrationEntry(entry)
+	s.Require().Equal([]string{"spiffe://otherdomain.org"}, created.FederatesWith)
+	s.RequireProtoEqual(created, s.fetchRegistrationEntry(created.EntryId))
+}
+
+func (s *Suite) TestRegistrationEntriesWithoutFederatesWith() {
+	entry := makeFederatedRegistrationEntry()
+	entry.FederatesWith = nil
+
+	// an entry that federates with nothing round trips with no federated ids
+	created := s.createRegistrationEntry(entry)
+	s.Require().Empty(created.FederatesWith)
+	s.RequireProtoEqual(created, s.fetchRegistrationEntry(created.EntryId))
+
+	// the same holds after an update that leaves the entry unfederated
+	created.Admin = true
+	updated, err := s.ds.UpdateRegistrationEntry(ctx, created, nil)
+	s.Require().NoError(err)
+	s.Require().Empty(updated.FederatesWith)
+	s.RequireProtoEqual(updated, s.fetchRegistrationEntry(updated.EntryId))
+
+	// and the entry can still be deleted
+	deleted, err := s.ds.DeleteRegistrationEntry(ctx, updated.EntryId)
+	s.Require().NoError(err)
+	s.Require().Empty(deleted.FederatesWith)
+}
+
 func (s *Suite) TestDeleteBundleRestrictedByRegistrationEntries() {
 	// create the bundle and associated entry
 	s.createBundle("spiffe://otherdomain.org")


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated? (no user facing behavior, schema, or configuration change)

**Affected functionality**

The SQL datastore write path for registration entries: `CreateRegistrationEntry`, `UpdateRegistrationEntry`, and `DeleteRegistrationEntry`. There is no schema change and no configuration change.

**Description of change**

Entry writes issue two federation queries that are not needed.

`makeFederatesWith` queries `bundles` for the requested trust domains and then verifies each requested id was found. When the caller passes an empty list the query cannot match a row and the verification loop has nothing to check, so it now returns early without issuing SQL. Both `createRegistrationEntry` and `updateRegistrationEntry` call it unconditionally today.

`modelToEntry` reads the `FederatesWith` association to populate its response. Create and update resolve that exact bundle set a few lines earlier, so the read asks the database to return a value the transaction already holds. The converter is split into `modelToEntry`, which reads the association as before, and `modelToEntryWithFederatesWith`, which takes the trust domains from the caller. Create and update use the latter. Delete keeps reading, because it reports the associations as they existed before the row was removed.

Both changes are behavior preserving whether or not a deployment uses federation, and neither introduces cached state or new configuration.

Two details worth flagging for review:

The trust domains are derived from the resolved bundle rows rather than the requested ids. Bundle rows are unique per trust domain, so this keeps the current behavior of collapsing a trust domain named more than once into a single association, which returning the request verbatim would not.

No ordering guarantee changes. `FederatesWith` ordering is unspecified today on both paths, since the association read has no `ORDER BY` and the entry read queries order by `e_id, selector_id, dns_name_id` with no federation column. This change neither adds nor removes a guarantee, and the new multi-bundle test compares trust domains as a set rather than asserting an order the queries do not promise.

The issue also proposed guarding the association append on create. That turned out to remove nothing, because GORM's `saveAssociations` iterates the slice it is passed and the loop body never runs for an empty set, so it is not included here.

**Measurements**

From our deployment at Uber, over a six hour window across roughly 18 MySQL instances, ranked by database time:

| Query | Share of DB time | Removed by |
|---|---|---|
| `SELECT bundles.* JOIN federated_registration_entries ... FOR UPDATE` | 13.8%, ranked first overall | the `modelToEntry` split |
| `SELECT * FROM bundles WHERE trust_domain IN (NULL) FOR UPDATE` | 4.1% | the `makeFederatesWith` early return |

**Tests**

The existing federation coverage in the datastore conformance suite passes unchanged, including `TestRegistrationEntriesFederatesWithSuccess`, `TestRegistrationEntriesFederatesWithAgainstMissingBundle`, the `Update FederatesWith` mask cases in both directions, and the `DeleteBundle*RegistrationEntries` cases.

Three suite tests are added for paths that were not covered before: `TestRegistrationEntriesFederatesWithMultipleBundles`, `TestRegistrationEntriesFederatesWithDuplicateTrustDomain`, and `TestRegistrationEntriesWithoutFederatesWith`.

This targets the gormv1 datastore, since that is the only implementation in the tree today. Happy to port it if the gormv2 migration lands first.

**Which issue this PR fixes**

fixes #7215
