### PR TITLE
federation: bootstrap https_spiffe trust from a config path

### DIFF
--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -183,6 +183,8 @@ type bundleEndpointACMEConfig struct {
 type federatesWithConfig struct {
 	BundleEndpointURL     string                 `hcl:"bundle_endpoint_url"`
 	BundleEndpointProfile ast.Node               `hcl:"bundle_endpoint_profile"`
+	BootstrapBundlePath   string                 `hcl:"bootstrap_bundle_path"`
+	BootstrapBundleFormat string                 `hcl:"bootstrap_bundle_format"`
 	UnusedKeyPositions    map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
 
@@ -524,6 +526,9 @@ func newServerConfig(c *Config, logOptions []log.Option, allowUnknownConfig, ski
 			case config.BundleEndpointProfile != nil:
 				trustDomainConfig, err = parseBundleEndpointProfile(config)
 				if err != nil {
+					return nil, fmt.Errorf("error parsing federation relationship for trust domain %q: %w", trustDomain, err)
+				}
+				if err := validateFederatesWithBootstrap(td, trustDomainConfig); err != nil {
 					return nil, fmt.Errorf("error parsing federation relationship for trust domain %q: %w", trustDomain, err)
 				}
 			default:
@@ -926,10 +931,45 @@ func parseBundleEndpointProfile(config federatesWithConfig) (trustDomainConfig *
 		return nil, errors.New(`no bundle endpoint profile defined; current supported profiles are "https_spiffe" and 'https_web"`)
 	}
 
+	format := strings.ToLower(strings.TrimSpace(config.BootstrapBundleFormat))
+	if config.BootstrapBundlePath != "" && format == "" {
+		format = bundleClient.BootstrapBundleFormatPEM
+	}
+
 	return &bundleClient.TrustDomainConfig{
-		EndpointURL:     config.BundleEndpointURL,
-		EndpointProfile: endpointProfile,
+		EndpointURL:           config.BundleEndpointURL,
+		EndpointProfile:       endpointProfile,
+		BootstrapBundlePath:   config.BootstrapBundlePath,
+		BootstrapBundleFormat: format,
 	}, nil
+}
+
+func validateFederatesWithBootstrap(td spiffeid.TrustDomain, cfg *bundleClient.TrustDomainConfig) error {
+	if cfg.BootstrapBundleFormat != "" && cfg.BootstrapBundlePath == "" {
+		return errors.New("bootstrap_bundle_format is set but bootstrap_bundle_path is empty")
+	}
+	if cfg.BootstrapBundlePath == "" {
+		return nil
+	}
+
+	switch cfg.BootstrapBundleFormat {
+	case bundleClient.BootstrapBundleFormatPEM, bundleClient.BootstrapBundleFormatSPIFFE:
+	default:
+		return fmt.Errorf("bootstrap_bundle_format must be %q or %q", bundleClient.BootstrapBundleFormatPEM, bundleClient.BootstrapBundleFormatSPIFFE)
+	}
+
+	if _, ok := cfg.EndpointProfile.(bundleClient.HTTPSWebProfile); ok {
+		return errors.New("bootstrap_bundle_path is only supported with the https_spiffe bundle endpoint profile")
+	}
+
+	spiffeProfile, ok := cfg.EndpointProfile.(bundleClient.HTTPSSPIFFEProfile)
+	if !ok {
+		return nil
+	}
+	if spiffeProfile.EndpointSPIFFEID.TrustDomain() != td {
+		return errors.New("bootstrap_bundle_path is only supported when the endpoint SPIFFE ID is in the federated trust domain")
+	}
+	return nil
 }
 
 func parseBundleEndpointProfileASTNode(node ast.Node) (string, error) {

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -958,13 +958,9 @@ func validateFederatesWithBootstrap(td spiffeid.TrustDomain, cfg *bundleClient.T
 		return fmt.Errorf("bootstrap_bundle_format must be %q or %q", bundleClient.BootstrapBundleFormatPEM, bundleClient.BootstrapBundleFormatSPIFFE)
 	}
 
-	if _, ok := cfg.EndpointProfile.(bundleClient.HTTPSWebProfile); ok {
-		return errors.New("bootstrap_bundle_path is only supported with the https_spiffe bundle endpoint profile")
-	}
-
 	spiffeProfile, ok := cfg.EndpointProfile.(bundleClient.HTTPSSPIFFEProfile)
 	if !ok {
-		return nil
+		return errors.New("bootstrap_bundle_path is only supported with the https_spiffe bundle endpoint profile")
 	}
 	if spiffeProfile.EndpointSPIFFEID.TrustDomain() != td {
 		return errors.New("bootstrap_bundle_path is only supported when the endpoint SPIFFE ID is in the federated trust domain")

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -964,6 +964,88 @@ func TestNewServerConfig(t *testing.T) {
 			},
 		},
 		{
+			msg: "federates_with bootstrap_bundle_path is parsed for https_spiffe",
+			input: func(c *Config) {
+				cfg := httpsSPIFFEConfigTest(t)
+				cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+				c.Server.Federation = &federationConfig{
+					FederatesWith: map[string]federatesWithConfig{
+						"domain1.test": cfg,
+					},
+				}
+			},
+			test: func(t *testing.T, c *server.Config) {
+				got := c.Federation.FederatesWith[spiffeid.RequireTrustDomainFromString("domain1.test")]
+				require.Equal(t, "/etc/spire/domain1.pem", got.BootstrapBundlePath)
+				require.Equal(t, bundleClient.BootstrapBundleFormatPEM, got.BootstrapBundleFormat)
+			},
+		},
+		{
+			msg: "federates_with bootstrap_bundle_path is rejected for https_web",
+			input: func(c *Config) {
+				cfg := webPKIConfigTest(t)
+				cfg.BootstrapBundlePath = "/etc/spire/domain2.pem"
+				c.Server.Federation = &federationConfig{
+					FederatesWith: map[string]federatesWithConfig{
+						"domain2.test": cfg,
+					},
+				}
+			},
+			expectError: true,
+			test: func(t *testing.T, c *server.Config) {
+				require.Nil(t, c)
+			},
+		},
+		{
+			msg: "federates_with bootstrap_bundle_path is rejected for a non-self-serving endpoint",
+			input: func(c *Config) {
+				cfg := httpsSPIFFEConfigTest(t)
+				cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+				c.Server.Federation = &federationConfig{
+					FederatesWith: map[string]federatesWithConfig{
+						"other.test": cfg,
+					},
+				}
+			},
+			expectError: true,
+			test: func(t *testing.T, c *server.Config) {
+				require.Nil(t, c)
+			},
+		},
+		{
+			msg: "federates_with bootstrap_bundle_format without path is rejected",
+			input: func(c *Config) {
+				cfg := httpsSPIFFEConfigTest(t)
+				cfg.BootstrapBundleFormat = bundleClient.BootstrapBundleFormatSPIFFE
+				c.Server.Federation = &federationConfig{
+					FederatesWith: map[string]federatesWithConfig{
+						"domain1.test": cfg,
+					},
+				}
+			},
+			expectError: true,
+			test: func(t *testing.T, c *server.Config) {
+				require.Nil(t, c)
+			},
+		},
+		{
+			msg: "federates_with bootstrap_bundle_format must be pem or spiffe",
+			input: func(c *Config) {
+				cfg := httpsSPIFFEConfigTest(t)
+				cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+				cfg.BootstrapBundleFormat = "der"
+				c.Server.Federation = &federationConfig{
+					FederatesWith: map[string]federatesWithConfig{
+						"domain1.test": cfg,
+					},
+				}
+			},
+			expectError: true,
+			test: func(t *testing.T, c *server.Config) {
+				require.Nil(t, c)
+			},
+		},
+		{
 			msg: "default_x509_svid_ttl is correctly parsed",
 			input: func(c *Config) {
 				c.Server.DefaultX509SVIDTTL = "2m"
@@ -2354,6 +2436,58 @@ func bundleEndpointProfileUnknownTest(t *testing.T) *bundleEndpointConfig {
 	require.NoError(t, hcl.Decode(config, configString))
 
 	return config
+}
+
+func TestValidateFederatesWithBootstrap(t *testing.T) {
+	td := spiffeid.RequireTrustDomainFromString("domain1.test")
+	spiffeCfg := &bundleClient.TrustDomainConfig{
+		EndpointURL: "https://192.168.1.1:1337",
+		EndpointProfile: bundleClient.HTTPSSPIFFEProfile{
+			EndpointSPIFFEID: spiffeid.RequireFromString("spiffe://domain1.test/bundle/endpoint"),
+		},
+	}
+
+	t.Run("ok", func(t *testing.T) {
+		cfg := *spiffeCfg
+		cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+		cfg.BootstrapBundleFormat = bundleClient.BootstrapBundleFormatPEM
+		require.NoError(t, validateFederatesWithBootstrap(td, &cfg))
+	})
+
+	t.Run("https_web", func(t *testing.T) {
+		cfg := &bundleClient.TrustDomainConfig{
+			EndpointURL:           "https://192.168.1.1:1337",
+			EndpointProfile:       bundleClient.HTTPSWebProfile{},
+			BootstrapBundlePath:   "/etc/spire/domain1.pem",
+			BootstrapBundleFormat: bundleClient.BootstrapBundleFormatPEM,
+		}
+		require.EqualError(t, validateFederatesWithBootstrap(td, cfg),
+			"bootstrap_bundle_path is only supported with the https_spiffe bundle endpoint profile")
+	})
+
+	t.Run("non-self-serving", func(t *testing.T) {
+		cfg := *spiffeCfg
+		cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+		cfg.BootstrapBundleFormat = bundleClient.BootstrapBundleFormatPEM
+		other := spiffeid.RequireTrustDomainFromString("other.test")
+		require.EqualError(t, validateFederatesWithBootstrap(other, &cfg),
+			"bootstrap_bundle_path is only supported when the endpoint SPIFFE ID is in the federated trust domain")
+	})
+
+	t.Run("format without path", func(t *testing.T) {
+		cfg := *spiffeCfg
+		cfg.BootstrapBundleFormat = bundleClient.BootstrapBundleFormatSPIFFE
+		require.EqualError(t, validateFederatesWithBootstrap(td, &cfg),
+			"bootstrap_bundle_format is set but bootstrap_bundle_path is empty")
+	})
+
+	t.Run("bad format", func(t *testing.T) {
+		cfg := *spiffeCfg
+		cfg.BootstrapBundlePath = "/etc/spire/domain1.pem"
+		cfg.BootstrapBundleFormat = "der"
+		require.EqualError(t, validateFederatesWithBootstrap(td, &cfg),
+			`bootstrap_bundle_format must be "pem" or "spiffe"`)
+	})
 }
 
 func httpsSPIFFEConfigTest(t *testing.T) federatesWithConfig {

--- a/cmd/spire-server/cli/run/run_test.go
+++ b/cmd/spire-server/cli/run/run_test.go
@@ -2438,6 +2438,10 @@ func bundleEndpointProfileUnknownTest(t *testing.T) *bundleEndpointConfig {
 	return config
 }
 
+type unknownEndpointProfile struct{}
+
+func (unknownEndpointProfile) Name() string { return "unknown" }
+
 func TestValidateFederatesWithBootstrap(t *testing.T) {
 	td := spiffeid.RequireTrustDomainFromString("domain1.test")
 	spiffeCfg := &bundleClient.TrustDomainConfig{
@@ -2458,6 +2462,17 @@ func TestValidateFederatesWithBootstrap(t *testing.T) {
 		cfg := &bundleClient.TrustDomainConfig{
 			EndpointURL:           "https://192.168.1.1:1337",
 			EndpointProfile:       bundleClient.HTTPSWebProfile{},
+			BootstrapBundlePath:   "/etc/spire/domain1.pem",
+			BootstrapBundleFormat: bundleClient.BootstrapBundleFormatPEM,
+		}
+		require.EqualError(t, validateFederatesWithBootstrap(td, cfg),
+			"bootstrap_bundle_path is only supported with the https_spiffe bundle endpoint profile")
+	})
+
+	t.Run("unknown profile", func(t *testing.T) {
+		cfg := &bundleClient.TrustDomainConfig{
+			EndpointURL:           "https://192.168.1.1:1337",
+			EndpointProfile:       unknownEndpointProfile{},
 			BootstrapBundlePath:   "/etc/spire/domain1.pem",
 			BootstrapBundleFormat: bundleClient.BootstrapBundleFormatPEM,
 		}

--- a/conf/server/server_full.conf
+++ b/conf/server/server_full.conf
@@ -103,6 +103,16 @@ server {
                 endpoint_spiffe_id = "spiffe://example.com/spire/server"
             }
 
+            # bootstrap_bundle_path: Path to a bundle used to authenticate the first
+            # https_spiffe fetch when this server has no copy of the federated bundle.
+            # Only valid when endpoint_spiffe_id is in this federated trust domain.
+            # The file is not watched. Default: "".
+            # bootstrap_bundle_path = "/etc/spire/domain1.pem"
+
+            # bootstrap_bundle_format: Format of bootstrap_bundle_path, "pem" or "spiffe".
+            # Default: "pem".
+            # bootstrap_bundle_format = "pem"
+
             # bundle_endpoint_profile "https_web": Configuration for the https_web profile.
             # bundle_endpoint_profile "https_web" {}
         }

--- a/doc/spire_server.md
+++ b/doc/spire_server.md
@@ -275,6 +275,7 @@ server {
             bundle_endpoint_profile "https_spiffe" {
                 endpoint_spiffe_id = "spiffe://domain2.test/beserver"
             }
+            bootstrap_bundle_path = "/etc/spire/domain2.pem"
         }
     }
 }
@@ -332,12 +333,16 @@ The optional `federates_with` section is a map of bundle endpoint profile config
 |---------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|---------|
 | bundle_endpoint_url                                           | URL of the SPIFFE bundle endpoint that provides the trust bundle to federate with. Must use the HTTPS protocol. |         |
 | bundle_endpoint_profile "&lt;https_web&vert;https_spiffe&gt;" | Configuration of the SPIFFE endpoint profile type.                                                              |         |
+| bootstrap_bundle_path                                         | Path to a bundle used to authenticate the first `https_spiffe` fetch if none is stored yet.                     |         |
+| bootstrap_bundle_format                                       | Format of `bootstrap_bundle_path`. Either `pem` or `spiffe`.                                                    | pem     |
 
 SPIRE supports the `https_web` and `https_spiffe` bundle endpoint profiles.
 
 The `https_web` profile does not require additional settings.
 
 Trust domains configured with the `https_spiffe` bundle endpoint profile must specify the expected SPIFFE ID of the remote SPIFFE bundle endpoint server using the `endpoint_spiffe_id` setting as part of the configuration.
+
+`bootstrap_bundle_path` replaces the need to run `spire-server bundle set` before the first `https_spiffe` poll. It authenticates that first connection only. The bundle returned by the endpoint is stored with a create, not an update. Subsequent refreshes use the stored bundle. The path is not watched.
 
 For more information about the different profiles defined in SPIFFE, along with the security considerations for setting up SPIFFE Federation, please refer to the [SPIFFE Federation standard](https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md).
 

--- a/pkg/server/bundle/client/bootstrap.go
+++ b/pkg/server/bundle/client/bootstrap.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/pemutil"
+)
+
+const (
+	BootstrapBundleFormatPEM    = "pem"
+	BootstrapBundleFormatSPIFFE = "spiffe"
+)
+
+func loadBootstrapX509Authorities(path, format string, td spiffeid.TrustDomain) ([]*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load bootstrap bundle %q: %w", path, err)
+	}
+
+	if format == "" {
+		format = BootstrapBundleFormatPEM
+	}
+
+	var certs []*x509.Certificate
+	switch format {
+	case BootstrapBundleFormatPEM:
+		certs, err = pemutil.ParseCertificates(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse bootstrap bundle %q: %w", path, err)
+		}
+	case BootstrapBundleFormatSPIFFE:
+		bundle, err := bundleutil.Unmarshal(td, data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse bootstrap bundle %q: %w", path, err)
+		}
+		certs = bundle.X509Authorities()
+	default:
+		return nil, fmt.Errorf("unknown bootstrap bundle format %q", format)
+	}
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("bootstrap bundle %q contains no X.509 authorities", path)
+	}
+	return certs, nil
+}

--- a/pkg/server/bundle/client/bootstrap_test.go
+++ b/pkg/server/bundle/client/bootstrap_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBootstrapX509Authorities(t *testing.T) {
+	cert := createCACertificate(t, "bootstrap")
+	td := trustDomain
+
+	t.Run("pem", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bundle.pem")
+		require.NoError(t, os.WriteFile(path, pemutil.EncodeCertificate(cert), 0600))
+
+		got, err := loadBootstrapX509Authorities(path, BootstrapBundleFormatPEM, td)
+		require.NoError(t, err)
+		require.Equal(t, cert.Raw, got[0].Raw)
+	})
+
+	t.Run("spiffe", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bundle.json")
+		bundle := spiffebundle.FromX509Authorities(td, []*x509.Certificate{cert})
+		data, err := bundleutil.Marshal(bundle)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0600))
+
+		got, err := loadBootstrapX509Authorities(path, BootstrapBundleFormatSPIFFE, td)
+		require.NoError(t, err)
+		require.Equal(t, cert.Raw, got[0].Raw)
+	})
+
+	t.Run("defaults to pem", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bundle.pem")
+		require.NoError(t, os.WriteFile(path, pemutil.EncodeCertificate(cert), 0600))
+
+		got, err := loadBootstrapX509Authorities(path, "", td)
+		require.NoError(t, err)
+		require.Equal(t, cert.Raw, got[0].Raw)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := loadBootstrapX509Authorities(filepath.Join(t.TempDir(), "missing.pem"), BootstrapBundleFormatPEM, td)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to load bootstrap bundle")
+	})
+
+	t.Run("unknown format", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bundle.pem")
+		require.NoError(t, os.WriteFile(path, pemutil.EncodeCertificate(cert), 0600))
+
+		_, err := loadBootstrapX509Authorities(path, "der", td)
+		require.EqualError(t, err, `unknown bootstrap bundle format "der"`)
+	})
+}

