### PR TITLE
httpchallenge: optionally verify client IP against hostname DNS

### DIFF
--- a/doc/plugin_server_nodeattestor_http_challenge.md
+++ b/doc/plugin_server_nodeattestor_http_challenge.md
@@ -18,7 +18,7 @@ spiffe://<trust_domain>/spire/agent/http_challenge/<hostname>
 | `required_port`         | Set to a port number to require clients to listen only on that port. If unset, all port numbers are allowed                                                                                                                         |                                     |
 | `allow_non_root_ports`  | Set to true to allow ports >= 1024 to be used by the agents with the advertised_port                                                                                                                                                | true                                |
 | `tofu`                  | Trust on first use of the successful challenge. Can only be disabled if allow_non_root_ports=false or required_port < 1024                                                                                                          | true                                |
-| `verify_client_ip`      | If `true`, validates the connecting peer's IP against DNS addresses for the attested hostname. Attestation fails if lookup fails or no address matches. Reflects the immediate connecting peer, which may be a load balancer.      | false                               |
+| `verify_client_ip`      | If `true`, validates the connecting peer's IP against DNS addresses for the attested hostname. Attestation fails if lookup fails or no address matches. Reflects the immediate connecting peer, which may be a load balancer.       | false                               |
 
 A sample configuration:
 

