### PR TITLE
Do not open log_file when validating configuration

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -304,8 +304,7 @@ func LoadConfig(name string, args []string, logOptions []log.Option, output io.W
 }
 
 // LoadConfigForValidation loads the configuration without opening log_file, so
-// that validating the config of a running agent does not append to that agent's
-// live log.
+// that validating the config of a running agent does not touch its log.
 func LoadConfigForValidation(name string, args []string, logOptions []log.Option, output io.Writer) (*agent.Config, error) {
 	return loadConfig(name, args, logOptions, output, false, true)
 }

--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -300,6 +300,17 @@ func Help(name string, writer io.Writer) string {
 }
 
 func LoadConfig(name string, args []string, logOptions []log.Option, output io.Writer, allowUnknownConfig bool) (*agent.Config, error) {
+	return loadConfig(name, args, logOptions, output, allowUnknownConfig, false)
+}
+
+// LoadConfigForValidation loads the configuration without opening log_file, so
+// that validating the config of a running agent does not append to that agent's
+// live log.
+func LoadConfigForValidation(name string, args []string, logOptions []log.Option, output io.Writer) (*agent.Config, error) {
+	return loadConfig(name, args, logOptions, output, false, true)
+}
+
+func loadConfig(name string, args []string, logOptions []log.Option, output io.Writer, allowUnknownConfig, skipLogFile bool) (*agent.Config, error) {
 	// First parse the CLI flags so we can get the config
 	// file path, if set
 	cliInput, err := parseFlags(name, args, output)
@@ -324,7 +335,7 @@ func LoadConfig(name string, args []string, logOptions []log.Option, output io.W
 		return nil, fmt.Errorf("error loading feature flags: %w", err)
 	}
 
-	return NewAgentConfig(input, logOptions, allowUnknownConfig)
+	return newAgentConfig(input, logOptions, allowUnknownConfig, skipLogFile)
 }
 
 func (cmd *Command) Run(args []string) int {
@@ -556,6 +567,10 @@ func (c *agentConfig) endpointEnabled() bool {
 }
 
 func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool) (*agent.Config, error) {
+	return newAgentConfig(c, logOptions, allowUnknownConfig, false)
+}
+
+func newAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig, skipLogFile bool) (*agent.Config, error) {
 	ac := &agent.Config{}
 
 	if err := validateConfig(c); err != nil {
@@ -604,7 +619,7 @@ func NewAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool)
 		logOptions = append(logOptions, log.WithSourceLocation())
 	}
 	var reopenableFile *log.ReopenableFile
