### PR TITLE
test: assert tpm_devid selectors and reject untrusted DevID CA

### DIFF
--- a/test/integration/suites/tpm-devid/03-test-attestation
+++ b/test/integration/suites/tpm-devid/03-test-attestation
@@ -14,10 +14,25 @@ for ((i=1;i<=MAXCHECKS;i++)); do
     AGENTS="$(docker compose exec -T spire-server /opt/spire/bin/spire-server agent list || true)"
     if echo "${AGENTS}" | grep -q "${EXPECTED_ID}"; then
         log-info "agent attested via tpm_devid"
-        exit 0
+        break
+    fi
+    if [ "${i}" -eq "${MAXCHECKS}" ]; then
+        log-warn "last agent list output: ${AGENTS}"
+        fail-now "agent did not attest as ${EXPECTED_ID} after ${MAXCHECKS} checks"
     fi
     sleep "${CHECKINTERVAL}"
 done
 
-log-warn "last agent list output: ${AGENTS}"
-fail-now "agent did not attest as ${EXPECTED_ID} after ${MAXCHECKS} checks"
+EXPECTED_SUBJECT="tpm_devid:subject:cn:devid-leaf"
+EXPECTED_ISSUER="tpm_devid:issuer:cn:devid-root"
+EXPECTED_CA="tpm_devid:ca:fingerprint:$(fingerprint conf/server/devid-ca.pem)"
+
+log-debug "checking selectors on ${EXPECTED_ID}"
+SHOW="$(docker compose exec -T spire-server \
+    /opt/spire/bin/spire-server agent show -spiffeID "${EXPECTED_ID}")"
+echo "${SHOW}"
+
+echo "${SHOW}" | grep -F "${EXPECTED_SUBJECT}" || fail-now "missing selector ${EXPECTED_SUBJECT}"
+echo "${SHOW}" | grep -F "${EXPECTED_ISSUER}" || fail-now "missing selector ${EXPECTED_ISSUER}"
+echo "${SHOW}" | grep -F "${EXPECTED_CA}" || fail-now "missing selector ${EXPECTED_CA}"
+log-info "tpm_devid selectors match the provisioned DevID certificate"

--- a/test/integration/suites/tpm-devid/04-test-untrusted-ca
+++ b/test/integration/suites/tpm-devid/04-test-untrusted-ca
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Recreate server and agent with a DevID CA that did not sign the provisioned
+# certificate. Keep swtpm and the agent DevID material as they are, so a pass
+# here is the chain check failing, not a missing TPM or a different credential.
+EXPECTED_ID="spiffe://domain.test/spire/agent/tpm_devid/$(fingerprint conf/agent/devid.crt.pem)"
+TRUSTED_CA_FP="$(fingerprint conf/server/devid-ca.pem)"
+
+log-debug "stopping attested agent and server..."
+docker compose stop spire-agent spire-server
+docker compose rm -f spire-agent spire-server
+
+log-debug "replacing devid-ca.pem with a CA that did not sign the DevID..."
+openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout conf/server/untrusted-devid-ca.key \
+    -out conf/server/devid-ca.pem \
+    -days 1 \
+    -subj "/CN=untrusted-devid-ca" \
+    >/dev/null 2>&1 \
+    || fail-now "failed to generate untrusted DevID CA"
+rm -f conf/server/untrusted-devid-ca.key
+
+UNTRUSTED_CA_FP="$(fingerprint conf/server/devid-ca.pem)"
+if [ "${TRUSTED_CA_FP}" = "${UNTRUSTED_CA_FP}" ]; then
+    fail-now "untrusted DevID CA has the same fingerprint as the provisioning CA"
+fi
+
+log-debug "starting server with untrusted DevID CA..."
+docker-spire-server-up spire-server
+
+log-debug "bootstrapping agent..."
+docker compose exec -T spire-server \
+    /opt/spire/bin/spire-server bundle show > conf/agent/bootstrap.crt
+
+log-debug "starting agent..."
+docker-up spire-agent
+
+MAXCHECKS=30
+CHECKINTERVAL=1
+for ((i=1;i<=MAXCHECKS;i++)); do
+    log-info "checking that untrusted DevID CA is rejected (${i} of ${MAXCHECKS})..."
+    AGENTS="$(docker compose exec -T spire-server /opt/spire/bin/spire-server agent list || true)"
+    if echo "${AGENTS}" | grep -q "${EXPECTED_ID}"; then
+        log-warn "agent list: ${AGENTS}"
+        fail-now "agent attested against a DevID CA that did not sign its certificate"
+    fi
+    if docker compose logs spire-server | grep -F "unable to verify DevID signature"; then
+        log-info "server rejected DevID signed by a different CA"
+        exit 0
+    fi
+    sleep "${CHECKINTERVAL}"
+done
+
+log-warn "server logs:"
+docker compose logs spire-server
+log-warn "agent logs:"
+docker compose logs spire-agent
+fail-now "timed out waiting for DevID signature verification to fail"

--- a/test/integration/suites/tpm-devid/04-test-untrusted-ca
+++ b/test/integration/suites/tpm-devid/04-test-untrusted-ca
@@ -11,12 +11,13 @@ docker compose stop spire-agent spire-server
 docker compose rm -f spire-agent spire-server
 
 log-debug "replacing devid-ca.pem with a CA that did not sign the DevID..."
+# provision wrote this as root; Linux bind mounts keep that, so unlink first.
+rm -f conf/server/devid-ca.pem
 openssl req -x509 -newkey rsa:2048 -nodes \
     -keyout conf/server/untrusted-devid-ca.key \
     -out conf/server/devid-ca.pem \
     -days 1 \
     -subj "/CN=untrusted-devid-ca" \
-    >/dev/null 2>&1 \
     || fail-now "failed to generate untrusted DevID CA"
 rm -f conf/server/untrusted-devid-ca.key
 

--- a/test/integration/suites/tpm-devid/README.md
+++ b/test/integration/suites/tpm-devid/README.md
@@ -15,5 +15,10 @@ agent reads, creates the DevID key under the storage root key the agent loads
 it with, and writes the DevID credentials for the agent and the CA bundles for
 the server.
 
+After the agent attests, the suite checks the selectors taken from the
+provisioned DevID certificate (`subject:cn`, `issuer:cn`, `ca:fingerprint`)
+and then points `devid_ca_path` at a CA that did not sign that certificate and
+asserts attestation is rejected.
+
 The unit tests continue to use the in-process simulator in `test/tpmsimulator`.
 This suite covers the plugin against a separate TPM implementation.


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

`tpm_devid` integration suite (`test/integration/suites/tpm-devid`).

**Description of change**

Follow-up from review on #7203. The suite only checked that the agent ID from the provisioned DevID cert showed up in `agent list`.

After that, it now runs `agent show` and checks `subject:cn`, `issuer:cn`, and `ca:fingerprint` against the certs the provisioner wrote.

A second step points `devid_ca_path` at a CA that did not sign the DevID, recreates the server and agent (swtpm and the DevID blobs stay), and asserts attestation is rejected with `unable to verify DevID signature`.

ECC DevID and the password options are still out, as discussed on #7203.

**Which issue this PR fixes**

Fixes #7249

**Test plan**

- [x] `SUITES=suites/tpm-devid make integration`
- [x] `make lint`