### PR TITLE
broker api: do not server JWT-SVIDs for dmin or downstream entries

### DIFF
--- a/doc/telemetry/telemetry.md
+++ b/doc/telemetry/telemetry.md
@@ -111,6 +111,7 @@ The following metrics are emitted:
 | Counter      | `delegated_identity_api`, `connection`                                   |                              | The Delegated Identity API has successfully established a connection.                 |
 | Gauge        | `delegated_identity_api`, `connections`                                  |                              | The number of active connection that the Delegated Identity API has.                  |
 | Latency      | `delegated_identity_api`, `subscribe_x509_svid` `first_x509_svid_update` |                              | The latency fetching first X.509-SVID in Delegated Identity API.                      |
+| Latency      | `broker_api`, `subscribe_x509_svids`, `first_update`                     |                              | The latency fetching first X.509-SVID in the SPIFFE Broker API.                       |
 
 Note: These are the keys and labels that SPIRE emits, but the format of the
 metric once ingested could vary depending on the metric collector. For example,

--- a/pkg/agent/broker/api/service.go
+++ b/pkg/agent/broker/api/service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spiffe/spire/pkg/agent/manager/cache"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/common/telemetry"
-	"github.com/spiffe/spire/pkg/common/telemetry/agent/adminapi"
+	brokertelemetry "github.com/spiffe/spire/pkg/common/telemetry/agent/broker"
 	"github.com/spiffe/spire/pkg/common/x509util"
 	"github.com/spiffe/spire/proto/spire/common"
 	"google.golang.org/grpc"