-	if c.Agent.LogFile != "" {
+	if c.Agent.LogFile != "" && !skipLogFile {
 		var err error
 		reopenableFile, err = log.NewReopenableFile(c.Agent.LogFile)
 		if err != nil {

--- a/cmd/spire-agent/cli/validate/validate.go
+++ b/cmd/spire-agent/cli/validate/validate.go
@@ -32,7 +32,7 @@ func (c *validateCommand) Synopsis() string {
 }
 
 func (c *validateCommand) Run(args []string) int {
-	if _, err := run.LoadConfig(commandName, args, nil, c.env.Stderr, false); err != nil {
+	if _, err := run.LoadConfigForValidation(commandName, args, nil, c.env.Stderr); err != nil {
 		// Ignore error since a failure to write to stderr cannot very well be reported
 		_ = c.env.ErrPrintf("SPIRE agent configuration file is invalid: %v\n", err)
 		return 1

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -243,8 +243,7 @@ func LoadConfig(name string, args []string, logOptions []log.Option, output io.W
 }
 
 // LoadConfigForValidation loads the configuration without opening log_file, so
-// that validating the config of a running server does not append to that
-// server's live log.
+// that validating the config of a running server does not touch its log.
 func LoadConfigForValidation(name string, args []string, logOptions []log.Option, output io.Writer) (*server.Config, error) {
 	return loadConfig(name, args, logOptions, output, false, true)
 }

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -239,6 +239,17 @@ func Help(name string, writer io.Writer) string {
 }
 
 func LoadConfig(name string, args []string, logOptions []log.Option, output io.Writer, allowUnknownConfig bool) (*server.Config, error) {
+	return loadConfig(name, args, logOptions, output, allowUnknownConfig, false)
+}
+
+// LoadConfigForValidation loads the configuration without opening log_file, so
+// that validating the config of a running server does not append to that
+// server's live log.
+func LoadConfigForValidation(name string, args []string, logOptions []log.Option, output io.Writer) (*server.Config, error) {
+	return loadConfig(name, args, logOptions, output, false, true)
+}
+
+func loadConfig(name string, args []string, logOptions []log.Option, output io.Writer, allowUnknownConfig, skipLogFile bool) (*server.Config, error) {
 	// First parse the CLI flags so we can get the config
 	// file path, if set
 	cliInput, err := parseFlags(name, args, output)
@@ -263,7 +274,7 @@ func LoadConfig(name string, args []string, logOptions []log.Option, output io.W
 		return nil, fmt.Errorf("error loading feature flags: %w", err)
 	}
 
-	return NewServerConfig(input, logOptions, allowUnknownConfig)
+	return newServerConfig(input, logOptions, allowUnknownConfig, skipLogFile)
 }
 
 // Run the SPIFFE Server
@@ -385,6 +396,10 @@ func mergeInput(fileInput *Config, cliInput *serverConfig) (*Config, error) {
 }
 
 func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool) (*server.Config, error) {
+	return newServerConfig(c, logOptions, allowUnknownConfig, false)
+}
+
+func newServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig, skipLogFile bool) (*server.Config, error) {
 	sc := &server.Config{}
 
 	if err := validateConfig(c); err != nil {
@@ -399,7 +414,7 @@ func NewServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig bool
 		logOptions = append(logOptions, log.WithSourceLocation())
 	}
 	var reopenableFile *log.ReopenableFile
-	if c.Server.LogFile != "" {
+	if c.Server.LogFile != "" && !skipLogFile {
 		var err error
 		reopenableFile, err = log.NewReopenableFile(c.Server.LogFile)
 		if err != nil {

--- a/cmd/spire-server/cli/validate/validate.go
+++ b/cmd/spire-server/cli/validate/validate.go
@@ -41,7 +41,7 @@ func (c *validateCommand) Synopsis() string {
 }
 
 func (c *validateCommand) Run(args []string) int {
-	config, err := run.LoadConfig(commandName, args, []log.Option{log.WithOutputWriter(io.Discard)}, c.env.Stderr, false)
+	config, err := run.LoadConfigForValidation(commandName, args, []log.Option{log.WithOutputWriter(io.Discard)}, c.env.Stderr)
 	if err != nil {
 		// Ignore error since a failure to write to stderr cannot very well be reported
 		_ = c.env.ErrPrintf("SPIRE server configuration file is invalid: %v\n", err)

--- a/cmd/spire-server/cli/validate/validate_test.go
+++ b/cmd/spire-server/cli/validate/validate_test.go
@@ -57,9 +57,8 @@ func (s *ValidateSuite) TestBadFlags() {
 	s.Contains(s.stderr.String(), "flag provided but not defined: -badflag")
 }
 
-// Validating the config of a running server must not disturb that server's log.
-// log_file from the config file otherwise overrides the io.Discard writer this
-// command passes, so validate would open the live log and append to it.
+// log_file otherwise overrides the io.Discard writer this command passes, so
+// validate would open and append to a running server's log.
 func (s *ValidateSuite) TestDoesNotTouchLogFile() {
 	configDir := s.T().TempDir()
 	logFile := filepath.Join(configDir, "server.log")

--- a/cmd/spire-server/cli/validate/validate_test.go
+++ b/cmd/spire-server/cli/validate/validate_test.go
@@ -2,6 +2,9 @@ package validate
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -52,4 +55,41 @@ func (s *ValidateSuite) TestBadFlags() {
 	s.NotEqual(0, code, "exit code")
 	s.Equal("", s.stdout.String(), "stdout")
 	s.Contains(s.stderr.String(), "flag provided but not defined: -badflag")
+}
+
+// Validating the config of a running server must not disturb that server's log.
+// log_file from the config file otherwise overrides the io.Discard writer this
+// command passes, so validate would open the live log and append to it.
+func (s *ValidateSuite) TestDoesNotTouchLogFile() {
+	configDir := s.T().TempDir()
+	logFile := filepath.Join(configDir, "server.log")
+
+	config := fmt.Sprintf(`
+server {
+	bind_address = "127.0.0.1"
+	bind_port = "8081"
+	trust_domain = "example.org"
+	data_dir = %q
+	log_file = %q
+}
+
+plugins {
+	DataStore "sql" {
+		plugin_data {
+			database_type = "sqlite3"
+			connection_string = %q
+		}
+	}
+	KeyManager "memory" {
+		plugin_data = {}
+	}
+}
+`, configDir, logFile, filepath.Join(configDir, "datastore.sqlite3"))
+
+	confPath := filepath.Join(configDir, "server.conf")
+	s.Require().NoError(os.WriteFile(confPath, []byte(config), 0600))
+
+	s.cmd.Run([]string{"-config", confPath})
+
+	s.NoFileExists(logFile, "validate must not create or write the configured log file")
 }


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

`spire-server validate` and `spire-agent validate`, specifically what they do with the `log_file` of the configuration being validated.

**Description of change**

Both validate commands are meant to be free of side effects, and the server one passes `log.WithOutputWriter(io.Discard)` to say so. That option is applied before the config file is read though, so a `log_file` in the file being validated overrides it. Validating the configuration of a running server therefore opens that server's live log and appends whatever the plugin loading in `ValidateConfig` produces.

This adds `LoadConfigForValidation`, which loads the configuration without opening `log_file` at all. No existing signature changed. `LoadConfig` and `NewServerConfig` are now thin wrappers over unexported variants carrying the extra flag, so no caller had to be touched.

The new test in `cmd/spire-server/cli/validate/validate_test.go` fails without the fix, I checked by flipping the flag back.

Nothing user facing changes, no new configuration and no behavior change for `spire-server run`, so I left the documentation box unchecked rather than checking it for a change that has nothing to document.

Split out of #7229, where @amartinezfayo suggested it was worth reviewing on its own.

**Which issue this PR fixes**

None, this is split out of #7229.