### PR TITLE
Update the ball-in-court assignee on author pushes and comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,13 @@ https://github.com/apps/dco
    - When you open this PR (or mark it ready for review), a maintainer is
      automatically assigned to it. The assignee shows whose turn it is to act
      next, so you can always see who currently holds the ball.
-   - Pushing new commits does not automatically reassign the PR to the
-     maintainer. Once you are done addressing comments, re-request a review
-     from the assigned maintainer (the "Reviewers" section of the PR has a
-     refresh icon next to their name). This puts the ball back in their court
-     so they know it is ready for another look.
+   - The assignee follows the conversation automatically. When you push new
+     commits or comment while the ball is with you, it moves back to the
+     maintainer who reviewed your PR, so there is nothing you need to click
+     to signal that it is ready for another look. If you still have several
+     rounds of changes coming, consider converting the PR to a draft and
+     marking it ready for review when done, since drafts do not move the
+     assignee.
    - When addressing review comments, please add new commits rather than
      force-pushing. Individual commits that address comments are easier to
      review than a single commit containing all the changes again. Pull

--- a/.github/workflows/assign_reviewer.yaml
+++ b/.github/workflows/assign_reviewer.yaml
@@ -2,44 +2,66 @@ name: assign-reviewer
 
 # Rotating assignee ("ball in court") for pull requests.
 #
-# This workflow does not request reviewers: the repository's CODEOWNERS file
+# This workflow does not request reviewers. The repository's CODEOWNERS file
 # already requests the maintainers on every PR. Instead it designates a single
 # maintainer as the PR assignee to show who owns the next action ("ball in
-# court"), and keeps that up to date as the review progresses:
+# court"), and keeps that up to date as the review progresses.
 #   - opened / ready_for_review -> a maintainer is chosen at random from the
 #     pool and set as the assignee.
 #   - a human re-requests a review while the ball is with the author -> the
 #     assignee flips to the requested maintainer.
+#   - the author pushes commits while holding the ball -> the assignee flips
+#     back to the pool member who reviewed most recently. Contributors rarely
+#     use the re-request button, so author activity is treated as the signal
+#     that the changes are ready to look at.
+#   - the author comments while holding the ball -> same flip as a push, so
+#     the maintainer sees that an author question awaits a response.
+#   - a pool member comments while holding the ball -> the assignee flips to
+#     the author, keeping the court with whoever must respond next.
 #
-# Review submissions (the flip to the author on changes requested, and the
-# reviewer staying assigned on approval) are handled by the companion
+# Activity-driven flips only happen when the acting user currently holds the
+# ball, so repeated pushes or comments by the same person are no-ops and
+# manual assignee changes are never overridden.
+#
+# Review submissions (the flip to the author on changes requested, the
+# reviewer staying assigned on approval, and the flip back when the author
+# replies on review threads) are handled by the companion
 # assign-reviewer-review-capture and assign-reviewer-review-apply workflows.
 # That split exists because review handling needs a write token on PRs from
-# forks, which the pull_request_review event does not provide; see those files.
+# forks, which the pull_request_review event does not provide. See those
+# files.
 #
-# The maintainer is picked at random from the pool, which evens out over time.
-# The selection is stateless: no persisted index or external state. The pool is
-# defined in .github/reviewer-pool.json, separate from CODEOWNERS, so it can be
-# adjusted for availability (leave, inactivity) without touching ownership.
+# The maintainer is picked at random from the pool, which evens out over
+# time. The selection is stateless, with no persisted index or external
+# state. The pool is defined in .github/reviewer-pool.json, separate from
+# CODEOWNERS, so it can be adjusted for availability (leave, inactivity)
+# without touching ownership.
 #
-# This runs on pull_request_target, which has a write-scoped token even for PRs
-# from forks. It is safe because the job never checks out or executes any code
-# from the PR; it only reads PR metadata and calls the assignee API, never
-# interpolating PR-controlled text into a shell.
+# The pull_request_target events carry a write-scoped token even for PRs from
+# forks, and issue_comment also runs from the default branch with a
+# write-scoped token. This is safe because the job never checks out or
+# executes any code from the PR. The checkout below fetches only the shared
+# helper script from a trusted ref (the PR base branch, or the default branch
+# for issue_comment), the job otherwise only reads PR metadata and calls the
+# assignee API, and PR-controlled text is never interpolated into a shell.
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, review_requested]
+    types: [opened, ready_for_review, review_requested, synchronize]
+  issue_comment:
+    types: [created]
 
 # Serialize runs per PR and per event action so overlapping events don't race
