### PR TITLE
Make Broker API keepalive enforcement min-time configurable

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -136,6 +136,10 @@ type agentConfig struct {
 //	            ]
 //	        },
 //	    ]
+//
+//	    # Shortest interval a broker may send keepalive pings without being
+//	    # sent GOAWAY. Defaults to gRPC's built-in 5 minutes.
+//	    keepalive_min_time = "10s"
 //	}
 type brokerHCLConfig struct {
 	// SocketPath binds the broker endpoint to a Unix domain socket at the
@@ -150,6 +154,11 @@ type brokerHCLConfig struct {
 	// broker endpoint. Each entry's `id` is any valid SPIFFE ID; cross-
 	// trust-domain broker identities are allowed.
 	Brokers []brokerHCLEntry `hcl:"brokers"`
+
+	// KeepaliveMinTime is the shortest interval a broker is allowed to send
+	// keepalive pings without being sent GOAWAY. Defaults to gRPC's
+	// built-in 5 minutes when unset.
+	KeepaliveMinTime string `hcl:"keepalive_min_time"`
 
 	UnusedKeyPositions map[string][]token.Pos `hcl:",unusedKeyPositions"`
 }
@@ -820,9 +829,19 @@ func newAgentConfig(c *Config, logOptions []log.Option, allowUnknownConfig, skip
 				AllowedReferenceTypes: allowedReferenceTypes,
 			})
 		}
+
+		var keepaliveMinTime time.Duration
+		if kmt := c.Agent.Experimental.Broker.KeepaliveMinTime; kmt != "" {
+			keepaliveMinTime, err = time.ParseDuration(kmt)
+			if err != nil {
+				return nil, fmt.Errorf("invalid experimental.broker.keepalive_min_time %q: %w", kmt, err)
+			}
+		}
+
 		ac.Broker = agent.BrokerConfig{
-			BindAddresses: bindAddrs,
-			Brokers:       brokers,
+			BindAddresses:    bindAddrs,
+			Brokers:          brokers,
+			KeepaliveMinTime: keepaliveMinTime,
 		}
 	}
 

