### PR TITLE
Fold DNS name before IDNA validation

### DIFF
--- a/pkg/common/x509util/dns.go
+++ b/pkg/common/x509util/dns.go
@@ -58,6 +58,9 @@ func validNonwildcardLabel(domain string) error {
 		return errNoWildcardAllowed
 	}
 
+	// DNS names are case insensitive (RFC 4343), IDNA validation is not.
+	domain = strings.ToLower(domain)
+
 	profile := idna.New(
 		idna.StrictDomainName(true),
 		idna.ValidateLabels(true),
@@ -83,18 +86,21 @@ func validNonwildcardLabel(domain string) error {
 func CheckForWildcardOverlap(names []string) error {
 	nm := map[string]struct{}{}
 
+	// DNS names are case insensitive (RFC 4343), compare them folded.
 	for _, name := range names {
-		nm[name] = struct{}{}
+		nm[strings.ToLower(name)] = struct{}{}
 	}
 
-	for name := range nm {
+	for _, name := range names {
+		folded := strings.ToLower(name)
+
 		// While we're checking, we don't need to care about wildcards
-		if strings.HasPrefix(name, "*") {
+		if strings.HasPrefix(folded, "*") {
 			continue
 		}
 
 		// Let's split this non-wildcard DNS name into its corresponding labels
-		labels := strings.Split(name, ".")
+		labels := strings.Split(folded, ".")
 		labels[0] = "*" // Let's now replace the first label with a wildcard
 		if _, ok := nm[strings.Join(labels, ".")]; ok {
 			return fmt.Errorf("name %q overlaps with an existing wildcard name in the list: %w", name, ErrWildcardOverlap)

--- a/pkg/common/x509util/dns.go
+++ b/pkg/common/x509util/dns.go
@@ -61,8 +61,10 @@ func validNonwildcardLabel(domain string) error {
 	// DNS names are case insensitive (RFC 4343), IDNA validation is not.
 	domain = strings.ToLower(domain)
 
+	// STD3 rules would reject characters that are common in practice, e.g.
+	// underscores.
 	profile := idna.New(
-		idna.StrictDomainName(true),
+		idna.StrictDomainName(false),
 		idna.ValidateLabels(true),
 		idna.VerifyDNSLength(true),
 		idna.CheckJoiners(true),

--- a/pkg/common/x509util/dns_test.go
+++ b/pkg/common/x509util/dns_test.go
@@ -86,6 +86,18 @@ func TestValidateAndNormalize(t *testing.T) {
 			dns:  "a-hello.com",
 		},
 		{
+			name: "uppercase",
+			dns:  "Example.COM",
+		},
+		{
+			name: "uppercase wildcard",
+			dns:  "*.Example.COM",
+		},
+		{
+			name: "uppercase single label",
+			dns:  "MY-HOST",
+		},
+		{
 			name:    "starting hyphen is not ok",
 			dns:     "-hello.com",
 			wantErr: x509util.ErrIDNAError,
@@ -131,6 +143,11 @@ func TestWildcardOverlap(t *testing.T) {
 		{
 			name: "no overlap if subdomain",
 			dns:  []string{"example.com", "*.example.com", "foo.bar.example.com"},
+		},
+		{
+			name:    "overlap with different case",
+			dns:     []string{"*.EXAMPLE.com", "Foo.example.COM"},
+			wantErr: x509util.ErrWildcardOverlap,
 		},
 	}
 

--- a/pkg/common/x509util/dns_test.go
+++ b/pkg/common/x509util/dns_test.go
@@ -34,6 +34,10 @@ func TestValidateAndNormalize(t *testing.T) {
 			dns:  "example.com",
 		},
 		{
+			name: "test_example.com",
+			dns:  "test_example.com",
+		},
+		{
 			name: "*.example.com",
 			dns:  "*.example.com",
 		},
@@ -96,6 +100,14 @@ func TestValidateAndNormalize(t *testing.T) {
 		{
 			name: "uppercase single label",
 			dns:  "MY-HOST",
+		},
+		{
+			name: "underscore is ok",
+			dns:  "my_service.example.com",
+		},
+		{
+			name: "underscore in single label is ok",
+			dns:  "my_service",
 		},
 		{
 			name:    "starting hyphen is not ok",


### PR DESCRIPTION
DNS names are case insensitive so this should be ok. This is required for the Go 1.27 update.