-# on the assignee. The action is part of the group on purpose: when a PR opens,
-# GitHub fires the "opened" event together with a burst of CODEOWNERS
-# "review_requested" events, and a single group plus cancel-in-progress: false
-# makes GitHub cancel all but the latest pending run, which can drop the
-# "opened" run that assigns the reviewer. Keeping each action in its own group
-# lets "opened" run on its own while same-action bursts still collapse safely.
+# on the assignee. The action is part of the group on purpose: when a PR
+# opens, GitHub fires the "opened" event together with a burst of CODEOWNERS
+# "review_requested" events, and a single group plus cancel-in-progress:
+# false makes GitHub cancel all but the latest pending run, which can drop
+# the "opened" run that assigns the reviewer. Keeping each action in its own
+# group lets "opened" run on its own while same-action bursts (rapid pushes,
+# comment streams) still collapse safely. issue_comment events carry an issue
+# payload instead of a pull_request one, hence the number fallback.
 concurrency:
-  group: assign-reviewer-${{ github.event.pull_request.number }}-${{ github.event_name }}-${{ github.event.action }}
+  group: assign-reviewer-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}-${{ github.event.action }}
   cancel-in-progress: false
 
 permissions:
@@ -49,85 +71,77 @@ jobs:
   assign-reviewer:
     runs-on: ubuntu-latest
     permissions:
-      contents: read       # read .github/reviewer-pool.json
+      contents: read       # check out the helper script, read .github/reviewer-pool.json
       issues: write        # add/remove assignees (the issues API endpoint)
       pull-requests: write # add/remove assignees on the pull request
     steps:
+      # Check out only the shared helper script, from a trusted ref. On
+      # pull_request_target the default checkout ref is the PR base branch,
+      # and on issue_comment it is the default branch, never the PR head.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const courtLib = require('./.github/workflows/scripts/assign_reviewer_lib.js');
+            const court = await courtLib({ github, context, core });
             const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
             const action = context.payload.action;
-            const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
-            const assignees = () => (pr.assignees || []).map(a => a.login);
 
-            // The reviewer pool lives in .github/reviewer-pool.json so it has a
-            // single, discoverable source of truth shared with the apply
-            // workflow (assign_reviewer_review_apply.yaml). Read it from the
-            // default branch (the API default ref) so a PR from a fork cannot
-            // substitute its own pool.
-            const { data: poolFile } = await github.rest.repos.getContent({
-              owner, repo, path: '.github/reviewer-pool.json',
-            });
-            const POOL = JSON.parse(
-              Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
-            ).reviewers;
-            const inPool = (login) => POOL.some(p => eq(p, login));
-            // The ball is in the author's court only when the author is assigned
-            // and no pool member other than the author also is, so a re-request
-            // does not override a maintainer who is still (for example,
-            // manually) co-assigned.
-            const authorHoldsBall = () => {
-              const current = assignees();
-              return current.some(a => eq(a, pr.user.login)) &&
-                !current.some(a => inPool(a) && !eq(a, pr.user.login));
-            };
-
-            // Make `login` the sole ball-in-court assignee among flow
-            // participants (the pool members and the PR author), leaving any
-            // unrelated, manually-added assignees untouched.
-            async function setCourt(login) {
-              const flow = [...POOL, pr.user.login];
-              const current = assignees();
-              const toRemove = current.filter(a =>
-                flow.some(f => eq(f, a)) && !eq(a, login));
-              if (toRemove.length > 0) {
-                await github.rest.issues.removeAssignees({
-                  owner, repo, issue_number: pr.number, assignees: toRemove,
-                });
-              }
-              if (!current.some(a => eq(a, login))) {
-                await github.rest.issues.addAssignees({
-                  owner, repo, issue_number: pr.number, assignees: [login],
-                });
-              }
-              core.info(`Ball in court: ${login}, PR #${pr.number}.`);
-            }
-
-            // Skip bot-authored PRs (for example Dependabot). These are handled
-            // by the auto-merge workflow and do not take part in the rotation.
-            if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
-              core.info(`PR #${pr.number} authored by bot ${pr.user.login}; skipping.`);
+            // issue_comment fires for plain issues too. Only PR comments take
+            // part in the ball-in-court flow.
+            if (context.eventName === 'issue_comment' &&
+                !context.payload.issue.pull_request) {
+              core.info(`Comment on #${context.payload.issue.number} is not on a pull request, skipping.`);
               return;
             }
 
