### PR TITLE
Fix flaky key-manager-vault test by waiting on deployment availability

### DIFF
--- a/test/integration/suites/key-manager-vault/02-deploy-spire-and-verify-auth
+++ b/test/integration/suites/key-manager-vault/02-deploy-spire-and-verify-auth
@@ -14,7 +14,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
               --from-literal=approle_id=$APPROLE_ID \
               --from-literal=secret_id=$SECRET_ID 
 ./bin/kubectl apply -k ./conf/server/approle-auth
-./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
+./bin/kubectl rollout status deployment -n spire spire-server --timeout=60s
 ./bin/kubectl delete -k ./conf/server/approle-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -22,7 +22,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
 # Verify K8s Auth
 log-info "verifying k8s auth..."
 ./bin/kubectl apply -k ./conf/server/k8s-auth
-./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
+./bin/kubectl rollout status deployment -n spire spire-server --timeout=60s
 ./bin/kubectl delete -k ./conf/server/k8s-auth
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
 
@@ -32,7 +32,7 @@ log-info "verifying cert auth..."
               --from-file=client.pem=client.pem \
               --from-file=client_key.pem=client_key.pem
 ./bin/kubectl apply -k ./conf/server/cert-auth
-./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
+./bin/kubectl rollout status deployment -n spire spire-server --timeout=60s
 ./bin/kubectl delete -k ./conf/server/cert-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -43,4 +43,4 @@ TOKEN=$(./bin/kubectl exec -n vault vault-0 -- vault token create -policy=spire 
 ./bin/kubectl create secret -n spire generic vault-credential \
               --from-literal=token=$TOKEN
 ./bin/kubectl apply -k ./conf/server/token-auth
-./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
+./bin/kubectl rollout status deployment -n spire spire-server --timeout=60s

--- a/test/integration/suites/key-manager-vault/02-deploy-spire-and-verify-auth
+++ b/test/integration/suites/key-manager-vault/02-deploy-spire-and-verify-auth
@@ -14,7 +14,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
               --from-literal=approle_id=$APPROLE_ID \
               --from-literal=secret_id=$SECRET_ID 
 ./bin/kubectl apply -k ./conf/server/approle-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
 ./bin/kubectl delete -k ./conf/server/approle-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -22,7 +22,7 @@ SECRET_ID=$(./bin/kubectl exec -n vault vault-0 -- vault write --format json -f 
 # Verify K8s Auth
 log-info "verifying k8s auth..."
 ./bin/kubectl apply -k ./conf/server/k8s-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
 ./bin/kubectl delete -k ./conf/server/k8s-auth
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
 
@@ -32,7 +32,7 @@ log-info "verifying cert auth..."
               --from-file=client.pem=client.pem \
               --from-file=client_key.pem=client_key.pem
 ./bin/kubectl apply -k ./conf/server/cert-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s
 ./bin/kubectl delete -k ./conf/server/cert-auth
 ./bin/kubectl delete secret -n spire vault-credential
 ./bin/kubectl wait pods -n spire -l app=spire-server --for=delete --timeout=60s
@@ -43,4 +43,4 @@ TOKEN=$(./bin/kubectl exec -n vault vault-0 -- vault token create -policy=spire 
 ./bin/kubectl create secret -n spire generic vault-credential \
               --from-literal=token=$TOKEN
 ./bin/kubectl apply -k ./conf/server/token-auth
-./bin/kubectl wait pods -n spire -l app=spire-server --for condition=Ready --timeout=60s
+./bin/kubectl wait deployment -n spire spire-server --for condition=Available --timeout=60s


### PR DESCRIPTION
The key-manager-vault suite intermittently fails in step `02-deploy-spire-and-verify-auth` with `error: no matching resources found`. Each auth phase runs `kubectl apply -k` and immediately waits for pod readiness with `kubectl wait pods -l app=spire-server --for condition=Ready`. If the wait lists pods before the ReplicaSet controller has created the pod object, the selector matches nothing and `kubectl wait` fails right away instead of waiting for a pod to appear. The token auth phase is the most exposed because the previous phase's pod is fully deleted right before it, leaving a window with zero matching pods.

This PR replaces the pod readiness waits with `kubectl rollout status deployment -n spire spire-server`. The `Deployment` object exists as soon as `kubectl apply` returns, so the wait can no longer race with pod creation, and `rollout status` completes only when the deployment's current revision is fully rolled out and available, which with the configured readiness probe verifies the same thing as before. The `--for=delete` waits are unaffected, since an already-deleted pod satisfies them.

An example of a failure is here: https://github.com/spiffe/spire/actions/runs/32851096531/job/97815545140

```
[2026-08-25T13:25:30Z] verifying token auth...
secret/vault-credential created
...
deployment.apps/spire-server created
error: no matching resources found
[2026-08-25T13:25:31Z] step 02-deploy-spire-and-verify-auth failed
```