--- a/doc/plugin_server_nodeattestor_http_challenge.md
+++ b/doc/plugin_server_nodeattestor_http_challenge.md
@@ -12,12 +12,13 @@ The SPIFFE ID has the form:
 spiffe://<trust_domain>/spire/agent/http_challenge/<hostname>
 ```
 
-| Configuration           | Description                                                                                                                                               | Default                             |
-|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
-| `allowed_dns_patterns`  | A list of regular expressions to match to the hostname being attested. If none match, attestation will fail. If unset, all hostnames are allowed.         |                                     |
-| `required_port`         | Set to a port number to require clients to listen only on that port. If unset, all port numbers are allowed                                               |                                     |
-| `allow_non_root_ports`  | Set to true to allow ports >= 1024 to be used by the agents with the advertised_port                                                                      | true                                |
-| `tofu`                  | Trust on first use of the successful challenge. Can only be disabled if allow_non_root_ports=false or required_port < 1024                                | true                                |
+| Configuration           | Description                                                                                                                                                                                                                         | Default                             |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| `allowed_dns_patterns`  | A list of regular expressions to match to the hostname being attested. If none match, attestation will fail. If unset, all hostnames are allowed.                                                                                   |                                     |
+| `required_port`         | Set to a port number to require clients to listen only on that port. If unset, all port numbers are allowed                                                                                                                         |                                     |
+| `allow_non_root_ports`  | Set to true to allow ports >= 1024 to be used by the agents with the advertised_port                                                                                                                                                | true                                |
+| `tofu`                  | Trust on first use of the successful challenge. Can only be disabled if allow_non_root_ports=false or required_port < 1024                                                                                                          | true                                |
+| `verify_client_ip`      | If `true`, validates the connecting peer's IP against DNS addresses for the attested hostname. Attestation fails if lookup fails or no address matches. Reflects the immediate connecting peer, which may be a load balancer.      | false                               |
 
 A sample configuration:
 
@@ -29,6 +30,9 @@ A sample configuration:
 
             # Only allow clients to use port 80
             required_port = 80
+
+            # Optional: when true, require the connecting peer IP to match a DNS address for the attested hostname
+            # verify_client_ip = true
 
             # Change the agent's SPIFFE ID format
             # agent_path_template = "/spire/agent/http_challenge/{{ .Hostname }}"
@@ -53,3 +57,5 @@ Trust On First Use (or TOFU) is one such option. For any given node, attestation
 With TOFU, it is still possible for non-agent code to complete node attestation before SPIRE Agent can, however this condition is easily and quickly detectable as SPIRE Agent will fail to start, and both SPIRE Agent and SPIRE Server will log the occurrence. Such cases should be investigated as possible security incidents.
 
 You also can require the port to be a trusted port that only trusted user such as root can open (port number < 1024).
+
+When `verify_client_ip` is enabled, the connecting peer's IP must match a DNS address for the attested hostname. This reflects the immediate peer and may be a load balancer rather than the agent.

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"regexp"
 	"sync"
@@ -17,8 +18,10 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	"github.com/spiffe/spire/pkg/common/plugin/httpchallenge"
 	"github.com/spiffe/spire/pkg/common/pluginconf"
+	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -39,10 +42,19 @@ func disableHTTPRedirects(req *http.Request, via []*http.Request) error {
 }
 
 func BuiltInTesting(client *http.Client, forceNonce string) catalog.BuiltIn {
+	return BuiltInTestingWithLookup(client, forceNonce, nil)
+}
+
+// BuiltInTestingWithLookup is BuiltInTesting with a DNS lookup hook.
+// A nil lookupIPs uses the system resolver.
+func BuiltInTestingWithLookup(client *http.Client, forceNonce string, lookupIPs func(context.Context, string) ([]net.IP, error)) catalog.BuiltIn {
 	plugin := New()
 	plugin.client = client
 	plugin.client.CheckRedirect = disableHTTPRedirects
 	plugin.forceNonce = forceNonce
+	if lookupIPs != nil {
+		plugin.lookupIPs = lookupIPs
+	}
 	return builtin(plugin)
 }
 
@@ -59,6 +71,7 @@ type configuration struct {
 	allowNonRootPorts bool
 	dnsPatterns       []*regexp.Regexp
 	tofu              bool
+	verifyClientIP    bool
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *configuration {
@@ -111,6 +124,7 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 		requiredPort:      hclConfig.RequiredPort,
 		allowNonRootPorts: allowNonRootPorts,
 		tofu:              tofu,
+		verifyClientIP:    hclConfig.VerifyClientIP,
 	}
 }
 
@@ -119,6 +133,7 @@ type Config struct {
 	RequiredPort       *int     `hcl:"required_port"`
 	AllowNonRootPorts  *bool    `hcl:"allow_non_root_ports"`
 	TOFU               *bool    `hcl:"tofu"`
+	VerifyClientIP     bool     `hcl:"verify_client_ip"`
 }
 
 type Plugin struct {
@@ -133,6 +148,7 @@ type Plugin struct {
 
 	client     *http.Client
 	forceNonce string
+	lookupIPs  func(context.Context, string) ([]net.IP, error)
 }
 
 func New() *Plugin {
@@ -177,6 +193,12 @@ func (p *Plugin) Attest(stream nodeattestorv1.NodeAttestor_AttestServer) error {
 
 	if err = validateHostName(attestationData.HostName, config.dnsPatterns); err != nil {
 		return err
+	}
+
+	if config.verifyClientIP {
+		if err := p.verifyConnectingClientIP(stream.Context(), attestationData.HostName); err != nil {
+			return err
+		}
 	}
 
 	challenge, err := httpchallenge.GenerateChallenge(p.forceNonce)
@@ -268,6 +290,49 @@ func (p *Plugin) getConfig() (*configuration, error) {
 		return nil, status.Errorf(codes.FailedPrecondition, "not configured")
 	}
 	return p.config, nil
+}
+
+func (p *Plugin) verifyConnectingClientIP(ctx context.Context, hostName string) error {
+	ips := metadata.ValueFromIncomingContext(ctx, nodeattestor.XForwardedClientIPKey)
+	if len(ips) == 0 || ips[0] == "" {
+		return status.Error(codes.Internal, "client IP not available for verification")
+	}
+	if len(ips) > 1 && p.log != nil {
+		p.log.Warn("Multiple client IP values found in metadata, using first value")
+	}
+	clientIP := net.ParseIP(ips[0])
+	if clientIP == nil {
+		return status.Errorf(codes.Internal, "invalid client IP %q", ips[0])
+	}
+
+	lookup := p.lookupIPs
+	if lookup == nil {
+		lookup = defaultLookupIPs
+	}
+	resolved, err := lookup(ctx, hostName)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to resolve hostname %q: %v", hostName, err)
+	}
+	for _, resolvedIP := range resolved {
+		if resolvedIP.Equal(clientIP) {
+			return nil
+		}
+	}
+	return status.Errorf(codes.PermissionDenied, "client IP %s does not match any address for hostname %q", clientIP, hostName)
+}
+
+func defaultLookupIPs(ctx context.Context, host string) ([]net.IP, error) {
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if addr.IP != nil {
+			ips = append(ips, addr.IP)
+		}
+	}
+	return ips, nil
 }
 
 func buildSelectorValues(hostName string) []string {

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spiffe/spire/pkg/server/plugin/nodeattestor"
 	nodeattestorbase "github.com/spiffe/spire/pkg/server/plugin/nodeattestor/base"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -41,13 +40,9 @@ func disableHTTPRedirects(req *http.Request, via []*http.Request) error {
 	return errors.New("http redirects are disabled")
 }
 
-func BuiltInTesting(client *http.Client, forceNonce string) catalog.BuiltIn {
-	return BuiltInTestingWithLookup(client, forceNonce, nil)
-}
-
-// BuiltInTestingWithLookup is BuiltInTesting with a DNS lookup hook.
-// A nil lookupIPs uses the system resolver.
-func BuiltInTestingWithLookup(client *http.Client, forceNonce string, lookupIPs func(context.Context, string) ([]net.IP, error)) catalog.BuiltIn {
+// BuiltInTesting builds the plugin for tests. A nil lookupIPs keeps the
+// system resolver.
+func BuiltInTesting(client *http.Client, forceNonce string, lookupIPs func(context.Context, string) ([]net.IP, error)) catalog.BuiltIn {
 	plugin := New()
 	plugin.client = client
 	plugin.client.CheckRedirect = disableHTTPRedirects
@@ -155,6 +150,9 @@ func New() *Plugin {
 	return &Plugin{
 		client: &http.Client{
 			CheckRedirect: disableHTTPRedirects,
+		},
+		lookupIPs: func(ctx context.Context, host string) ([]net.IP, error) {
+			return net.DefaultResolver.LookupIP(ctx, "ip", host)
 		},
 	}
 }
@@ -293,23 +291,19 @@ func (p *Plugin) getConfig() (*configuration, error) {
 }
 
 func (p *Plugin) verifyConnectingClientIP(ctx context.Context, hostName string) error {
-	ips := metadata.ValueFromIncomingContext(ctx, nodeattestor.XForwardedClientIPKey)
-	if len(ips) == 0 || ips[0] == "" {
+	ip := nodeattestor.ClientIPFromContext(ctx, p.log)
+	if ip == "" {
 		return status.Error(codes.Internal, "client IP not available for verification")
 	}
-	if len(ips) > 1 && p.log != nil {
-		p.log.Warn("Multiple client IP values found in metadata, using first value")
-	}
-	clientIP := net.ParseIP(ips[0])
+	clientIP := net.ParseIP(ip)
 	if clientIP == nil {
-		return status.Errorf(codes.Internal, "invalid client IP %q", ips[0])
+		return status.Errorf(codes.Internal, "invalid client IP %q", ip)
 	}
 
-	lookup := p.lookupIPs
-	if lookup == nil {
-		lookup = defaultLookupIPs
-	}
-	resolved, err := lookup(ctx, hostName)
+	lookupCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	resolved, err := p.lookupIPs(lookupCtx, hostName)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to resolve hostname %q: %v", hostName, err)
 	}
@@ -319,20 +313,6 @@ func (p *Plugin) verifyConnectingClientIP(ctx context.Context, hostName string) 
 		}
 	}
 	return status.Errorf(codes.PermissionDenied, "client IP %s does not match any address for hostname %q", clientIP, hostName)
-}
-
-func defaultLookupIPs(ctx context.Context, host string) ([]net.IP, error) {
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-	ips := make([]net.IP, 0, len(addrs))
-	for _, addr := range addrs {
-		if addr.IP != nil {
-			ips = append(ips, addr.IP)
-		}
-	}
-	return ips, nil
 }
 
 func buildSelectorValues(hostName string) []string {

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -3,6 +3,7 @@ package httpchallenge_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -21,7 +22,10 @@ import (
 	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakeagentstore"
 	"github.com/spiffe/spire/test/plugintest"
+	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
 )
 
 func TestConfigure(t *testing.T) {
@@ -504,7 +508,131 @@ func TestAttestSucceeds(t *testing.T) {
 	}
 }
 
+func TestVerifyClientIP(t *testing.T) {
+	payload := marshalPayload(t, &common_httpchallenge.AttestationData{
+		HostName:  "foo",
+		AgentName: "default",
+		Port:      80,
+	})
+	challengeFn := func(context.Context, []byte) ([]byte, error) {
+		return nil, nil
+	}
+	failingTransport := &http.Client{
+		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			t.Fatal("http challenge must not run when client IP verification fails")
+			return nil, errors.New("unreachable")
+		}),
+	}
+
+	t.Run("flag off does not look up DNS", func(t *testing.T) {
+		server, client := challengeServer(t)
+		defer server.Close()
+		lookedUp := false
+		plugin := loadPluginWithLookup(t, "", false, client, "123456789abcdefghijklmnopqrstuvwxyz", func(context.Context, string) ([]net.IP, error) {
+			lookedUp = true
+			return nil, errors.New("lookup should not run")
+		})
+		result, err := plugin.Attest(context.Background(), payload, challengeFn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, lookedUp)
+	})
+
+	t.Run("client IP not available", func(t *testing.T) {
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(context.Context, string) ([]net.IP, error) {
+				t.Fatal("lookup should not run when client IP is missing")
+				return nil, errors.New("unreachable")
+			})
+		result, err := plugin.Attest(context.Background(), payload, challengeFn)
+		spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "client IP not available for verification")
+		require.Nil(t, result)
+	})
+
+	t.Run("client IP does not match DNS", func(t *testing.T) {
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(_ context.Context, host string) ([]net.IP, error) {
+				require.Equal(t, "foo", host)
+				return []net.IP{net.ParseIP("192.0.2.99")}, nil
+			})
+		ctx := peerContext(net.ParseIP("192.0.2.1"))
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		spiretest.RequireGRPCStatusContains(t, err, codes.PermissionDenied, "does not match any address for hostname")
+		require.Nil(t, result)
+	})
+
+	t.Run("lookup error", func(t *testing.T) {
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(context.Context, string) ([]net.IP, error) {
+				return nil, errors.New("nxdomain")
+			})
+		ctx := peerContext(net.ParseIP("192.0.2.1"))
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "failed to resolve hostname \"foo\"")
+		require.Nil(t, result)
+	})
+
+	t.Run("empty lookup answers", func(t *testing.T) {
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(context.Context, string) ([]net.IP, error) {
+				return nil, nil
+			})
+		ctx := peerContext(net.ParseIP("192.0.2.1"))
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		spiretest.RequireGRPCStatusContains(t, err, codes.PermissionDenied, "does not match any address for hostname")
+		require.Nil(t, result)
+	})
+
+	t.Run("client IPv4 matches DNS", func(t *testing.T) {
+		server, client := challengeServer(t)
+		defer server.Close()
+		lookedUp := ""
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, client, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(_ context.Context, host string) ([]net.IP, error) {
+				lookedUp = host
+				return []net.IP{net.ParseIP("192.0.2.1")}, nil
+			})
+		ctx := peerContext(net.ParseIP("192.0.2.1"))
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, "foo", lookedUp)
+		require.Equal(t, "spiffe://example.org/spire/agent/http_challenge/foo", result.AgentID)
+	})
+
+	t.Run("client IPv6 matches DNS", func(t *testing.T) {
+		server, client := challengeServer(t)
+		defer server.Close()
+		ipv6 := net.ParseIP("2001:db8::1")
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, client, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(context.Context, string) ([]net.IP, error) {
+				return []net.IP{ipv6}, nil
+			})
+		ctx := peerContext(ipv6)
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+
+	t.Run("peer is one of several DNS addresses", func(t *testing.T) {
+		server, client := challengeServer(t)
+		defer server.Close()
+		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, client, "123456789abcdefghijklmnopqrstuvwxyz",
+			func(context.Context, string) ([]net.IP, error) {
+				return []net.IP{net.ParseIP("192.0.2.1"), net.ParseIP("192.0.2.2")}, nil
+			})
+		ctx := peerContext(net.ParseIP("192.0.2.2"))
+		result, err := plugin.Attest(ctx, payload, challengeFn)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+	})
+}
+
 func loadPlugin(t *testing.T, config string, testTOFU bool, client *http.Client, testNonce string) nodeattestor.NodeAttestor {
+	return loadPluginWithLookup(t, config, testTOFU, client, testNonce, nil)
+}
+
+func loadPluginWithLookup(t *testing.T, config string, testTOFU bool, client *http.Client, testNonce string, lookupIPs func(context.Context, string) ([]net.IP, error)) nodeattestor.NodeAttestor {
 	v1 := new(nodeattestor.V1)
 	agentStore := fakeagentstore.New()
 	var configureErr error
@@ -521,8 +649,32 @@ func loadPlugin(t *testing.T, config string, testTOFU bool, client *http.Client,
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
 	}
-	plugintest.Load(t, httpchallenge.BuiltInTesting(client, testNonce), v1, opts...)
+	plugintest.Load(t, httpchallenge.BuiltInTestingWithLookup(client, testNonce, lookupIPs), v1, opts...)
 	return v1
+}
+
+func peerContext(ip net.IP) context.Context {
+	return peer.NewContext(context.Background(), &peer.Peer{
+		Addr: &net.TCPAddr{IP: ip, Port: 12345},
+	})
+}
+
+func challengeServer(t *testing.T) (*httptest.Server, *http.Client) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/.well-known/spiffe/nodeattestor/http_challenge/") || !strings.HasSuffix(r.URL.Path, "/challenge") {
+			t.Errorf("Unexpected challenge path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`123456789abcdefghijklmnopqrstuvwxyz`))
+	}))
+	return server, newClientWithLocalIntercept(server.URL)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func marshalPayload(t *testing.T, attReq *common_httpchallenge.AttestationData) []byte {

--- a/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
+++ b/pkg/server/plugin/nodeattestor/httpchallenge/httpchallenge_test.go
@@ -519,8 +519,8 @@ func TestVerifyClientIP(t *testing.T) {
 	}
 	failingTransport := &http.Client{
 		Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-			t.Fatal("http challenge must not run when client IP verification fails")
-			return nil, errors.New("unreachable")
+			t.Error("http challenge must not run when client IP verification fails")
+			return nil, errors.New("http challenge must not run when client IP verification fails")
 		}),
 	}
 
@@ -541,8 +541,8 @@ func TestVerifyClientIP(t *testing.T) {
 	t.Run("client IP not available", func(t *testing.T) {
 		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
 			func(context.Context, string) ([]net.IP, error) {
-				t.Fatal("lookup should not run when client IP is missing")
-				return nil, errors.New("unreachable")
+				t.Error("lookup should not run when client IP is missing")
+				return nil, errors.New("lookup should not run when client IP is missing")
 			})
 		result, err := plugin.Attest(context.Background(), payload, challengeFn)
 		spiretest.RequireGRPCStatusContains(t, err, codes.Internal, "client IP not available for verification")
@@ -550,13 +550,15 @@ func TestVerifyClientIP(t *testing.T) {
 	})
 
 	t.Run("client IP does not match DNS", func(t *testing.T) {
+		lookedUp := ""
 		plugin := loadPluginWithLookup(t, "verify_client_ip = true", false, failingTransport, "123456789abcdefghijklmnopqrstuvwxyz",
 			func(_ context.Context, host string) ([]net.IP, error) {
-				require.Equal(t, "foo", host)
+				lookedUp = host
 				return []net.IP{net.ParseIP("192.0.2.99")}, nil
 			})
 		ctx := peerContext(net.ParseIP("192.0.2.1"))
 		result, err := plugin.Attest(ctx, payload, challengeFn)
+		require.Equal(t, "foo", lookedUp)
 		spiretest.RequireGRPCStatusContains(t, err, codes.PermissionDenied, "does not match any address for hostname")
 		require.Nil(t, result)
 	})
@@ -649,7 +651,7 @@ func loadPluginWithLookup(t *testing.T, config string, testTOFU bool, client *ht
 			TrustDomain: spiffeid.RequireTrustDomainFromString("example.org"),
 		}),
 	}
-	plugintest.Load(t, httpchallenge.BuiltInTestingWithLookup(client, testNonce, lookupIPs), v1, opts...)
+	plugintest.Load(t, httpchallenge.BuiltInTesting(client, testNonce, lookupIPs), v1, opts...)
 	return v1
 }
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

Server-side `http_challenge` node attestor. Optional config only; default behavior is unchanged.

**Description of change**

Adds `verify_client_ip` to the http_challenge server plugin (default `false`), following the x509pop option introduced in #6911 and the sshpop work in #7191.

When enabled, the connecting peer IP (from `X-Forwarded-Client-IP` on the node attestor facade) is checked against the DNS addresses for the attested hostname. Lookup failure or no matching address fails attestation. The check runs after hostname validation and before the HTTP challenge.

This is the second of the two remaining plugins from #6769 (sshpop merged as #7191). Split per maintainer guidance.

The IP comes from `ClientIPFromContext`, the helper added in #7191, so sshpop and this plugin read the metadata the same way. The DNS lookup gets a 10s timeout on the stream context. That's the same budget as the challenge fetch, but derived from the stream so an agent hanging up cancels the lookup.

**Test plan**

- [x] `go test ./pkg/server/plugin/nodeattestor/httpchallenge/`
- [x] Unit coverage for flag off (lookup not called), missing/mismatched/unresolvable client IP, IPv4/IPv6 match, and match among several DNS answers. Fail-closed cases use a transport that fatals if the HTTP challenge runs.

Part of #6769