+            // The pull_request payload snapshot can be stale during event
+            // bursts and issue_comment carries no pull_request payload at
+            // all, so always act on a fresh fetch.
+            const prNumber = context.payload.pull_request
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber,
+            });
+            const author = pr.user.login;
+
+            // Skip bot-authored PRs (for example Dependabot). These are handled
+            // by the auto-merge workflow and do not take part in the rotation.
+            if (court.isBot(pr.user)) {
+              core.info(`PR #${pr.number} authored by bot ${author}; skipping.`);
+              return;
+            }
+            // Comments can arrive on closed PRs.
+            if (pr.state !== 'open') {
+              core.info(`PR #${pr.number} is ${pr.state}, leaving court unchanged.`);
+              return;
+            }
+            // The rotation starts when a PR leaves draft (ready_for_review),
+            // so pushes and discussion on a draft move no assignee.
+            if (pr.draft) {
+              core.info(`PR #${pr.number} is a draft; skipping.`);
+              return;
+            }
+
+            const holder = court.courtHolder(pr);
+            const authorHoldsBall = holder !== null && court.eq(holder, author);
+
             // 1) New PR (or draft promoted to ready): pick a random pool member.
             if (action === 'opened' || action === 'ready_for_review') {
-              if (pr.draft) {
-                core.info(`PR #${pr.number} is a draft; skipping.`);
-                return;
-              }
               // Exclude the author so a maintainer who opens a PR is not made
               // the assignee of their own PR.
-              const candidates = POOL.filter(u => !eq(u, pr.user.login));
+              const candidates = court.pool.filter(u => !court.eq(u, author));
               if (candidates.length === 0) {
                 core.info('No eligible maintainers after excluding the author; skipping.');
                 return;
               }
               const reviewer = candidates[Math.floor(Math.random() * candidates.length)];
               core.info(`Selected assignee for PR #${pr.number}: ${reviewer}.`);
-              await setCourt(reviewer);
+              await court.setCourt(pr, reviewer);
               return;
             }
 
