### PR TITLE
Multi region kms keys

### DIFF
--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -15,6 +15,7 @@ The plugin accepts the following configuration options:
 | key_identifier_value             | string  | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                 |                                                         |
 | key_policy_file                  | string  | no                                          | A file path location to a custom key policy in JSON format                                                                | ""                                                      |
 | enable_tag_based_key_discovery   | boolean | no                                          | Enable tag-based key discovery (recommended). See [Tag-based Key Discovery](#tag-based-key-discovery).                    | false                                                   |
+| multi_region                     | boolean | no                                          | Create new keys as [multi-Region keys](#multi-region-keys). Replication is not performed by SPIRE.                        | false                                                   |
 
 ### Server Instance Identification
 
@@ -93,6 +94,43 @@ The plugin validates all user-defined tags during configuration. If any tag viol
 **Tag lifecycle**
 When the `key_tags` configuration block is updated, only newly created keys will be tagged with the new configuration. Existing keys will not have their tags updated.
 
+### Multi-Region Keys
+
+Setting `multi_region` to `true` causes the plugin to create new keys as AWS
+[multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html).
+Such a key is a multi-Region _primary_ key that is eligible to be replicated
+into other regions, where the resulting replica shares its key ID and key
+material and can therefore produce interchangeable signatures.
+
+Enabling this setting does not, on its own, provide cross-region failover.
+Some important caveats:
+
+- AWS never replicates keys on its own, and neither does SPIRE. Creating a
+  replica in another region is left to the operator, via `ReplicateKey`.
+- Aliases and tags are _independent_ properties of multi-Region keys and are
+  not copied to replicas. A replica is therefore not discoverable by this
+  plugin in its region, under either discovery mode, until an equivalent
+  alias or tag set is created alongside it there.
+- Key policies are independent too. `ReplicateKey` attaches the AWS default
+  key policy unless one is supplied, so the policy this plugin applies —
+  whether from `key_policy_file` or the generated default described under
+  [Key policy](#key-policy) — is not carried over, and an equivalent policy
+  must be supplied for each replica or the plugin will be denied access to
+  it.
+- The plugin creates a new key each time the SPIRE server rotates, so a
+  replica reflects the key that existed when it was created and does not
+  track subsequent rotations.
+- A key's multi-Region property cannot be changed after creation. Enabling
+  this setting affects only keys created from that point on; existing keys
+  are replaced as the server rotates.
+
+Creating a multi-Region primary key requires `iam:CreateServiceLinkedRole` in
+addition to `kms:CreateKey`; see [AWS KMS Access](#aws-kms-access). Replicating
+that key additionally requires `kms:ReplicateKey` on the primary key, granted
+in its key policy, and `kms:CreateKey` in an IAM policy in the replica region —
+plus `kms:TagResource` there if the replica is tagged. Those replication
+permissions are needed by whoever performs the replication, not by this plugin.
+
 ### AWS KMS Access
 
 Access to AWS KMS can be given by either setting the `access_key_id` and `secret_access_key`, or by ensuring that the plugin runs on an EC2 instance with a given IAM role that has a specific set of permissions.
@@ -111,13 +149,16 @@ The IAM role must have an attached policy with the following permissions:
 
 The following additional permissions are required depending on the configuration:
 
-| Permission         | Required when                                                           |
-|--------------------|-------------------------------------------------------------------------|
-| `kms:ListKeys`     | Using alias-based key discovery (current default)                       |
-| `kms:TagResource`  | Using tag-based key discovery or `key_tags`                             |
-| `tag:GetResources` | Using tag-based key discovery (`enable_tag_based_key_discovery = true`) |
+| Permission                    | Required when                                                           |
+|-------------------------------|-------------------------------------------------------------------------|
+| `kms:ListKeys`                | Using alias-based key discovery (current default)                       |
+| `kms:TagResource`             | Using tag-based key discovery or `key_tags`                             |
+| `tag:GetResources`            | Using tag-based key discovery (`enable_tag_based_key_discovery = true`) |
+| `iam:CreateServiceLinkedRole` | Creating multi-Region keys (`multi_region = true`)                      |
 
 `tag:GetResources` belongs to the Resource Groups Tagging API, not to KMS. It is an identity-based permission and must be granted in the IAM identity's policy. It cannot be granted through the KMS key policy (including the default policy generated by the plugin).
+
+`iam:CreateServiceLinkedRole` is likewise an identity-based permission and cannot be granted through a key policy. AWS KMS requires it from any principal creating a multi-Region primary key, so that it can create the `AWSServiceRoleForKeyManagementServiceMultiRegionKeys` role used to synchronize shared properties between related keys. Without it, `CreateKey` fails when `multi_region` is enabled.
 
 ### Key policy
 

--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -15,7 +15,8 @@ The plugin accepts the following configuration options:
 | key_identifier_value             | string  | Required if key_identifier_file is not set  | A static identifier for the SPIRE server instance (used instead of `key_identifier_file`)                                 |                                                         |
 | key_policy_file                  | string  | no                                          | A file path location to a custom key policy in JSON format                                                                | ""                                                      |
 | enable_tag_based_key_discovery   | boolean | no                                          | Enable tag-based key discovery (recommended). See [Tag-based Key Discovery](#tag-based-key-discovery).                    | false                                                   |
-| multi_region                     | boolean | no                                          | Create new keys as [multi-Region keys](#multi-region-keys). Replication is not performed by SPIRE.                        | false                                                   |
+| multi_region                     | boolean | no                                          | Create new keys as [multi-Region keys](#multi-region-keys).                                                               | false                                                   |
+| replica_regions                  | list    | no                                          | Regions that each new key is replicated into. Requires `multi_region`. See [Multi-Region Keys](#multi-region-keys).       | []                                                      |
 
 ### Server Instance Identification
 
@@ -102,34 +103,53 @@ Such a key is a multi-Region _primary_ key that is eligible to be replicated
 into other regions, where the resulting replica shares its key ID and key
 material and can therefore produce interchangeable signatures.
 
-Enabling this setting does not, on its own, provide cross-region failover.
-Some important caveats:
+`multi_region` on its own only makes keys eligible; AWS never replicates a key
+by itself. Listing regions in `replica_regions` additionally makes the plugin
+replicate each new key into those regions and create the alias — and, under
+tag-based discovery, the tags — that a SPIRE server running there needs in
+order to find it. Aliases and tags are _independent_ properties of multi-Region
+keys, so AWS does not copy them and the plugin must create them per region.
 
-- AWS never replicates keys on its own, and neither does SPIRE. Creating a
-  replica in another region is left to the operator, via `ReplicateKey`.
-- Aliases and tags are _independent_ properties of multi-Region keys and are
-  not copied to replicas. A replica is therefore not discoverable by this
-  plugin in its region, under either discovery mode, until an equivalent
-  alias or tag set is created alongside it there.
-- Key policies are independent too. `ReplicateKey` attaches the AWS default
-  key policy unless one is supplied, so the policy this plugin applies —
-  whether from `key_policy_file` or the generated default described under
-  [Key policy](#key-policy) — is not carried over, and an equivalent policy
-  must be supplied for each replica or the plugin will be denied access to
-  it.
-- The plugin creates a new key each time the SPIRE server rotates, so a
-  replica reflects the key that existed when it was created and does not
-  track subsequent rotations.
-- A key's multi-Region property cannot be changed after creation. Enabling
-  this setting affects only keys created from that point on; existing keys
-  are replaced as the server rotates.
+Replication happens asynchronously on a retrying queue per replica region. Key
+generation is on the CA rotation path, so it never blocks on a replica region: a
+region that is temporarily unreachable is retried with a backoff while the SPIRE
+server continues to operate normally, and because each region has its own queue,
+one unreachable region does not delay replication into the others. When a key is rotated, the
+replica it displaced is deleted only after the alias in that region has been
+repointed, so the alias never targets a key that is pending deletion.
 
-Creating a multi-Region primary key requires `iam:CreateServiceLinkedRole` in
-addition to `kms:CreateKey`; see [AWS KMS Access](#aws-kms-access). Replicating
-that key additionally requires `kms:ReplicateKey` on the primary key, granted
-in its key policy, and `kms:CreateKey` in an IAM policy in the replica region —
-plus `kms:TagResource` there if the replica is tagged. Those replication
-permissions are needed by whoever performs the replication, not by this plugin.
+#### Limitations
+
+This supports promote-then-start disaster recovery with a **cold standby**. It
+is not active-active, and the following constraints apply.
+
+- **Do not run a SPIRE server in a replica region while the primary is
+  running.** A failover server must reuse the primary's `key_identifier_value`
+  in order to find the replicated aliases, which means both servers would
+  discover the same keys and resolve to the same CA journal record, and would
+  then rotate against each other. Note that this conflicts with the guidance
+  under [Server Instance Identification](#server-instance-identification) that
+  the identifier is unique per server; a primary and its standby are the
+  exception, and only one of them may run at a time.
+- **The datastore in the failover region must be writable before the server
+  starts.** SPIRE server startup writes, so a read-only replica database cannot
+  host a running server.
+- **Replication is not a precondition for use of a key.** The plugin has no way
+  to tell the SPIRE server that a key has not yet reached a replica region, so
+  a CA may be prepared and activated while replication is still outstanding or
+  failing. Sustained replication failures are logged but do not otherwise
+  surface.
+- **A key's multi-Region property cannot be changed after creation.** Enabling
+  `multi_region` affects only keys created from that point on, and keys created
+  earlier are never replicated. The server replaces them as it rotates, so a
+  deployment converges within roughly a day, during which the replica regions
+  have partial coverage.
+- **Key policies are not replicated.** `ReplicateKey` attaches the AWS default
+  key policy unless one is supplied, so the policy this plugin applies — whether
+  from `key_policy_file` or the generated default described under
+  [Key policy](#key-policy) — does not carry over to a replica.
+- **Cost and quota scale with the number of regions**, since each rotation
+  creates a key in the primary region and one in every replica region.
 
 ### AWS KMS Access
 
@@ -149,14 +169,17 @@ The IAM role must have an attached policy with the following permissions:
 
 The following additional permissions are required depending on the configuration:
 
-| Permission                    | Required when                                                           |
-|-------------------------------|-------------------------------------------------------------------------|
-| `kms:ListKeys`                | Using alias-based key discovery (current default)                       |
-| `kms:TagResource`             | Using tag-based key discovery or `key_tags`                             |
-| `tag:GetResources`            | Using tag-based key discovery (`enable_tag_based_key_discovery = true`) |
-| `iam:CreateServiceLinkedRole` | Creating multi-Region keys (`multi_region = true`)                      |
+| Permission                    | Required when                                                               |
+|-------------------------------|-----------------------------------------------------------------------------|
+| `kms:ListKeys`                | Using alias-based key discovery (current default)                           |
+| `kms:TagResource`             | Using tag-based key discovery or `key_tags`                                 |
+| `tag:GetResources`            | Using tag-based key discovery (`enable_tag_based_key_discovery = true`)     |
+| `iam:CreateServiceLinkedRole` | Creating multi-Region keys (`multi_region = true`)                          |
+| `kms:ReplicateKey`            | Replicating keys (`replica_regions`); on the primary key, in its key policy |
 
 `tag:GetResources` belongs to the Resource Groups Tagging API, not to KMS. It is an identity-based permission and must be granted in the IAM identity's policy. It cannot be granted through the KMS key policy (including the default policy generated by the plugin).
+
+When `replica_regions` is configured, the identity also needs permissions in each replica region, because the plugin creates and maintains resources there directly: `kms:CreateKey` (which `ReplicateKey` requires in the destination region), `kms:CreateAlias`, `kms:UpdateAlias`, `kms:DescribeKey`, and `kms:ScheduleKeyDeletion` to remove replicas displaced by rotation. Add `kms:TagResource` there as well when tag-based discovery or `key_tags` is in use.
 
 `iam:CreateServiceLinkedRole` is likewise an identity-based permission and cannot be granted through a key policy. AWS KMS requires it from any principal creating a multi-Region primary key, so that it can create the `AWSServiceRoleForKeyManagementServiceMultiRegionKeys` role used to synchronize shared properties between related keys. Without it, `CreateKey` fails when `multi_region` is enabled.
 

--- a/doc/plugin_server_keymanager_aws_kms.md
+++ b/doc/plugin_server_keymanager_aws_kms.md
@@ -93,7 +93,11 @@ When using key tagging, you must add the `kms:TagResource` permission to the IAM
 The plugin validates all user-defined tags during configuration. If any tag violates AWS KMS tagging constraints, the plugin will fail to configure and report a detailed error message indicating the specific validation failure.
 
 **Tag lifecycle**
-When the `key_tags` configuration block is updated, only newly created keys will be tagged with the new configuration. Existing keys will not have their tags updated.
+When the `key_tags` configuration block is updated, newly-created primary keys
+use the new configuration, but existing primary keys are not updated. Current
+replicas in `replica_regions` are reconciled during configuration, so the plugin
+applies the configured tag values to them again; tags that were removed from
+the configuration are not removed from existing replicas.
 
 ### Multi-Region Keys
 
@@ -105,18 +109,27 @@ material and can therefore produce interchangeable signatures.
 
 `multi_region` on its own only makes keys eligible; AWS never replicates a key
 by itself. Listing regions in `replica_regions` additionally makes the plugin
-replicate each new key into those regions and create the alias — and, under
-tag-based discovery, the tags — that a SPIRE server running there needs in
-order to find it. Aliases and tags are _independent_ properties of multi-Region
-keys, so AWS does not copy them and the plugin must create them per region.
+replicate each current and newly-created multi-Region primary key into those
+regions, then apply the description, policy, alias, and tags that the replica
+needs. These properties are _independent_ properties of multi-Region keys, so
+AWS does not copy or synchronize them between regions.
 
 Replication happens asynchronously on a retrying queue per replica region. Key
 generation is on the CA rotation path, so it never blocks on a replica region: a
 region that is temporarily unreachable is retried with a backoff while the SPIRE
 server continues to operate normally, and because each region has its own queue,
-one unreachable region does not delay replication into the others. When a key is rotated, the
-replica it displaced is deleted only after the alias in that region has been
-repointed, so the alias never targets a key that is pending deletion.
+one unreachable region does not delay replication into the others. The plugin
+also queues existing multi-Region primary keys during configuration, so a
+restart, reconfiguration, or newly-added replica region does not need to wait
+for the next key rotation. Existing single-Region keys and keys that are already
+replicas are not queued.
+
+AWS initially creates a replica in the `Creating` state, during which KMS allows
+its alias to be assigned even though the key cannot sign. The plugin waits for
+the replica to become `Enabled` before moving the alias. When a key is rotated,
+the replica that the destination alias actually displaced is deleted only after
+the alias has been repointed, so the alias never targets a key that is pending
+deletion.
 
 #### Limitations
 
@@ -144,10 +157,10 @@ is not active-active, and the following constraints apply.
   earlier are never replicated. The server replaces them as it rotates, so a
   deployment converges within roughly a day, during which the replica regions
   have partial coverage.
-- **Key policies are not replicated.** `ReplicateKey` attaches the AWS default
-  key policy unless one is supplied, so the policy this plugin applies — whether
-  from `key_policy_file` or the generated default described under
-  [Key policy](#key-policy) — does not carry over to a replica.
+- **Key policy changes are not synchronized after creation.** The plugin supplies
+  the policy configured by `key_policy_file`, or its generated default policy,
+  when it creates each replica. However, AWS still treats each replica policy as
+  independent, so an out-of-band policy change must be applied in every region.
 - **Cost and quota scale with the number of regions**, since each rotation
   creates a key in the primary region and one in every replica region.
 

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -118,6 +118,9 @@ type Plugin struct {
 
 	// useTagBasedDiscovery indicates whether to use tag-based or alias-based key discovery
 	useTagBasedDiscovery bool
+
+	// multiRegion indicates whether new keys are created as multi-Region keys
+	multiRegion bool
 }
 
 // Config provides configuration context for the plugin
@@ -143,6 +146,20 @@ type Config struct {
 	// Note: When enabled, the plugin requires the tag:GetResources IAM
 	// permission (from the AWS Resource Groups Tagging API).
 	EnableTagBasedKeyDiscovery bool `hcl:"enable_tag_based_key_discovery" json:"enable_tag_based_key_discovery"`
+
+	// MultiRegion creates new keys as AWS multi-Region keys, which are
+	// eligible to be replicated to other regions. AWS never replicates keys
+	// on its own, and neither does SPIRE: replicating the key and creating
+	// the corresponding alias or tags in each replica region is left to the
+	// operator. Aliases and tags are not shared properties of multi-Region
+	// keys, so a replica is not discoverable by this plugin in its region
+	// until they are created there.
+	//
+	// A key cannot be converted after creation, so this only affects keys
+	// created from the point it is enabled.
+	//
+	// Default: false
+	MultiRegion bool `hcl:"multi_region" json:"multi_region"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
@@ -315,6 +332,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	p.trustDomain = req.CoreConfiguration.TrustDomain
 	p.serverID = serverID
 	p.useTagBasedDiscovery = useTagBasedDiscovery
+	p.multiRegion = newConfig.MultiRegion
 
 	// Build the tag list applied to every new key. SPIRE-specific tags are
 	// only included when tag-based discovery is enabled, so that the legacy
@@ -486,6 +504,7 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		KeyUsage:    types.KeyUsageTypeSignVerify,
 		KeySpec:     keySpec,
 		Policy:      p.keyPolicy,
+		MultiRegion: aws.Bool(p.multiRegion),
 	}
 
 	if p.useTagBasedDiscovery {

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -41,6 +41,10 @@ const (
 	keyArnTag    = "key_arn"
 	aliasNameTag = "alias_name"
 	reasonTag    = "reason"
+	replicaTag   = "replica_region"
+
+	// replicateQueueDepth bounds the per-region replication backlog.
+	replicateQueueDepth = 120
 
 	// KMS resource tags for key discovery
 	tagKeyServerTD   = "spire-server-td"   // Trust domain (no hashing needed - AWS allows dots and long values)
@@ -95,6 +99,7 @@ type pluginHooks struct {
 	disposeAliasesSignal chan error
 	disposeKeysSignal    chan error
 	keepActiveKeysSignal chan error
+	replicateSignal      chan error
 }
 
 // Plugin is the main representation of this keymanager plugin
@@ -121,6 +126,28 @@ type Plugin struct {
 
 	// multiRegion indicates whether new keys are created as multi-Region keys
 	multiRegion bool
+
+	// replicate carries keys awaiting replication, one queue per replica
+	// region. Queues are kept separate so that an unreachable region only
+	// delays its own replication rather than every region's.
+	replicate map[string]chan replicateRequest
+}
+
+// replicateRequest describes a newly created multi-Region primary key that
+// must be replicated into every configured replica region, along with the
+// metadata each replica needs in order to be discoverable in its own region.
+// Aliases and tags are independent properties of multi-Region keys, so AWS
+// does not copy them and the plugin must recreate them per region.
+type replicateRequest struct {
+	spireKeyID string
+	keyArn     string
+	aliasName  string
+	tags       []types.Tag
+
+	// supersededKeyArn is the key this one replaces, empty on first creation.
+	// Its replicas are deleted only after the alias in each replica region has
+	// been repointed, so the alias never targets a key pending deletion.
+	supersededKeyArn string
 }
 
 // Config provides configuration context for the plugin
@@ -148,18 +175,24 @@ type Config struct {
 	EnableTagBasedKeyDiscovery bool `hcl:"enable_tag_based_key_discovery" json:"enable_tag_based_key_discovery"`
 
 	// MultiRegion creates new keys as AWS multi-Region keys, which are
-	// eligible to be replicated to other regions. AWS never replicates keys
-	// on its own, and neither does SPIRE: replicating the key and creating
-	// the corresponding alias or tags in each replica region is left to the
-	// operator. Aliases and tags are not shared properties of multi-Region
-	// keys, so a replica is not discoverable by this plugin in its region
-	// until they are created there.
+	// eligible to be replicated to other regions. AWS never replicates a key
+	// on its own; set ReplicaRegions to have the plugin do it, along with the
+	// alias and tags each replica needs to be discoverable in its own region.
+	// With MultiRegion alone the keys are merely eligible.
 	//
 	// A key cannot be converted after creation, so this only affects keys
 	// created from the point it is enabled.
 	//
 	// Default: false
 	MultiRegion bool `hcl:"multi_region" json:"multi_region"`
+
+	// ReplicaRegions are the regions that each new multi-Region key is
+	// replicated into. Replication is performed asynchronously and retried,
+	// so a temporarily unreachable region does not block key generation.
+	// Requires MultiRegion to be enabled.
+	//
+	// Default: none
+	ReplicaRegions []string `hcl:"replica_regions" json:"replica_regions"`
 }
 
 func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginconf.Status) *Config {
@@ -192,6 +225,25 @@ func buildConfig(coreConfig catalog.CoreConfig, hclText string, status *pluginco
 
 	if newConfig.KeyIdentifierFile != "" && newConfig.KeyIdentifierValue != "" {
 		status.ReportError("configuration can't have a key identifier file and a key identifier value at the same time")
+	}
+
+	if len(newConfig.ReplicaRegions) > 0 && !newConfig.MultiRegion {
+		status.ReportError("replica_regions requires multi_region to be enabled")
+	}
+
+	seenReplicaRegions := make(map[string]struct{}, len(newConfig.ReplicaRegions))
+	for _, region := range newConfig.ReplicaRegions {
+		switch region {
+		case "":
+			status.ReportError("replica_regions must not contain an empty region")
+		case newConfig.Region:
+			status.ReportErrorf("replica region %q must be different from the configured region", region)
+		default:
+			if _, ok := seenReplicaRegions[region]; ok {
+				status.ReportErrorf("replica region %q is duplicated", region)
+			}
+			seenReplicaRegions[region] = struct{}{}
+		}
 	}
 
 	if len(newConfig.KeyTags) > 0 {
@@ -255,7 +307,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	}
 	p.log.Debug("Loaded server id", "server_id", serverID)
 
-	awsCfg, err := newAWSConfig(ctx, newConfig)
+	awsCfg, err := newAWSConfig(ctx, newConfig, newConfig.Region)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create client configuration: %v", err)
 	}
@@ -268,6 +320,24 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	kc, err := p.hooks.newKMSClient(awsCfg)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to create KMS client: %v", err)
+	}
+
+	// A client per replica region. Aliases are region-local resources, so the
+	// plugin needs to reach each replica region directly to make the replica
+	// discoverable there and to clean it up on rotation.
+	replicaClients := make(map[string]kmsClient, len(newConfig.ReplicaRegions))
+	replicateQueues := make(map[string]chan replicateRequest, len(newConfig.ReplicaRegions))
+	for _, region := range newConfig.ReplicaRegions {
+		replicaCfg, err := newAWSConfig(ctx, newConfig, region)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to load AWS config for replica region %q: %v", region, err)
+		}
+		rc, err := p.hooks.newKMSClient(replicaCfg)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to create KMS client for replica region %q: %v", region, err)
+		}
+		replicaClients[region] = rc
+		replicateQueues[region] = make(chan replicateRequest, replicateQueueDepth)
 	}
 
 	// Determine which discovery mode to use
@@ -333,6 +403,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	p.serverID = serverID
 	p.useTagBasedDiscovery = useTagBasedDiscovery
 	p.multiRegion = newConfig.MultiRegion
+	p.replicate = replicateQueues
 
 	// Build the tag list applied to every new key. SPIRE-specific tags are
 	// only included when tag-based discovery is enabled, so that the legacy
@@ -360,6 +431,9 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	// Start background tasks based on discovery mode
 	ctx, p.cancelTasks = context.WithCancel(context.Background())
 	go p.scheduleDeleteTask(ctx)
+	for region, replicaClient := range replicaClients {
+		go p.replicateTask(ctx, region, replicaClient, replicateQueues[region])
+	}
 
 	// Always refresh aliases so a downgrade to a version without
 	// tag-based discovery still finds keys with fresh aliases.
@@ -398,6 +472,8 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 	defer p.mu.Unlock()
 
 	spireKeyID := req.KeyId
+	supersededEntry, hasSuperseded := p.entries[spireKeyID]
+
 	newKeyEntry, err := p.createKey(ctx, spireKeyID, req.KeyType)
 	if err != nil {
 		return nil, err
@@ -409,6 +485,12 @@ func (p *Plugin) GenerateKey(ctx context.Context, req *keymanagerv1.GenerateKeyR
 	}
 
 	p.entries[spireKeyID] = *newKeyEntry
+
+	var supersededKeyArn string
+	if hasSuperseded {
+		supersededKeyArn = supersededEntry.Arn
+	}
+	p.enqueueReplication(spireKeyID, newKeyEntry, supersededKeyArn)
 
 	return &keymanagerv1.GenerateKeyResponse{
 		PublicKey: newKeyEntry.PublicKey,
@@ -484,6 +566,41 @@ func (p *Plugin) GetPublicKeys(context.Context, *keymanagerv1.GetPublicKeysReque
 	return &keymanagerv1.GetPublicKeysResponse{PublicKeys: keys}, nil
 }
 
+// tagsForKey returns the tags applied to a key belonging to the given SPIRE
+// key ID. Replicas are tagged with the same set, so this must stay the single
+// source of truth: a replica missing spire-key-id satisfies the tag-based
+// discovery filter but cannot be mapped back to a SPIRE key, and is silently
+// discarded in the replica region. The caller must hold p.mu.
+func (p *Plugin) tagsForKey(spireKeyID string) []types.Tag {
+	if !p.useTagBasedDiscovery {
+		// Legacy alias-based mode: only apply user-defined tags (if any).
+		if len(p.keyTags) == 0 {
+			return nil
+		}
+		return append([]types.Tag(nil), p.keyTags...)
+	}
+
+	// When tag-based discovery is enabled, append the per-key SPIRE key ID tag
+	// so the key can be looked up by ID via the tagging API, and stamp
+	// spire-last-update so the key is immediately eligible for staleness
+	// evaluation. Stamping at creation (rather than waiting for the first
+	// keepActiveKeys tick) ensures a key is never left with spire-active=true
+	// but no spire-last-update, which would make it undisposable by other
+	// servers if this server dies before that tick.
+	tags := make([]types.Tag, len(p.keyTags), len(p.keyTags)+2)
+	copy(tags, p.keyTags)
+	return append(tags,
+		types.Tag{
+			TagKey:   aws.String(tagKeySPIREKeyID),
+			TagValue: aws.String(spireKeyID),
+		},
+		types.Tag{
+			TagKey:   aws.String(tagKeyLastUpdate),
+			TagValue: aws.String(strconv.FormatInt(p.hooks.clk.Now().Unix(), 10)),
+		},
+	)
+}
+
 func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keymanagerv1.KeyType) (*keyEntry, error) {
 	description := p.descriptionFromSpireKeyID(spireKeyID)
 	keySpec, ok := keySpecFromKeyType(keyType)
@@ -507,32 +624,7 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		MultiRegion: aws.Bool(p.multiRegion),
 	}
 
-	if p.useTagBasedDiscovery {
-		// When tag-based discovery is enabled, append the per-key SPIRE key
-		// ID tag so the key can be looked up by ID via the tagging API, and
-		// stamp spire-last-update so the key is immediately eligible for
-		// staleness evaluation. Stamping at creation (rather than waiting for
-		// the first keepActiveKeys tick) ensures a key is never left with
-		// spire-active=true but no spire-last-update, which would make it
-		// undisposable by other servers if this server dies before that tick.
-		// Build a fresh slice to avoid mutating the shared p.keyTags slice.
-		tags := make([]types.Tag, len(p.keyTags), len(p.keyTags)+2)
-		copy(tags, p.keyTags)
-		tags = append(tags,
-			types.Tag{
-				TagKey:   aws.String(tagKeySPIREKeyID),
-				TagValue: aws.String(spireKeyID),
-			},
-			types.Tag{
-				TagKey:   aws.String(tagKeyLastUpdate),
-				TagValue: aws.String(strconv.FormatInt(p.hooks.clk.Now().Unix(), 10)),
-			},
-		)
-		createKeyInput.Tags = tags
-	} else if len(p.keyTags) > 0 {
-		// Legacy alias-based mode: only apply user-defined tags (if any).
-		createKeyInput.Tags = p.keyTags
-	}
+	createKeyInput.Tags = p.tagsForKey(spireKeyID)
 
 	key, err := p.kmsClient.CreateKey(ctx, createKeyInput)
 	if err != nil {
@@ -606,6 +698,204 @@ func (p *Plugin) setCache(keyEntries []*keyEntry) {
 		p.entries[e.PublicKey.Id] = *e
 		p.log.Debug("Key loaded", keyArnTag, e.Arn, aliasNameTag, e.AliasName)
 	}
+}
+
+// enqueueReplication schedules replication of a newly created key into the
+// configured replica regions. It never blocks: key generation is on the CA
+// rotation path, and a key missed here is replicated again on the next
+// rotation. The caller must hold p.mu.
+func (p *Plugin) enqueueReplication(spireKeyID string, entry *keyEntry, supersededKeyArn string) {
+	if len(p.replicate) == 0 {
+		return
+	}
+
+	req := replicateRequest{
+		spireKeyID:       spireKeyID,
+		keyArn:           entry.Arn,
+		aliasName:        entry.AliasName,
+		tags:             p.tagsForKey(spireKeyID),
+		supersededKeyArn: supersededKeyArn,
+	}
+
+	for region, queue := range p.replicate {
+		select {
+		case queue <- req:
+			p.log.Debug("Key enqueued for replication", keyArnTag, entry.Arn, replicaTag, region)
+		default:
+			p.log.Error("Failed to enqueue key for replication", keyArnTag, entry.Arn, replicaTag, region, reasonTag, "queue is full")
+		}
+	}
+}
+
+// isCurrentKey reports whether the given ARN is still the key the plugin holds
+// for that SPIRE key ID.
+func (p *Plugin) isCurrentKey(spireKeyID, keyArn string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	entry, ok := p.entries[spireKeyID]
+	return ok && entry.Arn == keyArn
+}
+
+// replicateTask is a long-running task that replicates keys into a single
+// replica region, and creates the alias that region needs to make the replica
+// discoverable. There is one of these per region, so a region that is
+// unreachable delays only its own replication and does not hold up the others.
+func (p *Plugin) replicateTask(ctx context.Context, region string, replicaClient kmsClient, queue chan replicateRequest) {
+	backoffMin := 1 * time.Second
+	backoffMax := 60 * time.Second
+	backoff := backoffMin
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case req := <-queue:
+			log := p.log.With(keyArnTag, req.keyArn, replicaTag, region)
+
+			// A request retried across a rotation is stale: replicating it now
+			// would repoint the replica alias back at a superseded key. Drop it
+			// and let the request for the current key do the work.
+			if !p.isCurrentKey(req.spireKeyID, req.keyArn) {
+				log.Debug("Discarding replication of superseded key")
+				p.notifyReplicate(nil)
+				continue
+			}
+
+			keyID, ok := parseKeyIDFromArn(req.keyArn)
+			if !ok {
+				// Not retryable, so drop it rather than spinning.
+				log.Error("Unable to determine key id for replication")
+				p.notifyReplicate(nil)
+				continue
+			}
+
+			err := p.replicateKeyToRegion(ctx, req, keyID, region, replicaClient)
+			if err == nil {
+				log.Debug("Key replicated")
+				backoff = backoffMin
+				p.notifyReplicate(nil)
+				continue
+			}
+
+			log.Error("Failed to replicate key", reasonTag, err)
+			select {
+			case queue <- req:
+				log.Debug("Key re-enqueued for replication")
+			default:
+				log.Error("Failed to re-enqueue key for replication")
+			}
+			p.notifyReplicate(err)
+			backoff = min(backoff*2, backoffMax)
+			p.hooks.clk.Sleep(backoff)
+		}
+	}
+}
+
+func (p *Plugin) replicateKeyToRegion(ctx context.Context, req replicateRequest, keyID, region string, replicaClient kmsClient) error {
+	log := p.log.With(keyArnTag, req.keyArn, replicaTag, region)
+
+	var replicaArn string
+	replicaResp, err := p.kmsClient.ReplicateKey(ctx, &kms.ReplicateKeyInput{
+		KeyId:         aws.String(req.keyArn),
+		ReplicaRegion: aws.String(region),
+		Tags:          req.tags,
+	})
+
+	var alreadyExistsErr *types.AlreadyExistsException
+	switch {
+	case err == nil:
+		if replicaResp.ReplicaKeyMetadata == nil || replicaResp.ReplicaKeyMetadata.Arn == nil {
+			return errors.New("malformed replicate key response: missing replica key arn")
+		}
+		replicaArn = *replicaResp.ReplicaKeyMetadata.Arn
+		log.Debug("Replica key created")
+	case errors.As(err, &alreadyExistsErr):
+		// A replica is already present, which is the normal case when an
+		// earlier attempt created the key but failed before the alias.
+		describeResp, describeErr := replicaClient.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(keyID)})
+		if describeErr != nil {
+			return fmt.Errorf("describing existing replica: %w", describeErr)
+		}
+		if describeResp.KeyMetadata == nil || describeResp.KeyMetadata.Arn == nil {
+			return errors.New("malformed describe key response: missing replica key arn")
+		}
+		replicaArn = *describeResp.KeyMetadata.Arn
+	default:
+		return fmt.Errorf("replicating key: %w", err)
+	}
+
+	// Aliases are an independent property of multi-Region keys, so AWS does
+	// not copy them. Without one the replica is invisible to a plugin running
+	// in the replica region.
+	_, err = replicaClient.CreateAlias(ctx, &kms.CreateAliasInput{
+		AliasName:   aws.String(req.aliasName),
+		TargetKeyId: aws.String(replicaArn),
+	})
+	if err != nil {
+		if !errors.As(err, &alreadyExistsErr) {
+			return fmt.Errorf("creating replica alias: %w", err)
+		}
+		_, err = replicaClient.UpdateAlias(ctx, &kms.UpdateAliasInput{
+			AliasName:   aws.String(req.aliasName),
+			TargetKeyId: aws.String(replicaArn),
+		})
+		if err != nil {
+			return fmt.Errorf("updating replica alias: %w", err)
+		}
+	}
+
+	// Only once the alias points at the new replica is it safe to remove the
+	// one it displaced.
+	return p.deleteSupersededReplica(ctx, req, region, replicaClient)
+}
+
+// deleteSupersededReplica schedules deletion of the replica that the alias in
+// this region no longer points at. It runs only after the alias has been
+// repointed, so a server starting in the replica region never finds its alias
+// targeting a key pending deletion, which would fail plugin configuration.
+//
+// AWS will also not finish deleting a multi-Region primary while any replica of
+// it remains, so without this the superseded primary lingers in PendingDeletion
+// indefinitely.
+func (p *Plugin) deleteSupersededReplica(ctx context.Context, req replicateRequest, region string, replicaClient kmsClient) error {
+	if req.supersededKeyArn == "" {
+		return nil
+	}
+
+	supersededKeyID, ok := parseKeyIDFromArn(req.supersededKeyArn)
+	if !ok {
+		p.log.Error("Unable to determine key id for replica deletion", keyArnTag, req.supersededKeyArn)
+		return nil
+	}
+
+	_, err := replicaClient.ScheduleKeyDeletion(ctx, &kms.ScheduleKeyDeletionInput{
+		KeyId:               aws.String(supersededKeyID),
+		PendingWindowInDays: aws.Int32(7),
+	})
+
+	var notFoundErr *types.NotFoundException
+	var invalidStateErr *types.KMSInvalidStateException
+	switch {
+	case err == nil:
+		p.log.Debug("Superseded replica key scheduled for deletion", keyArnTag, req.supersededKeyArn, replicaTag, region)
+		return nil
+	case errors.As(err, &notFoundErr):
+		// Never replicated into this region, or already gone.
+		return nil
+	case errors.As(err, &invalidStateErr):
+		// Already pending deletion.
+		return nil
+	default:
+		return fmt.Errorf("scheduling superseded replica for deletion: %w", err)
+	}
+}
+
+// parseKeyIDFromArn extracts the key id from a KMS key ARN. Related multi-Region
+// keys share a key id, so a replica can be addressed by the primary's key id
+// through the replica region's client.
+func parseKeyIDFromArn(keyArn string) (string, bool) {
+	_, keyID, found := strings.Cut(keyArn, ":key/")
+	return keyID, found
 }
 
 // scheduleDeleteTask ia a long-running task that deletes keys that were rotated
@@ -964,6 +1254,12 @@ func (p *Plugin) aliasPrefixForTrustDomain() string {
 func (p *Plugin) notifyDelete(err error) {
 	if p.hooks.scheduleDeleteSignal != nil {
 		p.hooks.scheduleDeleteSignal <- err
+	}
+}
+
+func (p *Plugin) notifyReplicate(err error) {
+	if p.hooks.replicateSignal != nil {
+		p.hooks.replicateSignal <- err
 	}
 }
 

--- a/pkg/server/plugin/keymanager/awskms/awskms.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms.go
@@ -83,9 +83,11 @@ func builtin(p *Plugin) catalog.BuiltIn {
 }
 
 type keyEntry struct {
-	Arn       string
-	AliasName string
-	PublicKey *keymanagerv1.PublicKey
+	Arn                string
+	AliasName          string
+	PublicKey          *keymanagerv1.PublicKey
+	MultiRegion        bool
+	MultiRegionKeyType types.MultiRegionKeyType
 }
 
 type pluginHooks struct {
@@ -133,21 +135,16 @@ type Plugin struct {
 	replicate map[string]chan replicateRequest
 }
 
-// replicateRequest describes a newly created multi-Region primary key that
-// must be replicated into every configured replica region, along with the
-// metadata each replica needs in order to be discoverable in its own region.
-// Aliases and tags are independent properties of multi-Region keys, so AWS
-// does not copy them and the plugin must recreate them per region.
+// replicateRequest holds the desired replica state, including metadata that
+// AWS does not copy from the primary.
 type replicateRequest struct {
-	spireKeyID string
-	keyArn     string
-	aliasName  string
-	tags       []types.Tag
-
-	// supersededKeyArn is the key this one replaces, empty on first creation.
-	// Its replicas are deleted only after the alias in each replica region has
-	// been repointed, so the alias never targets a key pending deletion.
-	supersededKeyArn string
+	spireKeyID        string
+	keyArn            string
+	aliasName         string
+	description       string
+	policy            *string
+	tags              []types.Tag
+	supersededKeyArns []string
 }
 
 // Config provides configuration context for the plugin
@@ -289,13 +286,14 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		return nil, err
 	}
 
+	var keyPolicy *string
 	if newConfig.KeyPolicyFile != "" {
 		policyBytes, err := os.ReadFile(newConfig.KeyPolicyFile)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to read file configured in 'key_policy_file': %v", err)
 		}
 		policyStr := string(policyBytes)
-		p.keyPolicy = &policyStr
+		keyPolicy = &policyStr
 	}
 
 	serverID := newConfig.KeyIdentifierValue
@@ -393,6 +391,18 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		}
 	}
 
+	if keyPolicy == nil && len(newConfig.ReplicaRegions) > 0 {
+		for _, entry := range keyEntries {
+			if entry.MultiRegion && entry.MultiRegionKeyType == types.MultiRegionKeyTypePrimary {
+				keyPolicy, err = p.createDefaultPolicy(ctx, sc)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "unable to create policy: %v", err)
+				}
+				break
+			}
+		}
+	}
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -404,6 +414,7 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 	p.useTagBasedDiscovery = useTagBasedDiscovery
 	p.multiRegion = newConfig.MultiRegion
 	p.replicate = replicateQueues
+	p.keyPolicy = keyPolicy
 
 	// Build the tag list applied to every new key. SPIRE-specific tags are
 	// only included when tag-based discovery is enabled, so that the legacy
@@ -421,6 +432,10 @@ func (p *Plugin) Configure(ctx context.Context, req *configv1.ConfigureRequest) 
 		p.keyTags = buildKeyTags(newConfig.KeyTags)
 	default:
 		p.keyTags = nil
+	}
+
+	for spireKeyID, entry := range p.entries {
+		p.enqueueReplication(spireKeyID, &entry, "")
 	}
 
 	// cancels previous tasks in case of re-configure
@@ -609,7 +624,7 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 	}
 
 	if p.keyPolicy == nil {
-		defaultPolicy, err := p.createDefaultPolicy(ctx)
+		defaultPolicy, err := p.createDefaultPolicy(ctx, p.stsClient)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "unable to create policy: %v", err)
 		}
@@ -643,16 +658,21 @@ func (p *Plugin) createKey(ctx context.Context, spireKeyID string, keyType keyma
 		return nil, status.Error(codes.Internal, "malformed get public key response")
 	}
 
-	return &keyEntry{
-		Arn:       *key.KeyMetadata.Arn,
-		AliasName: p.aliasFromSpireKeyID(spireKeyID),
+	entry := &keyEntry{
+		Arn:         *key.KeyMetadata.Arn,
+		AliasName:   p.aliasFromSpireKeyID(spireKeyID),
+		MultiRegion: p.multiRegion,
 		PublicKey: &keymanagerv1.PublicKey{
 			Id:          spireKeyID,
 			Type:        keyType,
 			PkixData:    pub.PublicKey,
 			Fingerprint: makeFingerprint(pub.PublicKey),
 		},
-	}, nil
+	}
+	if p.multiRegion {
+		entry.MultiRegionKeyType = types.MultiRegionKeyTypePrimary
+	}
+	return entry, nil
 }
 
 func (p *Plugin) assignAlias(ctx context.Context, entry *keyEntry) error {
@@ -700,21 +720,23 @@ func (p *Plugin) setCache(keyEntries []*keyEntry) {
 	}
 }
 
-// enqueueReplication schedules replication of a newly created key into the
-// configured replica regions. It never blocks: key generation is on the CA
-// rotation path, and a key missed here is replicated again on the next
-// rotation. The caller must hold p.mu.
+// enqueueReplication never blocks the CA rotation path. The caller must hold
+// p.mu.
 func (p *Plugin) enqueueReplication(spireKeyID string, entry *keyEntry, supersededKeyArn string) {
-	if len(p.replicate) == 0 {
+	if len(p.replicate) == 0 || !entry.MultiRegion || entry.MultiRegionKeyType != types.MultiRegionKeyTypePrimary {
 		return
 	}
 
 	req := replicateRequest{
-		spireKeyID:       spireKeyID,
-		keyArn:           entry.Arn,
-		aliasName:        entry.AliasName,
-		tags:             p.tagsForKey(spireKeyID),
-		supersededKeyArn: supersededKeyArn,
+		spireKeyID:  spireKeyID,
+		keyArn:      entry.Arn,
+		aliasName:   entry.AliasName,
+		description: p.descriptionFromSpireKeyID(spireKeyID),
+		policy:      p.keyPolicy,
+		tags:        p.tagsForKey(spireKeyID),
+	}
+	if supersededKeyArn != "" {
+		req.supersededKeyArns = []string{supersededKeyArn}
 	}
 
 	for region, queue := range p.replicate {
@@ -769,7 +791,7 @@ func (p *Plugin) replicateTask(ctx context.Context, region string, replicaClient
 				continue
 			}
 
-			err := p.replicateKeyToRegion(ctx, req, keyID, region, replicaClient)
+			err := p.replicateKeyToRegion(ctx, &req, keyID, region, replicaClient)
 			if err == nil {
 				log.Debug("Key replicated")
 				backoff = backoffMin
@@ -786,55 +808,90 @@ func (p *Plugin) replicateTask(ctx context.Context, region string, replicaClient
 			}
 			p.notifyReplicate(err)
 			backoff = min(backoff*2, backoffMax)
-			p.hooks.clk.Sleep(backoff)
+			select {
+			case <-ctx.Done():
+				return
+			case <-p.hooks.clk.After(backoff):
+			}
 		}
 	}
 }
 
-func (p *Plugin) replicateKeyToRegion(ctx context.Context, req replicateRequest, keyID, region string, replicaClient kmsClient) error {
+func (p *Plugin) replicateKeyToRegion(ctx context.Context, req *replicateRequest, keyID, region string, replicaClient kmsClient) error {
 	log := p.log.With(keyArnTag, req.keyArn, replicaTag, region)
 
-	var replicaArn string
+	var replicaMetadata *types.KeyMetadata
+	var replicaAlreadyExists bool
 	replicaResp, err := p.kmsClient.ReplicateKey(ctx, &kms.ReplicateKeyInput{
 		KeyId:         aws.String(req.keyArn),
 		ReplicaRegion: aws.String(region),
+		Description:   aws.String(req.description),
+		Policy:        req.policy,
 		Tags:          req.tags,
 	})
 
 	var alreadyExistsErr *types.AlreadyExistsException
 	switch {
 	case err == nil:
-		if replicaResp.ReplicaKeyMetadata == nil || replicaResp.ReplicaKeyMetadata.Arn == nil {
-			return errors.New("malformed replicate key response: missing replica key arn")
+		if replicaResp == nil || replicaResp.ReplicaKeyMetadata == nil {
+			return errors.New("malformed replicate key response: missing replica key metadata")
 		}
-		replicaArn = *replicaResp.ReplicaKeyMetadata.Arn
+		replicaMetadata = replicaResp.ReplicaKeyMetadata
 		log.Debug("Replica key created")
 	case errors.As(err, &alreadyExistsErr):
-		// A replica is already present, which is the normal case when an
-		// earlier attempt created the key but failed before the alias.
+		replicaAlreadyExists = true
 		describeResp, describeErr := replicaClient.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(keyID)})
 		if describeErr != nil {
 			return fmt.Errorf("describing existing replica: %w", describeErr)
 		}
-		if describeResp.KeyMetadata == nil || describeResp.KeyMetadata.Arn == nil {
-			return errors.New("malformed describe key response: missing replica key arn")
+		if describeResp == nil || describeResp.KeyMetadata == nil {
+			return errors.New("malformed describe key response: missing replica key metadata")
 		}
-		replicaArn = *describeResp.KeyMetadata.Arn
+		replicaMetadata = describeResp.KeyMetadata
 	default:
 		return fmt.Errorf("replicating key: %w", err)
 	}
 
-	// Aliases are an independent property of multi-Region keys, so AWS does
-	// not copy them. Without one the replica is invisible to a plugin running
-	// in the replica region.
-	_, err = replicaClient.CreateAlias(ctx, &kms.CreateAliasInput{
-		AliasName:   aws.String(req.aliasName),
-		TargetKeyId: aws.String(replicaArn),
-	})
+	replicaArn, err := enabledReplicaArn(replicaMetadata)
 	if err != nil {
-		if !errors.As(err, &alreadyExistsErr) {
+		return err
+	}
+
+	if replicaAlreadyExists && len(req.tags) > 0 {
+		_, err = replicaClient.TagResource(ctx, &kms.TagResourceInput{
+			KeyId: aws.String(replicaArn),
+			Tags:  req.tags,
+		})
+		if err != nil {
+			return fmt.Errorf("tagging existing replica: %w", err)
+		}
+	}
+
+	aliasTargetArn, aliasExists, err := replicaAliasTarget(ctx, replicaClient, req.aliasName)
+	if err != nil {
+		return err
+	}
+	if !aliasExists {
+		_, err = replicaClient.CreateAlias(ctx, &kms.CreateAliasInput{
+			AliasName:   aws.String(req.aliasName),
+			TargetKeyId: aws.String(replicaArn),
+		})
+		switch {
+		case err == nil:
+		case errors.As(err, &alreadyExistsErr):
+			aliasTargetArn, aliasExists, err = replicaAliasTarget(ctx, replicaClient, req.aliasName)
+			if err != nil {
+				return err
+			}
+			if !aliasExists {
+				return errors.New("replica alias exists but its target cannot be found")
+			}
+		default:
 			return fmt.Errorf("creating replica alias: %w", err)
 		}
+	}
+
+	if aliasExists && aliasTargetArn != replicaArn {
 		_, err = replicaClient.UpdateAlias(ctx, &kms.UpdateAliasInput{
 			AliasName:   aws.String(req.aliasName),
 			TargetKeyId: aws.String(replicaArn),
@@ -842,34 +899,66 @@ func (p *Plugin) replicateKeyToRegion(ctx context.Context, req replicateRequest,
 		if err != nil {
 			return fmt.Errorf("updating replica alias: %w", err)
 		}
+		req.supersededKeyArns = append(req.supersededKeyArns, aliasTargetArn)
 	}
 
-	// Only once the alias points at the new replica is it safe to remove the
-	// one it displaced.
-	return p.deleteSupersededReplica(ctx, req, region, replicaClient)
+	return p.deleteSupersededReplicas(ctx, req, replicaArn, region, replicaClient)
 }
 
-// deleteSupersededReplica schedules deletion of the replica that the alias in
-// this region no longer points at. It runs only after the alias has been
-// repointed, so a server starting in the replica region never finds its alias
-// targeting a key pending deletion, which would fail plugin configuration.
-//
-// AWS will also not finish deleting a multi-Region primary while any replica of
-// it remains, so without this the superseded primary lingers in PendingDeletion
-// indefinitely.
-func (p *Plugin) deleteSupersededReplica(ctx context.Context, req replicateRequest, region string, replicaClient kmsClient) error {
-	if req.supersededKeyArn == "" {
-		return nil
+func enabledReplicaArn(metadata *types.KeyMetadata) (string, error) {
+	if metadata == nil || metadata.Arn == nil {
+		return "", errors.New("malformed replica key metadata: missing arn")
 	}
+	if metadata.KeyState != types.KeyStateEnabled {
+		return "", fmt.Errorf("replica key is not enabled: state=%q", metadata.KeyState)
+	}
+	return *metadata.Arn, nil
+}
 
-	supersededKeyID, ok := parseKeyIDFromArn(req.supersededKeyArn)
+func replicaAliasTarget(ctx context.Context, replicaClient kmsClient, aliasName string) (string, bool, error) {
+	describeResp, err := replicaClient.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(aliasName)})
+	var notFoundErr *types.NotFoundException
+	switch {
+	case errors.As(err, &notFoundErr):
+		return "", false, nil
+	case err != nil:
+		return "", false, fmt.Errorf("describing replica alias target: %w", err)
+	case describeResp == nil || describeResp.KeyMetadata == nil || describeResp.KeyMetadata.Arn == nil:
+		return "", false, errors.New("malformed describe key response for replica alias")
+	default:
+		return *describeResp.KeyMetadata.Arn, true, nil
+	}
+}
+
+func (p *Plugin) deleteSupersededReplicas(ctx context.Context, req *replicateRequest, replicaArn, region string, replicaClient kmsClient) error {
+	currentKeyID, ok := parseKeyIDFromArn(replicaArn)
 	if !ok {
-		p.log.Error("Unable to determine key id for replica deletion", keyArnTag, req.supersededKeyArn)
-		return nil
+		return errors.New("unable to determine current replica key id")
 	}
+	seen := make(map[string]struct{}, len(req.supersededKeyArns))
+	for _, keyArn := range req.supersededKeyArns {
+		keyID, ok := parseKeyIDFromArn(keyArn)
+		if !ok {
+			p.log.Error("Unable to determine key id for replica deletion", keyArnTag, keyArn)
+			continue
+		}
+		if keyID == currentKeyID {
+			continue
+		}
+		if _, ok := seen[keyID]; ok {
+			continue
+		}
+		seen[keyID] = struct{}{}
+		if err := p.deleteSupersededReplica(ctx, keyArn, keyID, region, replicaClient); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
+func (p *Plugin) deleteSupersededReplica(ctx context.Context, keyArn, keyID, region string, replicaClient kmsClient) error {
 	_, err := replicaClient.ScheduleKeyDeletion(ctx, &kms.ScheduleKeyDeletionInput{
-		KeyId:               aws.String(supersededKeyID),
+		KeyId:               aws.String(keyID),
 		PendingWindowInDays: aws.Int32(7),
 	})
 
@@ -877,7 +966,7 @@ func (p *Plugin) deleteSupersededReplica(ctx context.Context, req replicateReque
 	var invalidStateErr *types.KMSInvalidStateException
 	switch {
 	case err == nil:
-		p.log.Debug("Superseded replica key scheduled for deletion", keyArnTag, req.supersededKeyArn, replicaTag, region)
+		p.log.Debug("Superseded replica key scheduled for deletion", keyArnTag, keyArn, replicaTag, region)
 		return nil
 	case errors.As(err, &notFoundErr):
 		// Never replicated into this region, or already gone.
@@ -1281,8 +1370,8 @@ func (p *Plugin) notifyDisposeKeys(err error) {
 	}
 }
 
-func (p *Plugin) createDefaultPolicy(ctx context.Context) (*string, error) {
-	result, err := p.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+func (p *Plugin) createDefaultPolicy(ctx context.Context, client stsClient) (*string, error) {
+	result, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
 		return nil, fmt.Errorf("cannot get caller identity: %w", err)
 	}

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -2842,6 +2842,360 @@ func TestGenerateKeyMultiRegion(t *testing.T) {
 	}
 }
 
+// setupReplicaTest builds a plugin whose KMS clients are dispatched by region,
+// so the primary and each replica region are backed by distinct fakes. This
+// mirrors AWS, where a replica is a separate key resource in another region.
+func setupReplicaTest(t *testing.T, replicaRegions ...string) (*pluginTest, map[string]*kmsClientFake) {
+	log, logHook := test.NewNullLogger()
+	log.Level = logrus.DebugLevel
+
+	c := clock.NewMock()
+	primary := newKMSClientFake(t, c)
+	replicas := make(map[string]*kmsClientFake, len(replicaRegions))
+	for _, region := range replicaRegions {
+		replica := newKMSClientFake(t, c)
+		replicas[region] = replica
+		primary.setPeer(region, replica)
+	}
+
+	fakeSTSClient := newSTSClientFake()
+	fakeTaggingClient := newTaggingClientFake()
+	p := newPlugin(
+		func(cfg aws.Config) (kmsClient, error) {
+			if replica, ok := replicas[cfg.Region]; ok {
+				return replica, nil
+			}
+			return primary, nil
+		},
+		func(aws.Config) (taggingClient, error) { return fakeTaggingClient, nil },
+		func(aws.Config) (stsClient, error) { return fakeSTSClient, nil },
+	)
+	km := new(keymanager.V1)
+	plugintest.Load(t, builtin(p), km, plugintest.Log(log))
+
+	p.hooks.clk = c
+	p.hooks.replicateSignal = make(chan error, 10)
+
+	return &pluginTest{
+		plugin:            p,
+		fakeKMSClient:     primary,
+		fakeSTSClient:     fakeSTSClient,
+		fakeTaggingClient: fakeTaggingClient,
+		logHook:           logHook,
+		clockHook:         c,
+	}, replicas
+}
+
+// advanceUntilSignal advances the mock clock until the task signals. Advancing
+// once would race the worker reaching its Sleep call, which with a mock clock
+// leaves it blocked indefinitely.
+func advanceUntilSignal(t *testing.T, c *clock.Mock, ch chan error) error {
+	t.Helper()
+	deadline := time.After(testTimeout)
+	for {
+		select {
+		case err := <-ch:
+			return err
+		case <-deadline:
+			t.Fatal("timed out waiting for replication signal")
+			return nil
+		default:
+			c.Add(time.Second)
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func configureReplicaRequest(t *testing.T, replicaRegions ...string) *configv1.ConfigureRequest {
+	regions, err := json.Marshal(replicaRegions)
+	require.NoError(t, err)
+
+	return &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "test.example.org"},
+		HclConfiguration: fmt.Sprintf(`{
+			"access_key_id": %q,
+			"secret_access_key": %q,
+			"region": %q,
+			"key_identifier_file": %q,
+			"enable_tag_based_key_discovery": true,
+			"multi_region": true,
+			"replica_regions": %s
+		}`, validAccessKeyID, validSecretAccessKey, validRegion, getKeyIdentifierFile(t), regions),
+	}
+}
+
+// TestReplicateKey covers the happy path: a new key is replicated into every
+// configured region and given an alias there, since AWS copies neither aliases
+// nor tags to a replica.
+func TestReplicateKey(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.fakeKMSClient.mu.RLock()
+	replicateCalls := ts.fakeKMSClient.replicateKeyCalls
+	ts.fakeKMSClient.mu.RUnlock()
+	require.Len(t, replicateCalls, 1)
+	require.Equal(t, replicaRegion, *replicateCalls[0].ReplicaRegion)
+
+	// The replica must carry the SPIRE tags, including spire-key-id. Without
+	// it the replica satisfies the tag-discovery filter but cannot be mapped
+	// back to a SPIRE key, so it is found and then discarded.
+	tags := make(map[string]string, len(replicateCalls[0].Tags))
+	for _, tag := range replicateCalls[0].Tags {
+		tags[*tag.TagKey] = *tag.TagValue
+	}
+	require.Equal(t, spireKeyID, tags[tagKeySPIREKeyID])
+	require.Equal(t, "test.example.org", tags[tagKeyServerTD])
+	require.Equal(t, "true", tags[tagKeyActive])
+
+	// The alias must exist in the replica region, or a server running there
+	// cannot discover the key.
+	replicaAliases := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, replicaAliases, 1)
+	require.Equal(t, aliasName, *replicaAliases[0].AliasName)
+}
+
+// TestReplicateKeyDeletesSupersededReplica verifies that rotation cleans up the
+// replica it displaced. AWS will not finish deleting a multi-Region primary
+// while any replica of it survives, so skipping this leaks a key per rotation.
+func TestReplicateKeyDeletesSupersededReplica(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	generate := func() {
+		_, err := ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+			KeyId:   spireKeyID,
+			KeyType: keymanagerv1.KeyType_EC_P256,
+		})
+		require.NoError(t, err)
+		require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+	}
+
+	generate()
+	generate()
+
+	replica := replicas[replicaRegion]
+	replica.mu.RLock()
+	deletions := replica.scheduleKeyDeletionCalls
+	replica.mu.RUnlock()
+	require.Len(t, deletions, 1, "the superseded replica should be scheduled for deletion exactly once")
+
+	// The alias in the replica region must point at the surviving key, never
+	// at one pending deletion, which would fail plugin configuration there.
+	replicaAliases := replica.store.ListAliases()
+	require.Len(t, replicaAliases, 1)
+	require.NotEqual(t, deletions[0], *replicaAliases[0].KeyEntry.KeyID)
+}
+
+// TestReplicateKeyRetries verifies that a failing region is retried rather than
+// dropped: the alternative is a silently stale replica until the next rotation.
+func TestReplicateKeyRetries(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	ts.fakeKMSClient.setReplicateKeyErr(errors.New("replica region unreachable"))
+
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err, "replication failure must not fail key generation")
+
+	err = waitForSignal(t, ts.plugin.hooks.replicateSignal)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "replica region unreachable")
+
+	// Recover, then let the retry through.
+	ts.fakeKMSClient.setReplicateKeyErr(nil)
+	require.NoError(t, advanceUntilSignal(t, ts.clockHook, ts.plugin.hooks.replicateSignal))
+
+	require.Len(t, replicas[replicaRegion].store.ListAliases(), 1)
+}
+
+// TestReplicateKeyDiscardsSupersededRequest verifies that a request left over
+// from an earlier rotation is dropped rather than replicated. Replaying it
+// would repoint the replica alias back at a key that has since been superseded.
+func TestReplicateKeyDiscardsSupersededRequest(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.plugin.mu.RLock()
+	supersededArn := ts.plugin.entries[spireKeyID].Arn
+	ts.plugin.mu.RUnlock()
+
+	// Rotate, so the first key is no longer current.
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.fakeKMSClient.mu.RLock()
+	callsBefore := len(ts.fakeKMSClient.replicateKeyCalls)
+	ts.fakeKMSClient.mu.RUnlock()
+
+	currentAliases := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, currentAliases, 1)
+	currentTarget := *currentAliases[0].KeyEntry.KeyID
+
+	// Replay the request belonging to the superseded key.
+	ts.plugin.replicate[replicaRegion] <- replicateRequest{
+		spireKeyID: spireKeyID,
+		keyArn:     supersededArn,
+		aliasName:  aliasName,
+	}
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.fakeKMSClient.mu.RLock()
+	callsAfter := len(ts.fakeKMSClient.replicateKeyCalls)
+	ts.fakeKMSClient.mu.RUnlock()
+	require.Equal(t, callsBefore, callsAfter, "a superseded request must not be replicated")
+
+	aliasesAfter := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, aliasesAfter, 1)
+	require.Equal(t, currentTarget, *aliasesAfter[0].KeyEntry.KeyID, "the replica alias must still point at the current key")
+}
+
+// TestReplicateKeyIsolatesFailingRegion is the reason replication uses a queue
+// per region. A region that cannot be reached must not hold up the others: with
+// a single shared queue, the retries for the failing region would starve every
+// later key, so the healthy region would never see the second key.
+func TestReplicateKeyIsolatesFailingRegion(t *testing.T) {
+	const healthyRegion, failingRegion = "eu-west-1", "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, healthyRegion, failingRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, healthyRegion, failingRegion))
+	require.NoError(t, err)
+
+	replicas[failingRegion].setCreateAliasesErr("region unreachable")
+
+	generate := func() {
+		_, err := ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+			KeyId:   spireKeyID,
+			KeyType: keymanagerv1.KeyType_EC_P256,
+		})
+		require.NoError(t, err, "an unreachable replica region must not fail key generation")
+	}
+
+	generate()
+	require.Eventually(t, func() bool {
+		return len(replicas[healthyRegion].store.ListAliases()) == 1
+	}, testTimeout, time.Millisecond, "the healthy region should replicate the first key")
+
+	// Rotate. The failing region is still retrying the first key; the healthy
+	// region must nonetheless pick this one up.
+	generate()
+
+	ts.plugin.mu.RLock()
+	currentArn := ts.plugin.entries[spireKeyID].Arn
+	ts.plugin.mu.RUnlock()
+	currentKeyID, ok := parseKeyIDFromArn(currentArn)
+	require.True(t, ok)
+
+	require.Eventually(t, func() bool {
+		aliases := replicas[healthyRegion].store.ListAliases()
+		return len(aliases) == 1 && *aliases[0].KeyEntry.KeyID == currentKeyID
+	}, testTimeout, time.Millisecond, "the healthy region should not be starved by the failing one")
+
+	require.Empty(t, replicas[failingRegion].store.ListAliases(), "the failing region should still have no alias")
+}
+
+// TestConfigureReplicaRegions covers validation of the replica region list.
+func TestConfigureReplicaRegions(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		multiRegon bool
+		regions    []string
+		err        string
+	}{
+		{
+			name:       "valid",
+			multiRegon: true,
+			regions:    []string{"ap-northeast-1", "eu-west-1"},
+		},
+		{
+			name:       "none configured",
+			multiRegon: true,
+		},
+		{
+			name:    "requires multi_region",
+			regions: []string{"ap-northeast-1"},
+			err:     "replica_regions requires multi_region to be enabled",
+		},
+		{
+			name:       "duplicated region",
+			multiRegon: true,
+			regions:    []string{"ap-northeast-1", "ap-northeast-1"},
+			err:        `replica region "ap-northeast-1" is duplicated`,
+		},
+		{
+			name:       "same as primary region",
+			multiRegon: true,
+			regions:    []string{validRegion},
+			err:        fmt.Sprintf("replica region %q must be different from the configured region", validRegion),
+		},
+		{
+			name:       "empty region",
+			multiRegon: true,
+			regions:    []string{""},
+			err:        "replica_regions must not contain an empty region",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+
+			configuredRegions := tt.regions
+			if configuredRegions == nil {
+				configuredRegions = []string{}
+			}
+			regions, err := json.Marshal(configuredRegions)
+			require.NoError(t, err)
+
+			_, err = ts.plugin.Configure(ctx, configureRequestWithString(fmt.Sprintf(`{
+				"access_key_id": %q,
+				"secret_access_key": %q,
+				"region": %q,
+				"key_identifier_file": %q,
+				"multi_region": %t,
+				"replica_regions": %s
+			}`, validAccessKeyID, validSecretAccessKey, validRegion, getKeyIdentifierFile(t), tt.multiRegon, regions)))
+
+			if tt.err != "" {
+				spiretest.RequireGRPCStatusContains(t, err, codes.InvalidArgument, tt.err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestFetchKeyEntryDetailsFromArn covers the defensive error branches of
 // tag-based key detail retrieval that are not exercised by the higher-level
 // Configure tests.

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -2588,6 +2588,19 @@ func configureTagBasedRequest(t *testing.T) *configv1.ConfigureRequest {
 	}
 }
 
+func configureRequestWithMultiRegion(t *testing.T, multiRegion bool) *configv1.ConfigureRequest {
+	return &configv1.ConfigureRequest{
+		CoreConfiguration: &configv1.CoreConfiguration{TrustDomain: "test.example.org"},
+		HclConfiguration: fmt.Sprintf(`{
+			"access_key_id": %q,
+			"secret_access_key": %q,
+			"region": %q,
+			"key_identifier_file": %q,
+			"multi_region": %t
+		}`, validAccessKeyID, validSecretAccessKey, validRegion, getKeyIdentifierFile(t), multiRegion),
+	}
+}
+
 // makeTaggedResource builds a ResourceTagMapping representing a KMS key that
 // is actively managed by the given server, with spire-key-id set.
 func makeTaggedResource(keyArn, spireKeyID, serverID, trustDomain string) rgtatypes.ResourceTagMapping {
@@ -2779,6 +2792,54 @@ func TestGenerateKeyTagBased(t *testing.T) {
 	require.Equal(t, "true", tags[tagKeyActive])
 	require.Equal(t, spireKeyID, tags[tagKeySPIREKeyID])
 	require.Equal(t, strconv.FormatInt(ts.clockHook.Now().Unix(), 10), tags[tagKeyLastUpdate])
+}
+
+// TestGenerateKeyMultiRegion verifies that the multi_region setting reaches
+// CreateKey. AWS only honors the multi-Region property at creation time, so
+// this is the only point at which it can take effect.
+func TestGenerateKeyMultiRegion(t *testing.T) {
+	for _, tt := range []struct {
+		name                string
+		configureRequest    *configv1.ConfigureRequest
+		expectedMultiRegion bool
+	}{
+		{
+			name:                "enabled",
+			configureRequest:    configureRequestWithMultiRegion(t, true),
+			expectedMultiRegion: true,
+		},
+		{
+			name:                "explicitly disabled",
+			configureRequest:    configureRequestWithMultiRegion(t, false),
+			expectedMultiRegion: false,
+		},
+		{
+			name:                "omitted defaults to disabled",
+			configureRequest:    configureRequestWithDefaults(t),
+			expectedMultiRegion: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := setupTest(t)
+
+			_, err := ts.plugin.Configure(ctx, tt.configureRequest)
+			require.NoError(t, err)
+
+			_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+				KeyId:   spireKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			})
+			require.NoError(t, err)
+
+			ts.fakeKMSClient.mu.RLock()
+			createCalls := ts.fakeKMSClient.createKeyCalls
+			ts.fakeKMSClient.mu.RUnlock()
+			require.Len(t, createCalls, 1)
+
+			require.NotNil(t, createCalls[0].MultiRegion)
+			require.Equal(t, tt.expectedMultiRegion, *createCalls[0].MultiRegion)
+		})
+	}
 }
 
 // TestFetchKeyEntryDetailsFromArn covers the defensive error branches of

--- a/pkg/server/plugin/keymanager/awskms/awskms_test.go
+++ b/pkg/server/plugin/keymanager/awskms/awskms_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/andres-erbsen/clock"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
 	rgtatypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
 	"github.com/aws/smithy-go"
@@ -2907,6 +2908,10 @@ func advanceUntilSignal(t *testing.T, c *clock.Mock, ch chan error) error {
 }
 
 func configureReplicaRequest(t *testing.T, replicaRegions ...string) *configv1.ConfigureRequest {
+	return configureReplicaRequestWithKeyPolicy(t, "", replicaRegions...)
+}
+
+func configureReplicaRequestWithKeyPolicy(t *testing.T, keyPolicyFile string, replicaRegions ...string) *configv1.ConfigureRequest {
 	regions, err := json.Marshal(replicaRegions)
 	require.NoError(t, err)
 
@@ -2917,10 +2922,11 @@ func configureReplicaRequest(t *testing.T, replicaRegions ...string) *configv1.C
 			"secret_access_key": %q,
 			"region": %q,
 			"key_identifier_file": %q,
+			"key_policy_file": %q,
 			"enable_tag_based_key_discovery": true,
 			"multi_region": true,
 			"replica_regions": %s
-		}`, validAccessKeyID, validSecretAccessKey, validRegion, getKeyIdentifierFile(t), regions),
+		}`, validAccessKeyID, validSecretAccessKey, validRegion, getKeyIdentifierFile(t), keyPolicyFile, regions),
 	}
 }
 
@@ -2998,6 +3004,218 @@ func TestReplicateKeyDeletesSupersededReplica(t *testing.T) {
 	replicaAliases := replica.store.ListAliases()
 	require.Len(t, replicaAliases, 1)
 	require.NotEqual(t, deletions[0], *replicaAliases[0].KeyEntry.KeyID)
+}
+
+func TestReplicateKeyDeletesReplicaSkippedByRotation(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	generate := func() string {
+		_, err := ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+			KeyId:   spireKeyID,
+			KeyType: keymanagerv1.KeyType_EC_P256,
+		})
+		require.NoError(t, err)
+
+		ts.plugin.mu.RLock()
+		keyArn := ts.plugin.entries[spireKeyID].Arn
+		ts.plugin.mu.RUnlock()
+		keyID, ok := parseKeyIDFromArn(keyArn)
+		require.True(t, ok)
+		return keyID
+	}
+
+	firstKeyID := generate()
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.fakeKMSClient.setReplicateKeyErr(errors.New("replica region unreachable"))
+	secondKeyID := generate()
+	require.Error(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	thirdKeyID := generate()
+	ts.fakeKMSClient.setReplicateKeyErr(nil)
+	require.NoError(t, advanceUntilSignal(t, ts.clockHook, ts.plugin.hooks.replicateSignal))
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	replicaAliases := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, replicaAliases, 1)
+	require.Equal(t, thirdKeyID, *replicaAliases[0].KeyEntry.KeyID)
+
+	replicas[replicaRegion].mu.RLock()
+	deletions := append([]string(nil), replicas[replicaRegion].scheduleKeyDeletionCalls...)
+	replicas[replicaRegion].mu.RUnlock()
+	require.ElementsMatch(t, []string{firstKeyID, secondKeyID}, deletions)
+}
+
+func TestConfigureReconcilesExistingMultiRegionKeys(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureRequestWithMultiRegion(t, true))
+	require.NoError(t, err)
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	_, err = ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(replicas[replicaRegion].store.ListAliases()) == 1
+	}, time.Second, time.Millisecond)
+	ts.fakeKMSClient.mu.RLock()
+	replicateCallCount := len(ts.fakeKMSClient.replicateKeyCalls)
+	ts.fakeKMSClient.mu.RUnlock()
+	require.Equal(t, 1, replicateCallCount)
+}
+
+func TestConfigureDoesNotReconcileSingleRegionKeys(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, _ := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureRequestWithDefaults(t))
+	require.NoError(t, err)
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+
+	_, err = ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	require.Never(t, func() bool {
+		ts.fakeKMSClient.mu.RLock()
+		defer ts.fakeKMSClient.mu.RUnlock()
+		return len(ts.fakeKMSClient.replicateKeyCalls) > 0
+	}, 100*time.Millisecond, time.Millisecond)
+}
+
+func TestConfigureDoesNotReconcileReplicaKeys(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, _ := setupReplicaTest(t, replicaRegion)
+	ts.fakeKMSClient.setEntries([]fakeKeyEntry{
+		{
+			AliasName:          aws.String(aliasName),
+			KeyID:              aws.String(keyID),
+			KeySpec:            types.KeySpecEccNistP256,
+			Enabled:            true,
+			PublicKey:          []byte("public key"),
+			MultiRegion:        true,
+			MultiRegionKeyType: types.MultiRegionKeyTypeReplica,
+		},
+	})
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+
+	require.Never(t, func() bool {
+		ts.fakeKMSClient.mu.RLock()
+		defer ts.fakeKMSClient.mu.RUnlock()
+		return len(ts.fakeKMSClient.replicateKeyCalls) > 0
+	}, 100*time.Millisecond, time.Millisecond)
+}
+
+func TestReplicateKeyPreservesPolicyAndDescription(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	for _, tt := range []struct {
+		name             string
+		configureRequest func(*testing.T) *configv1.ConfigureRequest
+		account          string
+		roleARN          string
+		policy           string
+	}{
+		{
+			name: "generated policy",
+			configureRequest: func(t *testing.T) *configv1.ConfigureRequest {
+				return configureReplicaRequest(t, replicaRegion)
+			},
+			account: "example-account-id",
+			roleARN: "arn:aws:sts::example-account-id:assumed-role/example-assumed-role-name/example-instance-id",
+			policy:  roleBasedPolicy,
+		},
+		{
+			name: "configured policy",
+			configureRequest: func(t *testing.T) *configv1.ConfigureRequest {
+				return configureReplicaRequestWithKeyPolicy(t, getCustomPolicyFile(t), replicaRegion)
+			},
+			policy: customPolicy,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ts, _ := setupReplicaTest(t, replicaRegion)
+			ts.fakeSTSClient.setGetCallerIdentityAccount(tt.account)
+			ts.fakeSTSClient.setGetCallerIdentityArn(tt.roleARN)
+			ts.fakeKMSClient.setExpectedKeyPolicy(aws.String(tt.policy))
+
+			_, err := ts.plugin.Configure(ctx, tt.configureRequest(t))
+			require.NoError(t, err)
+			_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+				KeyId:   spireKeyID,
+				KeyType: keymanagerv1.KeyType_EC_P256,
+			})
+			require.NoError(t, err)
+			require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+			ts.fakeKMSClient.mu.RLock()
+			replicateCalls := append([]kms.ReplicateKeyInput(nil), ts.fakeKMSClient.replicateKeyCalls...)
+			ts.fakeKMSClient.mu.RUnlock()
+			require.Len(t, replicateCalls, 1)
+			replicateCall := replicateCalls[0]
+			require.Equal(t, tt.policy, aws.ToString(replicateCall.Policy))
+			require.Equal(t, ts.plugin.descriptionFromSpireKeyID(spireKeyID), aws.ToString(replicateCall.Description))
+		})
+	}
+}
+
+func TestReplicateKeyWaitsUntilReplicaIsEnabled(t *testing.T) {
+	const replicaRegion = "ap-northeast-1"
+	ts, replicas := setupReplicaTest(t, replicaRegion)
+
+	_, err := ts.plugin.Configure(ctx, configureReplicaRequest(t, replicaRegion))
+	require.NoError(t, err)
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.NoError(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	firstAliases := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, firstAliases, 1)
+	firstKeyID := *firstAliases[0].KeyEntry.KeyID
+
+	ts.fakeKMSClient.setReplicateKeyState(types.KeyStateCreating)
+	_, err = ts.plugin.GenerateKey(ctx, &keymanagerv1.GenerateKeyRequest{
+		KeyId:   spireKeyID,
+		KeyType: keymanagerv1.KeyType_EC_P256,
+	})
+	require.NoError(t, err)
+	require.Error(t, waitForSignal(t, ts.plugin.hooks.replicateSignal))
+
+	ts.plugin.mu.RLock()
+	secondKeyArn := ts.plugin.entries[spireKeyID].Arn
+	ts.plugin.mu.RUnlock()
+	secondKeyID, ok := parseKeyIDFromArn(secondKeyArn)
+	require.True(t, ok)
+
+	aliasesWhileCreating := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, aliasesWhileCreating, 1)
+	require.Equal(t, firstKeyID, *aliasesWhileCreating[0].KeyEntry.KeyID)
+	require.Empty(t, replicas[replicaRegion].scheduleKeyDeletionCalls)
+
+	replicas[replicaRegion].setKeyState(secondKeyID, types.KeyStateEnabled)
+	require.NoError(t, advanceUntilSignal(t, ts.clockHook, ts.plugin.hooks.replicateSignal))
+
+	enabledAliases := replicas[replicaRegion].store.ListAliases()
+	require.Len(t, enabledAliases, 1)
+	require.Equal(t, secondKeyID, *enabledAliases[0].KeyEntry.KeyID)
+	require.Equal(t, []string{firstKeyID}, replicas[replicaRegion].scheduleKeyDeletionCalls)
 }
 
 // TestReplicateKeyRetries verifies that a failing region is retried rather than

--- a/pkg/server/plugin/keymanager/awskms/client.go
+++ b/pkg/server/plugin/keymanager/awskms/client.go
@@ -23,6 +23,7 @@ type kmsClient interface {
 	ListKeys(context.Context, *kms.ListKeysInput, ...func(*kms.Options)) (*kms.ListKeysOutput, error)
 	DeleteAlias(context.Context, *kms.DeleteAliasInput, ...func(*kms.Options)) (*kms.DeleteAliasOutput, error)
 	TagResource(context.Context, *kms.TagResourceInput, ...func(*kms.Options)) (*kms.TagResourceOutput, error)
+	ReplicateKey(context.Context, *kms.ReplicateKeyInput, ...func(*kms.Options)) (*kms.ReplicateKeyOutput, error)
 }
 
 type taggingClient interface {
@@ -45,9 +46,12 @@ func newSTSClient(c aws.Config) (stsClient, error) {
 	return sts.NewFromConfig(c), nil
 }
 
-func newAWSConfig(ctx context.Context, c *Config) (aws.Config, error) {
+// newAWSConfig builds a configuration for the given region. The region is
+// passed explicitly rather than read from c.Region so that clients can also be
+// built for the replica regions.
+func newAWSConfig(ctx context.Context, c *Config, region string) (aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithRegion(c.Region),
+		config.WithRegion(region),
 	)
 	if err != nil {
 		return aws.Config{}, err

--- a/pkg/server/plugin/keymanager/awskms/client_fake.go
+++ b/pkg/server/plugin/keymanager/awskms/client_fake.go
@@ -30,24 +30,31 @@ import (
 )
 
 type kmsClientFake struct {
-	t                        *testing.T
-	store                    fakeStore
-	mu                       sync.RWMutex
-	testKeys                 testkey.Keys
-	validAliasName           *regexp.Regexp
-	createKeyErr             error
-	describeKeyErr           error
-	describeKeyMalformed     bool
-	getPublicKeyErr          error
-	listAliasesErr           error
-	createAliasErr           error
-	updateAliasErr           error
-	scheduleKeyDeletionErr   error
-	signErr                  error
-	listKeysErr              error
-	deleteAliasErr           error
-	tagResourceErr           error
-	tagResourceCalls         []kms.TagResourceInput
+	t                      *testing.T
+	store                  fakeStore
+	mu                     sync.RWMutex
+	testKeys               testkey.Keys
+	validAliasName         *regexp.Regexp
+	createKeyErr           error
+	describeKeyErr         error
+	describeKeyMalformed   bool
+	getPublicKeyErr        error
+	listAliasesErr         error
+	createAliasErr         error
+	updateAliasErr         error
+	scheduleKeyDeletionErr error
+	signErr                error
+	listKeysErr            error
+	deleteAliasErr         error
+	tagResourceErr         error
+	replicateKeyErr        error
+	tagResourceCalls       []kms.TagResourceInput
+	replicateKeyCalls      []kms.ReplicateKeyInput
+
+	// peers maps a replica region to the fake client standing in for KMS in
+	// that region, so ReplicateKey can materialise the replica where the
+	// plugin will look for it.
+	peers                    map[string]*kmsClientFake
 	createKeyCalls           []kms.CreateKeyInput
 	scheduleKeyDeletionCalls []string
 
@@ -524,6 +531,72 @@ func (k *kmsClientFake) TagResource(_ context.Context, input *kms.TagResourceInp
 	call := *input
 	k.tagResourceCalls = append(k.tagResourceCalls, call)
 	return &kms.TagResourceOutput{}, nil
+}
+
+// ReplicateKey models AWS replication: the replica is a distinct key resource
+// in another region that shares the primary's key id and key material. It is
+// created in the peer fake standing in for that region.
+func (k *kmsClientFake) ReplicateKey(_ context.Context, input *kms.ReplicateKeyInput, _ ...func(*kms.Options)) (*kms.ReplicateKeyOutput, error) {
+	k.mu.Lock()
+	k.replicateKeyCalls = append(k.replicateKeyCalls, *input)
+	replicateKeyErr := k.replicateKeyErr
+	peer := k.peers[*input.ReplicaRegion]
+	k.mu.Unlock()
+
+	if replicateKeyErr != nil {
+		return nil, replicateKeyErr
+	}
+	if peer == nil {
+		return nil, fmt.Errorf("no fake KMS client registered for replica region %q", *input.ReplicaRegion)
+	}
+
+	primary, err := k.store.FetchKeyEntry(*input.KeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Related multi-Region keys share a key id, so a second replication into
+	// the same region is a conflict rather than a second key.
+	if existing, err := peer.store.FetchKeyEntry(*primary.KeyID); err == nil && existing != nil {
+		return nil, &types.AlreadyExistsException{}
+	}
+
+	replica := &fakeKeyEntry{
+		KeyID:        primary.KeyID,
+		Description:  primary.Description,
+		CreationDate: primary.CreationDate,
+		PublicKey:    primary.PublicKey,
+		privateKey:   primary.privateKey,
+		KeySpec:      primary.KeySpec,
+		Enabled:      true,
+	}
+	peer.store.SaveKeyEntry(replica)
+
+	return &kms.ReplicateKeyOutput{
+		ReplicaKeyMetadata: &types.KeyMetadata{
+			KeyId:       replica.KeyID,
+			Arn:         replica.Arn,
+			KeySpec:     replica.KeySpec,
+			Enabled:     true,
+			MultiRegion: aws.Bool(true),
+		},
+	}, nil
+}
+
+func (k *kmsClientFake) setReplicateKeyErr(err error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.replicateKeyErr = err
+}
+
+// setPeer registers the fake standing in for KMS in the given replica region.
+func (k *kmsClientFake) setPeer(region string, peer *kmsClientFake) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.peers == nil {
+		k.peers = make(map[string]*kmsClientFake)
+	}
+	k.peers[region] = peer
 }
 
 func (k *kmsClientFake) setTagResourceErr(fakeError string) {

--- a/pkg/server/plugin/keymanager/awskms/client_fake.go
+++ b/pkg/server/plugin/keymanager/awskms/client_fake.go
@@ -48,6 +48,7 @@ type kmsClientFake struct {
 	deleteAliasErr         error
 	tagResourceErr         error
 	replicateKeyErr        error
+	replicateKeyState      types.KeyState
 	tagResourceCalls       []kms.TagResourceInput
 	replicateKeyCalls      []kms.ReplicateKeyInput
 
@@ -75,8 +76,9 @@ type taggingClientFake struct {
 
 func newKMSClientFake(t *testing.T, c *clock.Mock) *kmsClientFake {
 	return &kmsClientFake{
-		t:     t,
-		store: newFakeStore(c),
+		t:                 t,
+		store:             newFakeStore(c),
+		replicateKeyState: types.KeyStateEnabled,
 
 		// Valid KMS alias name must match the expression below:
 		// https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateAlias.html#API_CreateAlias_RequestSyntax
@@ -177,6 +179,7 @@ func (k *kmsClientFake) CreateKey(_ context.Context, input *kms.CreateKeyInput, 
 		return nil, err
 	}
 
+	multiRegion := input.MultiRegion != nil && *input.MultiRegion
 	keyEntry := &fakeKeyEntry{
 		Description:  input.Description,
 		CreationDate: aws.Time(time.Unix(0, 0)),
@@ -184,16 +187,25 @@ func (k *kmsClientFake) CreateKey(_ context.Context, input *kms.CreateKeyInput, 
 		privateKey:   privateKey,
 		KeySpec:      input.KeySpec,
 		Enabled:      true,
+		KeyState:     types.KeyStateEnabled,
+		MultiRegion:  multiRegion,
+	}
+	if multiRegion {
+		keyEntry.MultiRegionKeyType = types.MultiRegionKeyTypePrimary
 	}
 
 	k.store.SaveKeyEntry(keyEntry)
 
 	return &kms.CreateKeyOutput{
 		KeyMetadata: &types.KeyMetadata{
-			KeyId:        keyEntry.KeyID,
-			Arn:          keyEntry.Arn,
-			Description:  keyEntry.Description,
-			CreationDate: keyEntry.CreationDate,
+			KeyId:                    keyEntry.KeyID,
+			Arn:                      keyEntry.Arn,
+			Description:              keyEntry.Description,
+			CreationDate:             keyEntry.CreationDate,
+			Enabled:                  keyEntry.Enabled,
+			KeyState:                 keyEntry.KeyState,
+			MultiRegion:              aws.Bool(keyEntry.MultiRegion),
+			MultiRegionConfiguration: keyEntry.multiRegionConfiguration(),
 		},
 	}, nil
 }
@@ -210,17 +222,20 @@ func (k *kmsClientFake) DescribeKey(_ context.Context, input *kms.DescribeKeyInp
 
 	keyEntry, err := k.store.FetchKeyEntry(*input.KeyId)
 	if err != nil {
-		return nil, err
+		return nil, &types.NotFoundException{Message: aws.String(err.Error())}
 	}
 
 	return &kms.DescribeKeyOutput{
 		KeyMetadata: &types.KeyMetadata{
-			KeyId:        keyEntry.KeyID,
-			Arn:          keyEntry.Arn,
-			KeySpec:      keyEntry.KeySpec,
-			Enabled:      keyEntry.Enabled,
-			Description:  keyEntry.Description,
-			CreationDate: keyEntry.CreationDate,
+			KeyId:                    keyEntry.KeyID,
+			Arn:                      keyEntry.Arn,
+			KeySpec:                  keyEntry.KeySpec,
+			Enabled:                  keyEntry.Enabled,
+			KeyState:                 keyEntry.KeyState,
+			Description:              keyEntry.Description,
+			CreationDate:             keyEntry.CreationDate,
+			MultiRegion:              aws.Bool(keyEntry.MultiRegion),
+			MultiRegionConfiguration: keyEntry.multiRegionConfiguration(),
 		},
 	}, nil
 }
@@ -424,6 +439,16 @@ func (k *kmsClientFake) setEntries(entries []fakeKeyEntry) {
 		return
 	}
 	for _, e := range entries {
+		if e.KeyState == "" {
+			if e.Enabled {
+				e.KeyState = types.KeyStateEnabled
+			} else {
+				e.KeyState = types.KeyStateDisabled
+			}
+		}
+		if e.MultiRegion && e.MultiRegionKeyType == "" {
+			e.MultiRegionKeyType = types.MultiRegionKeyTypePrimary
+		}
 		if e.KeyID != nil {
 			newEntry := e
 			k.store.SaveKeyEntry(&newEntry)
@@ -540,6 +565,7 @@ func (k *kmsClientFake) ReplicateKey(_ context.Context, input *kms.ReplicateKeyI
 	k.mu.Lock()
 	k.replicateKeyCalls = append(k.replicateKeyCalls, *input)
 	replicateKeyErr := k.replicateKeyErr
+	replicateKeyState := k.replicateKeyState
 	peer := k.peers[*input.ReplicaRegion]
 	k.mu.Unlock()
 
@@ -562,23 +588,28 @@ func (k *kmsClientFake) ReplicateKey(_ context.Context, input *kms.ReplicateKeyI
 	}
 
 	replica := &fakeKeyEntry{
-		KeyID:        primary.KeyID,
-		Description:  primary.Description,
-		CreationDate: primary.CreationDate,
-		PublicKey:    primary.PublicKey,
-		privateKey:   primary.privateKey,
-		KeySpec:      primary.KeySpec,
-		Enabled:      true,
+		KeyID:              primary.KeyID,
+		Description:        input.Description,
+		CreationDate:       primary.CreationDate,
+		PublicKey:          primary.PublicKey,
+		privateKey:         primary.privateKey,
+		KeySpec:            primary.KeySpec,
+		Enabled:            replicateKeyState == types.KeyStateEnabled,
+		KeyState:           replicateKeyState,
+		MultiRegion:        true,
+		MultiRegionKeyType: types.MultiRegionKeyTypeReplica,
 	}
 	peer.store.SaveKeyEntry(replica)
 
 	return &kms.ReplicateKeyOutput{
 		ReplicaKeyMetadata: &types.KeyMetadata{
-			KeyId:       replica.KeyID,
-			Arn:         replica.Arn,
-			KeySpec:     replica.KeySpec,
-			Enabled:     true,
-			MultiRegion: aws.Bool(true),
+			KeyId:                    replica.KeyID,
+			Arn:                      replica.Arn,
+			KeySpec:                  replica.KeySpec,
+			Enabled:                  replica.Enabled,
+			KeyState:                 replica.KeyState,
+			MultiRegion:              aws.Bool(true),
+			MultiRegionConfiguration: replica.multiRegionConfiguration(),
 		},
 	}, nil
 }
@@ -587,6 +618,16 @@ func (k *kmsClientFake) setReplicateKeyErr(err error) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 	k.replicateKeyErr = err
+}
+
+func (k *kmsClientFake) setReplicateKeyState(state types.KeyState) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.replicateKeyState = state
+}
+
+func (k *kmsClientFake) setKeyState(keyID string, state types.KeyState) {
+	require.NoError(k.t, k.store.SetKeyState(keyID, state))
 }
 
 // setPeer registers the fake standing in for KMS in the given replica region.
@@ -638,7 +679,17 @@ type fakeKeyEntry struct {
 	PublicKey            []byte
 	privateKey           crypto.Signer
 	Enabled              bool
+	KeyState             types.KeyState
 	KeySpec              types.KeySpec
+	MultiRegion          bool
+	MultiRegionKeyType   types.MultiRegionKeyType
+}
+
+func (e *fakeKeyEntry) multiRegionConfiguration() *types.MultiRegionConfiguration {
+	if !e.MultiRegion {
+		return nil
+	}
+	return &types.MultiRegionConfiguration{MultiRegionKeyType: e.MultiRegionKeyType}
 }
 
 type fakeAlias struct {
@@ -672,6 +723,22 @@ func (fs *fakeStore) DeleteKeyEntry(keyID string) {
 			delete(fs.aliases, k)
 		}
 	}
+}
+
+func (fs *fakeStore) SetKeyState(keyID string, state types.KeyState) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	keyEntry, ok := fs.keyEntries[keyID]
+	if !ok {
+		keyEntry, ok = fs.keyEntries[keyIDFromArn(keyID)]
+	}
+	if !ok {
+		return fmt.Errorf("no such key %q", keyID)
+	}
+	keyEntry.KeyState = state
+	keyEntry.Enabled = state == types.KeyStateEnabled
+	return nil
 }
 
 func (fs *fakeStore) SaveAlias(targetKeyID, aliasName string) error {
@@ -732,7 +799,10 @@ func (fs *fakeStore) ListAliases() []fakeAlias {
 				PublicKey:            v.KeyEntry.PublicKey,
 				privateKey:           v.KeyEntry.privateKey,
 				Enabled:              v.KeyEntry.Enabled,
+				KeyState:             v.KeyEntry.KeyState,
 				KeySpec:              v.KeyEntry.KeySpec,
+				MultiRegion:          v.KeyEntry.MultiRegion,
+				MultiRegionKeyType:   v.KeyEntry.MultiRegionKeyType,
 			},
 		})
 	}

--- a/pkg/server/plugin/keymanager/awskms/fetcher.go
+++ b/pkg/server/plugin/keymanager/awskms/fetcher.go
@@ -128,16 +128,21 @@ func (kf *keyFetcher) fetchKeyEntryDetails(ctx context.Context, alias types.Alia
 		return nil, status.Error(codes.Internal, "malformed get public key response")
 	}
 
-	return &keyEntry{
-		Arn:       *describeResp.KeyMetadata.Arn,
-		AliasName: *alias.AliasName,
+	entry := &keyEntry{
+		Arn:         *describeResp.KeyMetadata.Arn,
+		AliasName:   *alias.AliasName,
+		MultiRegion: aws.ToBool(describeResp.KeyMetadata.MultiRegion),
 		PublicKey: &keymanagerv1.PublicKey{
 			Id:          spireKeyID,
 			Type:        keyType,
 			PkixData:    publicKeyResp.PublicKey,
 			Fingerprint: makeFingerprint(publicKeyResp.PublicKey),
 		},
-	}, nil
+	}
+	if describeResp.KeyMetadata.MultiRegionConfiguration != nil {
+		entry.MultiRegionKeyType = describeResp.KeyMetadata.MultiRegionConfiguration.MultiRegionKeyType
+	}
+	return entry, nil
 }
 
 func (kf *keyFetcher) spireKeyIDFromAlias(aliasName string) (string, bool) {
@@ -277,16 +282,21 @@ func (kf *keyFetcher) fetchKeyEntryDetailsFromArn(ctx context.Context, keyArn st
 	trustDomain := sanitizeTrustDomain(kf.trustDomain)
 	aliasName := path.Join(aliasPrefix, trustDomain, kf.serverID, encodeKeyID(spireKeyID))
 
-	return &keyEntry{
-		Arn:       *describeResp.KeyMetadata.Arn,
-		AliasName: aliasName,
+	entry := &keyEntry{
+		Arn:         *describeResp.KeyMetadata.Arn,
+		AliasName:   aliasName,
+		MultiRegion: aws.ToBool(describeResp.KeyMetadata.MultiRegion),
 		PublicKey: &keymanagerv1.PublicKey{
 			Id:          spireKeyID,
 			Type:        keyType,
 			PkixData:    publicKeyResp.PublicKey,
 			Fingerprint: makeFingerprint(publicKeyResp.PublicKey),
 		},
-	}, nil
+	}
+	if describeResp.KeyMetadata.MultiRegionConfiguration != nil {
+		entry.MultiRegionKeyType = describeResp.KeyMetadata.MultiRegionConfiguration.MultiRegionKeyType
+	}
+	return entry, nil
 }
 
 // fetchKeyEntriesWithMigration performs tag-based discovery with automatic


### PR DESCRIPTION
**Pull Request check list**

- [X] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**
Keystore plugins (AWS to start with, but probably should extend to other cloud providers as well).

**Description of change**
Adds replication functionality to the AWS keystore plugin, to enable multi-region KMS keys for upstream server failover.

**Which issue this PR fixes**
#5919