@@ -148,7 +148,7 @@ func (s *Service) getCallerContext(ctx context.Context) (spiffeid.ID, error) {
 }
 
 func (s *Service) SubscribeToX509SVID(req *broker.SubscribeToX509SVIDRequest, stream broker.API_SubscribeToX509SVIDServer) error {
-	latency := adminapi.StartFirstX509SVIDUpdateLatency(s.metrics)
+	latency := brokertelemetry.StartFirstX509SVIDUpdateLatency(s.metrics)
 	ctx := stream.Context()
 	log := rpccontext.Logger(ctx)
 	var receivedFirstUpdate bool

--- a/pkg/agent/broker/api/service.go
+++ b/pkg/agent/broker/api/service.go
@@ -272,6 +272,11 @@ func (s *Service) FetchJWTSVID(ctx context.Context, req *broker.FetchJWTSVIDRequ
 	entries := s.manager.MatchingRegistrationEntries(selectors)
 	entries = hintsfilter.FilterRegistrations(entries, log)
 	for _, entry := range entries {
+		// Do not send admin nor downstream SVIDs to the caller
+		if entry.Admin || entry.Downstream {
+			continue
+		}
+
 		spiffeID, err := spiffeid.FromString(entry.SpiffeId)
 		if err != nil {
 			log.WithField(telemetry.SPIFFEID, entry.SpiffeId).WithError(err).Error("Invalid requested SPIFFE ID")

--- a/pkg/agent/broker/api/service_test.go
+++ b/pkg/agent/broker/api/service_test.go
@@ -15,9 +15,15 @@ import (
 	workloadattestor "github.com/spiffe/spire/pkg/agent/attestor/workload"
 	"github.com/spiffe/spire/pkg/agent/client"
 	"github.com/spiffe/spire/pkg/agent/manager"
+	"github.com/spiffe/spire/pkg/agent/manager/cache"
+	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/telemetry"
 	"github.com/spiffe/spire/proto/spire/common"
+	"github.com/spiffe/spire/test/fakes/fakemetrics"
+	"github.com/spiffe/spire/test/testca"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
@@ -213,9 +219,12 @@ func (a fakeAttestor) AttestReference(context.Context, *anypb.Any) ([]*common.Se
 type fakeManager struct {
 	manager.Manager
 
-	entries  []*common.RegistrationEntry
-	jwtSVIDs map[string]*client.JWTSVID
-	err      error
+	entries         []*common.RegistrationEntry
+	jwtSVIDs        map[string]*client.JWTSVID
+	err             error
+	subscribeErr    error
+	cacheSubscriber *fakeCacheSubscriber
+	bundleCache     *cache.BundleCache
 }
 
 func (m *fakeManager) MatchingRegistrationEntries([]*common.Selector) []*common.RegistrationEntry {
@@ -233,9 +242,451 @@ func (m *fakeManager) FetchJWTSVID(_ context.Context, entry *common.Registration
 	return svid, nil
 }
 
+func (m *fakeManager) SubscribeToCacheChanges(context.Context, cache.Selectors) (cache.Subscriber[cache.X509WorkloadUpdate], error) {
+	if m.subscribeErr != nil {
+		return nil, m.subscribeErr
+	}
+	return m.cacheSubscriber, nil
+}
+
+func (m *fakeManager) SubscribeToBundleChanges() *cache.BundleStream {
+	return m.bundleCache.SubscribeToBundleChanges()
+}
+
+type fakeCacheSubscriber struct {
+	ch chan *cache.X509WorkloadUpdate
+}
+
+func (s *fakeCacheSubscriber) Updates() <-chan *cache.X509WorkloadUpdate {
+	return s.ch
+}
+
+func (s *fakeCacheSubscriber) Finish() {}
+
+func TestGetCallerContext(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+
+	for _, tt := range []struct {
+		name       string
+		ctx        context.Context
+		expectCode codes.Code
+		expectID   spiffeid.ID
+	}{
+		{
+			name:       "no peer in context",
+			ctx:        context.Background(),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name: "peer with no auth info",
+			ctx: peer.NewContext(context.Background(), &peer.Peer{
+				Addr: &net.UnixAddr{Name: "/tmp/broker.sock", Net: "unix"},
+			}),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name: "auth info is not TLSInfo",
+			ctx: peer.NewContext(context.Background(), &peer.Peer{
+				Addr:     &net.UnixAddr{Name: "/tmp/broker.sock", Net: "unix"},
+				AuthInfo: insecureAuthInfo{},
+			}),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name: "TLSInfo has no SPIFFE ID",
+			ctx: peer.NewContext(context.Background(), &peer.Peer{
+				Addr:     &net.UnixAddr{Name: "/tmp/broker.sock", Net: "unix"},
+				AuthInfo: credentials.TLSInfo{},
+			}),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name:       "valid caller identity",
+			ctx:        brokerCallerContext(caller),
+			expectCode: codes.OK,
+			expectID:   caller,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(Config{})
+			id, err := s.getCallerContext(tt.ctx)
+			if tt.expectCode != codes.OK {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectCode, status.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectID, id)
+		})
+	}
+}
+
+type insecureAuthInfo struct{}
+
+func (insecureAuthInfo) AuthType() string { return "insecure" }
+
+func TestConstructValidSelectorsFromReference(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+	wantSelectors := []*common.Selector{{Type: "k8s", Value: "ns:default"}}
+
+	for _, tt := range []struct {
+		name       string
+		ref        *broker.WorkloadReference
+		attestErr  error
+		expectCode codes.Code
+	}{
+		{
+			name:       "nil reference",
+			ref:        nil,
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name:       "attestor returns a status error",
+			ref:        &broker.WorkloadReference{Reference: ref(k8sType)},
+			attestErr:  status.Error(codes.NotFound, "no such workload"),
+			expectCode: codes.NotFound,
+		},
+		{
+			name:       "attestor returns an opaque error",
+			ref:        &broker.WorkloadReference{Reference: ref(k8sType)},
+			attestErr:  errors.New("boom"),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name:       "success",
+			ref:        &broker.WorkloadReference{Reference: ref(k8sType)},
+			expectCode: codes.OK,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			log, _ := test.NewNullLogger()
+			s := New(Config{Attestor: fakeAttestor{selectors: wantSelectors, err: tt.attestErr}})
+
+			selectors, err := s.constructValidSelectorsFromReference(brokerCallerContext(caller), log, tt.ref)
+			if tt.expectCode != codes.OK {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectCode, status.Code(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, wantSelectors, selectors)
+		})
+	}
+}
+
+func TestComposeX509SVIDBySelectors(t *testing.T) {
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	ca := testca.New(t, trustDomain)
+	bundle := ca.Bundle()
+
+	workloadID := spiffeid.RequireFromPath(trustDomain, "/workload")
+	adminID := spiffeid.RequireFromPath(trustDomain, "/admin")
+	downstreamID := spiffeid.RequireFromPath(trustDomain, "/downstream")
+
+	workloadSVID := ca.CreateX509SVID(workloadID)
+	adminSVID := ca.CreateX509SVID(adminID)
+	downstreamSVID := ca.CreateX509SVID(downstreamID)
+
+	t.Run("admin and downstream identities are excluded", func(t *testing.T) {
+		update := &cache.X509WorkloadUpdate{
+			Bundle: bundle,
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: adminID.String(), Admin: true}, SVID: adminSVID.Certificates, PrivateKey: adminSVID.PrivateKey},
+				{Entry: &common.RegistrationEntry{SpiffeId: downstreamID.String(), Downstream: true}, SVID: downstreamSVID.Certificates, PrivateKey: downstreamSVID.PrivateKey},
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: workloadSVID.Certificates, PrivateKey: workloadSVID.PrivateKey},
+			},
+		}
+
+		resp, notAfters, err := composeX509SVIDBySelectors(update)
+		require.NoError(t, err)
+		require.Len(t, resp.Svids, 1)
+		require.Len(t, notAfters, 1)
+		assert.Equal(t, workloadID.String(), resp.Svids[0].SpiffeId)
+	})
+
+	t.Run("missing SVID is an error", func(t *testing.T) {
+		update := &cache.X509WorkloadUpdate{
+			Bundle: bundle,
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: nil, PrivateKey: workloadSVID.PrivateKey},
+			},
+		}
+
+		_, _, err := composeX509SVIDBySelectors(update)
+		assert.Error(t, err)
+	})
+
+	t.Run("federated bundles are marshaled", func(t *testing.T) {
+		federatedTD := spiffeid.RequireTrustDomainFromString("federated.test")
+		federatedBundle := testca.New(t, federatedTD).Bundle()
+
+		update := &cache.X509WorkloadUpdate{
+			Bundle: bundle,
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: workloadSVID.Certificates, PrivateKey: workloadSVID.PrivateKey},
+			},
+			FederatedBundles: map[spiffeid.TrustDomain]*cache.Bundle{
+				federatedTD: federatedBundle,
+			},
+		}
+
+		resp, _, err := composeX509SVIDBySelectors(update)
+		require.NoError(t, err)
+		require.Contains(t, resp.FederatedBundles, federatedTD.IDString())
+	})
+}
+
+type fakeX509SVIDStream struct {
+	grpc.ServerStream
+
+	ctx     context.Context
+	sentCh  chan *broker.SubscribeToX509SVIDResponse
+	sendErr error
+}
+
+func (s *fakeX509SVIDStream) Context() context.Context { return s.ctx }
+
+func (s *fakeX509SVIDStream) Send(resp *broker.SubscribeToX509SVIDResponse) error {
+	if s.sendErr != nil {
+		return s.sendErr
+	}
+	s.sentCh <- resp
+	return nil
+}
+
+func TestSubscribeToX509SVID(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	ca := testca.New(t, trustDomain)
+	workloadID := spiffeid.RequireFromPath(trustDomain, "/workload")
+	workloadSVID := ca.CreateX509SVID(workloadID)
+
+	t.Run("attestation error", func(t *testing.T) {
+		s := New(Config{Attestor: fakeAttestor{err: errors.New("boom")}, Metrics: fakemetrics.New()})
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+
+		err := s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, &fakeX509SVIDStream{ctx: ctx})
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("reference type not allowed for caller", func(t *testing.T) {
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Metrics:  fakemetrics.New(),
+			AllowedReferenceTypesByCaller: map[spiffeid.ID]ReferenceTypePolicy{
+				caller: {Types: map[string]ReferenceTypeAccess{pidType: {}}},
+			},
+		})
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+
+		err := s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, &fakeX509SVIDStream{ctx: ctx})
+		require.Error(t, err)
+		assert.Equal(t, codes.PermissionDenied, status.Code(err))
+	})
+
+	t.Run("identity missing SVID returns internal error", func(t *testing.T) {
+		update := &cache.X509WorkloadUpdate{
+			Bundle: ca.Bundle(),
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: nil, PrivateKey: workloadSVID.PrivateKey},
+			},
+		}
+		sub := &fakeCacheSubscriber{ch: make(chan *cache.X509WorkloadUpdate, 1)}
+		sub.ch <- update
+
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{cacheSubscriber: sub},
+			Metrics:  fakemetrics.New(),
+		})
+
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+		stream := &fakeX509SVIDStream{ctx: ctx, sentCh: make(chan *broker.SubscribeToX509SVIDResponse, 1)}
+
+		err := s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, stream)
+		require.Error(t, err)
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("subscribe error", func(t *testing.T) {
+		wantErr := errors.New("subscribe failed")
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{subscribeErr: wantErr},
+			Metrics:  fakemetrics.New(),
+		})
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+
+		err := s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, &fakeX509SVIDStream{ctx: ctx})
+		assert.Equal(t, wantErr, err)
+	})
+
+	t.Run("sends updates until context is cancelled", func(t *testing.T) {
+		update := &cache.X509WorkloadUpdate{
+			Bundle: ca.Bundle(),
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: workloadSVID.Certificates, PrivateKey: workloadSVID.PrivateKey},
+			},
+		}
+		sub := &fakeCacheSubscriber{ch: make(chan *cache.X509WorkloadUpdate, 1)}
+		sub.ch <- update
+
+		metrics := fakemetrics.New()
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{cacheSubscriber: sub},
+			Metrics:  metrics,
+		})
+
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		stream := &fakeX509SVIDStream{ctx: ctx, sentCh: make(chan *broker.SubscribeToX509SVIDResponse, 1)}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+				Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+			}, stream)
+		}()
+
+		resp := <-stream.sentCh
+		require.Len(t, resp.Svids, 1)
+		assert.Equal(t, workloadID.String(), resp.Svids[0].SpiffeId)
+
+		cancel()
+		require.NoError(t, <-errCh)
+
+		assert.Equal(t, []fakemetrics.MetricItem{
+			{
+				Type:   fakemetrics.MeasureSinceWithLabelsType,
+				Key:    []string{telemetry.DelegatedIdentityAPI, telemetry.SubscribeX509SVIDs, telemetry.FirstUpdate, telemetry.ElapsedTime},
+				Val:    0,
+				Labels: []telemetry.Label{},
+			},
+		}, metrics.AllMetrics())
+	})
+
+	t.Run("multiple identities in one update", func(t *testing.T) {
+		workload2ID := spiffeid.RequireFromPath(trustDomain, "/workload2")
+		workload2SVID := ca.CreateX509SVID(workload2ID)
+
+		update := &cache.X509WorkloadUpdate{
+			Bundle: ca.Bundle(),
+			Identities: []cache.X509Identity{
+				{Entry: &common.RegistrationEntry{SpiffeId: workloadID.String()}, SVID: workloadSVID.Certificates, PrivateKey: workloadSVID.PrivateKey},
+				{Entry: &common.RegistrationEntry{SpiffeId: workload2ID.String(), Admin: true}, SVID: workload2SVID.Certificates, PrivateKey: workload2SVID.PrivateKey},
+			},
+		}
+		sub := &fakeCacheSubscriber{ch: make(chan *cache.X509WorkloadUpdate, 1)}
+		sub.ch <- update
+
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{cacheSubscriber: sub},
+			Metrics:  fakemetrics.New(),
+		})
+
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		stream := &fakeX509SVIDStream{ctx: ctx, sentCh: make(chan *broker.SubscribeToX509SVIDResponse, 1)}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.SubscribeToX509SVID(&broker.SubscribeToX509SVIDRequest{
+				Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+			}, stream)
+		}()
+
+		resp := <-stream.sentCh
+		require.Len(t, resp.Svids, 1)
+		assert.Equal(t, workloadID.String(), resp.Svids[0].SpiffeId)
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+}
+
+func TestSubscribeToX509Bundles(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	ca := testca.New(t, trustDomain)
+
+	t.Run("attestation error", func(t *testing.T) {
+		s := New(Config{Attestor: fakeAttestor{err: errors.New("boom")}})
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+
+		err := s.SubscribeToX509Bundles(&broker.SubscribeToX509BundlesRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, &fakeX509BundlesStream{ctx: ctx})
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("sends bundle updates until context is cancelled", func(t *testing.T) {
+		bundleCache := cache.NewBundleCache(trustDomain, ca.Bundle())
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{bundleCache: bundleCache},
+		})
+
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		stream := &fakeX509BundlesStream{ctx: ctx, sentCh: make(chan *broker.SubscribeToX509BundlesResponse, 2)}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.SubscribeToX509Bundles(&broker.SubscribeToX509BundlesRequest{
+				Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+			}, stream)
+		}()
+
+		first := <-stream.sentCh
+		assert.Contains(t, first.Bundles, trustDomain.IDString())
+
+		federatedTD := spiffeid.RequireTrustDomainFromString("federated.test")
+		federatedBundle := testca.New(t, federatedTD).Bundle()
+		bundleCache.Update(map[spiffeid.TrustDomain]*cache.Bundle{
+			trustDomain: ca.Bundle(),
+			federatedTD: federatedBundle,
+		})
+
+		second := <-stream.sentCh
+		assert.Contains(t, second.Bundles, federatedTD.IDString())
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+}
+
+type fakeX509BundlesStream struct {
+	grpc.ServerStream
+
+	ctx    context.Context
+	sentCh chan *broker.SubscribeToX509BundlesResponse
+}
+
+func (s *fakeX509BundlesStream) Context() context.Context { return s.ctx }
+
+func (s *fakeX509BundlesStream) Send(resp *broker.SubscribeToX509BundlesResponse) error {
+	s.sentCh <- resp
+	return nil
+}
+
 func TestFetchJWTSVID(t *testing.T) {
 	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
 	workloadID := "spiffe://example.org/workload"
+	workload2ID := "spiffe://example.org/workload2"
 	adminID := "spiffe://example.org/admin"
 	downstreamID := "spiffe://example.org/downstream"
 
@@ -244,10 +695,16 @@ func TestFetchJWTSVID(t *testing.T) {
 		IssuedAt:  time.Unix(1000, 0),
 		ExpiresAt: time.Unix(2000, 0),
 	}
+	jwtSVID2 := &client.JWTSVID{
+		Token:     "jwt-token-2",
+		IssuedAt:  time.Unix(1000, 0),
+		ExpiresAt: time.Unix(2000, 0),
+	}
 
 	for _, tt := range []struct {
 		name        string
 		audience    []string
+		byCaller    map[spiffeid.ID]ReferenceTypePolicy
 		attestErr   error
 		fetchErr    error
 		entries     []*common.RegistrationEntry
@@ -265,6 +722,14 @@ func TestFetchJWTSVID(t *testing.T) {
 			expectCode: codes.Unauthenticated,
 		},
 		{
+			name:     "reference type not allowed for caller",
+			audience: []string{"aud"},
+			byCaller: map[spiffeid.ID]ReferenceTypePolicy{
+				caller: {Types: map[string]ReferenceTypeAccess{pidType: {}}},
+			},
+			expectCode: codes.PermissionDenied,
+		},
+		{
 			name:     "success",
 			audience: []string{"aud"},
 			entries: []*common.RegistrationEntry{
@@ -274,6 +739,28 @@ func TestFetchJWTSVID(t *testing.T) {
 			expectSvids: []*broker.JWTSVID{
 				{SpiffeId: workloadID, Svid: jwtSVID.Token},
 			},
+		},
+		{
+			name:     "success with two entries",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: workloadID},
+				{EntryId: "2", SpiffeId: workload2ID},
+			},
+			expectCode: codes.OK,
+			expectSvids: []*broker.JWTSVID{
+				{SpiffeId: workloadID, Svid: jwtSVID.Token},
+				{SpiffeId: workload2ID, Svid: jwtSVID2.Token},
+			},
+		},
+		{
+			name:     "fetch error",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: workloadID},
+			},
+			fetchErr:   errors.New("fetch failed"),
+			expectCode: codes.Unavailable,
 		},
 		{
 			name:     "admin entries are excluded",
@@ -310,11 +797,13 @@ func TestFetchJWTSVID(t *testing.T) {
 				Manager: &fakeManager{
 					entries: tt.entries,
 					jwtSVIDs: map[string]*client.JWTSVID{
-						workloadID: jwtSVID,
+						workloadID:  jwtSVID,
+						workload2ID: jwtSVID2,
 					},
 					err: tt.fetchErr,
 				},
-				Attestor: fakeAttestor{err: tt.attestErr},
+				Attestor:                      fakeAttestor{err: tt.attestErr},
+				AllowedReferenceTypesByCaller: tt.byCaller,
 			})
 
 			resp, err := s.FetchJWTSVID(brokerCallerContext(caller), &broker.FetchJWTSVIDRequest{
@@ -337,4 +826,62 @@ func TestFetchJWTSVID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubscribeToJWTBundles(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+	trustDomain := spiffeid.RequireTrustDomainFromString("example.org")
+	ca := testca.New(t, trustDomain)
+
+	t.Run("attestation error", func(t *testing.T) {
+		s := New(Config{Attestor: fakeAttestor{err: errors.New("boom")}})
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		defer cancel()
+
+		err := s.SubscribeToJWTBundles(&broker.SubscribeToJWTBundlesRequest{
+			Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+		}, &fakeJWTBundlesStream{ctx: ctx})
+		require.Error(t, err)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+	})
+
+	t.Run("sends JWKS-encoded bundle updates", func(t *testing.T) {
+		bundleCache := cache.NewBundleCache(trustDomain, ca.Bundle())
+		s := New(Config{
+			Attestor: fakeAttestor{},
+			Manager:  &fakeManager{bundleCache: bundleCache},
+		})
+
+		ctx, cancel := context.WithCancel(brokerCallerContext(caller))
+		stream := &fakeJWTBundlesStream{ctx: ctx, sentCh: make(chan *broker.SubscribeToJWTBundlesResponse, 1)}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- s.SubscribeToJWTBundles(&broker.SubscribeToJWTBundlesRequest{
+				Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+			}, stream)
+		}()
+
+		resp := <-stream.sentCh
+		wantJWKS, err := bundleutil.Marshal(ca.Bundle(), bundleutil.NoX509SVIDKeys(), bundleutil.StandardJWKS())
+		require.NoError(t, err)
+		assert.Equal(t, wantJWKS, resp.Bundles[trustDomain.IDString()])
+
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+}
+
+type fakeJWTBundlesStream struct {
+	grpc.ServerStream
+
+	ctx    context.Context
+	sentCh chan *broker.SubscribeToJWTBundlesResponse
+}
+
+func (s *fakeJWTBundlesStream) Context() context.Context { return s.ctx }
+
+func (s *fakeJWTBundlesStream) Send(resp *broker.SubscribeToJWTBundlesResponse) error {
+	s.sentCh <- resp
+	return nil
 }

--- a/pkg/agent/broker/api/service_test.go
+++ b/pkg/agent/broker/api/service_test.go
@@ -2,13 +2,24 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net"
+	"net/url"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/spiffe/go-spiffe/v2/exp/proto/spiffe/broker"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/agent/api/rpccontext"
+	workloadattestor "github.com/spiffe/spire/pkg/agent/attestor/workload"
+	"github.com/spiffe/spire/pkg/agent/client"
+	"github.com/spiffe/spire/pkg/agent/manager"
+	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -170,6 +181,160 @@ func TestAuthorizeReferenceType(t *testing.T) {
 			}
 			require.Error(t, err)
 			assert.Equal(t, tt.expectCode, status.Code(err))
+		})
+	}
+}
+
+func brokerCallerContext(caller spiffeid.ID) context.Context {
+	spiffeURL, _ := url.Parse(caller.String())
+	log, _ := test.NewNullLogger()
+	ctx := rpccontext.WithLogger(context.Background(), log)
+	return peer.NewContext(ctx, &peer.Peer{
+		Addr:     &net.UnixAddr{Name: "/tmp/broker.sock", Net: "unix"},
+		AuthInfo: credentials.TLSInfo{SPIFFEID: spiffeURL},
+	})
+}
+
+var _ workloadattestor.Attestor = fakeAttestor{}
+
+type fakeAttestor struct {
+	selectors []*common.Selector
+	err       error
+}
+
+func (a fakeAttestor) Attest(context.Context, int) ([]*common.Selector, error) {
+	return a.selectors, a.err
+}
+
+func (a fakeAttestor) AttestReference(context.Context, *anypb.Any) ([]*common.Selector, error) {
+	return a.selectors, a.err
+}
+
+type fakeManager struct {
+	manager.Manager
+
+	entries  []*common.RegistrationEntry
+	jwtSVIDs map[string]*client.JWTSVID
+	err      error
+}
+
+func (m *fakeManager) MatchingRegistrationEntries([]*common.Selector) []*common.RegistrationEntry {
+	return m.entries
+}
+
+func (m *fakeManager) FetchJWTSVID(_ context.Context, entry *common.RegistrationEntry, _ []string) (*client.JWTSVID, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	svid, ok := m.jwtSVIDs[entry.SpiffeId]
+	if !ok {
+		return nil, errors.New("no SVID for entry")
+	}
+	return svid, nil
+}
+
+func TestFetchJWTSVID(t *testing.T) {
+	caller := spiffeid.RequireFromString("spiffe://example.org/broker")
+	workloadID := "spiffe://example.org/workload"
+	adminID := "spiffe://example.org/admin"
+	downstreamID := "spiffe://example.org/downstream"
+
+	jwtSVID := &client.JWTSVID{
+		Token:     "jwt-token",
+		IssuedAt:  time.Unix(1000, 0),
+		ExpiresAt: time.Unix(2000, 0),
+	}
+
+	for _, tt := range []struct {
+		name        string
+		audience    []string
+		attestErr   error
+		fetchErr    error
+		entries     []*common.RegistrationEntry
+		expectCode  codes.Code
+		expectSvids []*broker.JWTSVID
+	}{
+		{
+			name:       "missing audience",
+			expectCode: codes.InvalidArgument,
+		},
+		{
+			name:       "attestation error",
+			audience:   []string{"aud"},
+			attestErr:  errors.New("attest failed"),
+			expectCode: codes.Unauthenticated,
+		},
+		{
+			name:     "success",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: workloadID},
+			},
+			expectCode: codes.OK,
+			expectSvids: []*broker.JWTSVID{
+				{SpiffeId: workloadID, Svid: jwtSVID.Token},
+			},
+		},
+		{
+			name:     "admin entries are excluded",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: adminID, Admin: true},
+			},
+			expectCode: codes.PermissionDenied,
+		},
+		{
+			name:     "downstream entries are excluded",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: downstreamID, Downstream: true},
+			},
+			expectCode: codes.PermissionDenied,
+		},
+		{
+			name:     "admin and downstream excluded, normal entry returned",
+			audience: []string{"aud"},
+			entries: []*common.RegistrationEntry{
+				{EntryId: "1", SpiffeId: adminID, Admin: true},
+				{EntryId: "2", SpiffeId: downstreamID, Downstream: true},
+				{EntryId: "3", SpiffeId: workloadID},
+			},
+			expectCode: codes.OK,
+			expectSvids: []*broker.JWTSVID{
+				{SpiffeId: workloadID, Svid: jwtSVID.Token},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s := New(Config{
+				Manager: &fakeManager{
+					entries: tt.entries,
+					jwtSVIDs: map[string]*client.JWTSVID{
+						workloadID: jwtSVID,
+					},
+					err: tt.fetchErr,
+				},
+				Attestor: fakeAttestor{err: tt.attestErr},
+			})
+
+			resp, err := s.FetchJWTSVID(brokerCallerContext(caller), &broker.FetchJWTSVIDRequest{
+				Audience:  tt.audience,
+				Reference: &broker.WorkloadReference{Reference: ref(k8sType)},
+			})
+
+			if tt.expectCode != codes.OK {
+				require.Error(t, err)
+				assert.Equal(t, tt.expectCode, status.Code(err))
+				assert.Nil(t, resp)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, resp.Svids, len(tt.expectSvids))
+			for i, want := range tt.expectSvids {
+				assert.Equal(t, want.SpiffeId, resp.Svids[i].SpiffeId)
+				assert.Equal(t, want.Svid, resp.Svids[i].Svid)
+			}
 		})
 	}
 }