@@ -137,14 +151,61 @@ jobs:
             //    that fires on open from overriding the rotated assignee.
             if (action === 'review_requested') {
               const reviewer = context.payload.requested_reviewer;
-              if (!reviewer || reviewer.type === 'Bot' || !inPool(reviewer.login)) {
+              if (!reviewer || reviewer.type === 'Bot' || !court.inPool(reviewer.login)) {
                 core.info('Review request is not for a pool member; skipping.');
                 return;
               }
-              if (!authorHoldsBall()) {
+              if (!authorHoldsBall) {
                 core.info(`Ball is not in the author's court on PR #${pr.number}; not overriding the rotation.`);
                 return;
               }
-              await setCourt(reviewer.login);
+              await court.setCourt(pr, reviewer.login);
+              return;
+            }
+
+            // 3) The author pushed commits. A push while the author holds the
+            //    ball hands it back to the pool member who reviewed most
+            //    recently. If the reviewer looks too early the cost is one
+            //    glance, while a missed hand-back stalls the PR.
+            if (action === 'synchronize') {
+              if (!authorHoldsBall) {
+                core.info(`Ball is not in the author's court on PR #${pr.number}, nothing to flip.`);
+                return;
+              }
+              const reviewer = await court.lastPoolReviewer(pr);
+              if (reviewer === null) {
+                core.info(`No pool member has reviewed PR #${pr.number} yet, leaving court unchanged.`);
+                return;
+              }
+              await court.setCourt(pr, reviewer);
+              return;
+            }
+
+            // 4) A conversation comment. The ball moves to the counterpart of
+            //    whoever spoke, but only when the speaker holds it, so streams
+            //    of comments from one side produce a single flip.
+            if (context.eventName === 'issue_comment') {
+              const commenter = context.payload.comment.user;
+              if (court.isBot(commenter)) {
+                core.info('Comment by a bot, leaving court unchanged.');
+                return;
+              }
+              if (holder === null || !court.eq(holder, commenter.login)) {
+                core.info(`Commenter does not hold the ball on PR #${pr.number}, leaving court unchanged.`);
+                return;
+              }
+              if (court.eq(commenter.login, author)) {
+                const reviewer = await court.lastPoolReviewer(pr);
+                if (reviewer === null) {
+                  core.info(`No pool member has reviewed PR #${pr.number} yet, leaving court unchanged.`);
+                  return;
+                }
+                await court.setCourt(pr, reviewer);
+                return;
+              }
+              // The holder is either the author or a pool member, so this is
+              // a pool member speaking while holding the ball. Their comment
+              // (an answer, a request) puts the author on point to respond.
+              await court.setCourt(pr, author);
               return;
             }

--- a/.github/workflows/assign_reviewer_review_apply.yaml
+++ b/.github/workflows/assign_reviewer_review_apply.yaml
@@ -8,20 +8,28 @@ name: assign-reviewer-review-apply
 # which is what lets it move the assignee where the pull_request_review event
 # could not.
 #
-# Ball-in-court rules applied here:
-#   - reviewer approves  -> the reviewer stays assigned (a maintainer merges).
-#   - changes requested or comment -> the author is assigned (their court).
+# Ball-in-court rules applied here
+#   - a pool member approves -> the reviewer stays assigned (a maintainer
+#     merges).
+#   - a pool member requests changes or comments -> the author is assigned
+#     (their court).
+#   - the author submits a review while holding the ball -> the ball returns
+#     to the pool member who reviewed most recently. Inline replies on review
+#     threads create an implicit "commented" review, so this mirrors the push
+#     and conversation-comment flips in assign_reviewer.yaml.
 #
-# Security: this never checks out or runs any PR code. The capture artifact is
-# treated as untrusted (a fork PR can run a modified capture, since
-# pull_request_review uses the PR's own workflow copy): it validates the PR
-# number is a positive integer and the review state is one of the known values,
-# binds the artifact to the triggering PR by requiring the re-fetched PR head to
-# equal the run's head SHA (so a forged pr_number cannot target a victim PR),
-# confirms via the API that the named reviewer actually submitted a review in
-# that state (so a forged artifact cannot fabricate one), skips bot-authored
-# PRs, only ever assigns a login that is in the pool or is the PR author
-# re-fetched from the API, and never interpolates artifact data into a shell.
+# Security. This never checks out or runs any PR code (the checkout below
+# fetches only the shared helper script from the default branch). The capture
+# artifact is treated as untrusted (a fork PR can run a modified capture,
+# since pull_request_review uses the PR's own workflow copy). It validates the
+# PR number is a positive integer and the review state is one of the known
+# values, binds the artifact to the triggering PR by requiring the re-fetched
+# PR head to equal the run's head SHA (so a forged pr_number cannot target a
+# victim PR), confirms via the API that the named reviewer actually submitted
+# a review in that state (so a forged artifact cannot fabricate one), skips
+# bot-authored PRs, only ever assigns a login that is in the pool or is the
+# PR author re-fetched from the API, and never interpolates artifact data
+# into a shell.
 
 on:
   workflow_run:
@@ -44,11 +52,18 @@ jobs:
     # Only act when the capture run succeeded (so the artifact exists).
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
-      contents: read       # read .github/reviewer-pool.json
+      contents: read       # check out the helper script, read .github/reviewer-pool.json
       issues: write        # add/remove assignees (the issues API endpoint)
       pull-requests: write # add/remove assignees on the pull request
       actions: read        # download the artifact from the capture run
     steps:
+      # Check out only the shared helper script. workflow_run always checks
+      # out the default branch, never PR code. This runs before the artifact
+      # download because checkout cleans the workspace.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/workflows/scripts
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: assign-reviewer-review
@@ -58,21 +73,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-
+            const courtLib = require('./.github/workflows/scripts/assign_reviewer_lib.js');
+            const court = await courtLib({ github, context, core });
             const { owner, repo } = context.repo;
-            const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
-
-            // The reviewer pool lives in .github/reviewer-pool.json so it has a
-            // single, discoverable source of truth shared with
-            // assign_reviewer.yaml. This workflow_run job already runs from the
-            // default branch, so the default ref is the trusted pool.
-            const { data: poolFile } = await github.rest.repos.getContent({
-              owner, repo, path: '.github/reviewer-pool.json',
-            });
-            const POOL = JSON.parse(
-              Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
-            ).reviewers;
-            const inPool = (login) => POOL.some(p => eq(p, login));
 
             // The artifact comes from a fork-triggered run; treat it as
             // untrusted and validate every field before use.
@@ -94,18 +97,12 @@ jobs:
               core.info(`Review state "${state}" does not change the court; nothing to do.`);
               return;
             }
-            // Only reviews from pool members drive the ball-in-court state.
-            if (!inPool(submitter)) {
-              core.info(`Review by ${submitter} is not from a pool member; leaving court unchanged.`);
-              return;
-            }
 
             // Re-fetch the PR so we act on its current author and assignees.
             const { data: pr } = await github.rest.pulls.get({
               owner, repo, pull_number: prNumber,
             });
             const author = pr.user.login;
-            const current = (pr.assignees || []).map(a => a.login);
 
             // Bind the artifact to the PR that actually triggered the capture
             // run. pull_request_review runs the PR's own copy of the capture
@@ -123,8 +120,8 @@ jobs:
 
             // Skip bot-authored PRs (for example Dependabot); they are owned by
             // the auto-merge workflow and do not take part in the rotation.
-            if (pr.user.type === 'Bot' || pr.user.login.endsWith('[bot]')) {
-              core.info(`PR #${prNumber} authored by bot ${pr.user.login}; skipping.`);
+            if (court.isBot(pr.user)) {
+              core.info(`PR #${prNumber} authored by bot ${author}; skipping.`);
               return;
             }
 
@@ -133,10 +130,12 @@ jobs:
               core.info(`PR #${prNumber} is ${pr.state}; leaving court unchanged.`);
               return;
             }
-            // A pool member can leave a comment review on their own PR; don't
-            // assign them to it (the open handler excludes the author too).
-            if (eq(submitter, author)) {
-              core.info(`Self-review by ${submitter} on PR #${prNumber}; leaving court unchanged.`);
+
+            // Reviews drive the court only when submitted by a pool member or
+            // by the PR author (inline replies create an implicit "commented"
+            // review).
+            if (!court.inPool(submitter) && !court.eq(submitter, author)) {
+              core.info(`Review by ${submitter} is not from a flow participant, leaving court unchanged.`);
               return;
             }
 
@@ -148,30 +147,40 @@ jobs:
               owner, repo, pull_number: prNumber, per_page: 100,
             });
             const reviewExists = reviews.some(r =>
-              r.user && eq(r.user.login, submitter) &&
+              r.user && court.eq(r.user.login, submitter) &&
               (r.state || '').toLowerCase() === state);
             if (!reviewExists) {
               core.info(`No ${state} review by ${submitter} on PR #${prNumber}; ignoring (forged or stale artifact).`);
               return;
             }
 
