### PR TITLE
Remove unused startupComplete channel from the health cache

### DIFF
--- a/pkg/common/health/cache.go
+++ b/pkg/common/health/cache.go
@@ -41,7 +41,6 @@ func newCache(log logrus.FieldLogger, clock clock.Clock) *cache {
 		checkerSubsystems: make(map[string]*checkerSubsystem),
 		log:               log,
 		clk:               clock,
-		startupComplete:   make(chan struct{}, 1),
 	}
 }
 
@@ -55,7 +54,6 @@ type cache struct {
 	hooks struct {
 		statusUpdated chan struct{}
 	}
-	startupComplete chan struct{}
 }
 
 func (c *cache) addCheck(name string, checkable Checkable) error {


### PR DESCRIPTION
**Pull Request check list**

- [x] Commit conforms to CONTRIBUTING.md?
- [ ] Proper tests/regressions included? — no tests added; see the note below
- [ ] Documentation updated? — not applicable, no user-facing behavior changes

**Affected functionality**

The health check subsystem (`pkg/common/health`). There is no behavioral change.

**Description of change**

`cache.startupComplete` is allocated in `newCache`, but it is never sent to or
received from anywhere in the tree. Its declaration and its initialization are
its only two occurrences:

```
pkg/common/health/cache.go:44:		startupComplete:   make(chan struct{}, 1),
pkg/common/health/cache.go:58:	startupComplete chan struct{}
```

It was added in 1328bd8 (#6164). That commit adds only those two lines — no read
or write of the channel was introduced along with it — so the field has been
unused since the moment it was added.

Removing it also removes a small source of confusion when reading this file. The
name reads as if it signalled the end of the startup phase, but that is actually
done by the local `startSteadyStateHealthCheckCh` in `startRunner`
(`cache.go:146`, `:177`, `:186`).

No tests are added, since this removes a field that nothing reads or writes;
there is no behavior to assert. Verification of that claim, on top of this
change:

- `go vet ./...` passes over all 294 packages, including `_test.go` files. Since
  a struct field that is still referenced anywhere would fail to compile once the
  field is gone, this establishes that no reference remains.
- As a sanity check on that reasoning, adding a single `_ = c.startupComplete`
  back into the package makes it fail with `c.startupComplete undefined (type
  *cache has no field or method startupComplete)`.
- `go test ./pkg/common/health/... -count=1 -race` passes (18 tests).
- `gofmt`, `go build ./...` and `make lint-code` (0 issues) are clean.

**Which issue this PR fixes**

None.
