### PR TITLE
Add BundlePublisher migration guidance to the Notifier plugin docs

### DIFF
--- a/doc/plugin_server_bundlepublisher_gcp_cloudstorage.md
+++ b/doc/plugin_server_bundlepublisher_gcp_cloudstorage.md
@@ -47,7 +47,7 @@ The following configuration uploads the local trust bundle contents to the `exam
 ```hcl
     BundlePublisher "gcp_cloudstorage" {
         plugin_data {
-            bucket = "spire-bundle"
+            bucket_name = "spire-bundle"
             object_name = "example.org"
             format = "spiffe"
         }
@@ -62,7 +62,7 @@ The following configuration uploads the local trust bundle contents to the `exam
     BundlePublisher "gcp_cloudstorage" {
         plugin_data {
             service_account_file = "/path/to/service/account/file"
-            bucket = "spire-bundle"
+            bucket_name = "spire-bundle"
             object_name = "example.org"
             format = "spiffe"
         }

--- a/doc/plugin_server_notifier_gcs_bundle.md
+++ b/doc/plugin_server_notifier_gcs_bundle.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > The Notifier plugin type is deprecated and will be removed in a future
 > release. Use the [`gcp_cloudstorage` BundlePublisher](/doc/plugin_server_bundlepublisher_gcp_cloudstorage.md)
-> plugin instead.
+> plugin instead. See [Migrating to the `gcp_cloudstorage` BundlePublisher](#migrating-to-the-gcp_cloudstorage-bundlepublisher).
 
 The `gcs_bundle` plugin responds to bundle loaded/updated events by fetching and
 pushing the latest root CA certificates from the trust bundle to an object in
@@ -56,6 +56,37 @@ credentials found in the `/path/to/service/account/file` file.
             bucket = "my-bucket"
             object_path = "spire-bundle.pem"
             service_account_file = "/path/to/service/account/file"
+        }
+    }
+```
+
+## Migrating to the `gcp_cloudstorage` BundlePublisher
+
+The [`gcp_cloudstorage` BundlePublisher](/doc/plugin_server_bundlepublisher_gcp_cloudstorage.md)
+uploads the trust bundle to a Google Cloud Storage object as well, and
+authenticates the same way, but the configuration options are named differently
+and the bundle format has to be set explicitly.
+
+| `gcs_bundle`           | `gcp_cloudstorage`     |
+|------------------------|------------------------|
+| `bucket`               | `bucket_name`          |
+| `object_path`          | `object_name`          |
+| `service_account_file` | `service_account_file` |
+
+Set `format` to `pem` to keep the object contents unchanged, since `gcs_bundle`
+uploads the X.509 authorities PEM encoded. The `spiffe` and `jwks` formats
+include the JWT authorities as well, so switching to one of them changes what
+consumers of the object read.
+
+The following configuration is equivalent to the first sample configuration
+above:
+
+```hcl
+    BundlePublisher "gcp_cloudstorage" {
+        plugin_data {
+            bucket_name = "my-bucket"
+            object_name = "spire-bundle.pem"
+            format = "pem"
         }
     }
 ```

--- a/doc/plugin_server_notifier_k8sbundle.md
+++ b/doc/plugin_server_notifier_k8sbundle.md
@@ -172,20 +172,20 @@ writes the trust bundle to a Kubernetes ConfigMap as well, but every cluster is
 configured under the `clusters` map, including the local one, and the settings
 that `k8sbundle` fills in by default have to be set explicitly.
 
-| `k8sbundle`             | `k8s_configmap`   | Notes                                                |
-|-------------------------|-------------------|------------------------------------------------------|
-| `namespace`             | `namespace`       | Required. `k8sbundle` defaults it to `spire`.        |
-| `config_map`            | `configmap_name`  | Required. `k8sbundle` defaults it to `spire-bundle`. |
-| `config_map_key`        | `configmap_key`   | Required. `k8sbundle` defaults it to `bundle.crt`.   |
-| `kube_config_file_path` | `kubeconfig_path` | In-cluster credentials are used when unset.          |
-| `clusters`              | `clusters`        | Holds every cluster, keyed by an arbitrary ID.       |
-| `webhook_label`         |                   | Rotating webhook CA bundles is not supported.        |
-| `api_service_label`     |                   | Rotating API service CA bundles is not supported.    |
+| `k8sbundle`             | `k8s_configmap`            | Notes                                                |
+|-------------------------|----------------------------|------------------------------------------------------|
+| `namespace`             | `clusters.namespace`       | Required. `k8sbundle` defaults it to `spire`.        |
+| `config_map`            | `clusters.configmap_name`  | Required. `k8sbundle` defaults it to `spire-bundle`. |
+| `config_map_key`        | `clusters.configmap_key`   | Required. `k8sbundle` defaults it to `bundle.crt`.   |
+| `kube_config_file_path` | `clusters.kubeconfig_path` | In-cluster credentials are used when unset.          |
+| `clusters`              | `clusters`                 | Holds every cluster, keyed by an arbitrary ID.       |
+| `webhook_label`         |                            | Rotating webhook CA bundles is not supported.        |
+| `api_service_label`     |                            | Rotating API service CA bundles is not supported.    |
 
-Set `format` to `pem` to keep the ConfigMap contents unchanged, since
-`k8sbundle` writes the X.509 authorities PEM encoded. The `spiffe` and `jwks`
-formats include the JWT authorities as well, so switching to one of them changes
-what agents bootstrapping from the ConfigMap read.
+Set each cluster's `format` to `pem` to keep the ConfigMap contents unchanged,
+since `k8sbundle` writes the X.509 authorities PEM encoded. The `spiffe` and
+`jwks` formats include the JWT authorities as well, so switching to one of them
+changes what agents bootstrapping from the ConfigMap read.
 
 Two differences are worth reviewing before switching:
 

--- a/doc/plugin_server_notifier_k8sbundle.md
+++ b/doc/plugin_server_notifier_k8sbundle.md
@@ -4,7 +4,8 @@
 > The Notifier plugin type is deprecated and will be removed in a future
 > release. Use the [`k8s_configmap` BundlePublisher](/doc/plugin_server_bundlepublisher_k8s_configmap.md)
 > plugin instead. Note that the BundlePublisher plugin does not support
-> rotating the CA bundle in webhooks or API services.
+> rotating the CA bundle in webhooks or API services. See
+> [Migrating to the `k8s_configmap` BundlePublisher](#migrating-to-the-k8s_configmap-bundlepublisher).
 
 The `k8sbundle` plugin responds to bundle loaded/updated events by fetching and
 pushing the latest root CA certificates from the trust bundle to a Kubernetes
@@ -161,5 +162,53 @@ server to
         }
         ]
       }    
