### PR TITLE
Fix LRU cache matching for workload subscribers

### DIFF
--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -244,8 +244,14 @@ func (c *LRUCache[SVID, Update]) NewSubscriber(selectors []*common.Selector) Sub
 	for s := range sub.set {
 		c.addSelectorIndexSub(s, sub)
 	}
-	// update lastAccessTimestamp of records containing provided selectors
-	c.updateLastAccessTimestamp(selectors)
+
+	records, recordsDone := c.getRecordsForSelectors(sub.set)
+	defer recordsDone()
+	now := c.clk.Now().UnixMilli()
+	for record := range records {
+		record.activeSubscriberCount++
+		record.lastAccessTimestamp = now
+	}
 	return sub
 }
 
@@ -297,6 +303,8 @@ func (c *LRUCache[SVID, Update]) UpdateEntries(update *UpdateEntries, checkSVID 
 	defer selAddDone()
 	selRem, selRemDone := allocSelectorSet()
 	defer selRemDone()
+	entrySelectors, entrySelectorsDone := allocSelectorSet()
+	defer entrySelectorsDone()
 	fedAdd, fedAddDone := allocStringSet()
 	defer fedAddDone()
 	fedRem, fedRemDone := allocStringSet()
@@ -347,6 +355,9 @@ func (c *LRUCache[SVID, Update]) UpdateEntries(update *UpdateEntries, checkSVID 
 		selectorsChanged := len(selAdd) > 0 || len(selRem) > 0
 		c.addSelectorIndicesRecord(selAdd, record)
 		c.delSelectorIndicesRecord(selRem, record)
+		if selectorsChanged {
+			record.activeSubscriberCount = c.countMatchingSubscribers(record.entry, entrySelectors)
+		}
 
 		// Determine if there were changes to FederatesWith declarations or
 		// if any federated bundles related to the entry were updated.
@@ -607,27 +618,11 @@ func (c *LRUCache[SVID, Update]) missingSVIDRecords(set selectorSet) bool {
 	return false
 }
 
-func (c *LRUCache[SVID, Update]) updateLastAccessTimestamp(selectors []*common.Selector) {
-	set, setFree := allocSelectorSet(selectors...)
-	defer setFree()
-
-	records, recordsDone := c.getRecordsForSelectors(set)
-	defer recordsDone()
-
-	now := c.clk.Now().UnixMilli()
-	for record := range records {
-		// Set lastAccessTimestamp so that svid LRU cache can be cleaned based on this timestamp
-		record.lastAccessTimestamp = now
-	}
-}
-
 // entries with active subscribers which are not cached will be put in staleEntries map
 // records which are not cached for remainder of max cache size will also be put in staleEntries map
 func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}, []recordAccessEvent) {
 	activeSubsByEntryID := make(map[string]struct{})
 	lastAccessTimestamps := make([]recordAccessEvent, 0, len(c.records))
-	entrySelectors, entrySelectorsDone := allocSelectorSet()
-	defer entrySelectorsDone()
 
 	// iterate over all selectors from cached entries and obtain:
 	// 1. entries that have active subscribers
@@ -635,7 +630,7 @@ func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}
 	//       so that SVID will be cached in next sync
 	// 2. get lastAccessTimestamp of each entry
 	for id, record := range c.records {
-		if c.hasMatchingSubscriber(record, entrySelectors) {
+		if record.activeSubscriberCount > 0 {
 			if _, ok := c.svids[record.entry.EntryId]; !ok {
 				c.staleEntries[id] = true
 			}
@@ -663,30 +658,31 @@ func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}
 	return activeSubsByEntryID, lastAccessTimestamps
 }
 
-func (c *LRUCache[SVID, Update]) hasMatchingSubscriber(record *lruCacheRecord, set selectorSet) bool {
+func (c *LRUCache[SVID, Update]) countMatchingSubscribers(entry *common.RegistrationEntry, set selectorSet) int {
 	clearSelectorSet(set)
-	set.Merge(record.entry.Selectors...)
+	set.Merge(entry.Selectors...)
 
 	var candidates *selectorsMapIndex
 	for sel := range set {
 		index := c.getSelectorIndexForRead(sel)
 		if index == nil || len(index.subs) == 0 {
-			return false
+			return 0
 		}
 		if candidates == nil || len(index.subs) < len(candidates.subs) {
 			candidates = index
 		}
 	}
 	if candidates == nil {
-		return false
+		return 0
 	}
 
+	count := 0
 	for sub := range candidates.subs {
 		if sub.superSetOf(set) {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }
 
 func (c *LRUCache[SVID, Update]) updateOrCreateRecord(newEntry *common.RegistrationEntry) (*lruCacheRecord, *common.RegistrationEntry) {
@@ -791,6 +787,12 @@ func (c *LRUCache[SVID, Update]) delSelectorIndexSub(s selector, sub baseSubscri
 func (c *LRUCache[SVID, Update]) unsubscribe(sub baseSubscriber) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	records, recordsDone := c.getRecordsForSelectors(sub.getSet())
+	defer recordsDone()
+	for record := range records {
+		record.activeSubscriberCount--
+	}
 	for selector := range sub.getSet() {
 		c.delSelectorIndexSub(selector, sub)
 	}
@@ -935,15 +937,13 @@ func (c *LRUCache[SVID, Update]) GatherFederatedBundles(entries []*common.Regist
 }
 
 type lruCacheRecord struct {
-	entry               *common.RegistrationEntry
-	subs                map[baseSubscriber]struct{}
-	lastAccessTimestamp int64
+	entry                 *common.RegistrationEntry
+	activeSubscriberCount int
+	lastAccessTimestamp   int64
 }
 
 func newLRUCacheRecord() *lruCacheRecord {
-	return &lruCacheRecord{
-		subs: make(map[baseSubscriber]struct{}),
-	}
+	return &lruCacheRecord{}
 }
 
 type selectorsMapIndex struct {

--- a/pkg/agent/manager/cache/lru_cache.go
+++ b/pkg/agent/manager/cache/lru_cache.go
@@ -626,6 +626,8 @@ func (c *LRUCache[SVID, Update]) updateLastAccessTimestamp(selectors []*common.S
 func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}, []recordAccessEvent) {
 	activeSubsByEntryID := make(map[string]struct{})
 	lastAccessTimestamps := make([]recordAccessEvent, 0, len(c.records))
+	entrySelectors, entrySelectorsDone := allocSelectorSet()
+	defer entrySelectorsDone()
 
 	// iterate over all selectors from cached entries and obtain:
 	// 1. entries that have active subscribers
@@ -633,16 +635,11 @@ func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}
 	//       so that SVID will be cached in next sync
 	// 2. get lastAccessTimestamp of each entry
 	for id, record := range c.records {
-		for _, sel := range record.entry.Selectors {
-			if index, ok := c.selectors[makeSelector(sel)]; ok && index != nil {
-				if len(index.subs) > 0 {
-					if _, ok := c.svids[record.entry.EntryId]; !ok {
-						c.staleEntries[id] = true
-					}
-					activeSubsByEntryID[id] = struct{}{}
-					break
-				}
+		if c.hasMatchingSubscriber(record, entrySelectors) {
+			if _, ok := c.svids[record.entry.EntryId]; !ok {
+				c.staleEntries[id] = true
 			}
+			activeSubsByEntryID[id] = struct{}{}
 		}
 		lastAccessTimestamps = append(lastAccessTimestamps, newRecordAccessEvent(record.lastAccessTimestamp, id))
 	}
@@ -664,6 +661,32 @@ func (c *LRUCache[SVID, Update]) syncSVIDsWithSubscribers() (map[string]struct{}
 	}
 
 	return activeSubsByEntryID, lastAccessTimestamps
+}
+
+func (c *LRUCache[SVID, Update]) hasMatchingSubscriber(record *lruCacheRecord, set selectorSet) bool {
+	clearSelectorSet(set)
+	set.Merge(record.entry.Selectors...)
+
+	var candidates *selectorsMapIndex
+	for sel := range set {
+		index := c.getSelectorIndexForRead(sel)
+		if index == nil || len(index.subs) == 0 {
+			return false
+		}
+		if candidates == nil || len(index.subs) < len(candidates.subs) {
+			candidates = index
+		}
+	}
+	if candidates == nil {
+		return false
+	}
+
+	for sub := range candidates.subs {
+		if sub.superSetOf(set) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *LRUCache[SVID, Update]) updateOrCreateRecord(newEntry *common.RegistrationEntry) (*lruCacheRecord, *common.RegistrationEntry) {

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -760,6 +760,49 @@ func TestSyncSVIDsWithSubscribers(t *testing.T) {
 	assert.Equal(t, svidCacheMaxSize, cache.CountSVIDs())
 }
 
+func TestSyncSVIDsIgnoresPartialSelectorMatches(t *testing.T) {
+	cache := newTestLRUCacheWithConfig(1, clock.NewMock(t))
+	filler := makeRegistrationEntry("FILLER", "Z")
+	foo := makeRegistrationEntry("FOO", "A")
+	bar := makeRegistrationEntry("BAR", "A", "B")
+
+	cache.UpdateEntries(&UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(filler),
+	}, nil)
+	cache.UpdateSVIDs(makeX509SVIDs(filler))
+	cache.UpdateEntries(&UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(filler, foo, bar),
+	}, nil)
+
+	sub := cache.NewSubscriber(makeSelectors("A"))
+	defer sub.Finish()
+	cache.SyncSVIDsWithSubscribers()
+
+	require.Equal(t, []*StaleEntry{{Entry: foo}}, cache.GetStaleEntries())
+}
+
+func TestLRUCacheEvictsSVIDWithPartialSubscriberMatch(t *testing.T) {
+	cache := newTestLRUCacheWithConfig(1, clock.NewMock(t))
+	foo := makeRegistrationEntry("FOO", "A")
+	bar := makeRegistrationEntry("BAR", "A", "B")
+	update := &UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(foo, bar),
+	}
+
+	cache.UpdateEntries(update, nil)
+	cache.UpdateSVIDs(makeX509SVIDs(foo, bar))
+	sub := cache.NewSubscriber(makeSelectors("A"))
+	defer sub.Finish()
+
+	cache.UpdateEntries(update, nil)
+
+	assert.Contains(t, cache.svids, foo.EntryId)
+	assert.NotContains(t, cache.svids, bar.EntryId)
+}
+
 func TestNotifySubscriberWhenSVIDIsAvailable(t *testing.T) {
 	cache := newTestLRUCache(t)
 

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -838,6 +838,31 @@ func TestLRUCacheTracksSubscribersByRecord(t *testing.T) {
 	assert.Zero(t, cache.records[bar.EntryId].activeSubscriberCount)
 }
 
+func TestLRUCacheSubscriberCountAfterSelectorAdded(t *testing.T) {
+	cache := newTestLRUCache(t)
+	foo := makeRegistrationEntry("FOO", "A")
+	bar := makeRegistrationEntry("BAR", "B")
+	update := &UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(foo, bar),
+	}
+	cache.UpdateEntries(update, nil)
+
+	sub := cache.NewSubscriber(makeSelectors("A", "B"))
+	assert.Equal(t, 1, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Equal(t, 1, cache.records[bar.EntryId].activeSubscriberCount)
+
+	foo = makeRegistrationEntry("FOO", "A", "B")
+	update.RegistrationEntries[foo.EntryId] = foo
+	cache.UpdateEntries(update, nil)
+	assert.Equal(t, 1, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Equal(t, 1, cache.records[bar.EntryId].activeSubscriberCount)
+
+	sub.Finish()
+	assert.Zero(t, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Zero(t, cache.records[bar.EntryId].activeSubscriberCount)
+}
+
 func TestNotifySubscriberWhenSVIDIsAvailable(t *testing.T) {
 	cache := newTestLRUCache(t)
 

--- a/pkg/agent/manager/cache/lru_cache_test.go
+++ b/pkg/agent/manager/cache/lru_cache_test.go
@@ -803,6 +803,41 @@ func TestLRUCacheEvictsSVIDWithPartialSubscriberMatch(t *testing.T) {
 	assert.NotContains(t, cache.svids, bar.EntryId)
 }
 
+func TestLRUCacheTracksSubscribersByRecord(t *testing.T) {
+	cache := newTestLRUCache(t)
+	subAB := cache.NewSubscriber(makeSelectors("A", "B"))
+	t.Cleanup(subAB.Finish)
+
+	foo := makeRegistrationEntry("FOO", "A")
+	bar := makeRegistrationEntry("BAR", "A", "B")
+	cache.UpdateEntries(&UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(foo, bar),
+	}, nil)
+	assert.Equal(t, 1, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Equal(t, 1, cache.records[bar.EntryId].activeSubscriberCount)
+
+	subA := cache.NewSubscriber(makeSelectors("A"))
+	t.Cleanup(subA.Finish)
+	assert.Equal(t, 2, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Equal(t, 1, cache.records[bar.EntryId].activeSubscriberCount)
+
+	subAB.Finish()
+	assert.Equal(t, 1, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Zero(t, cache.records[bar.EntryId].activeSubscriberCount)
+
+	bar = makeRegistrationEntry("BAR", "A")
+	cache.UpdateEntries(&UpdateEntries{
+		Bundles:             makeBundles(bundleV1),
+		RegistrationEntries: makeRegistrationEntries(foo, bar),
+	}, nil)
+	assert.Equal(t, 1, cache.records[bar.EntryId].activeSubscriberCount)
+
+	subA.Finish()
+	assert.Zero(t, cache.records[foo.EntryId].activeSubscriberCount)
+	assert.Zero(t, cache.records[bar.EntryId].activeSubscriberCount)
+}
+
 func TestNotifySubscriberWhenSVIDIsAvailable(t *testing.T) {
 	cache := newTestLRUCache(t)
 


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated? Not required; this does not change user-facing behavior.

**Affected functionality**

Agent X.509-SVID LRU cache prefetch and eviction.

**Description of change**

Require a subscriber's selector set to contain all selectors from a registration entry before treating the entry as active.

The lookup starts with the selector index containing the fewest subscribers, which keeps the number of full selector-set checks small.

Added regressions covering both stale-entry scheduling and LRU eviction when an entry only partially matches a subscriber.

**Which issue this PR fixes**

Fixes #7175