### PR TITLE
Reset rotator failed count on successful rotation

### DIFF
--- a/pkg/server/ca/rotator/rotator.go
+++ b/pkg/server/ca/rotator/rotator.go
@@ -60,7 +60,8 @@ type Config struct {
 type Rotator struct {
 	c Config
 
-	// For keeping track of number of failed rotations.
+	// For keeping track of number of failed rotations since the last fully
+	// successful rotation cycle.
 	failedRotationNum uint64
 }
 
@@ -156,7 +157,14 @@ func (r *Rotator) rotate(ctx context.Context) error {
 		r.c.Log.WithError(witKeyErr).Error("Unable to rotate WIT key")
 	}
 
-	return errors.Join(x509CAErr, jwtKeyErr, witKeyErr)
+	err := errors.Join(x509CAErr, jwtKeyErr, witKeyErr)
+	if err == nil {
+		// All keys are rotated at this time, so we can reset any failed
+		// rotation count.
+		atomic.StoreUint64(&r.failedRotationNum, 0)
+	}
+
+	return err
 }
 
 func (r *Rotator) rotateJWTKey(ctx context.Context) error {

--- a/pkg/server/ca/rotator/rotator_test.go
+++ b/pkg/server/ca/rotator/rotator_test.go
@@ -58,6 +58,51 @@ func TestHealthChecks(t *testing.T) {
 	require.Equal(t, expectStateMap, test.healthChecker.RunChecks())
 }
 
+func TestHealthCheckRecoversAfterSuccessfulRotation(t *testing.T) {
+	ctx := context.Background()
+	test := setupTest(t)
+
+	healthy := map[string]health.State{
+		"server.ca.rotator": {
+			Live:         true,
+			Ready:        true,
+			ReadyDetails: managerHealthDetails{},
+			LiveDetails:  managerHealthDetails{},
+		},
+	}
+	unhealthy := map[string]health.State{
+		"server.ca.rotator": {
+			Live:  false,
+			Ready: false,
+			ReadyDetails: managerHealthDetails{
+				RotationErr: "rotations exceed the threshold number of failures",
+			},
+			LiveDetails: managerHealthDetails{
+				RotationErr: "rotations exceed the threshold number of failures",
+			},
+		},
+	}
+
+	// Move past the preparation mark so every authority attempts to prepare
+	// its next slot.
+	test.clock.Add(time.Minute + time.Second)
+
+	// Only the JWT key fails to rotate. The X509 CA and WIT key keep
+	// succeeding, which must not clear the failure count.
+	test.fakeCAManager.prepareJWTKeyErr = errors.New("oh no")
+	for range failedRotationThreshold + 1 {
+		require.EqualError(t, test.rotator.rotate(ctx), "oh no")
+	}
+	require.Equal(t, uint64(failedRotationThreshold+1), test.rotator.failedRotationResult())
+	require.Equal(t, unhealthy, test.healthChecker.RunChecks())
+
+	test.fakeCAManager.prepareJWTKeyErr = nil
+	require.NoError(t, test.rotator.rotate(ctx))
+
+	require.Zero(t, test.rotator.failedRotationResult())
+	require.Equal(t, healthy, test.healthChecker.RunChecks())
+}
+
 func TestInitialize(t *testing.T) {
 	for _, tt := range []struct {
 		name             string


### PR DESCRIPTION
**Pull Request check list**

- [ ] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included?
- [ ] Documentation updated?

**Affected functionality**
spire-server CA's rotator health check.

**Description of change**
Once the rotator has failed more than the threshold, it never recovers and continously logs that the health check has failed.  Reseting the failure counter after a successful rotation seems like the right thing to do here.

