### PR TITLE
Allow external tools to move or delete the log file on Windows

### DIFF
--- a/pkg/common/log/openfile_posix.go
+++ b/pkg/common/log/openfile_posix.go
@@ -4,9 +4,7 @@ package log
 
 import "os"
 
-// openLogFile opens the log file for appending. A rename by an external
-// rotator leaves this descriptor writing to the renamed file, which is what
-// the SIGUSR2 reopen relies on.
+// openLogFile opens the log file for appending.
 func openLogFile(name string) (*os.File, error) {
 	return os.OpenFile(name, fileFlags, fileMode)
 }

--- a/pkg/common/log/openfile_posix.go
+++ b/pkg/common/log/openfile_posix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package log
+
+import "os"
+
+// openLogFile opens the log file for appending. A rename by an external
+// rotator leaves this descriptor writing to the renamed file, which is what
+// the SIGUSR2 reopen relies on.
+func openLogFile(name string) (*os.File, error) {
+	return os.OpenFile(name, fileFlags, fileMode)
+}

--- a/pkg/common/log/openfile_posix.go
+++ b/pkg/common/log/openfile_posix.go
@@ -4,6 +4,11 @@ package log
 
 import "os"
 
+const (
+	fileFlags = os.O_APPEND | os.O_CREATE | os.O_WRONLY
+	fileMode  = 0640
+)
+
 // openLogFile opens the log file for appending.
 func openLogFile(name string) (*os.File, error) {
 	return os.OpenFile(name, fileFlags, fileMode)

--- a/pkg/common/log/openfile_test.go
+++ b/pkg/common/log/openfile_test.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenLogFileAppends(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	logPath := filepath.Join(dir, "test.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("existing\n"), fileMode))
+
+	f, err := openLogFile(logPath)
+	require.NoError(t, err)
+
+	_, err = f.Write([]byte("appended\n"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.Equal(t, "existing\nappended\n", string(content))
+}
+
+func TestOpenLogFileCreatesMissingFile(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	logPath := filepath.Join(dir, "test.log")
+
+	f, err := openLogFile(logPath)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	assert.FileExists(t, logPath)
+}
+
+func TestOpenLogFileFailsOnMissingDirectory(t *testing.T) {
+	logPath := filepath.Join(spiretest.TempDir(t), "nope", "test.log")
+
+	_, err := openLogFile(logPath)
+	require.Error(t, err)
+}

--- a/pkg/common/log/openfile_test.go
+++ b/pkg/common/log/openfile_test.go
@@ -13,7 +13,7 @@ import (
 func TestOpenLogFileAppends(t *testing.T) {
 	dir := spiretest.TempDir(t)
 	logPath := filepath.Join(dir, "test.log")
-	require.NoError(t, os.WriteFile(logPath, []byte("existing\n"), fileMode))
+	require.NoError(t, os.WriteFile(logPath, []byte("existing\n"), 0600))
 
 	f, err := openLogFile(logPath)
 	require.NoError(t, err)

--- a/pkg/common/log/openfile_test.go
+++ b/pkg/common/log/openfile_test.go
@@ -18,7 +18,7 @@ func TestOpenLogFileAppends(t *testing.T) {
 	f, err := openLogFile(logPath)
 	require.NoError(t, err)
 
-	_, err = f.Write([]byte("appended\n"))
+	_, err = f.WriteString("appended\n")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 

--- a/pkg/common/log/openfile_windows.go
+++ b/pkg/common/log/openfile_windows.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// openLogFile opens the log file for appending, allowing other processes to
+// rename or delete it while SPIRE keeps writing.
+//
+// os.OpenFile cannot be used here because Go opens files with FILE_SHARE_READ
+// and FILE_SHARE_WRITE only. Without FILE_SHARE_DELETE our own handle is what
+// denies the rename, so an external rotator cannot move the file aside the way
+// it can on POSIX.
+func openLogFile(name string) (*os.File, error) {
+	namep, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	// The access rights mirror what Go grants for os.O_APPEND, which appends at
+	// the end of the file rather than at the current offset.
+	const access = windows.FILE_APPEND_DATA |
+		windows.FILE_WRITE_ATTRIBUTES |
+		windows.FILE_WRITE_EA |
+		windows.STANDARD_RIGHTS_WRITE |
+		windows.SYNCHRONIZE
+
+	handle, err := windows.CreateFile(
+		namep,
+		access,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_ALWAYS, // os.O_CREATE without os.O_EXCL or os.O_TRUNC
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+	}
+
+	return os.NewFile(uintptr(handle), name), nil
+}

--- a/pkg/common/log/openfile_windows.go
+++ b/pkg/common/log/openfile_windows.go
@@ -6,21 +6,17 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// openLogFile opens the log file for appending, allowing other processes to
-// rename or delete it while SPIRE keeps writing.
-//
-// os.OpenFile cannot be used here because Go opens files with FILE_SHARE_READ
-// and FILE_SHARE_WRITE only. Without FILE_SHARE_DELETE our own handle is what
-// denies the rename, so an external rotator cannot move the file aside the way
-// it can on POSIX.
+// openLogFile opens the log file for appending. It does not use os.OpenFile
+// because Go opens files with FILE_SHARE_READ and FILE_SHARE_WRITE only, and
+// without FILE_SHARE_DELETE our own handle is what denies an external rename.
 func openLogFile(name string) (*os.File, error) {
 	namep, err := windows.UTF16PtrFromString(name)
 	if err != nil {
 		return nil, &os.PathError{Op: "open", Path: name, Err: err}
 	}
 
-	// The access rights mirror what Go grants for os.O_APPEND, which appends at
-	// the end of the file rather than at the current offset.
+	// The rights Go grants for os.O_APPEND. GENERIC_WRITE is deliberately absent
+	// since it would append at the start of the file rather than the end.
 	const access = windows.FILE_APPEND_DATA |
 		windows.FILE_WRITE_ATTRIBUTES |
 		windows.FILE_WRITE_EA |

--- a/pkg/common/log/openfile_windows_test.go
+++ b/pkg/common/log/openfile_windows_test.go
@@ -1,0 +1,58 @@
+package log
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// An external rotator has to be able to move the log file aside while SPIRE is
+// writing to it. That only works if the file is opened with FILE_SHARE_DELETE,
+// which os.OpenFile does not pass.
+func TestOpenLogFileAllowsExternalRename(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	logPath := filepath.Join(dir, "test.log")
+	rotated := filepath.Join(dir, "test.log.1")
+
+	f, err := openLogFile(logPath)
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+	}()
+
+	_, err = f.Write([]byte("before rename"))
+	require.NoError(t, err)
+
+	require.NoError(t, os.Rename(logPath, rotated), "the log file must be renameable while it is open")
+
+	// The handle follows the file across the rename, as it does on POSIX, so
+	// writes keep landing in the rotated file until the reopen happens.
+	_, err = f.Write([]byte(" after rename"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	content, err := os.ReadFile(rotated)
+	require.NoError(t, err)
+	assert.Equal(t, "before rename after rename", string(content))
+	assert.NoFileExists(t, logPath)
+}
+
+func TestOpenLogFileAllowsExternalDelete(t *testing.T) {
+	dir := spiretest.TempDir(t)
+	logPath := filepath.Join(dir, "test.log")
+
+	f, err := openLogFile(logPath)
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+	}()
+
+	_, err = f.Write([]byte("content"))
+	require.NoError(t, err)
+
+	assert.NoError(t, os.Remove(logPath), "the log file must be deletable while it is open")
+}

--- a/pkg/common/log/openfile_windows_test.go
+++ b/pkg/common/log/openfile_windows_test.go
@@ -24,14 +24,14 @@ func TestOpenLogFileAllowsExternalRename(t *testing.T) {
 		_ = f.Close()
 	}()
 
-	_, err = f.Write([]byte("before rename"))
+	_, err = f.WriteString("before rename")
 	require.NoError(t, err)
 
 	require.NoError(t, os.Rename(logPath, rotated), "the log file must be renameable while it is open")
 
 	// The handle follows the file across the rename, as it does on POSIX, so
 	// writes keep landing in the rotated file until the reopen happens.
-	_, err = f.Write([]byte(" after rename"))
+	_, err = f.WriteString(" after rename")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
@@ -51,7 +51,7 @@ func TestOpenLogFileAllowsExternalDelete(t *testing.T) {
 		_ = f.Close()
 	}()
 
-	_, err = f.Write([]byte("content"))
+	_, err = f.WriteString("content")
 	require.NoError(t, err)
 
 	assert.NoError(t, os.Remove(logPath), "the log file must be deletable while it is open")

--- a/pkg/common/log/openfile_windows_test.go
+++ b/pkg/common/log/openfile_windows_test.go
@@ -10,9 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// An external rotator has to be able to move the log file aside while SPIRE is
-// writing to it. That only works if the file is opened with FILE_SHARE_DELETE,
-// which os.OpenFile does not pass.
+// Fails with os.OpenFile, which does not pass FILE_SHARE_DELETE.
 func TestOpenLogFileAllowsExternalRename(t *testing.T) {
 	dir := spiretest.TempDir(t)
 	logPath := filepath.Join(dir, "test.log")
@@ -29,8 +27,7 @@ func TestOpenLogFileAllowsExternalRename(t *testing.T) {
 
 	require.NoError(t, os.Rename(logPath, rotated), "the log file must be renameable while it is open")
 
-	// The handle follows the file across the rename, as it does on POSIX, so
-	// writes keep landing in the rotated file until the reopen happens.
+	// The handle follows the file across the rename, as it does on POSIX.
 	_, err = f.WriteString(" after rename")
 	require.NoError(t, err)
 	require.NoError(t, f.Close())

--- a/pkg/common/log/reopen.go
+++ b/pkg/common/log/reopen.go
@@ -7,11 +7,6 @@ import (
 	"sync"
 )
 
-const (
-	fileFlags = os.O_APPEND | os.O_CREATE | os.O_WRONLY
-	fileMode  = 0640
-)
-
 var _ ReopenableWriteCloser = (*ReopenableFile)(nil)
 
 type (

--- a/pkg/common/log/reopen.go
+++ b/pkg/common/log/reopen.go
@@ -38,7 +38,7 @@ type (
 )
 
 func NewReopenableFile(name string) (*ReopenableFile, error) {
-	file, err := os.OpenFile(name, fileFlags, fileMode)
+	file, err := openLogFile(name)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (r *ReopenableFile) Reopen() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	newFile, err := os.OpenFile(r.name, fileFlags, fileMode)
+	newFile, err := openLogFile(r.name)
 	if err != nil {
 		return fmt.Errorf("unable to reopen %s: %w", r.name, err)
 	}


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**

How `spire-server` and `spire-agent` open the file named by `log_file` on Windows. POSIX is untouched.

**Description of change**

While reviewing #7229 @amartinezfayo pointed out that what stops an external rotator from moving `log_file` aside on Windows is not Windows itself, it is that Go's `os.OpenFile` never passes `FILE_SHARE_DELETE`, so SPIRE's own handle is what denies the rename. He is right, and the practical effect today is that nobody can archive or move the log of a running SPIRE on Windows.

This opens the log file through `windows.CreateFile` with `FILE_SHARE_READ|FILE_SHARE_WRITE|FILE_SHARE_DELETE`. An external tool can then rename or delete the file while SPIRE keeps writing to the handle, the way a rename already behaves on POSIX.

The access mask, creation disposition and attributes are the same ones Go computes for `os.O_APPEND|os.O_CREATE|os.O_WRONLY` with mode 0640, so nothing else about the open changes. It uses `OPEN_ALWAYS` rather than the `CREATE_ALWAYS` used elsewhere in `pkg/common/diskutil`, since the latter would truncate the log on every open. POSIX keeps going through `os.OpenFile` unchanged.

**Worth knowing**

This does not on its own give Windows a working rotation loop. The only caller of `Reopen` is the POSIX signal handler, and `ReopenOnSignal` is a no-op stub on Windows, so nothing can tell a running SPIRE to start a new file. A rotator can move the log aside and SPIRE keeps writing into the renamed file, which is what makes archiving possible, but the reopen has to come from the service control code discussed in #7229 and is not in this PR.

Renaming is the pattern that works. Deleting is permitted now too, but a Windows delete is not a POSIX unlink. The name stays in the directory as delete pending until SPIRE closes the handle, so nothing can recreate the log at that path in the meantime.

**Which issue this PR fixes**

None, this comes out of the discussion in #7229.