### PR TITLE
agent/server: don't exit as crashed on context canceled errors from gRPC

### DIFF
--- a/cmd/spire-agent/cli/run/run.go
+++ b/cmd/spire-agent/cli/run/run.go
@@ -34,6 +34,7 @@ import (
 	"github.com/spiffe/spire/pkg/common/catalog"
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/config"
+	"github.com/spiffe/spire/pkg/common/errorutil"
 	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/idutil"
@@ -362,7 +363,7 @@ func (cmd *Command) Run(args []string) int {
 	defer stop()
 
 	err = a.Run(ctx)
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errorutil.IsCanceled(err) {
 		c.Log.WithError(err).Error("Agent crashed")
 		return 1
 	}

--- a/cmd/spire-server/cli/run/run.go
+++ b/cmd/spire-server/cli/run/run.go
@@ -33,6 +33,7 @@ import (
 	common_cli "github.com/spiffe/spire/pkg/common/cli"
 	"github.com/spiffe/spire/pkg/common/config"
 	"github.com/spiffe/spire/pkg/common/diskcertmanager"
+	"github.com/spiffe/spire/pkg/common/errorutil"
 	"github.com/spiffe/spire/pkg/common/fflag"
 	"github.com/spiffe/spire/pkg/common/health"
 	"github.com/spiffe/spire/pkg/common/log"
@@ -298,7 +299,7 @@ func (cmd *Command) Run(args []string) int {
 	defer stop()
 
 	err = s.Run(ctx)
-	if err != nil && !errors.Is(err, context.Canceled) {
+	if err != nil && !errorutil.IsCanceled(err) {
 		c.Log.WithError(err).Error("Server crashed")
 		return 1
 	}

--- a/pkg/common/errorutil/canceled.go
+++ b/pkg/common/errorutil/canceled.go
@@ -1,0 +1,14 @@
+package errorutil
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsCanceled returns true if err indicates that an operation was canceled.
+func IsCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
+}

--- a/pkg/common/errorutil/canceled_test.go
+++ b/pkg/common/errorutil/canceled_test.go
@@ -1,0 +1,59 @@
+package errorutil_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/spiffe/spire/pkg/common/errorutil"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsCanceled(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+		},
+		{
+			name: "other error",
+			err:  errors.New("oh no"),
+		},
+		{
+			name: "context canceled",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "wrapped context canceled",
+			err:  fmt.Errorf("wrapped: %w", context.Canceled),
+			want: true,
+		},
+		{
+			name: "gRPC context canceled",
+			err:  status.FromContextError(context.Canceled).Err(),
+			want: true,
+		},
+		{
+			name: "wrapped gRPC canceled",
+			err:  fmt.Errorf("wrapped: %w", status.Error(codes.Canceled, "canceled")),
+			want: true,
+		},
+		{
+			name: "other gRPC error",
+			err:  status.Error(codes.Internal, "oh no"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, errorutil.IsCanceled(testCase.err))
+		})
+	}
+}


### PR DESCRIPTION
The server and agent can exit with a gRPC context canceled error if stopped while it was starting up plugins. This error is different from context.Canceled so it needs to be handled separately.