--- a/pkg/server/bundle/client/manager.go
+++ b/pkg/server/bundle/client/manager.go
@@ -42,6 +42,15 @@ type TrustDomainConfig struct {
 	// EndpointProfile is the bundle endpoint profile used by the
 	// SPIFFE bundle endpoint server.
 	EndpointProfile EndpointProfileInfo
+
+	// BootstrapBundlePath is an optional path to a bundle used to authenticate
+	// the first https_spiffe fetch when the datastore has no copy of the
+	// federated bundle. It is not used after that fetch succeeds.
+	BootstrapBundlePath string
+
+	// BootstrapBundleFormat is the format of the file at BootstrapBundlePath.
+	// "pem" (default) or "spiffe".
+	BootstrapBundleFormat string
 }
 
 type EndpointProfileInfo interface {

--- a/pkg/server/bundle/client/updater.go
+++ b/pkg/server/bundle/client/updater.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"sync"
@@ -10,6 +11,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
 	"github.com/spiffe/spire/pkg/server/datastore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type BundleUpdaterConfig struct {
@@ -87,9 +90,20 @@ func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*spiffebundle.Bundle,
 	if err != nil {
 		return nil, nil, err
 	}
-	_, err = u.ds.SetBundle(ctx, bundle)
-	if err != nil {
-		return localFederatedBundleOrNil, nil, fmt.Errorf("failed to store fetched federated bundle: %w", err)
+	// First fetch is create-only so bootstrap auth cannot overwrite a stored bundle.
+	if localFederatedBundleOrNil == nil {
+		_, err = u.ds.CreateBundle(ctx, bundle)
+		if err != nil {
+			if status.Code(err) == codes.AlreadyExists {
+				return localFederatedBundleOrNil, fetchedFederatedBundle, nil
+			}
+			return localFederatedBundleOrNil, nil, fmt.Errorf("failed to store fetched federated bundle: %w", err)
+		}
+	} else {
+		_, err = u.ds.SetBundle(ctx, bundle)
+		if err != nil {
+			return localFederatedBundleOrNil, nil, fmt.Errorf("failed to store fetched federated bundle: %w", err)
+		}
 	}
 
 	return localFederatedBundleOrNil, fetchedFederatedBundle, nil
@@ -125,15 +139,30 @@ func (u *bundleUpdater) newClient(ctx context.Context, trustDomainConfig TrustDo
 			return nil, fmt.Errorf("failed to fetch local copy of bundle for %q: %w", trustDomain, err)
 		}
 
-		if localEndpointBundle == nil {
-			return nil, errors.New("can't perform SPIFFE Authentication: local copy of bundle not found")
+		rootCAs, err := rootCAsForSPIFFEAuth(localEndpointBundle, trustDomainConfig, trustDomain)
+		if err != nil {
+			return nil, err
 		}
 		clientConfig.SPIFFEAuth = &SPIFFEAuthConfig{
 			EndpointSpiffeID: spiffeAuth.EndpointSPIFFEID,
-			RootCAs:          localEndpointBundle.X509Authorities(),
+			RootCAs:          rootCAs,
 		}
 	}
 	return u.newClientHook(clientConfig)
+}
+
+func rootCAsForSPIFFEAuth(local *spiffebundle.Bundle, cfg TrustDomainConfig, td spiffeid.TrustDomain) ([]*x509.Certificate, error) {
+	if local != nil {
+		return local.X509Authorities(), nil
+	}
+	if cfg.BootstrapBundlePath == "" {
+		return nil, errors.New("can't perform SPIFFE Authentication: local copy of bundle not found")
+	}
+	certs, err := loadBootstrapX509Authorities(cfg.BootstrapBundlePath, cfg.BootstrapBundleFormat, td)
+	if err != nil {
+		return nil, fmt.Errorf("can't perform SPIFFE Authentication: %w", err)
+	}
+	return certs, nil
 }
 
 func fetchBundleIfExists(ctx context.Context, ds datastore.DataStore, trustDomain spiffeid.TrustDomain) (*spiffebundle.Bundle, error) {

--- a/pkg/server/bundle/client/updater.go
+++ b/pkg/server/bundle/client/updater.go
@@ -67,7 +67,7 @@ func NewBundleUpdater(config BundleUpdaterConfig) BundleUpdater {
 func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*spiffebundle.Bundle, *spiffebundle.Bundle, error) {
 	trustDomainConfig := u.GetTrustDomainConfig()
 
-	client, err := u.newClient(ctx, trustDomainConfig)
+	client, usedBootstrap, err := u.newClient(ctx, trustDomainConfig)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -90,12 +90,12 @@ func (u *bundleUpdater) UpdateBundle(ctx context.Context) (*spiffebundle.Bundle,
 	if err != nil {
 		return nil, nil, err
 	}
-	// First fetch is create-only so bootstrap auth cannot overwrite a stored bundle.
-	if localFederatedBundleOrNil == nil {
+	// Create if the store was empty at auth time so bootstrap roots cannot overwrite a bundle that appears before persist.
+	if localFederatedBundleOrNil == nil || usedBootstrap {
 		_, err = u.ds.CreateBundle(ctx, bundle)
 		if err != nil {
 			if status.Code(err) == codes.AlreadyExists {
-				return localFederatedBundleOrNil, fetchedFederatedBundle, nil
+				return localFederatedBundleOrNil, nil, nil
 			}
 			return localFederatedBundleOrNil, nil, fmt.Errorf("failed to store fetched federated bundle: %w", err)
 		}
@@ -126,43 +126,46 @@ func (u *bundleUpdater) SetTrustDomainConfig(trustDomainConfig TrustDomainConfig
 	return false
 }
 
-func (u *bundleUpdater) newClient(ctx context.Context, trustDomainConfig TrustDomainConfig) (Client, error) {
+func (u *bundleUpdater) newClient(ctx context.Context, trustDomainConfig TrustDomainConfig) (Client, bool, error) {
 	clientConfig := ClientConfig{
 		TrustDomain: u.td,
 		EndpointURL: trustDomainConfig.EndpointURL,
 	}
 
+	usedBootstrap := false
 	if spiffeAuth, ok := trustDomainConfig.EndpointProfile.(HTTPSSPIFFEProfile); ok {
-		trustDomain := spiffeAuth.EndpointSPIFFEID.TrustDomain()
-		localEndpointBundle, err := fetchBundleIfExists(ctx, u.ds, trustDomain)
+		endpointTD := spiffeAuth.EndpointSPIFFEID.TrustDomain()
+		localEndpointBundle, err := fetchBundleIfExists(ctx, u.ds, endpointTD)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch local copy of bundle for %q: %w", trustDomain, err)
+			return nil, false, fmt.Errorf("failed to fetch local copy of bundle for %q: %w", endpointTD, err)
 		}
 
-		rootCAs, err := rootCAsForSPIFFEAuth(localEndpointBundle, trustDomainConfig, trustDomain)
+		var rootCAs []*x509.Certificate
+		rootCAs, usedBootstrap, err = rootCAsForSPIFFEAuth(localEndpointBundle, trustDomainConfig, endpointTD, u.td)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		clientConfig.SPIFFEAuth = &SPIFFEAuthConfig{
 			EndpointSpiffeID: spiffeAuth.EndpointSPIFFEID,
 			RootCAs:          rootCAs,
 		}
 	}
-	return u.newClientHook(clientConfig)
+	client, err := u.newClientHook(clientConfig)
+	return client, usedBootstrap, err
 }
 
-func rootCAsForSPIFFEAuth(local *spiffebundle.Bundle, cfg TrustDomainConfig, td spiffeid.TrustDomain) ([]*x509.Certificate, error) {
+func rootCAsForSPIFFEAuth(local *spiffebundle.Bundle, cfg TrustDomainConfig, endpointTD, federatedTD spiffeid.TrustDomain) ([]*x509.Certificate, bool, error) {
 	if local != nil {
-		return local.X509Authorities(), nil
+		return local.X509Authorities(), false, nil
 	}
-	if cfg.BootstrapBundlePath == "" {
-		return nil, errors.New("can't perform SPIFFE Authentication: local copy of bundle not found")
+	if cfg.BootstrapBundlePath == "" || endpointTD != federatedTD {
+		return nil, false, errors.New("can't perform SPIFFE Authentication: local copy of bundle not found")
 	}
-	certs, err := loadBootstrapX509Authorities(cfg.BootstrapBundlePath, cfg.BootstrapBundleFormat, td)
+	certs, err := loadBootstrapX509Authorities(cfg.BootstrapBundlePath, cfg.BootstrapBundleFormat, endpointTD)
 	if err != nil {
-		return nil, fmt.Errorf("can't perform SPIFFE Authentication: %w", err)
+		return nil, false, fmt.Errorf("can't perform SPIFFE Authentication: %w", err)
 	}
-	return certs, nil
+	return certs, true, nil
 }
 
 func fetchBundleIfExists(ctx context.Context, ds datastore.DataStore, trustDomain spiffeid.TrustDomain) (*spiffebundle.Bundle, error) {

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -6,12 +6,17 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/spire/pkg/common/bundleutil"
+	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/pkg/server/datastore"
+	"github.com/spiffe/spire/proto/spire/common"
 	"github.com/spiffe/spire/test/fakes/fakedatastore"
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +44,8 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 		storedBundle *spiffebundle.Bundle
 		// the fake endpoint client
 		client fakeClient
+		// optional bootstrap bundle path
+		bootstrapPath string
 		// the expected error returned from Update()
 		err string
 	}{
@@ -46,6 +53,32 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 			name:        "providing no bundle",
 			trustDomain: trustDomain,
 			err:         "local copy of bundle not found",
+		},
+		{
+			name:           "bootstraps first fetch when local bundle is missing",
+			trustDomain:    trustDomain,
+			bootstrapPath:  writeBootstrapPEM(t, bundle1.X509Authorities()[0]),
+			endpointBundle: bundle2,
+			storedBundle:   bundle2,
+			client: fakeClient{
+				bundle: bundle2,
+			},
+		},
+		{
+			name:          "bootstrap path is ignored when local bundle exists",
+			trustDomain:   trustDomain,
+			localBundle:   bundle1,
+			bootstrapPath: filepath.Join(t.TempDir(), "missing.pem"),
+			storedBundle:  bundle1,
+			client: fakeClient{
+				bundle: bundle1,
+			},
+		},
+		{
+			name:          "missing bootstrap file",
+			trustDomain:   trustDomain,
+			bootstrapPath: filepath.Join(t.TempDir(), "missing.pem"),
+			err:           "failed to load bootstrap bundle",
 		},
 		{
 			name:           "bundle has no changes",
@@ -99,6 +132,7 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 					EndpointProfile: HTTPSSPIFFEProfile{
 						EndpointSPIFFEID: trustDomain.ID(),
 					},
+					BootstrapBundlePath: testCase.bootstrapPath,
 				},
 				newClientHook: func(client ClientConfig) (Client, error) {
 					return testCase.client, nil
@@ -147,6 +181,58 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 	}
 }
 
+func TestBundleUpdaterBootstrapCreateOnly(t *testing.T) {
+	bootstrapCA := createCACertificate(t, "bootstrap")
+	fetched := spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{createCACertificate(t, "fetched")})
+	changed := spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{createCACertificate(t, "changed")})
+	current := fetched
+
+	ds := &countingDataStore{DataStore: fakedatastore.New(t)}
+	updater := NewBundleUpdater(BundleUpdaterConfig{
+		DataStore:   ds,
+		TrustDomain: trustDomain,
+		TrustDomainConfig: TrustDomainConfig{
+			EndpointURL: "ENDPOINT_ADDRESS",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: trustDomain.ID(),
+			},
+			BootstrapBundlePath: writeBootstrapPEM(t, bootstrapCA),
+		},
+		newClientHook: func(ClientConfig) (Client, error) {
+			return fakeClient{bundle: current}, nil
+		},
+	})
+
+	_, endpointBundle, err := updater.UpdateBundle(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, endpointBundle)
+	require.Equal(t, 1, ds.creates)
+	require.Equal(t, 0, ds.sets)
+
+	current = changed
+	_, endpointBundle, err = updater.UpdateBundle(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, endpointBundle)
+	require.Equal(t, 1, ds.creates)
+	require.Equal(t, 1, ds.sets)
+}
+
+type countingDataStore struct {
+	datastore.DataStore
+	creates int
+	sets    int
+}
+
+func (d *countingDataStore) CreateBundle(ctx context.Context, b *common.Bundle) (*common.Bundle, error) {
+	d.creates++
+	return d.DataStore.CreateBundle(ctx, b)
+}
+
+func (d *countingDataStore) SetBundle(ctx context.Context, b *common.Bundle) (*common.Bundle, error) {
+	d.sets++
+	return d.DataStore.SetBundle(ctx, b)
+}
+
 func TestBundleUpdaterConfiguration(t *testing.T) {
 	configs := []TrustDomainConfig{
 		{
@@ -186,6 +272,13 @@ type fakeClient struct {
 
 func (c fakeClient) FetchBundle(context.Context) (*spiffebundle.Bundle, error) {
 	return c.bundle, c.err
+}
+
+func writeBootstrapPEM(t *testing.T, cert *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "bootstrap.pem")
+	require.NoError(t, os.WriteFile(path, pemutil.EncodeCertificate(cert), 0600))
+	return path
 }
 
 func createCACertificate(t *testing.T, cn string) *x509.Certificate {

--- a/pkg/server/bundle/client/updater_test.go
+++ b/pkg/server/bundle/client/updater_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spiffe/spire/test/spiretest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBundleUpdaterUpdateBundle(t *testing.T) {
@@ -46,6 +48,8 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 		client fakeClient
 		// optional bootstrap bundle path
 		bootstrapPath string
+		// if set, the SPIFFE auth roots passed to the client must be this cert
+		wantRootCA *x509.Certificate
 		// the expected error returned from Update()
 		err string
 	}{
@@ -58,6 +62,7 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 			name:           "bootstraps first fetch when local bundle is missing",
 			trustDomain:    trustDomain,
 			bootstrapPath:  writeBootstrapPEM(t, bundle1.X509Authorities()[0]),
+			wantRootCA:     bundle1.X509Authorities()[0],
 			endpointBundle: bundle2,
 			storedBundle:   bundle2,
 			client: fakeClient{
@@ -135,6 +140,11 @@ func TestBundleUpdaterUpdateBundle(t *testing.T) {
 					BootstrapBundlePath: testCase.bootstrapPath,
 				},
 				newClientHook: func(client ClientConfig) (Client, error) {
+					if testCase.wantRootCA != nil {
+						require.NotNil(t, client.SPIFFEAuth)
+						require.Len(t, client.SPIFFEAuth.RootCAs, 1)
+						require.Equal(t, testCase.wantRootCA.Raw, client.SPIFFEAuth.RootCAs[0].Raw)
+					}
 					return testCase.client, nil
 				},
 			})
@@ -231,6 +241,132 @@ func (d *countingDataStore) CreateBundle(ctx context.Context, b *common.Bundle) 
 func (d *countingDataStore) SetBundle(ctx context.Context, b *common.Bundle) (*common.Bundle, error) {
 	d.sets++
 	return d.DataStore.SetBundle(ctx, b)
+}
+
+func TestBundleUpdaterBootstrapCreateAlreadyExists(t *testing.T) {
+	fetched := spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{createCACertificate(t, "fetched")})
+	ds := &alreadyExistsDataStore{}
+	updater := NewBundleUpdater(BundleUpdaterConfig{
+		DataStore:   ds,
+		TrustDomain: trustDomain,
+		TrustDomainConfig: TrustDomainConfig{
+			EndpointURL: "ENDPOINT_ADDRESS",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: trustDomain.ID(),
+			},
+			BootstrapBundlePath: writeBootstrapPEM(t, createCACertificate(t, "bootstrap")),
+		},
+		newClientHook: func(ClientConfig) (Client, error) {
+			return fakeClient{bundle: fetched}, nil
+		},
+	})
+
+	localBundle, endpointBundle, err := updater.UpdateBundle(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, localBundle)
+	require.Nil(t, endpointBundle)
+	require.Equal(t, 1, ds.creates)
+	require.Equal(t, 0, ds.sets)
+}
+
+func TestBundleUpdaterBootstrapDoesNotOverwriteIfBundleAppears(t *testing.T) {
+	stored := spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{createCACertificate(t, "stored")})
+	storedProto, err := bundleutil.SPIFFEBundleToProto(stored)
+	require.NoError(t, err)
+	fetched := spiffebundle.FromX509Authorities(trustDomain, []*x509.Certificate{createCACertificate(t, "fetched")})
+
+	ds := &authMissThenPresentDataStore{present: storedProto}
+	updater := NewBundleUpdater(BundleUpdaterConfig{
+		DataStore:   ds,
+		TrustDomain: trustDomain,
+		TrustDomainConfig: TrustDomainConfig{
+			EndpointURL: "ENDPOINT_ADDRESS",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: trustDomain.ID(),
+			},
+			BootstrapBundlePath: writeBootstrapPEM(t, createCACertificate(t, "bootstrap")),
+		},
+		newClientHook: func(ClientConfig) (Client, error) {
+			return fakeClient{bundle: fetched}, nil
+		},
+	})
+
+	localBundle, endpointBundle, err := updater.UpdateBundle(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, localBundle)
+	require.Nil(t, endpointBundle)
+	require.Equal(t, 1, ds.creates)
+	require.Equal(t, 0, ds.sets)
+	require.Equal(t, storedProto, ds.present)
+}
+
+func TestBundleUpdaterBootstrapRequiresSelfServingEndpoint(t *testing.T) {
+	other := spiffeid.RequireTrustDomainFromString("other.test")
+	ds := fakedatastore.New(t)
+	updater := NewBundleUpdater(BundleUpdaterConfig{
+		DataStore:   ds,
+		TrustDomain: trustDomain,
+		TrustDomainConfig: TrustDomainConfig{
+			EndpointURL: "ENDPOINT_ADDRESS",
+			EndpointProfile: HTTPSSPIFFEProfile{
+				EndpointSPIFFEID: other.ID(),
+			},
+			BootstrapBundlePath: writeBootstrapPEM(t, createCACertificate(t, "bootstrap")),
+		},
+		newClientHook: func(ClientConfig) (Client, error) {
+			t.Fatal("client must not be created when bootstrap is not self-serving")
+			return nil, errors.New("unreachable")
+		},
+	})
+
+	_, _, err := updater.UpdateBundle(context.Background())
+	spiretest.RequireErrorContains(t, err, "local copy of bundle not found")
+}
+
+type alreadyExistsDataStore struct {
+	datastore.DataStore
+	creates int
+	sets    int
+}
+
+func (d *alreadyExistsDataStore) FetchBundle(context.Context, string) (*common.Bundle, error) {
+	return nil, nil
+}
+
+func (d *alreadyExistsDataStore) CreateBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	d.creates++
+	return nil, status.Error(codes.AlreadyExists, "already exists")
+}
+
+func (d *alreadyExistsDataStore) SetBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	d.sets++
+	return nil, errors.New("SetBundle must not run")
+}
+
+type authMissThenPresentDataStore struct {
+	datastore.DataStore
+	present *common.Bundle
+	fetches int
+	creates int
+	sets    int
+}
+
+func (d *authMissThenPresentDataStore) FetchBundle(context.Context, string) (*common.Bundle, error) {
+	d.fetches++
+	if d.fetches == 1 {
+		return nil, nil
+	}
+	return d.present, nil
+}
+
+func (d *authMissThenPresentDataStore) CreateBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	d.creates++
+	return nil, status.Error(codes.AlreadyExists, "already exists")
+}
+
+func (d *authMissThenPresentDataStore) SetBundle(context.Context, *common.Bundle) (*common.Bundle, error) {
+	d.sets++
+	return nil, errors.New("SetBundle must not run")
 }
 
 func TestBundleUpdaterConfiguration(t *testing.T) {


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

SPIRE Server federation (`federates_with`). Optional config; default behavior is unchanged.

**Description of change**

https_spiffe federation currently fails with `local copy of bundle not found` until someone runs `spire-server bundle set`. Following the design on #6322, this adds `bootstrap_bundle_path` (and optional `bootstrap_bundle_format`, default `pem`) so the first fetch can authenticate from a file when the datastore has no bundle.

The fetched bundle is stored with create, not update. Later polls use the stored copy. The path is not watched. Rejected on `https_web` and when the endpoint SPIFFE ID is outside the federated trust domain.

**Which issue this PR fixes**

Fixes #6322

**Test plan**

- [x] `go test ./pkg/server/bundle/client/ ./cmd/spire-server/cli/run/`
- [x] `make lint`