-            // Approve keeps the reviewer assigned; otherwise the author owns it.
-            const target = state === 'approved' ? submitter : author;
+            // The author reviewed their own PR. GitHub only allows "commented"
+            // self-reviews, and they mostly carry inline replies to review
+            // threads, so hand the ball back to the pool member who reviewed
+            // most recently, mirroring the push and conversation-comment
+            // handlers in assign_reviewer.yaml. Like there, the flip only
+            // happens while the author holds the ball, so manual assignee
+            // changes are never overridden.
+            if (court.eq(submitter, author)) {
+              if (state !== 'commented') {
+                core.info(`Unexpected ${state} self-review on PR #${prNumber}, leaving court unchanged.`);
+                return;
+              }
+              const holder = court.courtHolder(pr);
+              if (holder === null || !court.eq(holder, author)) {
+                core.info(`Author does not hold the ball on PR #${prNumber}, leaving court unchanged.`);
+                return;
+              }
+              const reviewer = await court.lastPoolReviewer(pr, reviews);
+              if (reviewer === null) {
+                core.info(`No pool member has reviewed PR #${prNumber} yet, leaving court unchanged.`);
+                return;
+              }
+              await court.setCourt(pr, reviewer);
+              return;
+            }
 
-            // Make `target` the sole ball-in-court assignee among flow
-            // participants (pool members and the author), leaving unrelated,
-            // manually-added assignees untouched.
-            const flow = [...POOL, author];
-            const toRemove = current.filter(a =>
-              flow.some(f => eq(f, a)) && !eq(a, target));
-            if (toRemove.length > 0) {
-              await github.rest.issues.removeAssignees({
-                owner, repo, issue_number: prNumber, assignees: toRemove,
-              });
-            }
-            if (!current.some(a => eq(a, target))) {
-              await github.rest.issues.addAssignees({
-                owner, repo, issue_number: prNumber, assignees: [target],
-              });
-            }
-            core.info(`Ball in court: ${target}, PR #${prNumber}.`);
+            // A pool member reviewed. Approve keeps the reviewer assigned (a
+            // maintainer merges); otherwise the author owns it.
+            const target = state === 'approved' ? submitter : author;
+            await court.setCourt(pr, target);

