### PR TITLE
Set WIT authorities when parsing a SPIFFE bundle

### DIFF
--- a/cmd/spire-server/cli/bundle/bundle_test.go
+++ b/cmd/spire-server/cli/bundle/bundle_test.go
@@ -284,6 +284,12 @@ func TestSet(t *testing.T) {
 						PublicKey: key1Pkix,
 					},
 				},
+				WitAuthorities: []*types.WITKey{
+					{
+						KeyId:     "WIT-KID",
+						PublicKey: key1Pkix,
+					},
+				},
 			},
 			setResponse: &bundlev1.BatchSetFederatedBundleResponse{
 				Results: []*bundlev1.BatchSetFederatedBundleResponse_Result{
@@ -368,6 +374,12 @@ func TestSet(t *testing.T) {
 				JwtAuthorities: []*types.JWTKey{
 					{
 						KeyId:     "KID",
+						PublicKey: key1Pkix,
+					},
+				},
+				WitAuthorities: []*types.WITKey{
+					{
+						KeyId:     "WIT-KID",
 						PublicKey: key1Pkix,
 					},
 				},

--- a/cmd/spire-server/cli/bundle/common.go
+++ b/cmd/spire-server/cli/bundle/common.go
@@ -2,7 +2,6 @@ package bundle
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -18,6 +17,7 @@ import (
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/spiffe/spire/cmd/spire-server/util"
 	"github.com/spiffe/spire/pkg/common/jwtutil"
+	"github.com/spiffe/spire/pkg/common/witutil"
 )
 
 const (
@@ -104,7 +104,7 @@ func bundleFromProto(bundleProto *types.Bundle) (*spiffebundle.Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	witAuthorities, err := witKeysFromProto(bundleProto.WitAuthorities)
+	witAuthorities, err := witutil.WITKeysFromProto(bundleProto.WitAuthorities)
 	if err != nil {
 		return nil, err
 	}
@@ -119,19 +119,6 @@ func bundleFromProto(bundleProto *types.Bundle) (*spiffebundle.Bundle, error) {
 		bundle.SetSequenceNumber(bundleProto.SequenceNumber)
 	}
 	return bundle, nil
-}
-
-// witKeysFromProto converts WIT keys from the given []*types.WITKey to map[string]crypto.PublicKey.
-func witKeysFromProto(proto []*types.WITKey) (map[string]crypto.PublicKey, error) {
-	keys := make(map[string]crypto.PublicKey)
-	for i, publicKey := range proto {
-		witSigningKey, err := x509.ParsePKIXPublicKey(publicKey.PublicKey)
-		if err != nil {
-			return nil, fmt.Errorf("unable to parse WIT signing key %d: %w", i, err)
-		}
-		keys[publicKey.KeyId] = witSigningKey
-	}
-	return keys, nil
 }
 
 // x509CertificatesFromProto converts X.509 certificates from the given []*types.X509Certificate to []*x509.Certificate

--- a/cmd/spire-server/cli/bundle/common_test.go
+++ b/cmd/spire-server/cli/bundle/common_test.go
@@ -61,6 +61,14 @@ diIqWtxAqBLFrx8zNS4=
             "crv": "P-256",
             "x": "fK-wKTnKL7KFLM27lqq5DC-bxrVaH6rDV-IcCSEOeL4",
             "y": "wq-g3TQWxYlV51TCPH030yXsRxvujD4hUUaIQrXk4KI"
+        },
+        {
+            "use": "wit-svid",
+            "kty": "EC",
+            "kid": "WIT-KID",
+            "crv": "P-256",
+            "x": "fK-wKTnKL7KFLM27lqq5DC-bxrVaH6rDV-IcCSEOeL4",
+            "y": "wq-g3TQWxYlV51TCPH030yXsRxvujD4hUUaIQrXk4KI"
         }
     ]
 }

--- a/cmd/spire-server/cli/federation/common_test.go
+++ b/cmd/spire-server/cli/federation/common_test.go
@@ -71,6 +71,14 @@ const (
                         "crv": "P-256",
                         "x": "fK-wKTnKL7KFLM27lqq5DC-bxrVaH6rDV-IcCSEOeL4",
                         "y": "wq-g3TQWxYlV51TCPH030yXsRxvujD4hUUaIQrXk4KI"
+                    },
+                    {
+                        "use": "wit-svid",
+                        "kty": "EC",
+                        "kid": "WIT-KID",
+                        "crv": "P-256",
+                        "x": "HxVuaUnxgi431G5D3g9hqeaQhEbsyQZXmaas7qsUC_c",
+                        "y": "SFd_uVlwYNkXrh0219eHUSD4o-4RGXoiMFJKysw5GK4"
                     }
                 ]
             }