--- a/pkg/agent/broker/api/service_test.go
+++ b/pkg/agent/broker/api/service_test.go
@@ -571,7 +571,7 @@ func TestSubscribeToX509SVID(t *testing.T) {
 		assert.Equal(t, []fakemetrics.MetricItem{
 			{
 				Type:   fakemetrics.MeasureSinceWithLabelsType,
-				Key:    []string{telemetry.DelegatedIdentityAPI, telemetry.SubscribeX509SVIDs, telemetry.FirstUpdate, telemetry.ElapsedTime},
+				Key:    []string{telemetry.BrokerAPI, telemetry.SubscribeX509SVIDs, telemetry.FirstUpdate, telemetry.ElapsedTime},
 				Val:    0,
 				Labels: []telemetry.Label{},
 			},

--- a/pkg/common/telemetry/agent/broker/broker.go
+++ b/pkg/common/telemetry/agent/broker/broker.go
@@ -1,0 +1,16 @@
+package broker
+
+import (
+	"github.com/spiffe/spire/pkg/common/telemetry"
+)
+
+// Call Counters (timing and success metrics)
+// Allows adding labels in-code
+
+// StartFirstX509SVIDUpdateLatency returns Latency metric
+// for SubscribeToX509SVID API fetching the first update from cache.
+func StartFirstX509SVIDUpdateLatency(m telemetry.Metrics) *telemetry.Latency {
+	return telemetry.StartLatencyMetric(m, telemetry.BrokerAPI, telemetry.SubscribeX509SVIDs, telemetry.FirstUpdate)
+}
+
+// End Call Counters


### PR DESCRIPTION
Similar to https://github.com/spiffe/spire/pull/6972.