--- a/.github/workflows/scripts/assign_reviewer_lib.js
+++ b/.github/workflows/scripts/assign_reviewer_lib.js
@@ -3,9 +3,13 @@
 //
 // The ball is tracked through the PR assignee. The court holder is the
 // single flow participant (a pool member or the PR author) currently
-// assigned. Handlers flip the court only when the acting user holds the
-// ball, so repeated events are no-ops and manual assignee changes are
-// never overridden.
+// assigned. Activity-driven flips (pushes, conversation comments, the
+// author's review replies) only happen when the acting user holds the
+// ball, so repeated events are no-ops and those flips never override a
+// manual assignee change. The initial assignment on open and the flips on
+// pool-member review submissions move the court unconditionally, and
+// setCourt only ever touches flow participants, leaving unrelated,
+// manually-added assignees in place.
 //
 // This file is always loaded from a trusted ref (the PR base branch, or
 // the default branch on workflow_run and issue_comment), never from PR

--- a/.github/workflows/scripts/assign_reviewer_lib.js
+++ b/.github/workflows/scripts/assign_reviewer_lib.js
@@ -1,0 +1,92 @@
+// Shared ball-in-court helpers for the assign-reviewer workflows
+// (assign_reviewer.yaml and assign_reviewer_review_apply.yaml).
+//
+// The ball is tracked through the PR assignee. The court holder is the
+// single flow participant (a pool member or the PR author) currently
+// assigned. Handlers flip the court only when the acting user holds the
+// ball, so repeated events are no-ops and manual assignee changes are
+// never overridden.
+//
+// This file is always loaded from a trusted ref (the PR base branch, or
+// the default branch on workflow_run and issue_comment), never from PR
+// code. See the checkout step in each workflow.
+
+module.exports = async function ({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const eq = (a, b) => a.toLowerCase() === b.toLowerCase();
+
+  // The reviewer pool lives in .github/reviewer-pool.json so it has a
+  // single, discoverable source of truth. Read it from the default branch
+  // (the API default ref) so a PR from a fork cannot substitute its own
+  // pool.
+  const { data: poolFile } = await github.rest.repos.getContent({
+    owner, repo, path: '.github/reviewer-pool.json',
+  });
+  const pool = JSON.parse(
+    Buffer.from(poolFile.content, poolFile.encoding).toString('utf8'),
+  ).reviewers;
+
+  const inPool = (login) => pool.some(p => eq(p, login));
+
+  const isBot = (user) =>
+    user.type === 'Bot' || user.login.endsWith('[bot]');
+
+  // The flow participant currently holding the ball, or null when no
+  // participant is assigned or the state is ambiguous (for example, a
+  // manually co-assigned maintainer next to the author). Handlers treat
+  // null as "do not touch".
+  function courtHolder(pr) {
+    const author = pr.user.login;
+    const assigned = (pr.assignees || []).map(a => a.login);
+    const maintainers = assigned.filter(a => inPool(a) && !eq(a, author));
+    const authorAssigned = assigned.some(a => eq(a, author));
+    if (authorAssigned && maintainers.length === 0) {
+      return author;
+    }
+    if (!authorAssigned && maintainers.length === 1) {
+      return maintainers[0];
+    }
+    return null;
+  }
+
+  // The pool member (other than the author) who most recently submitted a
+  // review, or null when nobody from the pool has reviewed yet. Used as
+  // the flip-back target when the author acts without re-requesting a
+  // review. Callers that already listed the PR's reviews can pass them to
+  // skip the refetch.
+  async function lastPoolReviewer(pr, reviews = null) {
+    reviews ??= await github.paginate(github.rest.pulls.listReviews, {
+      owner, repo, pull_number: pr.number, per_page: 100,
+    });
+    for (let i = reviews.length - 1; i >= 0; i--) {
+      const login = reviews[i].user && reviews[i].user.login;
+      if (login && inPool(login) && !eq(login, pr.user.login)) {
+        return login;
+      }
+    }
+    return null;
+  }
+
+  // Make `login` the sole ball-in-court assignee among flow participants
+  // (the pool members and the PR author), leaving any unrelated,
+  // manually-added assignees untouched.
+  async function setCourt(pr, login) {
+    const flow = [...pool, pr.user.login];
+    const current = (pr.assignees || []).map(a => a.login);
+    const toRemove = current.filter(a =>
+      flow.some(f => eq(f, a)) && !eq(a, login));
+    if (toRemove.length > 0) {
+      await github.rest.issues.removeAssignees({
+        owner, repo, issue_number: pr.number, assignees: toRemove,
+      });
+    }
+    if (!current.some(a => eq(a, login))) {
+      await github.rest.issues.addAssignees({
+        owner, repo, issue_number: pr.number, assignees: [login],
+      });
+    }
+    core.info(`Ball in court: ${login}, PR #${pr.number}.`);
+  }
+
+  return { pool, eq, inPool, isBot, courtHolder, lastPoolReviewer, setCourt };
+};

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,9 @@ conventions apply to the SPIRE repository:
 When you open a pull request, the description is pre-filled from our
 [pull request template](.github/PULL_REQUEST_TEMPLATE.md?plain=1), which
 explains how our review process works: the rotating "ball in court" assignee,
-re-requesting a review after you address comments, preferring new commits over
-force-pushing, and handling Copilot comments. Please follow the guidance shown
-there when you open and iterate on your PR.
+how the assignee moves as you push commits and discuss, preferring new commits
+over force-pushing, and handling Copilot comments. Please follow the guidance
+shown there when you open and iterate on your PR.
 
 ### SQL Plugin Changes
 


### PR DESCRIPTION
The assign-reviewer workflow moves the ball-in-court assignee to the author when a maintainer requests changes or comments, and it only moves back when the contributor explicitly re-requests a review. In practice contributors rarely use the re-request button, so the assignee keeps pointing at the author, maintainers assume the ball is not in their court, and the PR stalls with both sides waiting.

This PR treats author activity as the hand-back signal. A push of new commits or a conversation comment by the author, while the author holds the ball, flips the assignee back to the pool member who reviewed most recently. Inline replies on review threads produce an implicit `commented` review, so the same flip is applied in the `assign-reviewer-review-apply` workflow when the captured review was submitted by the author. Symmetrically, a conversation comment by a pool member who holds the ball hands it to the author, so questions and answers keep the assignee pointing at whoever must respond next. All activity flips are guarded on the acting user currently holding the ball, which makes repeated pushes or comment streams no-ops and keeps manual assignee changes untouched.

The decision helpers that were duplicated between `assign_reviewer.yaml` and `assign_reviewer_review_apply.yaml` (pool loading, court computation, assignee updates) now live in a shared script, `.github/workflows/scripts/assign_reviewer_lib.js`, which both workflows load from a trusted ref through a sparse checkout (the PR base branch on `pull_request_target`, the default branch on `issue_comment` and `workflow_run`), never from PR code. The handlers also re-fetch the PR before acting instead of trusting the event payload snapshot, and the draft skip now applies to every event, so pushes and discussion on a draft move no assignee and the rotation still starts at `ready_for_review`.

The PR template and the contributing guide are updated to describe the new flow instead of asking contributors to re-request a review.