@@ -98,6 +106,14 @@ const (
             "crv": "P-256",
             "x": "fK-wKTnKL7KFLM27lqq5DC-bxrVaH6rDV-IcCSEOeL4",
             "y": "wq-g3TQWxYlV51TCPH030yXsRxvujD4hUUaIQrXk4KI"
+        },
+        {
+            "use": "wit-svid",
+            "kty": "EC",
+            "kid": "WIT-KID",
+            "crv": "P-256",
+            "x": "HxVuaUnxgi431G5D3g9hqeaQhEbsyQZXmaas7qsUC_c",
+            "y": "SFd_uVlwYNkXrh0219eHUSD4o-4RGXoiMFJKysw5GK4"
         }
     ]
 }`

--- a/cmd/spire-server/cli/federation/create_test.go
+++ b/cmd/spire-server/cli/federation/create_test.go
@@ -116,6 +116,18 @@ func TestCreate(t *testing.T) {
 	}
 	require.Len(t, jwtAuthorities, 1)
 
+	var witAuthorities []*types.WITKey
+	for id, key := range spiffeBundle.WITAuthorities() {
+		keyBytes, err := x509.MarshalPKIXPublicKey(key)
+		require.NoError(t, err)
+
+		witAuthorities = append(witAuthorities, &types.WITKey{
+			KeyId:     id,
+			PublicKey: keyBytes,
+		})
+	}
+	require.Len(t, witAuthorities, 1)
+
 	frSPIFFEAuthority := &types.FederationRelationship{
 		TrustDomain:       "td-4.org",
 		BundleEndpointUrl: "https://td-4.org/bundle",
@@ -128,6 +140,7 @@ func TestCreate(t *testing.T) {
 			TrustDomain:     "td-4.org",
 			X509Authorities: x509Authorities,
 			JwtAuthorities:  jwtAuthorities,
+			WitAuthorities:  witAuthorities,
 		},
 	}
 

--- a/cmd/spire-server/cli/federation/update_test.go
+++ b/cmd/spire-server/cli/federation/update_test.go
@@ -116,6 +116,18 @@ func TestUpdate(t *testing.T) {
 	}
 	require.Len(t, jwtAuthorities, 1)
 
+	var witAuthorities []*types.WITKey
+	for id, key := range spiffeBundle.WITAuthorities() {
+		keyBytes, err := x509.MarshalPKIXPublicKey(key)
+		require.NoError(t, err)
+
+		witAuthorities = append(witAuthorities, &types.WITKey{
+			KeyId:     id,
+			PublicKey: keyBytes,
+		})
+	}
+	require.Len(t, witAuthorities, 1)
+
 	frSPIFFEAuthority := &types.FederationRelationship{
 		TrustDomain:       "td-4.org",
 		BundleEndpointUrl: "https://td-4.org/bundle",
@@ -128,6 +140,7 @@ func TestUpdate(t *testing.T) {
 			TrustDomain:     "td-4.org",
 			X509Authorities: x509Authorities,
 			JwtAuthorities:  jwtAuthorities,
+			WitAuthorities:  witAuthorities,
 		},
 	}
 

--- a/cmd/spire-server/util/util.go
+++ b/cmd/spire-server/util/util.go
@@ -21,6 +21,7 @@ import (
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/jwtutil"
 	"github.com/spiffe/spire/pkg/common/pemutil"
+	"github.com/spiffe/spire/pkg/common/witutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -260,6 +261,12 @@ func protoFromSpiffeBundle(bundle *spiffebundle.Bundle) (*api_types.Bundle, erro
 		return nil, err
 	}
 	resp.JwtAuthorities = jwtAuthorities
+
+	witAuthorities, err := witutil.ProtoFromWITKeys(bundle.WITAuthorities())
+	if err != nil {
+		return nil, err
+	}
+	resp.WitAuthorities = witAuthorities
 
 	if r, ok := bundle.RefreshHint(); ok {
 		resp.RefreshHint = int64(r.Seconds())

--- a/pkg/common/jwtutil/jwt.go
+++ b/pkg/common/jwtutil/jwt.go
@@ -29,7 +29,7 @@ func ProtoFromJWTKeys(keys map[string]crypto.PublicKey) ([]*types.JWTKey, error)
 	for kid, key := range keys {
 		pkixBytes, err := x509.MarshalPKIXPublicKey(key)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to marshal JWT public key: %w", err)
 		}
 		resp = append(resp, &types.JWTKey{
 			PublicKey: pkixBytes,

--- a/pkg/common/witutil/wit.go
+++ b/pkg/common/witutil/wit.go
@@ -1,0 +1,41 @@
+package witutil
+
+import (
+	"crypto"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+)
+
+// WITKeysFromProto converts WIT keys from the given []*types.WITKey to map[string]crypto.PublicKey.
+// The key ID of the public key is used as the key in the returned map.
+func WITKeysFromProto(proto []*types.WITKey) (map[string]crypto.PublicKey, error) {
+	keys := make(map[string]crypto.PublicKey)
+	for i, publicKey := range proto {
+		witSigningKey, err := x509.ParsePKIXPublicKey(publicKey.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse WIT signing key %d: %w", i, err)
+		}
+		keys[publicKey.KeyId] = witSigningKey
+	}
+	return keys, nil
+}
+
+// ProtoFromWITKeys converts WIT keys from the given map[string]crypto.PublicKey to []*types.WITKey
+func ProtoFromWITKeys(keys map[string]crypto.PublicKey) ([]*types.WITKey, error) {
+	var resp []*types.WITKey
+
+	for kid, key := range keys {
+		pkixBytes, err := x509.MarshalPKIXPublicKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal WIT public key: %w", err)
+		}
+		resp = append(resp, &types.WITKey{
+			PublicKey: pkixBytes,
+			KeyId:     kid,
+		})
+	}
+
+	return resp, nil
+}

--- a/pkg/common/witutil/wit_test.go
+++ b/pkg/common/witutil/wit_test.go
@@ -1,0 +1,100 @@
+package witutil
+
+import (
+	"crypto"
+	"crypto/x509"
+	"testing"
+
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"github.com/spiffe/spire/test/spiretest"
+	"github.com/spiffe/spire/test/testkey"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWITKeysFromProto(t *testing.T) {
+	publicKey := testkey.MustEC256().Public()
+	pkixBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name        string
+		proto       []*types.WITKey
+		expectKeys  map[string]crypto.PublicKey
+		expectError string
+	}{
+		{
+			name:       "no keys",
+			expectKeys: map[string]crypto.PublicKey{},
+		},
+		{
+			name: "success",
+			proto: []*types.WITKey{
+				{KeyId: "key-id-1", PublicKey: pkixBytes},
+			},
+			expectKeys: map[string]crypto.PublicKey{"key-id-1": publicKey},
+		},
+		{
+			name: "malformed public key",
+			proto: []*types.WITKey{
+				{KeyId: "key-id-1", PublicKey: pkixBytes},
+				{KeyId: "key-id-2", PublicKey: []byte("malformed")},
+			},
+			expectError: "unable to parse WIT signing key 1: asn1: structure error:",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := WITKeysFromProto(tt.proto)
+
+			if tt.expectError != "" {
+				require.ErrorContains(t, err, tt.expectError)
+				require.Nil(t, keys)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expectKeys, keys)
+		})
+	}
+}
+
+func TestProtoFromWITKeys(t *testing.T) {
+	publicKey := testkey.MustEC256().Public()
+	pkixBytes, err := x509.MarshalPKIXPublicKey(publicKey)
+	require.NoError(t, err)
+
+	for _, tt := range []struct {
+		name        string
+		keys        map[string]crypto.PublicKey
+		expectProto []*types.WITKey
+		expectError string
+	}{
+		{
+			name: "no keys",
+		},
+		{
+			name: "success",
+			keys: map[string]crypto.PublicKey{"key-id-1": publicKey},
+			expectProto: []*types.WITKey{
+				{KeyId: "key-id-1", PublicKey: pkixBytes},
+			},
+		},
+		{
+			name:        "unsupported public key type",
+			keys:        map[string]crypto.PublicKey{"key-id-1": "not a public key"},
+			expectError: "failed to marshal WIT public key: x509: unsupported public key type: string",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			proto, err := ProtoFromWITKeys(tt.keys)
+
+			if tt.expectError != "" {
+				require.EqualError(t, err, tt.expectError)
+				require.Nil(t, proto)
+				return
+			}
+
+			require.NoError(t, err)
+			spiretest.AssertProtoListEqual(t, tt.expectProto, proto)
+		})
+	}
+}

--- a/pkg/server/api/bundle_test.go
+++ b/pkg/server/api/bundle_test.go
@@ -197,6 +197,48 @@ func TestProtoToBundle(t *testing.T) {
 			},
 		},
 		{
+			name: "tainted flag is not propagated",
+			bundle: &types.Bundle{
+				TrustDomain: td.Name(),
+				X509Authorities: []*types.X509Certificate{
+					{
+						Asn1:    rootCA.Raw,
+						Tainted: true,
+					},
+				},
+				JwtAuthorities: []*types.JWTKey{
+					{
+						PublicKey: pkixBytes,
+						KeyId:     "key-id-1",
+						Tainted:   true,
+					},
+				},
+				WitAuthorities: []*types.WITKey{
+					{
+						PublicKey: pkixBytes,
+						KeyId:     "wit-key-id-1",
+						Tainted:   true,
+					},
+				},
+			},
+			expectBundle: &common.Bundle{
+				TrustDomainId: td.IDString(),
+				RootCas:       []*common.Certificate{{DerBytes: rootCA.Raw}},
+				JwtSigningKeys: []*common.PublicKey{
+					{
+						PkixBytes: pkixBytes,
+						Kid:       "key-id-1",
+					},
+				},
+				WitSigningKeys: []*common.PublicKey{
+					{
+						PkixBytes: pkixBytes,
+						Kid:       "wit-key-id-1",
+					},
+				},
+			},
+		},
+		{
 			name: "Invalid X.509 certificate bytes",
 			bundle: &types.Bundle{
 				TrustDomain:    td.Name(),


### PR DESCRIPTION
`protoFromSpiffeBundle` builds the API bundle type with only X.509 and JWT authorities, so any WIT keys in a bundle file are dropped without reporting anything. This affects `spire-server bundle set -format spiffe` and the `federation create` and `federation update` commands, which all parse their bundle through `util.ParseBundle`. The read direction was completed in #7243, so `bundle show` now displays WIT authorities that `bundle set` cannot ingest.

This PR carries WIT keys through that conversion. The helpers move to a new `witutil` package mirroring `jwtutil`, replacing the local `witKeysFromProto` in the bundle CLI so both directions live in one place.

The JWT and WIT conversions now run back to back, and both reported a marshal failure without naming the authority set, which left `ParseBundle` surfacing a bare `x509: unsupported public key type`. Each error now names the key type, matching what #7243 did in `bundleutil`.

Tests:

- `bundle set -format spiffe` and the `federation create` and `federation update` JSON data path assert the WIT authorities sent to the server. The WIT key in the federation fixture carries its own key material, distinct from the JWT entry, so a crosswire fails on more than the key ID.
- `ProtoToBundle` gets a case covering that the tainted flag on a request is not propagated to the datastore bundle, which was a deliberate decision during the #7243 review that no test covered.