--- a/cmd/spire-agent/cli/run/run_test.go
+++ b/cmd/spire-agent/cli/run/run_test.go
@@ -1261,6 +1261,48 @@ func TestNewAgentConfig(t *testing.T) {
 			},
 		},
 		{
+			msg: "broker keepalive_min_time parses a duration",
+			input: func(c *Config) {
+				c.Agent.Experimental.Broker = &brokerHCLConfig{
+					BindAddress:      "127.0.0.1:8443",
+					KeepaliveMinTime: "10s",
+					Brokers: []brokerHCLEntry{
+						{
+							ID: "spiffe://example.org/broker",
+							AllowedReferenceTypes: []brokerAllowedReferenceTypeHCLEntry{
+								{TypeURL: "*"},
+							},
+						},
+					},
+				}
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.Equal(t, 10*time.Second, c.Broker.KeepaliveMinTime)
+			},
+		},
+		{
+			msg:                "broker keepalive_min_time rejects an invalid duration",
+			expectError:        true,
+			requireErrorPrefix: `invalid experimental.broker.keepalive_min_time "not-a-duration"`,
+			input: func(c *Config) {
+				c.Agent.Experimental.Broker = &brokerHCLConfig{
+					BindAddress:      "127.0.0.1:8443",
+					KeepaliveMinTime: "not-a-duration",
+					Brokers: []brokerHCLEntry{
+						{
+							ID: "spiffe://example.org/broker",
+							AllowedReferenceTypes: []brokerAllowedReferenceTypeHCLEntry{
+								{TypeURL: "*"},
+							},
+						},
+					},
+				}
+			},
+			test: func(t *testing.T, c *agent.Config) {
+				require.Nil(t, c)
+			},
+		},
+		{
 			msg: "availability_target parses a duration",
 			input: func(c *Config) {
 				c.Agent.AvailabilityTarget = "24h"

--- a/doc/spire_agent.md
+++ b/doc/spire_agent.md
@@ -668,14 +668,25 @@ reference type is safe over the network; it defaults to false, so UDS is
 allowed but TCP is denied. Use a single object with `type_url = "*"` to
 allow any reference type the agent's attestor stack understands.
 
+`keepalive_min_time` sets the shortest interval a broker may send gRPC
+keepalive pings without being disconnected. It accepts a Go duration
+string (e.g. `"10s"`) and defaults to gRPC's built-in 5 minutes when
+unset. Lower it when a broker needs to ping more frequently than every
+5 minutes to detect an unresponsive agent in a timely manner. Per gRPC's
+own enforcement semantics, this only applies while the broker holds an
+open subscription stream (e.g. `SubscribeToX509SVID`); pings sent with
+no active stream are governed by gRPC's separate, much longer idle-ping
+timeout regardless of this setting.
+
 ```hcl
 agent {
     trust_domain = "example.org"
     ...
     experimental {
         broker {
-            socket_path  = "/run/spire/broker-sockets/broker.sock"  # POSIX UDS
-            bind_address = "0.0.0.0:8443"                           # optional TCP
+            socket_path        = "/run/spire/broker-sockets/broker.sock"  # POSIX UDS
+            bind_address       = "0.0.0.0:8443"                           # optional TCP
+            keepalive_min_time = "10s"                                    # optional, defaults to 5m
 
             brokers = [
                 {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -338,15 +338,16 @@ func (a *Agent) Run(ctx context.Context) error {
 
 	if len(a.c.Broker.BindAddresses) != 0 {
 		brokerEndpoints, err := broker.New(&broker.Config{
-			BindAddrs:    a.c.Broker.BindAddresses,
-			Manager:      mgr,
-			Log:          a.c.Log,
-			Metrics:      metrics,
-			Attestor:     workloadAttestor,
-			Brokers:      a.c.Broker.Brokers,
-			SVIDSource:   liveAgentSVIDSource{m: mgr},
-			BundleSource: mgr.GetX509Bundle(),
-			TLSPolicy:    a.c.TLSPolicy,
+			BindAddrs:        a.c.Broker.BindAddresses,
+			Manager:          mgr,
+			Log:              a.c.Log,
+			Metrics:          metrics,
+			Attestor:         workloadAttestor,
+			Brokers:          a.c.Broker.Brokers,
+			SVIDSource:       liveAgentSVIDSource{m: mgr},
+			BundleSource:     mgr.GetX509Bundle(),
+			TLSPolicy:        a.c.TLSPolicy,
+			KeepaliveMinTime: a.c.Broker.KeepaliveMinTime,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create broker endpoints: %w", err)

--- a/pkg/agent/broker/endpoints.go
+++ b/pkg/agent/broker/endpoints.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
@@ -21,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/reflection"
@@ -56,6 +58,11 @@ type Config struct {
 	// TLSPolicy controls the post-quantum-safe TLS policy applied to the
 	// inbound mTLS listener.
 	TLSPolicy tlspolicy.Policy
+
+	// KeepaliveMinTime is the shortest interval a broker is allowed to send
+	// keepalive pings without being sent GOAWAY. Zero defers to gRPC's
+	// built-in default of 5 minutes.
+	KeepaliveMinTime time.Duration
 }
 
 // Broker identifies a broker authorized to talk to the SPIFFE Broker API
@@ -154,6 +161,7 @@ func (e *Endpoints) ListenAndServe(ctx context.Context) error {
 		grpc.Creds(credentials.NewTLS(tlsConfig)),
 		grpc.UnaryInterceptor(unaryInterceptor),
 		grpc.StreamInterceptor(streamInterceptor),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{MinTime: e.c.KeepaliveMinTime}),
 	)
 
 	e.registerBrokerAPI(server)

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -147,6 +147,11 @@ type BrokerConfig struct {
 	// Brokers enumerates the brokers authorized to talk to this agent's
 	// broker endpoint.
 	Brokers []broker.Broker
+
+	// KeepaliveMinTime is the shortest interval a broker is allowed to send
+	// keepalive pings without being sent GOAWAY. Zero defers to gRPC's
+	// built-in default of 5 minutes.
+	KeepaliveMinTime time.Duration
 }
 
 func New(c *Config) *Agent {


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [x] Proper tests/regressions included?
- [x] Documentation updated?

**Affected functionality**

The agent's SPIFFE Broker API endpoint (`pkg/agent/broker`), specifically its gRPC server's keepalive ping enforcement policy.

**Description of change**

The Broker API's gRPC server never set `grpc.KeepaliveEnforcementPolicy`, so gRPC silently applied its built-in default of a 5-minute minimum interval between client keepalive pings (while a stream is active). Brokers that want to detect an unresponsive agent faster than every 5 minutes had no way to ping more frequently without being disconnected, and no config knob existed to change it.

This adds an optional `keepalive_min_time` key to the agent's `experimental.broker` HCL block (a Go duration string, e.g. `"10s"`), threaded through `agent.BrokerConfig` -> `broker.Config` -> the gRPC server's `KeepaliveEnforcementPolicy` option. Leaving it unset keeps the field at its zero value, which gRPC's own server logic treats as "use the built-in 5-minute default," so behavior for existing deployments is unchanged. Documentation for the new key was added to `doc/spire_agent.md`, including a note that (per gRPC's own semantics) it only takes effect while a subscription stream is open.

Validation performed:
- `go build ./...`
- `go vet ./pkg/agent/... ./cmd/spire-agent/...`
- `gofmt -l` on changed files
- `go test ./pkg/agent/broker/... ./cmd/spire-agent/cli/run/... ./pkg/agent/...` (includes two new table-driven cases covering valid and invalid `keepalive_min_time` values)
- `golangci-lint run --max-issues-per-linter=0 --max-same-issues=0` on the changed packages (0 issues)
- `go mod tidy` (no diff)

Not run: a timing-based integration test that opens a live streaming RPC and races gRPC's internal ping-strike timers to directly observe GOAWAY vs. no-GOAWAY. See the commit message for why this was judged disproportionate for a config-plumbing change that reuses a standard, already-tested grpc-go API exactly as requested in the issue.

**Which issue this PR fixes**

fixes #7264