+    }
+```
+
+## Migrating to the `k8s_configmap` BundlePublisher
+
+The [`k8s_configmap` BundlePublisher](/doc/plugin_server_bundlepublisher_k8s_configmap.md)
+writes the trust bundle to a Kubernetes ConfigMap as well, but every cluster is
+configured under the `clusters` map, including the local one, and the settings
+that `k8sbundle` fills in by default have to be set explicitly.
+
+| `k8sbundle`             | `k8s_configmap`   | Notes                                                |
+|-------------------------|-------------------|------------------------------------------------------|
+| `namespace`             | `namespace`       | Required. `k8sbundle` defaults it to `spire`.        |
+| `config_map`            | `configmap_name`  | Required. `k8sbundle` defaults it to `spire-bundle`. |
+| `config_map_key`        | `configmap_key`   | Required. `k8sbundle` defaults it to `bundle.crt`.   |
+| `kube_config_file_path` | `kubeconfig_path` | In-cluster credentials are used when unset.          |
+| `clusters`              | `clusters`        | Holds every cluster, keyed by an arbitrary ID.       |
+| `webhook_label`         |                   | Rotating webhook CA bundles is not supported.        |
+| `api_service_label`     |                   | Rotating API service CA bundles is not supported.    |
+
+Set `format` to `pem` to keep the ConfigMap contents unchanged, since
+`k8sbundle` writes the X.509 authorities PEM encoded. The `spiffe` and `jwks`
+formats include the JWT authorities as well, so switching to one of them changes
+what agents bootstrapping from the ConfigMap read.
+
+Two differences are worth reviewing before switching:
+
+- The bundle is written with a server-side apply, which creates the ConfigMap
+  when it does not exist, so the Service Account needs `create` on ConfigMaps in
+  addition to `get` and `patch`.
+- An empty `clusters` map is a valid configuration under which the bundle is
+  never published, so make sure the local cluster is listed.
+
+The following configuration is equivalent to a `k8sbundle` notifier running
+in-cluster with default settings:
+
+```hcl
+    BundlePublisher "k8s_configmap" {
+        plugin_data {
+            clusters = {
+                "local" = {
+                    namespace = "spire"
+                    configmap_name = "spire-bundle"
+                    configmap_key = "bundle.crt"
+                    format = "pem"
+                }
+            }
+        }
     }
 ```


### PR DESCRIPTION
The Notifier plugin type was deprecated in #7222, and both notifier docs now point at the BundlePublisher plugin that replaces them. The pointer alone leaves out the parts of the migration that are not mechanical, so an operator following it has to diff two reference docs to work out what actually changes.

This PR adds a migration section to each notifier doc, with the configuration mapping and the behavior differences that matter when switching.

**`gcs_bundle`**

- `bucket` and `object_path` become `bucket_name` and `object_name`, while `service_account_file` keeps its name and the authentication behavior is unchanged.
- `format` is required and has no equivalent in the notifier. Setting it to `pem` keeps the object contents unchanged, since `gcs_bundle` uploads the X.509 authorities PEM encoded, while `spiffe` and `jwks` include the JWT authorities as well.

**`k8sbundle`**

- Every cluster is configured under the `clusters` map, including the local one, and `namespace`, `configmap_name`, `configmap_key` and `format` are all required where `k8sbundle` defaulted them to `spire`, `spire-bundle` and `bundle.crt`.
- `k8s_configmap` writes the ConfigMap with a server-side apply that creates it when it does not exist, so the Service Account needs `create` on ConfigMaps in addition to `get` and `patch`.
- An empty `clusters` map is a valid configuration under which the bundle is never published, which is an easy state to land in when moving the settings over.

Both sections end with a configuration equivalent to the notifier sample it replaces, and the deprecation warning at the top of each doc now links to the section.

While writing the `gcs_bundle` mapping I noticed that the two sample configurations in the `gcp_cloudstorage` doc set `bucket`, but the plugin reads `bucket_name`. HCL drops the unknown key, so configuring from either sample fails with `configuration is missing the bucket name`. This PR fixes both samples.
