### PR TITLE
Run the milestone check in its own workflow

### DIFF
--- a/.github/workflows/milestone_check.yaml
+++ b/.github/workflows/milestone_check.yaml
@@ -1,0 +1,50 @@
+name: Milestone Check
+on:
+  pull_request:
+    # milestoned and demilestoned are not part of the default activity types.
+    # They re-run this check when the milestone changes, so a red check turns
+    # green as soon as a milestone is assigned without pushing a new commit.
+    types: [opened, reopened, synchronize, milestoned, demilestoned]
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  contents: read
+
+jobs:
+  milestone-check:
+    name: milestone-check
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Check milestone
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            # The merge group head ref has the format
+            # refs/heads/gh-readonly-queue/<base>/pr-<number>-<sha>
+            PR_NUMBER=$(echo "$MERGE_GROUP_HEAD_REF" | grep -oP 'pr-\K[0-9]+' || true)
+            if [ -z "$PR_NUMBER" ]; then
+              echo "Error: Could not extract PR number from head_ref: $MERGE_GROUP_HEAD_REF"
+              exit 1
+            fi
+          fi
+
+          MILESTONE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json milestone --jq '.milestone.title // empty')
+
+          if [ -z "$MILESTONE" ]; then
+            echo "Error: PR #$PR_NUMBER does not have a milestone assigned."
+            echo "Please assign a milestone before merging."
+            exit 1
+          fi
+
+          echo "PR #$PR_NUMBER has milestone: $MILESTONE"

--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -605,56 +605,16 @@ jobs:
           name: binaries-windows
           path: ./artifacts/
 
-  milestone-check:
-    name: milestone-check
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'merge_group'
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Get PR number from merge group
-        id: get-pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Extract PR number from merge group head ref (format: refs/heads/gh-readonly-queue/main/pr-<number>-<sha>)
-          PR_NUMBER=$(echo "${{ github.event.merge_group.head_ref }}" | grep -oP 'pr-\K[0-9]+')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "Error: Could not extract PR number from head_ref: ${{ github.event.merge_group.head_ref }}"
-            exit 1
-          fi
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "Found PR number: $PR_NUMBER"
-      - name: Check milestone
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_NUMBER="${{ steps.get-pr.outputs.pr_number }}"
-          MILESTONE=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json milestone --jq '.milestone.title // empty')
-
-          if [ -z "$MILESTONE" ]; then
-            echo "Error: PR #$PR_NUMBER does not have a milestone assigned."
-            echo "Please assign a milestone before merging."
-            exit 1
-          fi
-
-          echo "PR #$PR_NUMBER has milestone: $MILESTONE"
-
   success:
     runs-on: ubuntu-22.04
-    needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, integration-k8s, lint-windows, unit-test-windows, artifacts-windows, integration-windows, milestone-check]
+    needs: [lint, unit-test, unit-test-race-detector, artifacts, integration, integration-k8s, lint-windows, unit-test-windows, artifacts-windows, integration-windows]
     if: always()
     timeout-minutes: 30
     permissions:
       contents: read
     steps:
       - name: Check for failures
-        if: |
-          contains(needs.*.result, 'failure') ||
-          contains(needs.*.result, 'cancelled') ||
-          (contains(needs.*.result, 'skipped') && needs.milestone-check.result != 'skipped')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
         run: |
           echo "One or more required jobs failed, were cancelled, or were skipped"
           exit 1


### PR DESCRIPTION
The `milestone-check` job in the PR Build workflow only runs on `merge_group` events, and the only required status check that depends on it is `success`, which waits for every build job before it reports. A PR that enters the merge queue without a milestone is therefore only removed from the queue once the full build has finished. In this run the job failed 7 seconds in, and `success` reported the failure 23 minutes later: https://github.com/spiffe/spire/actions/runs/33979840609/job/101342978697. Nothing flags the missing milestone on the PR itself before it is queued, since the job never runs on `pull_request` events.

This PR moves the check into a new `Milestone Check` workflow with a single `milestone-check` job. It triggers on `pull_request` with the `opened`, `reopened`, `synchronize`, `milestoned` and `demilestoned` activity types, and on `merge_group`. The two milestone types are not in the default set, so they are listed explicitly. Assigning a milestone re-runs the check and turns it green without a new commit, and removing one turns it red again. Keeping the check in its own workflow means those events do not re-run the full build. On a `pull_request` event the PR number comes from the event payload, and on a `merge_group` event it is parsed from the queue head ref as before. The job in `pr_build.yaml` is removed, and the `success` job no longer needs the special case for a skipped `milestone-check`.

The extraction of the PR number from the head ref also gets `|| true`, since `run` steps use `bash -eo pipefail` and a `grep` with no match aborted the step before the error message could print.

After this merges, I'll add `milestone-check` to the required status checks on `main` alongside `success` and `check-dco`. The merge queue removes a PR as soon as any required check fails, so with that in place a missing milestone is reported within seconds of entering the queue. Adding the required check before the merge would leave other queued PRs waiting on a check that their merge commit cannot produce yet.
